### PR TITLE
RSDEV-243 Have help icon in top right corner open Lighthouse

### DIFF
--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -15,6 +15,7 @@ import { listItemIconClasses } from "@mui/material/ListItemIcon";
 import { paperClasses } from "@mui/material/Paper";
 import { cardActionAreaClasses } from "@mui/material/CardActionArea";
 import { buttonClasses } from "@mui/material/Button";
+import { iconButtonClasses } from "@mui/material/IconButton";
 import { outlinedInputClasses } from "@mui/material/OutlinedInput";
 import { gridClasses } from "@mui/x-data-grid";
 import { alertTitleClasses } from "@mui/material/AlertTitle";
@@ -189,7 +190,14 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
                 },
                 [`& .${svgIconClasses.root}`]: {
                   color: prefersMoreContrast ? "rgb(0,0,0)" : contrastTextColor,
+                  transition: "all .3s ease",
                 },
+                [`& .${iconButtonClasses.root}.${iconButtonClasses.disabled}`]:
+                  {
+                    [`& .${svgIconClasses.root}`]: {
+                      opacity: 0.5,
+                    },
+                  },
               },
               [`& .${textFieldClasses.root}`]: {
                 background: lighterInteractiveColor,

--- a/src/main/webapp/ui/src/eln/gallery/components/AppBar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/AppBar.js
@@ -15,7 +15,8 @@ import InputAdornment from "@mui/material/InputAdornment";
 import { styled } from "@mui/material/styles";
 import CloseIcon from "@mui/icons-material/Close";
 import AccessibilityTips from "../../../components/AccessibilityTips";
-import HelpLinkIcon from "../../../components/HelpLinkIcon";
+import HelpDocs from "../../../components/Help/HelpDocs";
+import HelpIcon from "@mui/icons-material/Help";
 
 const StyledCloseIcon = styled(CloseIcon)(({ theme }) => ({
   color: theme.palette.standardIcon.main,
@@ -136,8 +137,18 @@ export default function GalleryAppBar({
             supportsHighContrastMode
           />
         </Box>
-        <Box ml={1} sx={{ transform: "translateY(2px)" }}>
-          <HelpLinkIcon title="Importing from Gallery help" link="#" />
+        <Box ml={1}>
+          <HelpDocs
+            Action={({ onClick, disabled }) => (
+              <IconButtonWithTooltip
+                size="small"
+                onClick={onClick}
+                icon={<HelpIcon />}
+                title="Open Help"
+                disabled={disabled}
+              />
+            )}
+          />
         </Box>
       </Toolbar>
     </AppBar>

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -16,6 +16,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import useViewportDimensions from "../../util/useViewportDimensions";
 import Alerts from "../../Inventory/components/Alerts";
 import { DisableDragAndDropByDefault } from "../../components/useFileImportDragAndDrop";
+import Analytics from "../../components/Analytics";
 
 function WholePage() {
   const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");
@@ -86,9 +87,11 @@ window.addEventListener("load", () => {
           <StyledEngineProvider injectFirst>
             <CssBaseline />
             <ThemeProvider theme={createAccentedTheme(COLOR)}>
-              <DisableDragAndDropByDefault>
-                <WholePage />
-              </DisableDragAndDropByDefault>
+              <Analytics>
+                <DisableDragAndDropByDefault>
+                  <WholePage />
+                </DisableDragAndDropByDefault>
+              </Analytics>
             </ThemeProvider>
           </StyledEngineProvider>
         </ErrorBoundary>


### PR DESCRIPTION
This change makes the help button in the header of the new Gallery page open the Lighthouse-driven help popup that we use throughout the product.

My intention is that as more of the ELN is reactified this will become the standard way of accessing help as the current mechanism is inconsistent: the floating action button doesn't work on mobile and has to be hidden/moved when opening dialogs, and Inventory has a button in the sidebar which wont work on pages that don't need a sidebar.


https://github.com/rspace-os/rspace-web/assets/8805923/f21112de-098f-4ef0-9edd-57869c961961

Note that like in Inventory, the button is disabled until all of the third-party scripts have been loaded. Ordinarily, I don't like disabled buttons but the loading of this functionality seems to be very robust and pretty quick so the additional complexity of providing a fallback doesn't seem worth it.