### PR TITLE
RSDEV-261 Split singular subsample from sample create dialog

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
+++ b/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
@@ -179,12 +179,11 @@ function CreateInContextDialog({
         explanation:
           selectedResult instanceof SampleModel &&
           selectedResult.subSamples.length === 1 ? (
-            "Split this sample's only subsample into two subsamples."
+            "Split this sample's only subsample into multiple subsamples."
           ) : (
             <>
-              Only samples with a single subsample can be split. <br />
-              Go to a specific subsample and then open this Create dialog to
-              split it.
+              Only samples with a single subsample can be split directly. <br />
+              Go to a specific subsample and open its Create dialog to split it.
             </>
           ),
         disabled: !(

--- a/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
+++ b/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
@@ -173,6 +173,25 @@ function CreateInContextDialog({
         explanation: "A new Template will be created from the selected Sample.",
         disabled: false,
       },
+      {
+        id: "sa-2",
+        name: "Split",
+        explanation:
+          selectedResult instanceof SampleModel &&
+          selectedResult.subSamples.length === 1 ? (
+            "Split this sample's only subsample into two subsamples."
+          ) : (
+            <>
+              Only samples with a single subsample can be split. <br />
+              Go to a specific subsample and then open this Create dialog to
+              split it.
+            </>
+          ),
+        disabled: !(
+          selectedResult instanceof SampleModel &&
+          selectedResult.subSamples.length === 1
+        ),
+      },
     ],
     SAMPLE_TEMPLATE: [
       {
@@ -297,6 +316,12 @@ function CreateInContextDialog({
     ) {
       if (createOption === createActions[selectedResult.type][0].name) {
         createStore.setTemplateCreationContext(menuID);
+      }
+      if (createOption === createActions[selectedResult.type][1].name) {
+        await searchStore.search.splitRecord(
+          parseInt(splitCopies, 10),
+          selectedResult.subSamples[0]
+        );
       }
     }
     onClose();
@@ -464,6 +489,8 @@ function CreateInContextDialog({
             {selectedResult instanceof SubSampleModel && (
               <SplitCopiesSelector />
             )}
+            {selectedResult instanceof SampleModel &&
+              selectedResult.subSamples.length === 1 && <SplitCopiesSelector />}
             {createActions[selectedResult.type].length === 0 && (
               <NoValue label="No option available." />
             )}


### PR DESCRIPTION
When a sample only has one subsample, it is obvious which subsample a user would like to split so this change adds "Split" as an option to the sample's Create dialog, alleviating the need for the user to navigate to the subsample page.