### PR TITLE
add IgnoreInServiceLoggerAspct annotation that can stop logging parameter of long-execution call

### DIFF
--- a/src/main/java/com/researchspace/service/NfsManager.java
+++ b/src/main/java/com/researchspace/service/NfsManager.java
@@ -7,6 +7,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.netfiles.NfsClient;
+import com.researchspace.webapp.controller.IgnoreInServiceLoggerAspct;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -50,6 +51,7 @@ public interface NfsManager {
   /**
    * @return "logged.as.-username" if logged in, null if not, or error code if error
    */
+  @IgnoreInServiceLoggerAspct(ignoreAllRequestParams = true)
   String loginToNfs(
       Long fileSystemId,
       String nfsusername,

--- a/src/main/java/com/researchspace/webapp/controller/IgnoreInServiceLoggerAspct.java
+++ b/src/main/java/com/researchspace/webapp/controller/IgnoreInServiceLoggerAspct.java
@@ -1,0 +1,27 @@
+package com.researchspace.webapp.controller;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate a service-level method with this annotation if automated logging with {@link
+ * ServiceLoggerAspct} should be limited for annotated method.
+ *
+ * <p>The class follows convention of {@link IgnoreInLoggingInterceptor}.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IgnoreInServiceLoggerAspct {
+
+  /**
+   * If set to true, the method invocation will be recorded, but not the request parameters. This is
+   * useful for logging events that contain sensitive information, but where we still want to record
+   * the fact that the method was called.
+   *
+   * @return <code>true</code> if the method call should be logged, without request params, or
+   *     <code>false</code>( default) if the method should not be logged at all.
+   */
+  boolean ignoreAllRequestParams() default false;
+}


### PR DESCRIPTION
This PR adds `IgnoreInServiceLoggerAspct` annotation, which works similarly to `IgnoreInLoggingInterceptor` annotation, i.e. can be used for marking method for which connected aspect (`ServiceLoggerAspct`) shouldn't print parameters passed to the method.

This should solve [issue#42](https://github.com/rspace-os/rspace-web/issues/42) and also internal issue RSPAC-2017.