### PR TITLE
RSDEV-261 Add split option to samples "Create" dialog when there is only one subsample

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
+++ b/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
@@ -179,12 +179,11 @@ function CreateInContextDialog({
         explanation:
           selectedResult instanceof SampleModel &&
           selectedResult.subSamples.length === 1 ? (
-            "Split this sample's only subsample into two subsamples."
+            "Split this sample's only subsample into multiple subsamples."
           ) : (
             <>
-              Only samples with a single subsample can be split. <br />
-              Go to a specific subsample and then open this Create dialog to
-              split it.
+              Only samples with a single subsample can be split directly. <br />
+              Go to a specific subsample and open its Create dialog to split it.
             </>
           ),
         disabled: !(

--- a/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
+++ b/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
@@ -375,39 +375,46 @@ function CreateInContextDialog({
     const MIN = 2;
     const MAX = 100;
     return (
-      <FormControl>
-        <NumberField
-          name="copies"
-          autoFocus
-          value={splitCopies}
-          onChange={({ target }) => {
-            setSplitCopies(parseInt(target.value, 10));
-            setValidState(target.checkValidity() && target.value !== "");
-          }}
-          error={!validState}
-          variant="outlined"
-          size="small"
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">Copies</InputAdornment>
-            ),
-          }}
-          inputProps={{
-            min: MIN,
-            max: MAX,
-            step: 1,
-          }}
-          onKeyDown={({ key }) => {
-            if (key === "Enter" && validState) void onSubmitHandler();
-          }}
-          disabled={disabled}
-        />
-        {/* FormHelperText used rather than NumberField's helperText prop so that the text is always shown, not only when there's an error. */}
-        <FormHelperText error={!validState}>
-          {`The total number of subsamples wanted, including the source (min ${MIN}
+      <Box
+        sx={{
+          ml: 3,
+          width: (theme) => `calc(100% - ${theme.spacing(3)})`,
+        }}
+      >
+        <FormControl>
+          <NumberField
+            name="copies"
+            autoFocus
+            value={splitCopies}
+            onChange={({ target }) => {
+              setSplitCopies(parseInt(target.value, 10));
+              setValidState(target.checkValidity() && target.value !== "");
+            }}
+            error={!validState}
+            variant="outlined"
+            size="small"
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">Copies</InputAdornment>
+              ),
+            }}
+            inputProps={{
+              min: MIN,
+              max: MAX,
+              step: 1,
+            }}
+            onKeyDown={({ key }) => {
+              if (key === "Enter" && validState) void onSubmitHandler();
+            }}
+            disabled={disabled}
+          />
+          {/* FormHelperText used rather than NumberField's helperText prop so that the text is always shown, not only when there's an error. */}
+          <FormHelperText error={!validState}>
+            {`The total number of subsamples wanted, including the source (min ${MIN}
           , max ${MAX})`}
-        </FormHelperText>
-      </FormControl>
+          </FormHelperText>
+        </FormControl>
+      </Box>
     );
   }
 

--- a/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
+++ b/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
@@ -173,6 +173,25 @@ function CreateInContextDialog({
         explanation: "A new Template will be created from the selected Sample.",
         disabled: false,
       },
+      {
+        id: "sa-2",
+        name: "Split",
+        explanation:
+          selectedResult instanceof SampleModel &&
+          selectedResult.subSamples.length === 1 ? (
+            "Split this sample's only subsample into two subsamples."
+          ) : (
+            <>
+              Only samples with a single subsample can be split. <br />
+              Go to a specific subsample and then open this Create dialog to
+              split it.
+            </>
+          ),
+        disabled: !(
+          selectedResult instanceof SampleModel &&
+          selectedResult.subSamples.length === 1
+        ),
+      },
     ],
     SAMPLE_TEMPLATE: [
       {
@@ -297,6 +316,12 @@ function CreateInContextDialog({
     ) {
       if (createOption === createActions[selectedResult.type][0].name) {
         createStore.setTemplateCreationContext(menuID);
+      }
+      if (createOption === createActions[selectedResult.type][1].name) {
+        await searchStore.search.splitRecord(
+          parseInt(splitCopies, 10),
+          selectedResult.subSamples[0]
+        );
       }
     }
     onClose();
@@ -464,6 +489,8 @@ function CreateInContextDialog({
             {selectedResult instanceof SubSampleModel && (
               <SplitCopiesSelector />
             )}
+            {selectedResult instanceof SampleModel &&
+              selectedResult.subSamples.length === 1 && <SplitCopiesSelector />}
             {createActions[selectedResult.type].length === 0 && (
               <NoValue label="No option available." />
             )}

--- a/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
+++ b/src/main/webapp/ui/src/Inventory/Mixed/CreateDialog.js
@@ -371,7 +371,7 @@ function CreateInContextDialog({
     }
   );
 
-  function SplitCopiesSelector(): Node {
+  function SplitCopiesSelector({ disabled }: {| disabled: boolean |}): Node {
     const MIN = 2;
     const MAX = 100;
     return (
@@ -400,7 +400,7 @@ function CreateInContextDialog({
           onKeyDown={({ key }) => {
             if (key === "Enter" && validState) void onSubmitHandler();
           }}
-          disabled={false}
+          disabled={disabled}
         />
         {/* FormHelperText used rather than NumberField's helperText prop so that the text is always shown, not only when there's an error. */}
         <FormHelperText error={!validState}>
@@ -486,10 +486,16 @@ function CreateInContextDialog({
               <LocationSelector container={selectedResult} />
             )}
             {selectedResult instanceof SubSampleModel && (
-              <SplitCopiesSelector />
+              <SplitCopiesSelector
+                disabled={createOption !== createActions.SUBSAMPLE[0].name}
+              />
             )}
             {selectedResult instanceof SampleModel &&
-              selectedResult.subSamples.length === 1 && <SplitCopiesSelector />}
+              selectedResult.subSamples.length === 1 && (
+                <SplitCopiesSelector
+                  disabled={createOption !== createActions.SAMPLE[1].name}
+                />
+              )}
             {createActions[selectedResult.type].length === 0 && (
               <NoValue label="No option available." />
             )}


### PR DESCRIPTION
This change adds a split option to the Sample create dialog, which when there is just one subsamples allows the user to quickly split that one subsample.
<img width="704" alt="image" src="https://github.com/rspace-os/rspace-web/assets/8805923/b29e8b0d-4d31-47d1-8d2a-de1994ac28ad">

When there are multiple subsamples the split option is disabled, with an explanation of what to do instead.
<img width="699" alt="image" src="https://github.com/rspace-os/rspace-web/assets/8805923/4b0e3c5a-27fa-49c5-bb42-b0ba02bbc49b">
