### PR TITLE
Issue 46 sysadmin delete button

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/DeploymentPropertiesController.java
+++ b/src/main/java/com/researchspace/webapp/controller/DeploymentPropertiesController.java
@@ -94,6 +94,9 @@ public class DeploymentPropertiesController extends BaseController {
   @Value("${jove.api.url}")
   private String joveApiUrl;
 
+  @Value("${sysadmin.delete.user}")
+  private String sysadminDeleteUser;
+
   /**
    * Service to return the value of property stored in the deployment.properties file. Uses a
    * whitelist strategy to only return properties that should be exposed.
@@ -105,8 +108,7 @@ public class DeploymentPropertiesController extends BaseController {
   @GetMapping("/ajax/property")
   @IgnoreInLoggingInterceptor(ignoreAll = true)
   @ResponseBody
-  public String getPropertyValue(
-      @RequestParam(value = "name", required = true) String propertyName) {
+  public String getPropertyValue(@RequestParam(value = "name") String propertyName) {
     // managed props e.g. for RSPAC-861
     List<SystemPropertyValue> dbProperties = sysPropertyMgr.getAllSysadminProperties();
     for (SystemPropertyValue spv : dbProperties) {
@@ -161,6 +163,8 @@ public class DeploymentPropertiesController extends BaseController {
         return googleDriveClientId;
       case "aspose.enabled":
         return String.valueOf(isAsposeEnabled());
+      case "sysadmin.delete.user":
+        return sysadminDeleteUser;
       default:
         throw new IllegalArgumentException("No property available for name: " + propertyName);
     }

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.js
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.js
@@ -83,6 +83,8 @@ import Badge from "@mui/material/Badge";
 import docLinks from "../../../assets/DocLinks";
 import createAccentedTheme from "../../../accentedTheme";
 import UserAliasIcon from "@mui/icons-material/ContactEmergency";
+import { useDeploymentProperty } from "../../useDeploymentProperty";
+import * as Parsers from "../../../util/parsers";
 
 const Panel = ({
   anchorEl,
@@ -646,10 +648,20 @@ const DeleteAction = ({
   const { addAlert } = React.useContext(AlertContext);
   const [open, setOpen] = React.useState(false);
   const [username, setUsername] = React.useState("");
+  const canDelete = useDeploymentProperty("sysadmin.delete.user");
 
-  const allowedToDelete: Result<User> = selectedUser.mapError(
-    () => new Error("Only one user can be deleted at a time.")
-  );
+  const allowedToDelete: Result<User> = FetchingData.getSuccessValue(canDelete)
+    .flatMap(Parsers.isBoolean)
+    .flatMap(Parsers.isTrue)
+    .mapError(
+      () =>
+        new Error('The deployment property "sysadmin.delete.user" is false.')
+    )
+    .flatMap(() =>
+      selectedUser.mapError(
+        () => new Error("Only one user can be deleted at a time.")
+      )
+    );
 
   return (
     <>

--- a/src/main/webapp/ui/src/eln/sysadmin/users/useUserListing.js
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/useUserListing.js
@@ -317,11 +317,14 @@ export function useUserListing(): {|
           >("/system/ajax/removeUserAccount/", {
             userId: id,
           });
-          if (typeof data.error !== "undefined") {
-            throw new Error(data.error.errorMessages[0]);
-          } else {
-            refreshListing();
-          }
+          Parsers.isObject(data)
+            .flatMap(Parsers.isNotNull)
+            .flatMap(Parsers.getValueWithKey("exceptionMessage"))
+            .flatMap(Parsers.isString)
+            .do((exceptionMessage) => {
+              throw new Error(exceptionMessage);
+            });
+          refreshListing();
         } catch (error) {
           if (error.response?.data?.message) {
             const message = error.response.data.message;


### PR DESCRIPTION
The delete user sysadmin menu item is now disabled if the deployment property is set, with an explanation as such.
<img width="536" alt="image" src="https://github.com/rspace-os/rspace-web/assets/8805923/87c7d0f8-770c-47be-9ec3-e11125f52697">

Furthermore, I've fixed the error handling for the network request to ensure that any other reason for the deletion operation failing is made apparent.