### PR TITLE
RSDEV-81 Type radio field for samples to guide subsample creation

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/NumberOfSubSamples.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/NumberOfSubSamples.js
@@ -59,7 +59,7 @@ function NumberOfSubSamples({
 
   const errorMessage = valid
     ? ""
-    : `Should be a positive integer smaller than or equal to ${MAX}.`;
+    : `Must be an integer value of at least ${MIN} and no more than ${MAX}.`;
 
   const withSpecifiedLocations: boolean = // inImaGridContainer
     sample.newSampleSubSampleTargetLocations?.some(

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/NumberOfSubSamples.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/NumberOfSubSamples.js
@@ -102,9 +102,9 @@ function NumberOfSubSamples({
                   <>
                     <OptionHeading>Individual Sample</OptionHeading>
                     <OptionExplanation>
-                      The sample is made up of one subsample, representing the
-                      physical location of the sample. Sample actions are
-                      equivalent to subsample actions.
+                      The sample is made up of <strong>one subsample</strong>,
+                      representing the physical location of the sample. Sample
+                      actions are equivalent to subsample actions.
                     </OptionExplanation>
                   </>
                 ),
@@ -115,10 +115,10 @@ function NumberOfSubSamples({
                   <>
                     <OptionHeading>Sample with subsamples</OptionHeading>
                     <OptionExplanation>
-                      The sample is made up of multiple subsamples, which
-                      represent related physical items originating from the same
-                      batch. Sample actions affect the entire group of
-                      subsamples.
+                      The sample is made up of{" "}
+                      <strong>multiple subsamples</strong>, which represent
+                      related physical items originating from the same batch.
+                      Sample actions affect the entire group of subsamples.
                     </OptionExplanation>
                   </>
                 ),

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/NumberOfSubSamples.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/NumberOfSubSamples.js
@@ -12,11 +12,14 @@ import RadioField, {
   OptionExplanation,
 } from "../../../components/Inputs/RadioField";
 import { styled } from "@mui/material/styles";
+import { textFieldClasses } from "@mui/material/TextField";
 
 const NestedFormField = styled(FormField)(({ theme }) => ({
   marginTop: "0 !important",
   marginLeft: `${theme.spacing(4)} !important`,
-  width: `calc(100% - ${theme.spacing(4)})`,
+  [`& .${textFieldClasses.root}`]: {
+    maxWidth: `min(100px, calc(100% - ${theme.spacing(4)}))`,
+  },
 }));
 
 const MIN = 2;

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/NumberOfSubSamples.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/NumberOfSubSamples.js
@@ -7,8 +7,19 @@ import SampleModel, {
   type SubSampleTargetLocation,
 } from "../../../stores/models/SampleModel";
 import FormField from "../../../components/Inputs/FormField";
+import RadioField, {
+  OptionHeading,
+  OptionExplanation,
+} from "../../../components/Inputs/RadioField";
+import { styled } from "@mui/material/styles";
 
-const MIN = 1;
+const NestedFormField = styled(FormField)(({ theme }) => ({
+  marginTop: "0 !important",
+  marginLeft: `${theme.spacing(4)} !important`,
+  width: `calc(100% - ${theme.spacing(4)})`,
+}));
+
+const MIN = 2;
 const MAX = 100;
 
 type NumberOfSubSamplesArgs = {|
@@ -21,7 +32,8 @@ function NumberOfSubSamples({
   sample,
 }: NumberOfSubSamplesArgs): Node {
   const [valid, setValid] = useState(true);
-  const [count, setCount] = useState("1");
+  const [count, setCount] = useState("2");
+  const [type, setType] = useState<"SINGULAR" | "MANY">("SINGULAR");
 
   const handleChange = ({
     target,
@@ -58,24 +70,82 @@ function NumberOfSubSamples({
     sample.beingCreatedInContainer && withSpecifiedLocations;
 
   return (
-    <FormField
-      helperText={errorMessage}
-      label={`Number of ${sample.subSampleAlias.plural}`}
-      error={!valid}
-      value={count}
-      disabled={fixedNumberOfSubSamples}
-      renderInput={(props) => (
-        <NumberField
-          {...props}
-          onChange={handleChange}
-          inputProps={{
-            min: MIN,
-            max: MAX,
-            step: 1,
-          }}
+    <>
+      <FormField
+        label="Type"
+        value={type}
+        doNotAttachIdToLabel
+        asFieldset
+        renderInput={({ id: _id, error: _error, ...props }) => (
+          <RadioField
+            name="type"
+            onChange={({ target: { value } }) => {
+              if (!value) return;
+              setType(value);
+              if (value === "MANY") {
+                sample.setAttributesDirty({
+                  newSampleSubSamplesCount: parseInt(count, 10),
+                });
+              } else {
+                sample.setAttributesDirty({
+                  newSampleSubSamplesCount: 1,
+                });
+              }
+            }}
+            options={[
+              {
+                value: "SINGULAR",
+                label: (
+                  <>
+                    <OptionHeading>Individual Sample</OptionHeading>
+                    <OptionExplanation>
+                      The sample is made up of one subsample, representing the
+                      physical location of the sample. Sample actions are
+                      equivalent to subsample actions.
+                    </OptionExplanation>
+                  </>
+                ),
+              },
+              {
+                value: "MANY",
+                label: (
+                  <>
+                    <OptionHeading>Sample with subsamples</OptionHeading>
+                    <OptionExplanation>
+                      The sample is made up of multiple subsamples, which
+                      represent related physical items originating from the same
+                      batch. Sample actions affect the entire group of
+                      subsamples.
+                    </OptionExplanation>
+                  </>
+                ),
+              },
+            ]}
+            {...props}
+          />
+        )}
+      />
+      {type === "MANY" && (
+        <NestedFormField
+          helperText={errorMessage}
+          label={`Number of ${sample.subSampleAlias.plural}`}
+          error={!valid}
+          value={count}
+          disabled={fixedNumberOfSubSamples}
+          renderInput={(props) => (
+            <NumberField
+              {...props}
+              onChange={handleChange}
+              inputProps={{
+                min: MIN,
+                max: MAX,
+                step: 1,
+              }}
+            />
+          )}
         />
       )}
-    />
+    </>
   );
 }
 

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/Quantity.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/Quantity.js
@@ -12,6 +12,14 @@ import FormField from "../../components/Inputs/FormField";
 import NavigateContext from "../../../stores/contexts/Navigate";
 import Link from "@mui/material/Link";
 import { Optional } from "../../../util/optional";
+import { styled } from "@mui/material/styles";
+import { textFieldClasses } from "@mui/material/TextField";
+
+const CustomFormField = styled(FormField)(() => ({
+  [`& .${textFieldClasses.root}`]: {
+    maxWidth: "264px",
+  },
+}));
 
 type QuantityArgs = {|
   onErrorStateChange: (boolean) => void,
@@ -113,7 +121,7 @@ function Quantity({ onErrorStateChange, sample }: QuantityArgs): Node {
   return (
     <>
       {!sample.id && sample.quantity && (
-        <FormField
+        <CustomFormField
           label={`Quantity${
             (sample.newSampleSubSamplesCount ?? 2) > 1
               ? " per " + alias.alias

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/Quantity.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/Quantity.js
@@ -74,6 +74,7 @@ function Quantity({ onErrorStateChange, sample }: QuantityArgs): Node {
     const count = sample.newSampleSubSamplesCount;
     if (count === null || typeof count === "undefined")
       return Optional.empty<string>();
+    if (count === 1) return Optional.empty<string>();
 
     if (unitStore.units.length) {
       const totalQuantity = sample.quantityValue * count;
@@ -113,7 +114,11 @@ function Quantity({ onErrorStateChange, sample }: QuantityArgs): Node {
     <>
       {!sample.id && sample.quantity && (
         <FormField
-          label={`Quantity per ${alias.alias}`}
+          label={`Quantity${
+            (sample.newSampleSubSamplesCount ?? 2) > 1
+              ? " per " + alias.alias
+              : ""
+          }`}
           explanation="Quantity units can also be changed by editing templates."
           value={amount}
           error={!valid}
@@ -137,10 +142,12 @@ function Quantity({ onErrorStateChange, sample }: QuantityArgs): Node {
                       value={sample.quantityUnitId}
                       handleChange={handleChangeQuantityUnit}
                     />
-                    <InputAdornment position="start">
-                      {"per "}
-                      {sample.template ? alias.alias : "subsample"}
-                    </InputAdornment>
+                    {(sample.newSampleSubSamplesCount ?? 2) > 1 && (
+                      <InputAdornment position="start">
+                        {"per "}
+                        {sample.template ? alias.alias : "subsample"}
+                      </InputAdornment>
+                    )}
                   </>
                 ),
               }}

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/__tests__/Quantity.test.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/__tests__/Quantity.test.js
@@ -31,6 +31,84 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("Quantity", () => {
+  describe("Unit selector", () => {
+    test('When there is only one subsample being created, "per subsample" should not be shown.', () => {
+      fc.assert(
+        fc.property(fc.nat(1000), (quantity) => {
+          const sample = makeMockSample({
+            id: null,
+            quantity: {
+              numericValue: quantity,
+              unitId: 1,
+            },
+          });
+          sample.setAttributes({
+            newSampleSubSamplesCount: 1,
+          });
+          const rootStore = makeMockRootStore({
+            uiStore: {},
+            unitStore: {
+              units: [
+                {
+                  id: 1,
+                  label: "foo",
+                  category: "mass",
+                  description: "foo is mass",
+                },
+              ],
+              unitsOfCategory: () => [],
+            },
+          });
+          const { container } = render(
+            <storesContext.Provider value={rootStore}>
+              <Quantity onErrorStateChange={() => {}} sample={sample} />
+            </storesContext.Provider>
+          );
+          expect(container).not.toHaveTextContent(/per subsample/);
+        })
+      );
+    });
+    test('When there are multiple subsamples being created, "per subsample" should be shown.', () => {
+      fc.assert(
+        fc.property(
+          fc.tuple(fc.nat(1000), fc.nat(100)),
+          ([quantity, count]) => {
+            fc.pre(count >= 2);
+            const sample = makeMockSample({
+              id: null,
+              quantity: {
+                numericValue: quantity,
+                unitId: 1,
+              },
+            });
+            sample.setAttributes({
+              newSampleSubSamplesCount: count,
+            });
+            const rootStore = makeMockRootStore({
+              uiStore: {},
+              unitStore: {
+                units: [
+                  {
+                    id: 1,
+                    label: "foo",
+                    category: "mass",
+                    description: "foo is mass",
+                  },
+                ],
+                unitsOfCategory: () => [],
+              },
+            });
+            const { container } = render(
+              <storesContext.Provider value={rootStore}>
+                <Quantity onErrorStateChange={() => {}} sample={sample} />
+              </storesContext.Provider>
+            );
+            expect(container).toHaveTextContent(/per subsample/);
+          }
+        )
+      );
+    });
+  });
   describe("Helper text should render correctly.", () => {
     test("Whole units of quantity should have zero decimal places.", () => {
       fc.assert(

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/__tests__/Quantity.test.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/__tests__/Quantity.test.js
@@ -37,6 +37,7 @@ describe("Quantity", () => {
         fc.property(
           fc.tuple(fc.nat(1000), fc.nat(100)),
           ([quantity, count]) => {
+            fc.pre(count >= 2);
             const sample = makeMockSample({
               id: null,
               quantity: {
@@ -77,6 +78,7 @@ describe("Quantity", () => {
         fc.property(
           fc.tuple(fc.float({ min: 0, max: 1000 }), fc.nat(100)),
           ([quantity, count]) => {
+            fc.pre(count >= 2);
             const sample = makeMockSample({
               id: null,
               quantity: {

--- a/src/main/webapp/ui/src/Inventory/components/Inputs/FormField.js
+++ b/src/main/webapp/ui/src/Inventory/components/Inputs/FormField.js
@@ -5,6 +5,7 @@ import BaseFormField, {
   type FormFieldArgs as BaseFormFieldArgs,
 } from "../../../components/Inputs/FormField";
 import { makeStyles } from "tss-react/mui";
+import clsx from "clsx";
 
 /**
  * This component renders form fields specifically used by the main Inventory
@@ -57,5 +58,10 @@ const useStyles = makeStyles()(() => ({
 
 export default function FormField<T>(props: FormFieldArgs<T>): Node {
   const { classes } = useStyles();
-  return <BaseFormField {...props} className={classes.formControl} />;
+  return (
+    <BaseFormField
+      {...props}
+      className={clsx(props.className, classes.formControl)}
+    />
+  );
 }


### PR DESCRIPTION
This change modifies the form for creating samples, guiding the user through the instantiation of the subsamples to make it clearer when working with indivisible substances.

Currently, the form looks like this

<img width="716" alt="image" src="https://github.com/rspace-os/rspace-web/assets/8805923/fcab88a3-2ff1-449d-991d-39a6cf5fb8c7">

and after this change is behaves like this

https://github.com/rspace-os/rspace-web/assets/8805923/379455b3-2230-4f92-a365-f4567fc89e6d

The user is guided through the two options which either creates one subsample (which should largely be transparent), or allows the user to specify multiple subsamples. The quantity field then adjusts accordingly.