### PR TITLE
RSDEV-232: Track copy/move files to IRods

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/GalleryApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GalleryApiController.java
@@ -3,10 +3,12 @@ package com.researchspace.api.v1.controller;
 import com.researchspace.api.v1.GalleryApi;
 import com.researchspace.api.v1.model.ApiConfiguredLocation;
 import com.researchspace.api.v1.model.ApiExternalStorageInfo;
+import com.researchspace.api.v1.model.ApiExternalStorageOperationInfo;
 import com.researchspace.api.v1.model.ApiExternalStorageOperationResult;
 import com.researchspace.api.v1.model.NfsUserFileSystem;
 import com.researchspace.model.EcatMediaFile;
 import com.researchspace.model.User;
+import com.researchspace.model.netfiles.ExternalStorageLocation;
 import com.researchspace.model.netfiles.NfsClientType;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
@@ -14,6 +16,7 @@ import com.researchspace.netfiles.ApiNfsCredentials;
 import com.researchspace.netfiles.NfsAuthentication;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.service.BaseRecordManager;
+import com.researchspace.service.ExternalStorageManager;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.RecordDeletionManager;
 import java.util.LinkedHashMap;
@@ -54,6 +57,8 @@ public class GalleryApiController extends BaseApiController implements GalleryAp
 
   @Autowired private BaseRecordManager baseRecordManager;
 
+  @Autowired private ExternalStorageManager externalStorageManager;
+
   @Autowired
   @Qualifier("nfsUserPasswordAuthentication")
   private NfsAuthentication nfsAuthentication;
@@ -70,11 +75,13 @@ public class GalleryApiController extends BaseApiController implements GalleryAp
       NfsManager nfsManager,
       RecordDeletionManager deletionManager,
       BaseRecordManager baseRecordManager,
-      NfsAuthentication nfsAuthentication) {
+      NfsAuthentication nfsAuthentication,
+      ExternalStorageManager externalStorageManager) {
     this.nfsManager = nfsManager;
     this.deletionManager = deletionManager;
     this.baseRecordManager = baseRecordManager;
     this.nfsAuthentication = nfsAuthentication;
+    this.externalStorageManager = externalStorageManager;
   }
 
   @PostConstruct
@@ -170,14 +177,31 @@ public class GalleryApiController extends BaseApiController implements GalleryAp
     NfsClient nfsClient =
         validateCredentialsAndLoginNfs(credentials, errors, user, nfsFileStore.getFileSystem());
 
