### PR TITLE
RSDEV-249 Prevent items from being drag-and-dropped into Snippets folders on new Gallery page

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -233,24 +233,26 @@ const CustomTransition = styled(({ children, in: open, className }) => (
 const Breadcrumb = ({
   label,
   onClick,
-  folderName,
   path,
   selectedSection,
+  folder,
 }: {|
   label: string,
   onClick: () => void,
-  folderName: string,
   path: $ReadOnlyArray<GalleryFile>,
   selectedSection: string,
+  folder?: GalleryFile,
 |}) => {
   const { setNodeRef: setDropRef, isOver } = useDroppable({
-    id: `/${[selectedSection, ...path.map(({ name }) => name), folderName].join(
-      "/"
-    )}/`,
+    id: `/${[
+      selectedSection,
+      ...path.map(({ name }) => name),
+      folder?.name ?? "",
+    ].join("/")}/`,
     disabled: false,
     data: {
       path,
-      name: folderName,
+      destination: folder ? { key: "folder", folder } : { key: "root" },
     },
   });
   const dropStyle: { [string]: string | number } = isOver
@@ -341,7 +343,7 @@ const CustomTreeItem = ({
     disabled: !/Folder/.test(file.type),
     data: {
       path: file.path,
-      name: file.name,
+      destination: { key: "folder", folder: file },
     },
   });
   const {
@@ -746,7 +748,7 @@ const FileCard = styled(
         disabled: !/Folder/.test(file.type),
         data: {
           path: file.path,
-          name: file.name,
+          destination: { key: "folder", folder: file },
         },
       });
       const {
@@ -1268,9 +1270,9 @@ export default function GalleryMainPanel({
               target: `/${[
                 selectedSection,
                 ...event.over.data.current.path.map(({ name }) => name),
-                ...(event.over.data.current.name === ""
+                ...(event.over.data.current.destination.key === "root"
                   ? []
-                  : [event.over.data.current.name]),
+                  : [event.over.data.current.destination.folder.name]),
               ].join("/")}/`,
               section: selectedSection,
             })
@@ -1316,15 +1318,14 @@ export default function GalleryMainPanel({
                   label={gallerySectionLabel[selectedSection]}
                   onClick={() => clearPath()}
                   path={[]}
-                  folderName=""
                   selectedSection={selectedSection}
                 />
                 {path.map((folder) => (
                   <Breadcrumb
+                    folder={folder}
                     label={folder.name}
                     key={idToString(folder.id)}
                     onClick={() => folder.open?.()}
-                    folderName={folder.name}
                     path={folder.path}
                     selectedSection={selectedSection}
                   />

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1267,13 +1267,7 @@ export default function GalleryMainPanel({
               : [idOfFileJustBeingDragged]
           )
             .to({
-              target: `/${[
-                selectedSection,
-                ...event.over.data.current.path.map(({ name }) => name),
-                ...(event.over.data.current.destination.key === "root"
-                  ? []
-                  : [event.over.data.current.destination.folder.name]),
-              ].join("/")}/`,
+              destination: event.over.data.current.destination,
               section: selectedSection,
             })
             .then(() => {

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -161,6 +161,20 @@ export function useGalleryActions(): {|
           | {| key: "folder", folder: GalleryFile |},
         section: string,
       |}) => {
+        if (
+          destination.key === "folder" &&
+          destination.folder.isSnippetFolder
+        ) {
+          addAlert(
+            mkAlert({
+              variant: "error",
+              title: "Cannot drag files into SNIPPETS folders.",
+              message:
+                "Share them and they will automatically appear in these folders.",
+            })
+          );
+          return;
+        }
         const target = `/${[
           section,
           ...(destination.key === "folder"

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -17,7 +17,7 @@ export function useGalleryActions(): {|
   createFolder: ($ReadOnlyArray<GalleryFile>, Id, string) => Promise<void>,
   moveFilesWithIds: ($ReadOnlyArray<number>) => {|
     to: ({|
-      target: string,
+      destination: {| key: "root" |} | {| key: "folder", folder: GalleryFile |},
       section: string,
     |}) => Promise<void>,
   |},
@@ -153,12 +153,21 @@ export function useGalleryActions(): {|
   function moveFilesWithIds(fileIds: $ReadOnlyArray<number>) {
     return {
       to: async ({
-        target,
+        destination,
         section,
       }: {|
-        target: string,
+        destination:
+          | {| key: "root" |}
+          | {| key: "folder", folder: GalleryFile |},
         section: string,
       |}) => {
+        const target = `/${[
+          section,
+          ...(destination.key === "folder"
+            ? destination.folder.path.map(({ name }) => name)
+            : []),
+          ...(destination.key === "root" ? [] : [destination.folder.name]),
+        ].join("/")}/`;
         const formData = new FormData();
         formData.append("target", target);
         fileIds.forEach((fileId) => {

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -175,13 +175,14 @@ export function useGalleryActions(): {|
           );
           return;
         }
-        const target = `/${[
-          section,
-          ...(destination.key === "folder"
-            ? destination.folder.path.map(({ name }) => name)
-            : []),
-          ...(destination.key === "root" ? [] : [destination.folder.name]),
-        ].join("/")}/`;
+        const target =
+          destination.key === "root"
+            ? `/${section}/`
+            : `/${[
+                section,
+                ...destination.folder.path.map(({ name }) => name),
+                ...[destination.folder.name],
+              ].join("/")}/`;
         const formData = new FormData();
         formData.append("target", target);
         fileIds.forEach((fileId) => {

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -21,6 +21,10 @@ export type GalleryFile = {|
   thumbnailUrl: string,
   path: $ReadOnlyArray<GalleryFile>,
   open?: () => void,
+
+  isFolder: boolean,
+  isSystemFolder: boolean,
+  isSnippetFolder: boolean,
 |};
 
 /**
@@ -121,10 +125,12 @@ function generateIconSrc(
   extension: string | null,
   thumbnailId: number | null,
   id: number,
-  modificationDate: number
+  modificationDate: number,
+  isFolder: boolean,
+  isSystemFolder: boolean
 ) {
-  if (/Folder/.test(type)) {
-    if (/System/.test(type)) {
+  if (isFolder) {
+    if (isSystemFolder) {
       if (/snippets/i.test(name)) return "/images/icons/folder-shared.png";
       return "/images/icons/folder-api-inbox.png";
     }
@@ -188,6 +194,8 @@ export function useGalleryListing({
     extension: string | null,
     thumbnailId: number | null
   ): GalleryFile {
+    const isFolder = /Folder/.test(type);
+    const isSystemFolder = /System Folder/.test(type);
     const ret: GalleryFile = {
       id,
       name,
@@ -199,16 +207,21 @@ export function useGalleryListing({
         extension,
         thumbnailId,
         id,
-        modificationDate
+        modificationDate,
+        isFolder,
+        isSystemFolder
       ),
       path,
-      ...(/Folder/.test(type)
+      ...(isFolder
         ? {
             open: () => {
               setPath([...path, ret]);
             },
           }
         : {}),
+      isFolder,
+      isSystemFolder,
+      isSnippetFolder: isSystemFolder && /SNIPPETS/.test(name),
     };
     return ret;
   }


### PR DESCRIPTION
System folders that include the substring "SNIPPETS" are populated based on how the user has chosen to share their snippets, not by manually moving them around. As such, the drag-and-drop functionality on the new Gallery page should throw an error rather than attempt to move the snippets, as doing so will result in nothing being done but nonetheless the backend responding with a 200.