-    Set<EcatMediaFile> mediaFileSet = retrieveMediaFiles(recordIds, user, errors);
+    Map<Long, EcatMediaFile> mediaFileMapById =
+        retrieveMediaFiles(recordIds, user, errors).stream()
+            .collect(Collectors.toMap(EcatMediaFile::getId, value -> value));
+
     log.info(
         "Preparing file list {} to be copied into IRODS path [{}]",
-        mediaFileSet,
+        mediaFileMapById.values(),
         nfsFileStore.getPath());
     try {
       // store the files to the IRODS server
-      result = nfsManager.uploadFilesToNfs(mediaFileSet, nfsFileStore.getPath(), nfsClient);
+      result =
+          nfsManager.uploadFilesToNfs(mediaFileMapById.values(), nfsFileStore.getPath(), nfsClient);
+
+      ExternalStorageLocation externalLocation;
+      for (ApiExternalStorageOperationInfo resultInfo : result.getFileInfoDetails()) {
+        if (resultInfo.getSucceeded()) {
+          externalLocation = new ExternalStorageLocation();
+          externalLocation.setFileStore(nfsFileStore);
+          externalLocation.setOperationUser(user);
+          externalLocation.setExternalStorageId(resultInfo.getExternalStorageId());
+          externalLocation.setConnectedMediaFile(mediaFileMapById.get(resultInfo.getRecordId()));
+          externalStorageManager.saveExternalStorageLocation(externalLocation);
+        }
+      }
+
     } catch (Exception e) {
       log.error("An error occurred while uploading files to IRODS: ", e);
       errors.addError(new ObjectError("nfsClient", e.getMessage()));

--- a/src/main/java/com/researchspace/api/v1/model/ApiExternalStorageOperationInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiExternalStorageOperationInfo.java
@@ -1,5 +1,6 @@
 package com.researchspace.api.v1.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -20,6 +21,8 @@ public class ApiExternalStorageOperationInfo
   @JsonProperty("recordId")
   private Long recordId;
 
+  @JsonIgnore private Long externalStorageId;
+
   @JsonProperty("fileName")
   private String fileName;
 
@@ -31,15 +34,22 @@ public class ApiExternalStorageOperationInfo
   private String reason;
 
   public ApiExternalStorageOperationInfo(
-      Long recordId, String fileName, Boolean succeeded, String reason) {
+      Long recordId, Long externalStorageId, String fileName, Boolean succeeded, String reason) {
     this.recordId = recordId;
+    this.externalStorageId = externalStorageId;
     this.fileName = fileName;
     this.succeeded = succeeded;
     this.reason = reason;
   }
 
-  public ApiExternalStorageOperationInfo(Long recordId, String fileName, Boolean succeeded) {
-    this(recordId, fileName, succeeded, null);
+  public ApiExternalStorageOperationInfo(
+      Long recordId, Long externalStorageId, String fileName, Boolean succeeded) {
+    this(recordId, externalStorageId, fileName, succeeded, null);
+  }
+
+  public ApiExternalStorageOperationInfo(
+      Long recordId, String fileName, Boolean succeeded, String reason) {
+    this(recordId, null, fileName, succeeded, reason);
   }
 
   @Override

--- a/src/main/java/com/researchspace/api/v1/model/ApiExternalStorageOperationResult.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiExternalStorageOperationResult.java
@@ -12,12 +12,14 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
 @EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor
 @JsonPropertyOrder(
     value = {"numFilesInput", "numFilesSucceed", "numFilesFailed", "fileInfoDetails", "_links"})
+@ToString(callSuper = true)
 public class ApiExternalStorageOperationResult extends LinkableApiObject {
 
   @JsonProperty("fileInfoDetails")
@@ -86,6 +88,7 @@ public class ApiExternalStorageOperationResult extends LinkableApiObject {
       result.add(
           new ApiExternalStorageOperationInfo(
               currentEntry.getKey().getId(),
+              null,
               currentEntry.getKey().getFileName(),
               StringUtils.isBlank(currentEntry.getValue()),
               currentEntry.getValue()));

--- a/src/main/java/com/researchspace/dao/ExternalStorageDao.java
+++ b/src/main/java/com/researchspace/dao/ExternalStorageDao.java
@@ -1,0 +1,14 @@
+package com.researchspace.dao;
+
+import com.researchspace.model.netfiles.ExternalStorageLocation;
+import java.util.List;
+
+/**
+ * Data Access Object for external storage locations
+ *
+ * @author nico
+ */
+public interface ExternalStorageDao extends GenericDao<ExternalStorageLocation, Long> {
+
+  List<ExternalStorageLocation> getAllByOperationUser(Long operationUserId);
+}

--- a/src/main/java/com/researchspace/dao/hibernate/ExternalStorageDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/ExternalStorageDaoHibernate.java
@@ -1,0 +1,27 @@
+package com.researchspace.dao.hibernate;
+
+import com.researchspace.dao.ExternalStorageDao;
+import com.researchspace.dao.GenericDaoHibernate;
+import com.researchspace.model.netfiles.ExternalStorageLocation;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository(value = "externalStorageDao")
+public class ExternalStorageDaoHibernate extends GenericDaoHibernate<ExternalStorageLocation, Long>
+    implements ExternalStorageDao {
+
+  public ExternalStorageDaoHibernate() {
+    super(ExternalStorageLocation.class);
+  }
+
+  @Override
+  public List<ExternalStorageLocation> getAllByOperationUser(Long operationUserId) {
+    List<ExternalStorageLocation> externalStorageLocations =
+        sessionFactory
+            .getCurrentSession()
+            .createQuery("from ExternalStorageLocation where operationUser_Id=:operationUserId ")
+            .setLong("operationUserId", operationUserId)
+            .list();
+    return externalStorageLocations;
+  }
+}

--- a/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
@@ -114,10 +114,15 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
     deleteOAuthTokens(userId, session);
     deleteOAuthApps(userId, session);
     deleteGroupMembershipEvent(userId, session);
+    deleteExternalStorageLocation(userId, session);
 
     userDao.remove(userId);
 
     return new ServiceOperationResult<>(toDelete, true, "Temporary [" + userId + "] deleted");
+  }
+
+  private void deleteExternalStorageLocation(Long userId, Session session) {
+    execute(userId, session, "delete from ExternalStorageLocation where operationUser_id=:id");
   }
 
   // this is called at the end, as userToDelete is removed from any groups in the same transaction,

--- a/src/main/java/com/researchspace/netfiles/irods/IRODSClient.java
+++ b/src/main/java/com/researchspace/netfiles/irods/IRODSClient.java
@@ -218,8 +218,11 @@ public class IRODSClient extends NfsAbstractClient implements NfsClient {
           iRodsFile = irodsFileFactory.instanceIRODSFile(iRODSAbsolutePathFilename);
           dtoIRODS.putOperation(currentFile, iRodsFile, null, null);
           if (iRodsFile.exists()) {
+            Long irodsFileId =
+                (long) getIrodsDataObject(new NfsTarget(iRODSAbsolutePathFilename)).getId();
             result.add(
-                new ApiExternalStorageOperationInfo(currentRecordId, currentFile.getName(), true));
+                new ApiExternalStorageOperationInfo(
+                    currentRecordId, irodsFileId, currentFile.getName(), true));
             log.info(
                 "File [{}] successfully copied into IRODS path [{}]",
                 currentFile.getName(),

--- a/src/main/java/com/researchspace/service/ExternalStorageManager.java
+++ b/src/main/java/com/researchspace/service/ExternalStorageManager.java
@@ -1,0 +1,20 @@
+package com.researchspace.service;
+
+import com.researchspace.model.User;
+import com.researchspace.model.netfiles.ExternalStorageLocation;
+import java.util.List;
+
+/**
+ * Manager for handling external storage locations
+ *
+ * @author nico
+ */
+public interface ExternalStorageManager {
+
+  ExternalStorageLocation saveExternalStorageLocation(
+      ExternalStorageLocation externalStorageLocation);
+
+  List<ExternalStorageLocation> getAllExternalStorageLocations();
+
+  List<ExternalStorageLocation> getAllExternalStorageLocationsByUser(User operationUser);
+}

--- a/src/main/java/com/researchspace/service/impl/ExternalStorageManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/ExternalStorageManagerImpl.java
@@ -1,0 +1,35 @@
+package com.researchspace.service.impl;
+
+import com.researchspace.dao.ExternalStorageDao;
+import com.researchspace.model.User;
+import com.researchspace.model.netfiles.ExternalStorageLocation;
+import com.researchspace.service.ExternalStorageManager;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementation of ExternalStorageManager interface.
+ *
+ * @author nico
+ */
+@Service
+public class ExternalStorageManagerImpl implements ExternalStorageManager {
+
+  @Autowired private ExternalStorageDao externalStorageDao;
+
+  public ExternalStorageLocation saveExternalStorageLocation(
+      ExternalStorageLocation externalStorageLocation) {
+    return externalStorageDao.save(externalStorageLocation);
+  }
+
+  @Override
+  public List<ExternalStorageLocation> getAllExternalStorageLocations() {
+    return externalStorageDao.getAll();
+  }
+
+  @Override
+  public List<ExternalStorageLocation> getAllExternalStorageLocationsByUser(User operationUser) {
+    return externalStorageDao.getAllByOperationUser(operationUser.getId());
+  }
+}

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -105,6 +105,7 @@
         <mapping class="com.researchspace.model.Organisation"/>
         <mapping class="com.researchspace.model.netfiles.NfsFileStore"/>
         <mapping class="com.researchspace.model.netfiles.NfsFileSystem"/>
+        <mapping class="com.researchspace.model.netfiles.ExternalStorageLocation"/>
         <mapping class="com.researchspace.maintenance.model.WhiteListedSysAdminIPAddress"/>
         <mapping class="com.researchspace.model.record.RecordUserFavorites"/>
         <mapping class="com.researchspace.model.system.SystemProperty"/>

--- a/src/main/resources/sqlUpdates/changeLog-1.100.xml
+++ b/src/main/resources/sqlUpdates/changeLog-1.100.xml
@@ -1,0 +1,66 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <!-- Changes for version 1.100 June 2024 -->
+
+  <!-- Please read DatabaseChangeGuidelines in this folder before committing
+      new changesets ! -->
+
+  <!-- Add changesets here... -->
+
+  <changeSet id="31-05-2024a" author="nico" context="run">
+    <comment>Adding ExternalStorageLocation table</comment>
+    <createTable tableName="ExternalStorageLocation">
+      <column autoIncrement="true" name="id" type="BIGINT(19)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="externalStorageId" type="BIGINT(19)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="operationDate" type="BIGINT(19)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="fileStore_id" type="BIGINT(19)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="connectedMediaFile_id" type="BIGINT(19)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="operationUser_id" type="BIGINT(19)">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <sql>alter table ExternalStorageLocation engine=InnoDB, CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;</sql>
+  </changeSet>
+
+  <changeSet id="31-05-2024b" author="nico" context="run">
+    <comment>Adding foreign key from ExternalStorageLocation to User</comment>
+    <addForeignKeyConstraint
+      baseColumnNames="operationUser_id" baseTableName="ExternalStorageLocation"
+      constraintName="FK9091AB6ADF43265C" deferrable="false"
+      initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+      referencedColumnNames="id" referencedTableName="User" />
+  </changeSet>
+
+  <changeSet id="31-05-2024c" author="nico" context="run">
+    <comment>Adding foreign key from ExternalStorageLocation to NfsFileStore</comment>
+    <addForeignKeyConstraint
+      baseColumnNames="fileStore_id" baseTableName="ExternalStorageLocation"
+      constraintName="FK9091AB6ADF43287D" deferrable="false"
+      initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+      referencedColumnNames="id" referencedTableName="NfsFileStore" />
+  </changeSet>
+
+  <changeSet id="31-05-2024d" author="nico" context="run">
+    <comment>Adding foreign key from ExternalStorageLocation to EcatMediaFile</comment>
+    <addForeignKeyConstraint
+      baseColumnNames="connectedMediaFile_id" baseTableName="ExternalStorageLocation"
+      constraintName="FK9091AB6ADF43244B" deferrable="false"
+      initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+      referencedColumnNames="id" referencedTableName="EcatMediaFile" />
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -129,6 +129,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-102.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-1.98.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-212.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-1.100.xml"/>
 
     <!--  ensure that customUpdates-changeLog.xml always runs LAST! -->
     <include relativeToChangelogFile="true" file="customUpdates-changeLog.xml"/>

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryApiControllerTest.java
@@ -25,7 +25,7 @@ import com.researchspace.netfiles.ApiNfsCredentials;
 import com.researchspace.netfiles.NfsAuthentication;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.service.BaseRecordManager;
-import com.researchspace.service.DocumentAlreadyEditedException;
+import com.researchspace.service.ExternalStorageManager;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.RecordDeletionManager;
 import java.io.IOException;
@@ -49,6 +49,7 @@ class GalleryApiControllerTest {
   @Mock private RecordDeletionManager deletionManager;
   @Mock private BaseRecordManager baseRecordManager;
   @Mock private NfsAuthentication nfsAuthentication;
+  @Mock private ExternalStorageManager externalStorageManager;
   @Mock private User user;
 
   private GalleryApiController galleryApiController;
@@ -63,7 +64,12 @@ class GalleryApiControllerTest {
   public void setup() throws IOException {
     MockitoAnnotations.openMocks(this);
     galleryApiController =
-        new GalleryApiController(nfsManager, deletionManager, baseRecordManager, nfsAuthentication);
+        new GalleryApiController(
+            nfsManager,
+            deletionManager,
+            baseRecordManager,
+            nfsAuthentication,
+            externalStorageManager);
     galleryApiController.rsBaseLink =
         UriComponentsBuilder.fromHttpUrl("http://url").path(API_GALLERY_V1);
     ;
@@ -91,7 +97,7 @@ class GalleryApiControllerTest {
     when(baseRecordManager.retrieveMediaFile(any(), eq(789L)))
         .thenThrow(new ObjectRetrievalFailureException("EcatMediaFile", "789"));
 
-    when(nfsManager.uploadFilesToNfs(anySet(), anyString(), any()))
+    when(nfsManager.uploadFilesToNfs(anyCollection(), anyString(), any()))
         .thenReturn(new ApiExternalStorageOperationResult());
     when(deletionManager.deleteMediaFileSet(anySet(), any()))
         .thenReturn(new CompositeRecordOperationResult<>());
@@ -317,12 +323,11 @@ class GalleryApiControllerTest {
         new ApiNfsCredentials(null, USERNAME, PASSWORD),
         new BeanPropertyBindingResult(validRecordIds, "bean"),
         user);
-    verify(nfsManager).uploadFilesToNfs(anySet(), anyString(), any());
+    verify(nfsManager).uploadFilesToNfs(anyCollection(), anyString(), any());
   }
 
   @Test
-  void testMoveToIrodsFailure()
-      throws UnsupportedOperationException, IOException, DocumentAlreadyEditedException {
+  void testMoveToIrodsFailure() throws UnsupportedOperationException, IOException {
     doThrow(new ObjectRetrievalFailureException("EcatMediaFile", 2L))
         .when(deletionManager)
         .deleteMediaFileSet(anySet(), any(User.class));

--- a/src/test/java/com/researchspace/testutils/DatabaseCleaner.java
+++ b/src/test/java/com/researchspace/testutils/DatabaseCleaner.java
@@ -59,6 +59,7 @@ public class DatabaseCleaner {
     jdbcTemplate.update("delete from OfflineRecordUser");
     jdbcTemplate.update("delete from WhiteListedSysAdminIPAddress");
 
+    jdbcTemplate.update("delete from ExternalStorageLocation");
     jdbcTemplate.update("delete from NfsFileStore");
     jdbcTemplate.update("delete from NfsFileSystem");
     jdbcTemplate.update("delete from UserKeyPair");


### PR DESCRIPTION
✅  Tested successfully on AWS https://rsdev-232-new-8.researchspace.com/ 

- Moved the file `Screenshot 2021-03-04 at 08.47.57.png` to IRODS
- Copied the file `Screenshot 2021-03-03 at 18.42.40.png` to IRODS 
- and finally verified that the system created 2 rows with the right values on the `ExternalStorageLocation` table.

```
MariaDB [rspace]> select base.*, ecat.*, loc.*,base.deleted+0 from    BaseRecord base      inner join         EcatMediaFile ecat             on base.id = ecat.id      inner join         ExternalStorageLocation loc             on loc.connectedMediaFile_id = ecat.id;
+-----+---------+-----------+---------------------+--------------------+-------------+---------------------+------------------------+------------+---------------------------------------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+------------+-----------+----------+---------------------+------------+-------------------------+-------------+-----------+-----------------------------------------------------+-------+-----+-----------------+---------+----+-------------------+---------------+--------------+-----------------------+------------------+----------------+
| id  | deleted | createdBy | creationDate        | creationDateMillis | description | modificationDate    | modificationDateMillis | modifiedBy | name                                  | iconId | acl                                                                                                                                                                                                               | signed | type       | witnessed | owner_id | deletedDate         | fromImport | originalCreatorUsername | contentType | extension | fileName                                            | size  | id  | fileProperty_id | version | id | externalStorageId | operationDate | fileStore_id | connectedMediaFile_id | operationUser_id | base.deleted+0 |
+-----+---------+-----------+---------------------+--------------------+-------------+---------------------+------------------------+------------+---------------------------------------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+------------+-----------+----------+---------------------+------------+-------------------------+-------------+-----------+-----------------------------------------------------+-------+-----+-----------------+---------+----+-------------------+---------------+--------------+-----------------------+------------------+----------------+
| 156 |         | sysadmin1 | 2021-03-05 14:47:19 |      1614955639809 | NULL        | 2021-03-05 14:47:19 |          1614955639809 | sysadmin1  | Screenshot 2021-03-04 at 08.47.57.png |     -1 | sysadmin1=RECORD:WRITE:&sysadmin1=RECORD:CREATE:&sysadmin1=RECORD:CREATE_FOLDER:&sysadmin1=RECORD:DELETE:&sysadmin1=RECORD:SEND:&sysadmin1=RECORD:FOLDER_RECEIVE:&sysadmin1=RECORD:RENAME:&sysadmin1=RECORD:COPY: |        | MEDIA_FILE |           |      -12 | 2024-06-12 12:26:52 |            | NULL                    | image/x-png | png       | Screenshot_2021-03-04_at_08.47.57_1614955639799.png | 50857 | 156 |              24 |       1 |  1 |             11098 | 1718195212518 |            1 |                   156 |              -12 |              1 |
| 157 |         | sysadmin1 | 2021-03-05 14:47:20 |      1614955640104 | NULL        | 2021-03-05 14:47:20 |          1614955640104 | sysadmin1  | Screenshot 2021-03-03 at 18.42.40.png |     -1 | sysadmin1=RECORD:WRITE:&sysadmin1=RECORD:CREATE:&sysadmin1=RECORD:CREATE_FOLDER:&sysadmin1=RECORD:DELETE:&sysadmin1=RECORD:SEND:&sysadmin1=RECORD:FOLDER_RECEIVE:&sysadmin1=RECORD:RENAME:&sysadmin1=RECORD:COPY: |        | MEDIA_FILE |           |      -12 | NULL                |            | NULL                    | image/x-png | png       | Screenshot_2021-03-03_at_18.42.40_1614955640100.png | 30224 | 157 |              27 |       1 |  2 |             11099 | 1718195222903 |            1 |                   157 |              -12 |              0 |
+-----+---------+-----------+---------------------+--------------------+-------------+---------------------+------------------------+------------+---------------------------------------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+------------+-----------+----------+---------------------+------------+-------------------------+-------------+-----------+-----------------------------------------------------+-------+-----+-----------------+---------+----+-------------------+---------------+--------------+-----------------------+------------------+----------------+
2 rows in set (0.001 sec)

MariaDB [rspace]>
```