### PR TITLE
RSDEV-264 Add an actions menu to the new gallery

### DIFF
--- a/src/main/webapp/ui/src/Toolbar/Gallery/IrodsWrapper.js
+++ b/src/main/webapp/ui/src/Toolbar/Gallery/IrodsWrapper.js
@@ -1,7 +1,7 @@
 //@flow
 
 import React, { type Node } from "react";
-import MoveToIrods from "./MoveToIrods";
+import MoveToIrods from "../../eln/gallery/components/MoveToIrods";
 
 export default function IrodsWrapper(): Node {
   const [dialogOpen, setDialogOpen] = React.useState(false);

--- a/src/main/webapp/ui/src/Toolbar/Gallery/IrodsWrapper.js
+++ b/src/main/webapp/ui/src/Toolbar/Gallery/IrodsWrapper.js
@@ -1,0 +1,36 @@
+//@flow
+
+import React, { type Node } from "react";
+import MoveToIrods from "./MoveToIrods";
+
+export default function IrodsWrapper(): Node {
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [selectedIds, setSelectedIds] = React.useState<$ReadOnlyArray<string>>(
+    []
+  );
+
+  React.useEffect(() => {
+    const handler = (
+      event: Event & { detail: { ids: Array<string>, ... }, ... }
+    ) => {
+      setSelectedIds(event.detail.ids);
+      setDialogOpen(true);
+    };
+    window.addEventListener("OPEN_IRODS_DIALOG", handler);
+    return () => {
+      window.removeEventListener("OPEN_IRODS_DIALOG", handler);
+    };
+  }, []);
+
+  return (
+    <MoveToIrods
+      selectedIds={selectedIds}
+      dialogOpen={dialogOpen}
+      setDialogOpen={(newState) => {
+        setDialogOpen(newState);
+        // eslint-disable-next-line no-undef
+        if (!newState) gallery();
+      }}
+    />
+  );
+}

--- a/src/main/webapp/ui/src/Toolbar/Gallery/MoveToIrods.js
+++ b/src/main/webapp/ui/src/Toolbar/Gallery/MoveToIrods.js
@@ -125,24 +125,16 @@ const ErrorAlert = ({ message }: {| message: string |}) => {
 };
 
 type MoveCopyDialogArgs = {|
-  selectedIdsProp?: $ReadOnlyArray<string>,
-  openProp?: boolean,
+  selectedIds: $ReadOnlyArray<string>,
+  dialogOpen: boolean,
+  setDialogOpen: (boolean) => void,
 |};
 
-function MoveCopyDialog({ selectedIdsProp, openProp }: MoveCopyDialogArgs) {
-  const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [selectedIds, setSelectedIds] = React.useState<$ReadOnlyArray<string>>(
-    []
-  );
-
-  React.useEffect(() => {
-    if (typeof openProp !== "undefined") setDialogOpen(openProp);
-  }, [openProp]);
-
-  React.useEffect(() => {
-    if (typeof selectedIdsProp !== "undefined") setSelectedIds(selectedIdsProp);
-  }, [selectedIdsProp]);
-
+function MoveCopyDialog({
+  selectedIds,
+  dialogOpen,
+  setDialogOpen,
+}: MoveCopyDialogArgs) {
   const irods = useIrods(selectedIds);
   const [locationsAnchorEl, setLocationsAnchorEl] = React.useState(null);
   const [selectedDestination, setSelectedDestination] =
@@ -189,24 +181,14 @@ function MoveCopyDialog({ selectedIdsProp, openProp }: MoveCopyDialogArgs) {
   }
 
   React.useEffect(() => {
-    const handler = (
-      event: Event & { detail: { ids: Array<string>, ... }, ... }
-    ) => {
-      setSelectedIds(event.detail.ids);
-      /*
-       * selectedDestination is reset because the IrodsLocations are
-       * paramaterised by the files that are being moved. This allows the
-       * RESTful API to adjust the available locations based on the particular
-       * files being moved.
-       */
-      setSelectedDestination(null);
-      setDialogOpen(true);
-    };
-    window.addEventListener("OPEN_IRODS_DIALOG", handler);
-    return () => {
-      window.removeEventListener("OPEN_IRODS_DIALOG", handler);
-    };
-  }, []);
+    /*
+     * selectedDestination is reset because the IrodsLocations are
+     * paramaterised by the files that are being moved. This allows the RESTful
+     * API to adjust the available locations based on the particular files
+     * being moved.
+     */
+    setSelectedDestination(null);
+  }, [selectedIds]);
 
   const onSubmit = () => {
     if (!selectedDestination)
@@ -218,8 +200,6 @@ function MoveCopyDialog({ selectedIdsProp, openProp }: MoveCopyDialogArgs) {
           .then(() => {
             setDialogOpen(false);
             setShowUsernamePasswordForm(false);
-            // eslint-disable-next-line no-undef
-            gallery();
           })
           .finally(() => {
             setOperationInProgress(false);
@@ -232,8 +212,6 @@ function MoveCopyDialog({ selectedIdsProp, openProp }: MoveCopyDialogArgs) {
           .then(() => {
             setDialogOpen(false);
             setShowUsernamePasswordForm(false);
-            // eslint-disable-next-line no-undef
-            gallery();
           })
           .finally(() => {
             setOperationInProgress(false);
@@ -436,14 +414,23 @@ function MoveCopyDialog({ selectedIdsProp, openProp }: MoveCopyDialogArgs) {
 }
 
 type WrapperArgs = {|
-  selectedIds?: $ReadOnlyArray<string>,
-  open?: boolean,
+  selectedIds: $ReadOnlyArray<string>,
+  dialogOpen: boolean,
+  setDialogOpen: (boolean) => void,
 |};
 
-export default function Wrapper({ selectedIds, open }: WrapperArgs): Node {
+export default function Wrapper({
+  selectedIds,
+  dialogOpen,
+  setDialogOpen,
+}: WrapperArgs): Node {
   return (
     <ThemeProvider theme={createAccentedTheme(COLOR)}>
-      <MoveCopyDialog selectedIdsProp={selectedIds} openProp={open} />
+      <MoveCopyDialog
+        selectedIds={selectedIds}
+        dialogOpen={dialogOpen}
+        setDialogOpen={setDialogOpen}
+      />
     </ThemeProvider>
   );
 }

--- a/src/main/webapp/ui/src/Toolbar/Gallery/MoveToIrods.js
+++ b/src/main/webapp/ui/src/Toolbar/Gallery/MoveToIrods.js
@@ -69,8 +69,7 @@ const CustomDialog = styled(Dialog)(() => ({
     height: "calc(90% - 32px)", // 16px margin above and below dialog
   },
   "& .MuiDialogContent-root": {
-    width: "calc(100% - 32px)",
-    height: "calc(100% - 66px)", // 48px being the height of DialogActions + its own 16px of padding
+    height: "calc(100% - 48px)", // 32px being the height of DialogActions + its own 16px of padding
     overflowY: "auto",
     paddingBottom: 0,
   },
@@ -125,11 +124,24 @@ const ErrorAlert = ({ message }: {| message: string |}) => {
   );
 };
 
-function MoveCopyDialog() {
+type MoveCopyDialogArgs = {|
+  selectedIdsProp?: $ReadOnlyArray<string>,
+  openProp?: boolean,
+|};
+
+function MoveCopyDialog({ selectedIdsProp, openProp }: MoveCopyDialogArgs) {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [selectedIds, setSelectedIds] = React.useState<$ReadOnlyArray<string>>(
     []
   );
+
+  React.useEffect(() => {
+    if (typeof openProp !== "undefined") setDialogOpen(openProp);
+  }, [openProp]);
+
+  React.useEffect(() => {
+    if (typeof selectedIdsProp !== "undefined") setSelectedIds(selectedIdsProp);
+  }, [selectedIdsProp]);
 
   const irods = useIrods(selectedIds);
   const [locationsAnchorEl, setLocationsAnchorEl] = React.useState(null);
@@ -423,10 +435,15 @@ function MoveCopyDialog() {
   );
 }
 
-export default function Wrapper(): Node {
+type WrapperArgs = {|
+  selectedIds?: $ReadOnlyArray<string>,
+  open?: boolean,
+|};
+
+export default function Wrapper({ selectedIds, open }: WrapperArgs): Node {
   return (
     <ThemeProvider theme={createAccentedTheme(COLOR)}>
-      <MoveCopyDialog />
+      <MoveCopyDialog selectedIdsProp={selectedIds} openProp={open} />
     </ThemeProvider>
   );
 }

--- a/src/main/webapp/ui/src/Toolbar/Gallery/Toolbar.js
+++ b/src/main/webapp/ui/src/Toolbar/Gallery/Toolbar.js
@@ -15,7 +15,7 @@ import BaseSearch from "../../components/BaseSearch";
 import DMPToolMenuItem from "../../eln-dmp-integration/DMPTool/DMPToolMenuItem";
 import ArgosMenuItem from "../../eln-dmp-integration/Argos/ArgosMenuItem";
 import DMPOnlineMenuItem from "../../eln-dmp-integration/DMPOnline/DMPOnlineMenuItem";
-import MoveToIrods from "./MoveToIrods";
+import IrodsWrapper from "./IrodsWrapper";
 import Alerts from "../../components/Alerts/Alerts";
 import CssBaseline from "@mui/material/CssBaseline";
 
@@ -211,7 +211,7 @@ export default function GalleryToolbar(): Node {
       <ThemeProvider theme={materialTheme}>
         <BaseToolbar content={Content} />
         <Alerts>
-          <MoveToIrods />
+          <IrodsWrapper />
         </Alerts>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/src/main/webapp/ui/src/Toolbar/Gallery/Toolbar.js
+++ b/src/main/webapp/ui/src/Toolbar/Gallery/Toolbar.js
@@ -17,6 +17,7 @@ import ArgosMenuItem from "../../eln-dmp-integration/Argos/ArgosMenuItem";
 import DMPOnlineMenuItem from "../../eln-dmp-integration/DMPOnline/DMPOnlineMenuItem";
 import MoveToIrods from "./MoveToIrods";
 import Alerts from "../../components/Alerts/Alerts";
+import CssBaseline from "@mui/material/CssBaseline";
 
 const ButtonWrapper = styled.div`
   button {
@@ -206,6 +207,7 @@ export default function GalleryToolbar(): Node {
 
   return (
     <StyledEngineProvider injectFirst>
+      <CssBaseline />
       <ThemeProvider theme={materialTheme}>
         <BaseToolbar content={Content} />
         <Alerts>

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -85,6 +85,9 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
   const prefersMoreContrast = window.matchMedia(
     "(prefers-contrast: more)"
   ).matches;
+  const prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
 
   // All of these strings are formatted specifically so MUI can parse them and perform its own arithmetic
 
@@ -238,10 +241,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
         MuiDialog: {
           defaultProps: {
             TransitionProps: {
-              timeout: window.matchMedia("(prefers-reduced-motion: reduce)")
-                .matches
-                ? 0
-                : 200,
+              timeout: prefersReducedMotion ? 0 : 200,
             },
           },
           styleOverrides: {
@@ -295,8 +295,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
         MuiDrawer: {
           styleOverrides: {
             root: {
-              transition: window.matchMedia("(prefers-reduced-motion: reduce)")
-                .matches
+              transition: prefersReducedMotion
                 ? "none !important"
                 : "width .25s cubic-bezier(0.4, 0, 0.2, 1)",
               [`& .${listItemButtonClasses.root}`]: {
@@ -342,9 +341,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
               [`& .${paperClasses.root}`]: {
                 backgroundColor: secondaryBackground,
                 borderRight: accentedBorder,
-                transition: window.matchMedia(
-                  "(prefers-reduced-motion: reduce)"
-                ).matches
+                transition: prefersReducedMotion
                   ? "none !important"
                   : "width .25s cubic-bezier(0.4, 0, 0.2, 1)",
               },
@@ -746,7 +743,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
             paper: {
               boxShadow: "none",
               border: accentedBorder,
-              ...(window.matchMedia("(prefers-reduced-motion: reduce)").matches
+              ...(prefersReducedMotion
                 ? {
                     transition: "none !important",
                   }

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -292,6 +292,10 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
         MuiDrawer: {
           styleOverrides: {
             root: {
+              transition: window.matchMedia("(prefers-reduced-motion: reduce)")
+                .matches
+                ? "none !important"
+                : "width .25s cubic-bezier(0.4, 0, 0.2, 1)",
               [`& .${listItemButtonClasses.root}`]: {
                 paddingLeft: baseTheme.spacing(3),
                 border: "none",
@@ -335,6 +339,11 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
               [`& .${paperClasses.root}`]: {
                 backgroundColor: secondaryBackground,
                 borderRight: accentedBorder,
+                transition: window.matchMedia(
+                  "(prefers-reduced-motion: reduce)"
+                ).matches
+                  ? "none !important"
+                  : "width .25s cubic-bezier(0.4, 0, 0.2, 1)",
               },
             },
           },

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -292,7 +292,6 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
         MuiDrawer: {
           styleOverrides: {
             root: {
-              backgroundColor: secondaryBackground,
               [`& .${listItemButtonClasses.root}`]: {
                 paddingLeft: baseTheme.spacing(3),
                 border: "none",
@@ -334,6 +333,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
                 },
               },
               [`& .${paperClasses.root}`]: {
+                backgroundColor: secondaryBackground,
                 borderRight: accentedBorder,
               },
             },

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -434,6 +434,26 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
                   ),
                 },
               },
+              "&:has(.MuiInputAdornment-positionStart)": {
+                paddingLeft: 0,
+                "& .MuiOutlinedInput-input": {
+                  paddingTop: "5px",
+                  paddingBottom: "5px",
+                },
+              },
+              "& .MuiInputAdornment-root": {
+                height: "100%",
+                paddingLeft: baseTheme.spacing(1),
+                paddingRight: baseTheme.spacing(1),
+                borderRight: accentedBorder,
+                backgroundColor: lighterInteractiveColor,
+                "& .MuiTypography-root": {
+                  textTransform: "uppercase",
+                  fontWeight: 700,
+                  fontSize: "0.9rem",
+                  lineHeight: "31px",
+                },
+              },
             },
             notchedOutline: {
               borderColor: accentedBackground,

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -734,6 +734,11 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
             paper: {
               boxShadow: "none",
               border: accentedBorder,
+              ...(window.matchMedia("(prefers-reduced-motion: reduce)").matches
+                ? {
+                    transition: "none !important",
+                  }
+                : {}),
             },
           },
         },

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -116,7 +116,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
    */
   const mainBackground = prefersMoreContrast
     ? "rgb(255,255,255)"
-    : `hsl(${accent.background.hue}deg, ${accent.background.saturation}%, 99%)`;
+    : `hsl(${accent.background.hue}deg, ${accent.background.saturation}%, 98%)`;
   /**
    * This may seem pointless to define as its just white, but defining it this
    * way allows us to dynamically apply darken
@@ -142,7 +142,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
   // Interactive elements: text fields in app bar, chips
   const lighterInteractiveColor = prefersMoreContrast
     ? secondaryBackground
-    : `hsl(${accent.main.hue}deg, 30%, 90%)`;
+    : `hsl(${accent.main.hue}deg, ${accent.main.saturation}%, 90%)`;
 
   // Links are slightly darker to more closely match surrounding text
   const linkColor = prefersMoreContrast

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -251,6 +251,9 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
               borderRadius: 6,
               backgroundColor: mainBackground,
             },
+            paperFullScreen: {
+              borderRadius: 0,
+            },
           },
         },
         MuiDialogContent: {

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -24,6 +24,7 @@ import { radioClasses } from "@mui/material/Radio";
 import { chipClasses } from "@mui/material/Chip";
 import { formLabelClasses } from "@mui/material/FormLabel";
 import { inputLabelClasses } from "@mui/material/InputLabel";
+import { inputAdornmentClasses } from "@mui/material/InputAdornment";
 
 /**
  * This theme is used for pages that use the new styling, wherein the page (or
@@ -204,6 +205,9 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
                 borderRadius: "3px",
                 [`& .${inputBaseClasses.root}`]: {
                   paddingLeft: baseTheme.spacing(1),
+                  [`&:has(.${inputAdornmentClasses.positionStart})`]: {
+                    paddingLeft: 0,
+                  },
                   [`& .${svgIconClasses.root}`]: {
                     fill: prefersMoreContrast
                       ? "rgb(0,0,0)"
@@ -434,20 +438,20 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
                   ),
                 },
               },
-              "&:has(.MuiInputAdornment-positionStart)": {
+              [`&:has(.${inputAdornmentClasses.positionStart})`]: {
                 paddingLeft: 0,
-                "& .MuiOutlinedInput-input": {
+                [`& .${outlinedInputClasses.input}`]: {
                   paddingTop: "5px",
                   paddingBottom: "5px",
                 },
               },
-              "& .MuiInputAdornment-root": {
+              [`& .${inputAdornmentClasses.root}`]: {
                 height: "100%",
                 paddingLeft: baseTheme.spacing(1),
                 paddingRight: baseTheme.spacing(1),
                 borderRight: accentedBorder,
                 backgroundColor: lighterInteractiveColor,
-                "& .MuiTypography-root": {
+                [`& .${typographyClasses.root}`]: {
                   textTransform: "uppercase",
                   fontWeight: 700,
                   fontSize: "0.9rem",

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -245,6 +245,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
               overflow: "hidden",
               border: dialogBorder,
               borderRadius: 6,
+              backgroundColor: mainBackground,
             },
           },
         },

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -95,7 +95,7 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
 
   const linkButtonText = prefersMoreContrast
     ? "rgb(0,0,0)"
-    : `hsl(${accent.main.hue}deg, 13%, 50%)`;
+    : `hsl(${accent.main.hue}deg, ${accent.main.saturation}%, 40%)`;
 
   /**
    * A background colour that can be used behind headers, toolbars, and other

--- a/src/main/webapp/ui/src/components/AccessibilityTips.js
+++ b/src/main/webapp/ui/src/components/AccessibilityTips.js
@@ -26,6 +26,7 @@ const StyledPopover = styled(
 type AccessibilityTipsArgs = {|
   supportsHighContrastMode?: boolean,
   supportsReducedMotion?: boolean,
+  supports2xZoom?: boolean,
   elementType: "dialog" | "panel" | "page",
 |};
 
@@ -48,6 +49,7 @@ type AccessibilityTipsArgs = {|
 export default function AccessibilityTips({
   supportsHighContrastMode,
   supportsReducedMotion,
+  supports2xZoom,
   elementType,
 }: AccessibilityTipsArgs): Node {
   const [anchorEl, setAnchorEl] = React.useState<EventTarget | null>(null);
@@ -159,6 +161,30 @@ export default function AccessibilityTips({
               ,{" "}
               <Link href="https://support.google.com/accessibility/android/answer/11183305">
                 Android
+              </Link>
+            </Alert>
+          )}
+          {supports2xZoom && (
+            <Alert severity="info" elevation={0} aria-label="Tip">
+              <AlertTitle>
+                This {elementType} supports up to 200% zoom magnification.
+              </AlertTitle>
+              To enable, adjust your browser&apos;s settings:
+              <br />
+              <Link href="https://support.google.com/chrome/answer/96810?hl=en&co=GENIE.Platform%3DDesktop">
+                Chrome
+              </Link>
+              ,{" "}
+              <Link href="https://support.apple.com/en-gb/guide/safari/ibrw1068/mac">
+                Safari
+              </Link>
+              ,{" "}
+              <Link href="https://support.microsoft.com/en-us/microsoft-edge/accessibility-features-in-microsoft-edge-4c696192-338e-9465-b2cd-bd9b698ad19a">
+                Edge
+              </Link>
+              ,{" "}
+              <Link href="https://support.mozilla.org/en-US/kb/font-size-and-zoom-increase-size-of-web-pages">
+                Firefox
               </Link>
             </Alert>
           )}

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/ArgosNewMenuItem.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/ArgosNewMenuItem.js
@@ -21,6 +21,7 @@ export default function ArgosNewMenuItem(): Node {
         onClick={() => {
           setShowDMPDialog(true);
         }}
+        aria-haspopup="dialog"
       />
       <DMPDialog open={showDMPDialog} setOpen={setShowDMPDialog} />
     </>

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/ArgosNewMenuItem.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/ArgosNewMenuItem.js
@@ -7,7 +7,13 @@ import ArgosIcon from "../../eln/apps/icons/Argos.svg";
 import { COLOR } from "../../eln/apps/integrations/Argos";
 import CardMedia from "@mui/material/CardMedia";
 
-export default function ArgosNewMenuItem(): Node {
+type ArgosNewMenuItemArgs = {|
+  onDialogClose: () => void,
+|};
+
+export default function ArgosNewMenuItem({
+  onDialogClose,
+}: ArgosNewMenuItemArgs): Node {
   const [showDMPDialog, setShowDMPDialog] = React.useState(false);
 
   return (
@@ -23,7 +29,13 @@ export default function ArgosNewMenuItem(): Node {
         }}
         aria-haspopup="dialog"
       />
-      <DMPDialog open={showDMPDialog} setOpen={setShowDMPDialog} />
+      <DMPDialog
+        open={showDMPDialog}
+        setOpen={(b) => {
+          setShowDMPDialog(b);
+          if (!b) onDialogClose();
+        }}
+      />
     </>
   );
 }

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPOnline/DMPOnlineNewMenuItem.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPOnline/DMPOnlineNewMenuItem.js
@@ -7,7 +7,13 @@ import DMPonlineIcon from "../../eln/apps/icons/dmponline.svg";
 import { COLOR } from "../../eln/apps/integrations/DMPonline";
 import CardMedia from "@mui/material/CardMedia";
 
-export default function DMPonlineNewMenuItem(): Node {
+type DMPonlineNewMenuItemArgs = {|
+  onDialogClose: () => void,
+|};
+
+export default function DMPonlineNewMenuItem({
+  onDialogClose,
+}: DMPonlineNewMenuItemArgs): Node {
   const [showDMPDialog, setShowDMPDialog] = React.useState(false);
 
   return (
@@ -23,7 +29,13 @@ export default function DMPonlineNewMenuItem(): Node {
         }}
         aria-haspopup="dialog"
       />
-      <DMPDialog open={showDMPDialog} setOpen={setShowDMPDialog} />
+      <DMPDialog
+        open={showDMPDialog}
+        setOpen={(b) => {
+          setShowDMPDialog(b);
+          onDialogClose();
+        }}
+      />
     </>
   );
 }

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPOnline/DMPOnlineNewMenuItem.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPOnline/DMPOnlineNewMenuItem.js
@@ -21,6 +21,7 @@ export default function DMPonlineNewMenuItem(): Node {
         onClick={() => {
           setShowDMPDialog(true);
         }}
+        aria-haspopup="dialog"
       />
       <DMPDialog open={showDMPDialog} setOpen={setShowDMPDialog} />
     </>

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPToolNewMenuItem.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPToolNewMenuItem.js
@@ -33,6 +33,7 @@ export default function DMPToolNewMenuItem(): Node {
         onClick={() => {
           setShowDMPDialog(true);
         }}
+        aria-haspopup="dialog"
       />
       <DMPDialog open={showDMPDialog} setOpen={setShowDMPDialog} />
     </>

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPToolNewMenuItem.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPToolNewMenuItem.js
@@ -9,7 +9,13 @@ import CardMedia from "@mui/material/CardMedia";
 import axios from "axios";
 import { mapNullable } from "../../util/Util";
 
-export default function DMPToolNewMenuItem(): Node {
+type DMPToolNewMenuItemArgs = {|
+  onDialogClose: () => void,
+|};
+
+export default function DMPToolNewMenuItem({
+  onDialogClose,
+}: DMPToolNewMenuItemArgs): Node {
   const [DMPHost, setDMPHost] = React.useState<?string>();
   const [showDMPDialog, setShowDMPDialog] = React.useState(false);
 
@@ -35,7 +41,13 @@ export default function DMPToolNewMenuItem(): Node {
         }}
         aria-haspopup="dialog"
       />
-      <DMPDialog open={showDMPDialog} setOpen={setShowDMPDialog} />
+      <DMPDialog
+        open={showDMPDialog}
+        setOpen={(b) => {
+          setShowDMPDialog(b);
+          onDialogClose();
+        }}
+      />
     </>
   );
 }

--- a/src/main/webapp/ui/src/eln/gallery/common.js
+++ b/src/main/webapp/ui/src/eln/gallery/common.js
@@ -28,28 +28,28 @@ export const gallerySectionCollectiveNoun = {
 
 export const COLOR = {
   main: {
-    hue: 190,
-    saturation: 30,
-    lightness: 80,
+    hue: 280,
+    saturation: 8,
+    lightness: 70,
   },
   darker: {
-    hue: 190,
-    saturation: 30,
-    lightness: 32,
+    hue: 280,
+    saturation: 8,
+    lightness: 22,
   },
   contrastText: {
-    hue: 190,
-    saturation: 20,
-    lightness: 29,
+    hue: 280,
+    saturation: 8,
+    lightness: 19,
   },
   background: {
-    hue: 190,
-    saturation: 30,
-    lightness: 80,
+    hue: 280,
+    saturation: 8,
+    lightness: 70,
   },
   backgroundContrastText: {
-    hue: 190,
-    saturation: 20,
+    hue: 280,
+    saturation: 4,
     lightness: 29,
   },
 };

--- a/src/main/webapp/ui/src/eln/gallery/common.js
+++ b/src/main/webapp/ui/src/eln/gallery/common.js
@@ -29,8 +29,8 @@ export const gallerySectionCollectiveNoun = {
 export const COLOR = {
   main: {
     hue: 280,
-    saturation: 8,
-    lightness: 70,
+    saturation: 7,
+    lightness: 81,
   },
   darker: {
     hue: 280,
@@ -44,8 +44,8 @@ export const COLOR = {
   },
   background: {
     hue: 280,
-    saturation: 8,
-    lightness: 70,
+    saturation: 7,
+    lightness: 81,
   },
   backgroundContrastText: {
     hue: 280,

--- a/src/main/webapp/ui/src/eln/gallery/common.js
+++ b/src/main/webapp/ui/src/eln/gallery/common.js
@@ -1,5 +1,7 @@
 //@flow
 
+import { COLORS as baseThemeColors } from "../../theme";
+
 export const gallerySectionLabel = {
   Images: "Images",
   Audios: "Audio",
@@ -53,3 +55,6 @@ export const COLOR = {
     lightness: 29,
   },
 };
+
+export const SELECTED_OR_FOCUS_BLUE = `hsl(${baseThemeColors.primary.hue}deg, ${baseThemeColors.primary.saturation}%, ${baseThemeColors.primary.lightness}%)`;
+export const SELECTED_OR_FOCUS_BORDER = `2px solid ${SELECTED_OR_FOCUS_BLUE}`;

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -120,6 +120,14 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
     return Result.Ok(null);
   };
 
+  const deleteAllowed = (): Result<null> => {
+    if (selection.isEmpty)
+      return Result.Error([new Error("Nothing selected.")]);
+    if (selection.asSet().some((f) => f.isSystemFolder))
+      return Result.Error([new Error("Cannot delete system folders.")]);
+    return Result.Ok(null);
+  };
+
   return (
     <>
       <Button
@@ -202,7 +210,9 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           .orElse(null)}
         <NewMenuItem
           title="Delete"
-          subheader={selection.isEmpty ? "Nothing selected." : ""}
+          subheader={deleteAllowed()
+            .map(() => "")
+            .orElseGet(([e]) => e.message)}
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           avatar={<DeleteOutlineOutlinedIcon />}
@@ -213,7 +223,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             });
           }}
           compact
-          disabled={selection.isEmpty}
+          disabled={deleteAllowed().isError}
         />
         <NewMenuItem
           title="Export"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -36,7 +36,7 @@ type ActionsMenuArgs = {|
 
 function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
   const [actionsMenuAnchorEl, setActionsMenuAnchorEl] = React.useState(null);
-  const { deleteFiles } = useGalleryActions();
+  const { deleteFiles, duplicateFiles } = useGalleryActions();
   const selection = useGallerySelection();
 
   return (
@@ -62,14 +62,18 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
       >
         <NewMenuItem
           title="Duplicate"
-          subheader=""
+          subheader={selection.isEmpty() ? "Nothing selected." : ""}
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           avatar={<AddToPhotosIcon />}
           onClick={() => {
-            setActionsMenuAnchorEl(null);
+            void duplicateFiles(selection.asSet()).then(() => {
+              refreshListing();
+              setActionsMenuAnchorEl(null);
+            });
           }}
           compact
+          disabled={selection.isEmpty()}
         />
         <NewMenuItem
           title="Move"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -142,6 +142,14 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
       });
   };
 
+  const moveToIrodsAllowed = (): Result<null> => {
+    if (selection.isEmpty)
+      return Result.Error([new Error("Nothing selected.")]);
+    if (selection.asSet().some((f) => f.isSystemFolder))
+      return Result.Error([new Error("Cannot move system folders to iRODS.")]);
+    return Result.Ok(null);
+  };
+
   return (
     <>
       <Button
@@ -250,7 +258,9 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
         />
         <NewMenuItem
           title="Move to iRODS"
-          subheader=""
+          subheader={moveToIrodsAllowed()
+            .map(() => "")
+            .orElseGet(([e]) => e.message)}
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           // TODO: iRODS logo
@@ -259,6 +269,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             setIrodsOpen(true);
           }}
           compact
+          disabled={moveToIrodsAllowed().isError}
         />
         <MoveToIrods
           selectedIds={selection

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -13,7 +13,6 @@ import DriveFileRenameOutlineIcon from "@mui/icons-material/DriveFileRenameOutli
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import AcUnitIcon from "@mui/icons-material/AcUnit";
-import ShareIcon from "@mui/icons-material/Share";
 import GroupIcon from "@mui/icons-material/Group";
 import CropIcon from "@mui/icons-material/Crop";
 import { observer } from "mobx-react-lite";
@@ -235,18 +234,6 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           avatar={<CropIcon />}
-          onClick={() => {
-            setActionsMenuAnchorEl(null);
-          }}
-          compact
-          disabled
-        />
-        <NewMenuItem
-          title="Publish"
-          subheader="Only PDFs can be published."
-          backgroundColor={COLOR.background}
-          foregroundColor={COLOR.contrastText}
-          avatar={<ShareIcon />}
           onClick={() => {
             setActionsMenuAnchorEl(null);
           }}

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -17,7 +17,8 @@ import ShareIcon from "@mui/icons-material/Share";
 import GroupIcon from "@mui/icons-material/Group";
 import CropIcon from "@mui/icons-material/Crop";
 import { observer } from "mobx-react-lite";
-import { useGalleryActions, useGallerySelection } from "../useGalleryActions";
+import { useGalleryActions } from "../useGalleryActions";
+import { useGallerySelection } from "../useGallerySelection";
 
 const StyledMenu = styled(Menu)(({ open }) => ({
   "& .MuiPaper-root": {

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -41,7 +41,13 @@ const RenameDialog = ({
   const [newName, setNewName] = React.useState("");
   const { rename } = useGalleryActions();
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+      }}
+    >
       <form
         onSubmit={(e) => {
           e.preventDefault();

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -31,6 +31,7 @@ import MoveToIrods, { COLOR as IRODS_COLOR } from "./MoveToIrods";
 import IrodsLogo from "./IrodsLogo.svg";
 import SvgIcon from "@mui/material/SvgIcon";
 import Avatar from "@mui/material/Avatar";
+import MoveDialog from "./MoveDialog";
 
 const RenameDialog = ({
   open,
@@ -122,6 +123,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
   const theme = useTheme();
 
   const [renameOpen, setRenameOpen] = React.useState(false);
+  const [moveOpen, setMoveOpen] = React.useState(false);
   const [irodsOpen, setIrodsOpen] = React.useState(false);
 
   const duplicateAllowed = (): Result<null> => {
@@ -186,7 +188,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
   const moveAllowed = (): Result<null> => {
     if (selection.isEmpty)
       return Result.Error([new Error("Nothing selected.")]);
-    return Result.Error([new Error("Not yet available.")]);
+    return Result.Ok(null);
   };
 
   return (
@@ -237,10 +239,17 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           foregroundColor={COLOR.contrastText}
           avatar={<OpenWithIcon />}
           onClick={() => {
-            setActionsMenuAnchorEl(null);
+            setMoveOpen(true);
           }}
           compact
           disabled={moveAllowed().isError}
+        />
+        <MoveDialog
+          open={moveOpen}
+          onClose={() => {
+            setMoveOpen(false);
+            setActionsMenuAnchorEl(null);
+          }}
         />
         <NewMenuItem
           title="Rename"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -112,6 +112,14 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
 
   const [renameOpen, setRenameOpen] = React.useState(false);
 
+  const duplicateAllowed = (): Result<null> => {
+    if (selection.isEmpty)
+      return Result.Error([new Error("Nothing selected.")]);
+    if (selection.asSet().some((f) => /System Folder/.test(f.type)))
+      return Result.Error([new Error("Cannot duplicate system folders.")]);
+    return Result.Ok(null);
+  };
+
   return (
     <>
       <Button
@@ -135,7 +143,9 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
       >
         <NewMenuItem
           title="Duplicate"
-          subheader={selection.isEmpty ? "Nothing selected." : ""}
+          subheader={duplicateAllowed()
+            .map(() => "")
+            .orElseGet(([e]) => e.message)}
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           avatar={<AddToPhotosIcon />}
@@ -146,7 +156,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             });
           }}
           compact
-          disabled={selection.isEmpty}
+          disabled={duplicateAllowed().isError}
         />
         <NewMenuItem
           title="Move"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -12,7 +12,6 @@ import OpenWithIcon from "@mui/icons-material/OpenWith";
 import DriveFileRenameOutlineIcon from "@mui/icons-material/DriveFileRenameOutline";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
-import AcUnitIcon from "@mui/icons-material/AcUnit";
 import GroupIcon from "@mui/icons-material/Group";
 import CropIcon from "@mui/icons-material/Crop";
 import { observer } from "mobx-react-lite";
@@ -29,6 +28,9 @@ import DialogActions from "@mui/material/DialogActions";
 import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
 import MoveToIrods, { COLOR as IRODS_COLOR } from "./MoveToIrods";
+import IrodsLogo from "./IrodsLogo.svg";
+import SvgIcon from "@mui/material/SvgIcon";
+import Avatar from "@mui/material/Avatar";
 
 const RenameDialog = ({
   open,
@@ -318,8 +320,18 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             .orElseGet(([e]) => e.message)}
           backgroundColor={IRODS_COLOR.background}
           foregroundColor={IRODS_COLOR.contrastText}
-          // TODO: iRODS logo
-          avatar={<AcUnitIcon />}
+          avatar={
+            <Avatar
+              variant="square"
+              sx={{
+                width: 28,
+                height: 28,
+                bgcolor: `hsl(${IRODS_COLOR.main.hue}deg, ${IRODS_COLOR.main.saturation}%, ${IRODS_COLOR.main.lightness}%, 100%)`,
+                border: `4px solid hsl(${IRODS_COLOR.main.hue}deg, ${IRODS_COLOR.main.saturation}%, ${IRODS_COLOR.main.lightness}%, 100%)`,
+              }}
+              src={IrodsLogo}
+            />
+          }
           onClick={() => {
             setIrodsOpen(true);
           }}

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -363,7 +363,7 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
             }
           }}
         />
-        <Divider />
+        <Divider aria-orientation="horizontal" />
         <NewMenuItem
           title="Delete"
           subheader={deleteAllowed()

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -5,7 +5,7 @@ import ChecklistIcon from "@mui/icons-material/Checklist";
 import Button from "@mui/material/Button";
 import { COLOR } from "../common";
 import AddToPhotosIcon from "@mui/icons-material/AddToPhotos";
-import { styled } from "@mui/material/styles";
+import { styled, useTheme, darken, lighten } from "@mui/material/styles";
 import Menu from "@mui/material/Menu";
 import NewMenuItem from "./NewMenuItem";
 import OpenWithIcon from "@mui/icons-material/OpenWith";
@@ -20,6 +20,7 @@ import { type GalleryFile, idToString } from "../useGalleryListing";
 import { useGalleryActions } from "../useGalleryActions";
 import { useGallerySelection } from "../useGallerySelection";
 import Dialog from "@mui/material/Dialog";
+import Divider from "@mui/material/Divider";
 import TextField from "@mui/material/TextField";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -115,6 +116,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
   const [actionsMenuAnchorEl, setActionsMenuAnchorEl] = React.useState(null);
   const { deleteFiles, duplicateFiles } = useGalleryActions();
   const selection = useGallerySelection();
+  const theme = useTheme();
 
   const [renameOpen, setRenameOpen] = React.useState(false);
   const [irodsOpen, setIrodsOpen] = React.useState(false);
@@ -252,23 +254,6 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           ))
           .orElse(null)}
         <NewMenuItem
-          title="Delete"
-          subheader={deleteAllowed()
-            .map(() => "")
-            .orElseGet(([e]) => e.message)}
-          backgroundColor={COLOR.background}
-          foregroundColor={COLOR.contrastText}
-          avatar={<DeleteOutlineOutlinedIcon />}
-          onClick={() => {
-            void deleteFiles(selection.asSet()).then(() => {
-              refreshListing();
-              setActionsMenuAnchorEl(null);
-            });
-          }}
-          compact
-          disabled={deleteAllowed().isError}
-        />
-        <NewMenuItem
           title="Export"
           subheader=""
           backgroundColor={COLOR.background}
@@ -335,6 +320,24 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
               refreshListing();
             }
           }}
+        />
+        <Divider />
+        <NewMenuItem
+          title="Delete"
+          subheader={deleteAllowed()
+            .map(() => "")
+            .orElseGet(([e]) => e.message)}
+          backgroundColor={lighten(theme.palette.error.light, 0.5)}
+          foregroundColor={darken(theme.palette.error.dark, 0.3)}
+          avatar={<DeleteOutlineOutlinedIcon />}
+          onClick={() => {
+            void deleteFiles(selection.asSet()).then(() => {
+              refreshListing();
+              setActionsMenuAnchorEl(null);
+            });
+          }}
+          compact
+          disabled={deleteAllowed().isError}
         />
       </StyledMenu>
     </>

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -100,6 +100,7 @@ const RenameDialog = ({
 
 const StyledMenu = styled(Menu)(({ open }) => ({
   "& .MuiPaper-root": {
+    minWidth: "212px",
     ...(open
       ? {
           transform: "translate(0px, 4px) !important",

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -115,7 +115,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
   const duplicateAllowed = (): Result<null> => {
     if (selection.isEmpty)
       return Result.Error([new Error("Nothing selected.")]);
-    if (selection.asSet().some((f) => /System Folder/.test(f.type)))
+    if (selection.asSet().some((f) => f.isSystemFolder))
       return Result.Error([new Error("Cannot duplicate system folders.")]);
     return Result.Ok(null);
   };

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -243,6 +243,7 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
           }}
           compact
           disabled={moveAllowed().isError}
+          aria-haspopup="dialog"
         />
         <MoveDialog
           open={moveOpen}
@@ -266,6 +267,7 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
           }}
           compact
           disabled={renameAllowed().isError}
+          aria-haspopup="dialog"
         />
         {selection
           .asSet()
@@ -348,6 +350,7 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
           }}
           compact
           disabled={moveToIrodsAllowed().isError}
+          aria-haspopup="dialog"
         />
         <MoveToIrods
           selectedIds={selection

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -27,7 +27,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
-import MoveToIrods from "../../../Toolbar/Gallery/MoveToIrods";
+import MoveToIrods from "./MoveToIrods";
 
 const RenameDialog = ({
   open,

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -29,7 +29,6 @@ import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
 import MoveToIrods, { COLOR as IRODS_COLOR } from "./MoveToIrods";
 import IrodsLogo from "./IrodsLogo.svg";
-import SvgIcon from "@mui/material/SvgIcon";
 import Avatar from "@mui/material/Avatar";
 import MoveDialog from "./MoveDialog";
 
@@ -252,6 +251,7 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
             setActionsMenuAnchorEl(null);
           }}
           section={section}
+          refreshListing={refreshListing}
         />
         <NewMenuItem
           title="Rename"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -156,6 +156,14 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
     return Result.Ok(null);
   };
 
+  const sharingSnippetsAllowed = (): Result<null> => {
+    if (selection.isEmpty)
+      return Result.Error([new Error("Nothing selected.")]);
+    if (selection.asSet().some((f) => !f.isSnippet))
+      return Result.Error([new Error("Only snippets may be shared.")]);
+    return Result.Error([new Error("Not yet available.")]);
+  };
+
   return (
     <>
       <Button
@@ -277,7 +285,9 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
         />
         <NewMenuItem
           title="Share"
-          subheader="Only snippets can be shared."
+          subheader={sharingSnippetsAllowed()
+            .map(() => "")
+            .orElseGet(([e]) => e.message)}
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           avatar={<GroupIcon />}
@@ -285,7 +295,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             setActionsMenuAnchorEl(null);
           }}
           compact
-          disabled
+          disabled={sharingSnippetsAllowed().isError}
         />
         <NewMenuItem
           title="Move to iRODS"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -176,6 +176,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
         MenuListProps={{
           disablePadding: true,
         }}
+        keepMounted
       >
         <NewMenuItem
           title="Duplicate"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -16,7 +16,7 @@ import AcUnitIcon from "@mui/icons-material/AcUnit";
 import GroupIcon from "@mui/icons-material/Group";
 import CropIcon from "@mui/icons-material/Crop";
 import { observer } from "mobx-react-lite";
-import { type GalleryFile } from "../useGalleryListing";
+import { type GalleryFile, idToString } from "../useGalleryListing";
 import { useGalleryActions } from "../useGalleryActions";
 import { useGallerySelection } from "../useGallerySelection";
 import Dialog from "@mui/material/Dialog";
@@ -27,6 +27,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
+import MoveToIrods from "../../../Toolbar/Gallery/MoveToIrods";
 
 const RenameDialog = ({
   open,
@@ -110,6 +111,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
   const selection = useGallerySelection();
 
   const [renameOpen, setRenameOpen] = React.useState(false);
+  const [irodsOpen, setIrodsOpen] = React.useState(false);
 
   const duplicateAllowed = (): Result<null> => {
     if (selection.isEmpty)
@@ -254,9 +256,17 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           // TODO: iRODS logo
           avatar={<AcUnitIcon />}
           onClick={() => {
-            setActionsMenuAnchorEl(null);
+            //setActionsMenuAnchorEl(null);
+            setIrodsOpen(true);
           }}
           compact
+        />
+        <MoveToIrods
+          selectedIds={selection
+            .asSet()
+            .map(({ id }) => idToString(id))
+            .toArray()}
+          open={irodsOpen}
         />
         <NewMenuItem
           title="Edit"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -26,8 +26,9 @@ import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
-import SubmitSpinnerButton from "../../../components/SubmitSpinnerButton";
+import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import { match } from "../../../util/Util";
+import Result from "../../../util/result";
 
 const RenameDialog = ({
   open,
@@ -70,12 +71,21 @@ const RenameDialog = ({
           >
             Cancel
           </Button>
-          <SubmitSpinnerButton
-            type="submit"
+          <ValidatingSubmitButton
             loading={false}
-            disabled={false}
-            label="Rename"
-          />
+            onClick={() => {
+              void rename(file, newName).then(() => {
+                onClose();
+              });
+            }}
+            validationResult={
+              newName.length === 0
+                ? Result.Error([new Error("Empty name is not permitted.")])
+                : Result.Ok(null)
+            }
+          >
+            Rename
+          </ValidatingSubmitButton>
         </DialogActions>
       </form>
     </Dialog>
@@ -175,6 +185,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
               onClose={() => {
                 setRenameOpen(false);
                 setActionsMenuAnchorEl(null);
+                refreshListing();
               }}
               file={file}
             />

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -256,7 +256,6 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           // TODO: iRODS logo
           avatar={<AcUnitIcon />}
           onClick={() => {
-            //setActionsMenuAnchorEl(null);
             setIrodsOpen(true);
           }}
           compact
@@ -266,7 +265,14 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             .asSet()
             .map(({ id }) => idToString(id))
             .toArray()}
-          open={irodsOpen}
+          dialogOpen={irodsOpen}
+          setDialogOpen={(newState) => {
+            setIrodsOpen(newState);
+            if (!newState) {
+              setActionsMenuAnchorEl(null);
+              refreshListing();
+            }
+          }}
         />
         <NewMenuItem
           title="Edit"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -114,9 +114,10 @@ const StyledMenu = styled(Menu)(({ open }) => ({
 
 type ActionsMenuArgs = {|
   refreshListing: () => void,
+  section: string,
 |};
 
-function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
+function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
   const [actionsMenuAnchorEl, setActionsMenuAnchorEl] = React.useState(null);
   const { deleteFiles, duplicateFiles } = useGalleryActions();
   const selection = useGallerySelection();
@@ -250,6 +251,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             setMoveOpen(false);
             setActionsMenuAnchorEl(null);
           }}
+          section={section}
         />
         <NewMenuItem
           title="Rename"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -164,6 +164,14 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
     return Result.Error([new Error("Not yet available.")]);
   };
 
+  const imageEditingAllowed = (): Result<null> => {
+    if (selection.isEmpty)
+      return Result.Error([new Error("Nothing selected.")]);
+    if (selection.asSet().some((f) => !f.isImage))
+      return Result.Error([new Error("Only images may be edited.")]);
+    return Result.Error([new Error("Not yet available.")]);
+  };
+
   return (
     <>
       <Button
@@ -273,7 +281,9 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
         />
         <NewMenuItem
           title="Edit"
-          subheader="Only images can be edited in place."
+          subheader={imageEditingAllowed()
+            .map(() => "")
+            .orElseGet(([e]) => e.message)}
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           avatar={<CropIcon />}
@@ -281,7 +291,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             setActionsMenuAnchorEl(null);
           }}
           compact
-          disabled
+          disabled={imageEditingAllowed().isError}
         />
         <NewMenuItem
           title="Share"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -264,6 +264,30 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           compact
         />
         <NewMenuItem
+          title="Edit"
+          subheader="Only images can be edited in place."
+          backgroundColor={COLOR.background}
+          foregroundColor={COLOR.contrastText}
+          avatar={<CropIcon />}
+          onClick={() => {
+            setActionsMenuAnchorEl(null);
+          }}
+          compact
+          disabled
+        />
+        <NewMenuItem
+          title="Share"
+          subheader="Only snippets can be shared."
+          backgroundColor={COLOR.background}
+          foregroundColor={COLOR.contrastText}
+          avatar={<GroupIcon />}
+          onClick={() => {
+            setActionsMenuAnchorEl(null);
+          }}
+          compact
+          disabled
+        />
+        <NewMenuItem
           title="Move to iRODS"
           subheader={moveToIrodsAllowed()
             .map(() => "")
@@ -291,30 +315,6 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
               refreshListing();
             }
           }}
-        />
-        <NewMenuItem
-          title="Edit"
-          subheader="Only images can be edited in place."
-          backgroundColor={COLOR.background}
-          foregroundColor={COLOR.contrastText}
-          avatar={<CropIcon />}
-          onClick={() => {
-            setActionsMenuAnchorEl(null);
-          }}
-          compact
-          disabled
-        />
-        <NewMenuItem
-          title="Share"
-          subheader="Only snippets can be shared."
-          backgroundColor={COLOR.background}
-          foregroundColor={COLOR.contrastText}
-          avatar={<GroupIcon />}
-          onClick={() => {
-            setActionsMenuAnchorEl(null);
-          }}
-          compact
-          disabled
         />
       </StyledMenu>
     </>

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -175,6 +175,12 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
     return Result.Error([new Error("Not yet available.")]);
   };
 
+  const exportAllowed = (): Result<null> => {
+    if (selection.isEmpty)
+      return Result.Error([new Error("Nothing selected.")]);
+    return Result.Error([new Error("Not yet available.")]);
+  };
+
   return (
     <>
       <Button
@@ -256,7 +262,9 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           .orElse(null)}
         <NewMenuItem
           title="Export"
-          subheader=""
+          subheader={exportAllowed()
+            .map(() => "")
+            .orElseGet(([e]) => e.message)}
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           avatar={<FileDownloadIcon />}
@@ -264,6 +272,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             setActionsMenuAnchorEl(null);
           }}
           compact
+          disabled={exportAllowed().isError}
         />
         <NewMenuItem
           title="Edit"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -181,6 +181,12 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
     return Result.Error([new Error("Not yet available.")]);
   };
 
+  const moveAllowed = (): Result<null> => {
+    if (selection.isEmpty)
+      return Result.Error([new Error("Nothing selected.")]);
+    return Result.Error([new Error("Not yet available.")]);
+  };
+
   return (
     <>
       <Button
@@ -222,7 +228,9 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
         />
         <NewMenuItem
           title="Move"
-          subheader=""
+          subheader={moveAllowed()
+            .map(() => "")
+            .orElseGet(([e]) => e.message)}
           backgroundColor={COLOR.background}
           foregroundColor={COLOR.contrastText}
           avatar={<OpenWithIcon />}
@@ -230,6 +238,7 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
             setActionsMenuAnchorEl(null);
           }}
           compact
+          disabled={moveAllowed().isError}
         />
         <NewMenuItem
           title="Rename"

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -27,7 +27,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
-import MoveToIrods from "./MoveToIrods";
+import MoveToIrods, { COLOR as IRODS_COLOR } from "./MoveToIrods";
 
 const RenameDialog = ({
   open,
@@ -268,8 +268,8 @@ function ActionsMenu({ refreshListing }: ActionsMenuArgs): Node {
           subheader={moveToIrodsAllowed()
             .map(() => "")
             .orElseGet(([e]) => e.message)}
-          backgroundColor={COLOR.background}
-          foregroundColor={COLOR.contrastText}
+          backgroundColor={IRODS_COLOR.background}
+          foregroundColor={IRODS_COLOR.contrastText}
           // TODO: iRODS logo
           avatar={<AcUnitIcon />}
           onClick={() => {

--- a/src/main/webapp/ui/src/eln/gallery/components/AppBar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/AppBar.js
@@ -129,6 +129,7 @@ function GalleryAppBar({
                   setSearchTerm(appliedSearchTerm);
                   setShowTextfield(appliedSearchTerm !== "");
                 },
+                "aria-label": "Search current folder",
               }}
             />
           </form>

--- a/src/main/webapp/ui/src/eln/gallery/components/AppBar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/AppBar.js
@@ -139,6 +139,7 @@ function GalleryAppBar({
             elementType="dialog"
             supportsReducedMotion
             supportsHighContrastMode
+            supports2xZoom
           />
         </Box>
         <Box ml={1}>

--- a/src/main/webapp/ui/src/eln/gallery/components/IrodsLogo.svg
+++ b/src/main/webapp/ui/src/eln/gallery/components/IrodsLogo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 200 200" >  
+  <path d="M136.24,110.16a35,35,0,0,0,17.18-12.73,34.25,34.25,0,0,0-3.72-44.34A33.65,33.65,0,0,0,125,42.93H78.42v21H125A13.37,13.37,0,0,1,134.83,68a13,13,0,0,1,4,9.5,13.19,13.19,0,0,1-4,9.67,13.4,13.4,0,0,1-9.83,4H78.42v21h34.19l24.45,41.46h24.45Z" fill="#fff" style="
+    transform: scale(1.3) translate(-24px, -26px);
+"></path>
+  <rect x="39.17" y="90.34" width="20.98" height="62.03" fill="#fff" style="
+    transform: scale(1.3) translate(-24px, -26px);
+"></rect>
+  <rect x="39.17" y="41.7" width="20.98" height="20.98" fill="#fff" style="
+    transform: scale(1.3) translate(-24px, -26px);
+"></rect>
+</svg>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -638,7 +638,7 @@ const GridView = observer(
            * regains focus this will then run again
            */
           const { x, y } = tabIndexCoord;
-          if (selection.isEmpty()) selection.append(listing.list[y * cols + x]);
+          if (selection.isEmpty) selection.append(listing.list[y * cols + x]);
         }}
       >
         {listing.list.map((file, index) => (

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -360,11 +360,11 @@ const CustomTreeItem = observer(
           await uploadFiles([...file.path, file], file.id, files);
           refreshListing();
         }),
-        disabled: !/Folder/.test(file.type),
+        disabled: !file.isFolder,
       });
     const { setNodeRef: setDropRef, isOver } = useDroppable({
       id: file.id,
-      disabled: !/Folder/.test(file.type),
+      disabled: !file.isFolder,
       data: {
         path: file.path,
         destination: { key: "folder", folder: file },
@@ -483,7 +483,7 @@ const CustomTreeItem = observer(
             borderRadius: "4px",
           }}
         >
-          {/Folder/.test(file.type) && (
+          {file.isFolder && (
             <TreeItemContent
               file={file}
               path={path}
@@ -754,11 +754,11 @@ const FileCard = styled(
              * placed inside a folder into which the user cannot currently see
              */
           },
-          disabled: !/Folder/.test(file.type),
+          disabled: !file.isFolder,
         });
       const { setNodeRef: setDropRef, isOver } = useDroppable({
         id: file.id,
-        disabled: !/Folder/.test(file.type),
+        disabled: !file.isFolder,
         data: {
           path: file.path,
           destination: { key: "folder", folder: file },

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -28,7 +28,8 @@ import {
   type Id,
   idToString,
 } from "../useGalleryListing";
-import { useGalleryActions, useGallerySelection } from "../useGalleryActions";
+import { useGalleryActions } from "../useGalleryActions";
+import { useGallerySelection } from "../useGallerySelection";
 import { doNotAwait } from "../../../util/Util";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import { SimpleTreeView } from "@mui/x-tree-view/SimpleTreeView";

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -26,7 +26,11 @@ import Avatar from "@mui/material/Avatar";
 import FileIcon from "@mui/icons-material/InsertDriveFile";
 import * as FetchingData from "../../../util/fetchingData";
 import { type GalleryFile, type Id, idToString } from "../useGalleryListing";
-import { useGalleryActions } from "../useGalleryActions";
+import {
+  useGalleryActions,
+  folderDestination,
+  rootDestination,
+} from "../useGalleryActions";
 import { useGallerySelection } from "../useGallerySelection";
 import { doNotAwait } from "../../../util/Util";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
@@ -185,7 +189,7 @@ const Breadcrumb = ({
     disabled: false,
     data: {
       path,
-      destination: folder ? { key: "folder", folder } : { key: "root" },
+      destination: folder ? folderDestination(folder) : rootDestination(),
     },
   });
   const dropStyle: { [string]: string | number } = isOver
@@ -510,7 +514,7 @@ const FileCard = styled(
         disabled: !file.isFolder,
         data: {
           path: file.path,
-          destination: { key: "folder", folder: file },
+          destination: folderDestination(file),
         },
       });
       const {

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -944,7 +944,10 @@ function GalleryMainPanel({
             </Grid>
             <Grid item sx={{ mt: 0.5 }}>
               <Stack direction="row" spacing={1}>
-                <ActionsMenu refreshListing={refreshListing} />
+                <ActionsMenu
+                  refreshListing={refreshListing}
+                  section={selectedSection}
+                />
                 <Button
                   variant="outlined"
                   size="small"

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -12,28 +12,24 @@ import Grid from "@mui/material/Grid";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Chip from "@mui/material/Chip";
 import Fade from "@mui/material/Fade";
-import { gallerySectionLabel, COLOR } from "../common";
+import {
+  gallerySectionLabel,
+  COLOR,
+  SELECTED_OR_FOCUS_BORDER,
+  SELECTED_OR_FOCUS_BLUE,
+} from "../common";
 import { styled } from "@mui/material/styles";
 import useViewportDimensions from "../../../util/useViewportDimensions";
 import Card from "@mui/material/Card";
 import CardActionArea from "@mui/material/CardActionArea";
 import Avatar from "@mui/material/Avatar";
 import FileIcon from "@mui/icons-material/InsertDriveFile";
-import { COLORS as baseThemeColors } from "../../../theme";
 import * as FetchingData from "../../../util/fetchingData";
-import * as MapUtils from "../../../util/MapUtils";
-import {
-  useGalleryListing,
-  type GalleryFile,
-  type Id,
-  idToString,
-} from "../useGalleryListing";
+import { type GalleryFile, type Id, idToString } from "../useGalleryListing";
 import { useGalleryActions } from "../useGalleryActions";
 import { useGallerySelection } from "../useGallerySelection";
 import { doNotAwait } from "../../../util/Util";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
-import { SimpleTreeView } from "@mui/x-tree-view/SimpleTreeView";
-import { TreeItem } from "@mui/x-tree-view/TreeItem";
 import {
   useDroppable,
   useDraggable,
@@ -48,23 +44,19 @@ import Button from "@mui/material/Button";
 import GridIcon from "@mui/icons-material/ViewCompact";
 import TreeIcon from "@mui/icons-material/AccountTree";
 import Menu from "@mui/material/Menu";
-import Box from "@mui/material/Box";
 import NewMenuItem from "./NewMenuItem";
-import Collapse from "@mui/material/Collapse";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import Slide from "@mui/material/Slide";
 import Stack from "@mui/material/Stack";
-import { runInAction } from "mobx";
-import { useLocalObservable, observer } from "mobx-react-lite";
+import { observer } from "mobx-react-lite";
 import { useFileImportDropZone } from "../../../components/useFileImportDragAndDrop";
-import AlertContext, { mkAlert } from "../../../stores/contexts/Alert";
 import ActionsMenu from "./ActionsMenu";
 import RsSet from "../../../util/set";
-
-const SELECTED_OR_FOCUS_BLUE = `hsl(${baseThemeColors.primary.hue}deg, ${baseThemeColors.primary.saturation}%, ${baseThemeColors.primary.lightness}%)`;
-const SELECTED_OR_FOCUS_BORDER = `2px solid ${SELECTED_OR_FOCUS_BLUE}`;
+import TreeView from "./TreeView";
+import { COLORS as baseThemeColors } from "../../../theme";
+import PlaceholderLabel from "./PlaceholderLabel";
 
 const StyledMenu = styled(Menu)(({ open }) => ({
   "& .MuiPaper-root": {
@@ -171,89 +163,6 @@ const ImportDropzone = styled(
   },
 }));
 
-type TreeItemContentArgs = {|
-  file: GalleryFile,
-  path: $ReadOnlyArray<GalleryFile>,
-  section: string,
-  idMap: Map<string, GalleryFile>,
-  refreshListing: () => void,
-|};
-
-const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
-  ({
-    path,
-    file,
-    section,
-    idMap,
-    refreshListing,
-  }: TreeItemContentArgs): Node => {
-    const { galleryListing } = useGalleryListing({
-      section,
-      searchTerm: "",
-      path: [...path, file],
-    });
-
-    React.useEffect(() => {
-      FetchingData.getSuccessValue(galleryListing).do((listing) => {
-        if (listing.tag === "empty") return;
-        runInAction(() => {
-          for (const f of listing.list) idMap.set(idToString(f.id), f);
-        });
-      });
-    }, [galleryListing]);
-
-    return FetchingData.match(galleryListing, {
-      /*
-       * nothing is shown whilst loading otherwise the UI ends up being quite
-       * janky when there ends up being nothing in the folder
-       */
-      loading: () => null,
-      error: (error) => <>{error}</>,
-      success: (listing) =>
-        listing.tag === "list"
-          ? listing.list.map((f, i) => (
-              <CustomTreeItem
-                file={f}
-                index={i}
-                path={[...path, file]}
-                section={section}
-                key={idToString(f.id)}
-                idMap={idMap}
-                refreshListing={refreshListing}
-              />
-            ))
-          : null,
-    });
-  }
-);
-
-const CustomTransition = styled(({ children, in: open, className }) => (
-  <div className={className}>
-    <Collapse
-      in={open}
-      timeout={
-        window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 200
-      }
-    >
-      {children}
-    </Collapse>
-  </div>
-))(({ in: open }) => ({
-  "& .MuiCollapse-wrapperInner > .MuiBox-root": {
-    transform:
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches || open
-        ? "none"
-        : "translateX(-10px) !important",
-    opacity:
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches || open
-        ? 1
-        : "0 !important",
-    transition: window.matchMedia("(prefers-reduced-motion: reduce)").matches
-      ? "none"
-      : "all .2s ease",
-  },
-}));
-
 const Breadcrumb = ({
   label,
   onClick,
@@ -268,9 +177,11 @@ const Breadcrumb = ({
   folder?: GalleryFile,
 |}) => {
   const { setNodeRef: setDropRef, isOver } = useDroppable({
-    id: `/${[selectedSection, ...path.map(({ name }) => name), folder?.name ?? ""].join(
-      "/"
-    )}/`,
+    id: `/${[
+      selectedSection,
+      ...path.map(({ name }) => name),
+      folder?.name ?? "",
+    ].join("/")}/`,
     disabled: false,
     data: {
       path,
@@ -335,168 +246,6 @@ const CustomBreadcrumbs = ({
     </Breadcrumbs>
   );
 };
-
-const CustomTreeItem = observer(
-  ({
-    file,
-    index,
-    path,
-    section,
-    idMap,
-    refreshListing,
-  }: {|
-    file: GalleryFile,
-    index: number,
-    path: $ReadOnlyArray<GalleryFile>,
-    section: string,
-    idMap: Map<string, GalleryFile>,
-    refreshListing: () => void,
-  |}) => {
-    const { uploadFiles } = useGalleryActions();
-    const selection = useGallerySelection();
-    const { onDragEnter, onDragOver, onDragLeave, onDrop, over } =
-      useFileImportDropZone({
-        onDrop: doNotAwait(async (files) => {
-          await uploadFiles([...file.path, file], file.id, files);
-          refreshListing();
-        }),
-        disabled: !file.isFolder,
-      });
-    const { setNodeRef: setDropRef, isOver } = useDroppable({
-      id: file.id,
-      disabled: !file.isFolder,
-      data: {
-        path: file.path,
-        destination: { key: "folder", folder: file },
-      },
-    });
-    const {
-      attributes,
-      listeners,
-      setNodeRef: setDragRef,
-      transform,
-    } = useDraggable({
-      disabled: false,
-      id: file.id,
-      data: {
-        /*
-         * If this `file` is one of the selected files then all of the selected
-         * files are to be moved by the drag operation. If it is not included
-         * then just move this file.
-         */
-        filesBeingMoved: selection.includes(file)
-          ? selection.asSet()
-          : new RsSet([file]),
-      },
-    });
-    const dndContext = useDndContext();
-
-    const dragStyle: { [string]: string | number } = transform
-      ? {
-          transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(1.1)`,
-          zIndex: 1, // just needs to be rendered above Nodes later in the DOM
-          position: "relative",
-          boxShadow: `hsl(${COLOR.main.hue}deg 66% 10% / 20%) 0px 2px 16px 8px`,
-          maxWidth: "max-content",
-        }
-      : {};
-    const dropStyle: { [string]: string | number } = isOver
-      ? {
-          border: SELECTED_OR_FOCUS_BORDER,
-        }
-      : {
-          border: `2px solid hsl(${COLOR.background.hue}deg, ${COLOR.background.saturation}%, 99%)`,
-        };
-    const inGroupBeingDraggedStyle: { [string]: string | number } =
-      (
-        dndContext.active?.data.current?.filesBeingMoved ?? new RsSet()
-      ).hasWithEq(file, (a, b) => a.id === b.id) &&
-      dndContext.active?.id !== file.id
-        ? {
-            opacity: 0.2,
-          }
-        : {};
-    const fileUploadDropping: { [string]: string | number } = over
-      ? {
-          border: SELECTED_OR_FOCUS_BORDER,
-        }
-      : {};
-
-    return (
-      <Box
-        sx={{
-          transitionDelay: `${(index + 1) * 0.04}s !important`,
-        }}
-      >
-        <TreeItem
-          itemId={idToString(file.id)}
-          label={
-            <Box
-              sx={{
-                display: "flex",
-                pointerEvents: "none",
-                userSelect: "none",
-              }}
-            >
-              <Avatar
-                src={file.thumbnailUrl}
-                imgProps={{
-                  role: "presentation",
-                }}
-                variant="rounded"
-                sx={{
-                  width: "24px",
-                  height: "24px",
-                  aspectRatio: "1 / 1",
-                  fontSize: "5em",
-                  margin: "2px 12px 2px 8px",
-                  background: "white",
-                }}
-              >
-                <FileIcon fontSize="inherit" />
-              </Avatar>
-              {file.name}
-            </Box>
-          }
-          slots={{ groupTransition: CustomTransition }}
-          /*
-           * These are for dragging files from outside the browser
-           */
-          onDrop={onDrop}
-          onDragOver={onDragOver}
-          onDragEnter={onDragEnter}
-          onDragLeave={onDragLeave}
-          /*
-           * These are for dragging files between folders within the gallery
-           */
-          ref={(node) => {
-            setDropRef(node);
-            setDragRef(node);
-          }}
-          {...listeners}
-          {...attributes}
-          style={{
-            ...dragStyle,
-            ...dropStyle,
-            ...inGroupBeingDraggedStyle,
-            ...fileUploadDropping,
-            borderRadius: "4px",
-          }}
-        >
-          {file.isFolder && (
-            <TreeItemContent
-              file={file}
-              path={path}
-              section={section}
-              idMap={idMap}
-              refreshListing={refreshListing}
-            />
-          )}
-        </TreeItem>
-      </Box>
-    );
-  }
-);
 
 const GridView = observer(
   ({
@@ -1050,169 +799,6 @@ const FileCard = styled(
   boxShadow: selected
     ? "none"
     : `hsl(${COLOR.main.hue} 66% 20% / 20%) 0px 2px 8px 0px`,
-}));
-
-const TreeView = observer(
-  ({
-    listing,
-    path,
-    selectedSection,
-    refreshListing,
-  }: {|
-    listing:
-      | {| tag: "empty", reason: string |}
-      | {| tag: "list", list: $ReadOnlyArray<GalleryFile> |},
-    path: $ReadOnlyArray<GalleryFile>,
-    selectedSection: string,
-    refreshListing: () => void,
-  |}) => {
-    const { addAlert } = React.useContext(AlertContext);
-    const selection = useGallerySelection();
-    const [expandedItems, setExpandedItems] = React.useState<
-      $ReadOnlyArray<GalleryFile["id"]>
-    >([]);
-
-    /*
-     * Problem is, this map only contains the root level files/folders
-     */
-    const idMap = useLocalObservable(() => {
-      const map = new Map<string, GalleryFile>();
-      if (listing.tag === "empty") return map;
-      for (const file of listing.list) map.set(idToString(file.id), file);
-      return map;
-    });
-
-    if (listing.tag === "empty")
-      return (
-        <div key={listing.reason}>
-          <Fade
-            in={true}
-            timeout={
-              window.matchMedia("(prefers-reduced-motion: reduce)").matches
-                ? 0
-                : 300
-            }
-          >
-            <div>
-              <PlaceholderLabel>{listing.reason}</PlaceholderLabel>
-            </div>
-          </Fade>
-        </div>
-      );
-    return (
-      <SimpleTreeView
-        expandedItems={expandedItems}
-        onExpandedItemsChange={(_event, nodeIds) => {
-          setExpandedItems(nodeIds);
-        }}
-        selectedItems={selection
-          .asSet()
-          .map(({ id }) => idToString(id))
-          .toArray()}
-        onItemSelectionToggle={(
-          event,
-          itemId: string | $ReadOnlyArray<string>,
-          selected
-        ) => {
-          /*
-           * If there are multiple files selected and the user taps any file
-           * (already selected or not) then this function is called twice: first
-           * with `itemId` as an array of all of the selected nodes with
-           * `selected` set to false, followed by `itemId` as a string value and
-           * `selected` set to true. The idea being, that you can first clear the
-           * data structure being passed as `selectedItems` and then add back the
-           * singular selected item. However, because we wish to handle ctrl/meta
-           * keys, we ignore this first invocation and instead just consider
-           * whether the tapped file is already selected or not to toggle its
-           * state. As such, we can ignore the first invocation where `itemId` is
-           * an array.
-           */
-          if (Array.isArray(itemId)) return;
-          /*
-           * It's not possible for us to support shift-clicking in tree view
-           * because there's no data structure we can query to find a range of
-           * adjacent nodes. There's simply no way for us to get the itemIds of
-           * the nodes between two selected nodes; even more so if the user were
-           * to attempt to select nodes are different levels of the hierarchy.
-           * SimpleTreeView does have a multiSelect mode but attempting to use it
-           * just results in console errors.
-           */
-          if (event.shiftKey) {
-            if (selected) {
-              addAlert(
-                mkAlert({
-                  title: "Shift selection is not supported in tree view.",
-                  message:
-                    "Either use command/ctrl to select each in turn, or use grid view.",
-                  variant: "warning",
-                })
-              );
-            }
-            return;
-          }
-          if (event.ctrlKey || event.metaKey) {
-            MapUtils.get(idMap, itemId).do((file) => {
-              if (selection.includes(file)) {
-                selection.remove(file);
-              } else {
-                selection.append(file);
-              }
-            });
-          } else {
-            selection.clear();
-            if (selected) {
-              MapUtils.get(idMap, itemId).do((file) => {
-                selection.append(file);
-              });
-            }
-          }
-        }}
-      >
-        {listing.list.map((file, index) => (
-          <CustomTreeItem
-            index={index}
-            file={file}
-            path={path}
-            key={idToString(file.id)}
-            section={selectedSection}
-            idMap={idMap}
-            refreshListing={refreshListing}
-          />
-        ))}
-      </SimpleTreeView>
-    );
-  }
-);
-
-const PlaceholderLabel = styled(({ children, className }) => (
-  <Grid container className={className}>
-    <Grid
-      item
-      sx={{
-        p: 1,
-        pt: 2,
-        pr: 5,
-      }}
-    >
-      {children}
-    </Grid>
-  </Grid>
-))(() => ({
-  justifyContent: "stretch",
-  alignItems: "stretch",
-  height: "100%",
-  "& > *": {
-    fontSize: "2rem",
-    fontWeight: 700,
-    color: window.matchMedia("(prefers-contrast: more)").matches
-      ? "black"
-      : "hsl(190deg, 20%, 29%, 37%)",
-    flexGrow: 1,
-    textAlign: "center",
-
-    overflowWrap: "anywhere",
-    overflow: "hidden",
-  },
 }));
 
 type GalleryMainPanelArgs = {|

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -959,6 +959,7 @@ function GalleryMainPanel({
                   onClick={(e) => {
                     setViewMenuAnchorEl(e.target);
                   }}
+                  aria-haspopup="menu"
                 >
                   Views
                 </Button>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1105,7 +1105,10 @@ const TreeView = observer(
         onExpandedItemsChange={(_event, nodeIds) => {
           setExpandedItems(nodeIds);
         }}
-        selectedItems={selection.asTreeViewModel()}
+        selectedItems={selection
+          .asSet()
+          .map(({ id }) => idToString(id))
+          .toArray()}
         onItemSelectionToggle={(
           event,
           itemId: string | $ReadOnlyArray<string>,

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -21,6 +21,7 @@ import * as FetchingData from "../../../util/fetchingData";
 import { GallerySelection, useGallerySelection } from "../useGallerySelection";
 import { useGalleryActions, rootDestination } from "../useGalleryActions";
 import RsSet from "../../../util/set";
+import useViewportDimensions from "../../../util/useViewportDimensions";
 
 type MoveDialogArgs = {|
   open: boolean,
@@ -37,6 +38,7 @@ const MoveDialog = ({
   selectedFiles,
   refreshListing,
 }: MoveDialogArgs): Node => {
+  const viewport = useViewportDimensions();
   const { galleryListing } = useGalleryListing({
     section,
     searchTerm: "",
@@ -64,9 +66,10 @@ const MoveDialog = ({
         e.stopPropagation();
       }}
       scroll="paper"
+      fullScreen={viewport.isViewportVerySmall}
     >
       <DialogTitle>Move</DialogTitle>
-      <DialogContent sx={{ overflow: "hidden" }}>
+      <DialogContent sx={{ overflow: "hidden", flexGrow: 0 }}>
         <DialogContentText variant="body2">
           Choose a folder, enter a path, or tap the &quot;top-level&quot;
           button.

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -78,7 +78,17 @@ const MoveDialog = observer(
         </DialogContent>
         <DialogActions>
           <SubmitSpinnerButton
-            onClick={() => {}}
+            onClick={() => {
+              void moveFiles(selectedFiles)
+                .to({
+                  destination: { key: "root" },
+                  section,
+                })
+                .then(() => {
+                  refreshListing();
+                  onClose();
+                });
+            }}
             disabled={false}
             loading={false}
             label="Make top-level"

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -11,6 +11,10 @@ import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
 import SubmitSpinnerButton from "../../../components/SubmitSpinnerButton";
 import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import Grid from "@mui/material/Grid";
 import TreeView from "./TreeView";
 import { useGalleryListing, type GalleryFile } from "../useGalleryListing";
 import * as FetchingData from "../../../util/fetchingData";
@@ -82,57 +86,79 @@ const MoveDialog = observer(
           })}
         </DialogContent>
         <DialogActions>
-          <SubmitSpinnerButton
-            onClick={() => {
-              void moveFiles(selectedFiles)
-                .to({
-                  destination: rootDestination(),
-                  section,
-                })
-                .then(() => {
-                  refreshListing();
-                  onClose();
-                });
-            }}
-            disabled={false}
-            loading={false}
-            label="Make top-level"
-          />
-          <Box flexGrow={1}></Box>
-          <Button
-            onClick={() => {
-              onClose();
-            }}
-          >
-            Cancel
-          </Button>
-          <ValidatingSubmitButton
-            loading={false}
-            onClick={() => {
-              const folder = selection.asSet().only.orElseGet(() => {
-                throw new Error("More than one folder is selected");
-              });
-              void moveFiles(selectedFiles)
-                .to({
-                  destination: folderDestination(folder),
-                  section,
-                })
-                .then(() => {
-                  refreshListing();
-                  onClose();
-                });
-            }}
-            validationResult={(() => {
-              const files = selection.asSet();
-              if (files.isEmpty)
-                return Result.Error([new Error("No folder is selected.")]);
-              return files.only
-                .toResult(() => new Error("More than one folder is selected."))
-                .map(() => null);
-            })()}
-          >
-            Move
-          </ValidatingSubmitButton>
+          <Grid container spacing={1} direction="column">
+            <Grid item>
+              <TextField
+                fullWidth
+                size="small"
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">Path</InputAdornment>
+                  ),
+                }}
+                placeholder="Tap a folder or type a path here"
+              />
+            </Grid>
+            <Grid item>
+              <Stack direction="row" spacing={1}>
+                <SubmitSpinnerButton
+                  onClick={() => {
+                    void moveFiles(selectedFiles)
+                      .to({
+                        destination: rootDestination(),
+                        section,
+                      })
+                      .then(() => {
+                        refreshListing();
+                        onClose();
+                      });
+                  }}
+                  disabled={false}
+                  loading={false}
+                  label="Make top-level"
+                />
+                <Box flexGrow={1}></Box>
+                <Button
+                  onClick={() => {
+                    onClose();
+                  }}
+                >
+                  Cancel
+                </Button>
+                <ValidatingSubmitButton
+                  loading={false}
+                  onClick={() => {
+                    const folder = selection.asSet().only.orElseGet(() => {
+                      throw new Error("More than one folder is selected");
+                    });
+                    void moveFiles(selectedFiles)
+                      .to({
+                        destination: folderDestination(folder),
+                        section,
+                      })
+                      .then(() => {
+                        refreshListing();
+                        onClose();
+                      });
+                  }}
+                  validationResult={(() => {
+                    const files = selection.asSet();
+                    if (files.isEmpty)
+                      return Result.Error([
+                        new Error("No folder is selected."),
+                      ]);
+                    return files.only
+                      .toResult(
+                        () => new Error("More than one folder is selected.")
+                      )
+                      .map(() => null);
+                  })()}
+                >
+                  Move
+                </ValidatingSubmitButton>
+              </Stack>
+            </Grid>
+          </Grid>
         </DialogActions>
       </Dialog>
     );

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -19,12 +19,17 @@ import * as FetchingData from "../../../util/fetchingData";
 type MoveDialogArgs = {|
   open: boolean,
   onClose: () => void,
+  section: string,
 |};
 
-export default function MoveDialog({ open, onClose }: MoveDialogArgs): Node {
+export default function MoveDialog({
+  open,
+  onClose,
+  section,
+}: MoveDialogArgs): Node {
   const { galleryListing, path, clearPath, folderId, refreshListing } =
     useGalleryListing({
-      section: "images",
+      section,
       searchTerm: "",
       path: [],
     });

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -11,6 +11,10 @@ import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
 import SubmitSpinnerButton from "../../../components/SubmitSpinnerButton";
 import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import TreeView from "./TreeView";
+import { useGalleryListing, type GalleryFile } from "../useGalleryListing";
+import * as FetchingData from "../../../util/fetchingData";
 
 type MoveDialogArgs = {|
   open: boolean,
@@ -18,6 +22,13 @@ type MoveDialogArgs = {|
 |};
 
 export default function MoveDialog({ open, onClose }: MoveDialogArgs): Node {
+  const { galleryListing, path, clearPath, folderId, refreshListing } =
+    useGalleryListing({
+      section: "images",
+      searchTerm: "",
+      path: [],
+    });
+
   return (
     <Dialog
       open={open}
@@ -25,46 +36,56 @@ export default function MoveDialog({ open, onClose }: MoveDialogArgs): Node {
       onKeyDown={(e) => {
         e.stopPropagation();
       }}
+      scroll="paper"
     >
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          // do move
-        }}
-      >
-        <DialogTitle>Move</DialogTitle>
-        <DialogContent>
-          <DialogContentText variant="body2" sx={{ mb: 2 }}>
-            Choose a folder, enter a path, or tap the &quot;top-level&quot;
-            button.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <SubmitSpinnerButton
-            onClick={() => {}}
-            disabled={false}
-            loading={false}
-            label="Make top-level"
-          />
-          <Box flexGrow={1}></Box>
-          <Button
-            onClick={() => {
-              onClose();
-            }}
-          >
-            Cancel
-          </Button>
-          <ValidatingSubmitButton
-            loading={false}
-            onClick={() => {
-              // do move
-            }}
-            validationResult={Result.Ok(null)}
-          >
-            Move
-          </ValidatingSubmitButton>
-        </DialogActions>
-      </form>
+      <DialogTitle>Move</DialogTitle>
+      <DialogContent sx={{ overflow: "hidden" }}>
+        <DialogContentText variant="body2">
+          Choose a folder, enter a path, or tap the &quot;top-level&quot;
+          button.
+        </DialogContentText>
+      </DialogContent>
+      <DialogContent sx={{ pt: 0 }}>
+        {FetchingData.match(galleryListing, {
+          loading: () => <></>,
+          error: (error) => <>{error}</>,
+          success: (listing) => (
+            <Box sx={{ overflowY: "auto" }}>
+              <TreeView
+                listing={listing}
+                path={[]}
+                selectedSection="images"
+                refreshListing={refreshListing}
+              />
+            </Box>
+          ),
+        })}
+      </DialogContent>
+      <DialogActions>
+        <SubmitSpinnerButton
+          onClick={() => {}}
+          disabled={false}
+          loading={false}
+          label="Make top-level"
+        />
+        <Box flexGrow={1}></Box>
+        <Button
+          onClick={() => {
+            onClose();
+          }}
+        >
+          Cancel
+        </Button>
+        <ValidatingSubmitButton
+          loading={false}
+          onClick={() => {
+            // do move
+          }}
+          validationResult={Result.Ok(null)}
+        >
+          Move
+        </ValidatingSubmitButton>
+      </DialogActions>
     </Dialog>
   );
 }

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -122,7 +122,14 @@ const MoveDialog = observer(
                   onClose();
                 });
             }}
-            validationResult={Result.Ok(null)}
+            validationResult={(() => {
+              const files = selection.asSet();
+              if (files.isEmpty)
+                return Result.Error([new Error("No folder is selected.")]);
+              return files.only
+                .toResult(() => new Error("More than one folder is selected."))
+                .map(() => null);
+            })()}
           >
             Move
           </ValidatingSubmitButton>

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -5,6 +5,12 @@ import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
+import Result from "../../../util/result";
+import SubmitSpinnerButton from "../../../components/SubmitSpinnerButton";
+import Box from "@mui/material/Box";
 
 type MoveDialogArgs = {|
   open: boolean,
@@ -33,6 +39,31 @@ export default function MoveDialog({ open, onClose }: MoveDialogArgs): Node {
             button.
           </DialogContentText>
         </DialogContent>
+        <DialogActions>
+          <SubmitSpinnerButton
+            onClick={() => {}}
+            disabled={false}
+            loading={false}
+            label="Make top-level"
+          />
+          <Box flexGrow={1}></Box>
+          <Button
+            onClick={() => {
+              onClose();
+            }}
+          >
+            Cancel
+          </Button>
+          <ValidatingSubmitButton
+            loading={false}
+            onClick={() => {
+              // do move
+            }}
+            validationResult={Result.Ok(null)}
+          >
+            Move
+          </ValidatingSubmitButton>
+        </DialogActions>
       </form>
     </Dialog>
   );

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -151,15 +151,15 @@ const MoveDialog = observer(
                   }}
                   validationResult={(() => {
                     const files = selection.asSet();
-                    if (files.isEmpty)
+                    if (files.isEmpty && pathString === "")
                       return Result.Error([
                         new Error("No folder is selected."),
                       ]);
-                    return files.only
-                      .toResult(
-                        () => new Error("More than one folder is selected.")
-                      )
-                      .map(() => null);
+                    if (files.size > 1)
+                      return Result.Error([
+                        new Error("More than one folder is selected."),
+                      ]);
+                    return Result.Ok(null);
                   })()}
                 >
                   Move

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -1,6 +1,6 @@
 //@flow
 
-import React, { type Node, type ComponentType } from "react";
+import React, { type Node } from "react";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -11,87 +11,119 @@ import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
 import SubmitSpinnerButton from "../../../components/SubmitSpinnerButton";
 import Box from "@mui/material/Box";
-import Stack from "@mui/material/Stack";
 import TreeView from "./TreeView";
 import { useGalleryListing, type GalleryFile } from "../useGalleryListing";
 import * as FetchingData from "../../../util/fetchingData";
+import { GallerySelection, useGallerySelection } from "../useGallerySelection";
+import { observer } from "mobx-react-lite";
+import { useGalleryActions } from "../useGalleryActions";
+import RsSet from "../../../util/set";
 
 type MoveDialogArgs = {|
   open: boolean,
   onClose: () => void,
   section: string,
+  selectedFiles: RsSet<GalleryFile>,
+  refreshListing: () => void,
 |};
 
-export default function MoveDialog({
-  open,
-  onClose,
-  section,
-}: MoveDialogArgs): Node {
-  const { galleryListing, path, clearPath, folderId, refreshListing } =
-    useGalleryListing({
+const MoveDialog = observer(
+  ({
+    open,
+    onClose,
+    section,
+    selectedFiles,
+    refreshListing,
+  }: MoveDialogArgs): Node => {
+    const { galleryListing } = useGalleryListing({
       section,
       searchTerm: "",
       path: [],
     });
+    const { moveFiles } = useGalleryActions();
+    const selection = useGallerySelection();
 
+    return (
+      <Dialog
+        open={open}
+        onClose={onClose}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+        }}
+        scroll="paper"
+      >
+        <DialogTitle>Move</DialogTitle>
+        <DialogContent sx={{ overflow: "hidden" }}>
+          <DialogContentText variant="body2">
+            Choose a folder, enter a path, or tap the &quot;top-level&quot;
+            button.
+          </DialogContentText>
+        </DialogContent>
+        <DialogContent sx={{ pt: 0 }}>
+          {FetchingData.match(galleryListing, {
+            loading: () => <></>,
+            error: (error) => <>{error}</>,
+            success: (listing) => (
+              <Box sx={{ overflowY: "auto" }}>
+                <TreeView
+                  listing={listing}
+                  path={[]}
+                  selectedSection="images"
+                  refreshListing={refreshListing}
+                  filter={(file) => file.isFolder}
+                />
+              </Box>
+            ),
+          })}
+        </DialogContent>
+        <DialogActions>
+          <SubmitSpinnerButton
+            onClick={() => {}}
+            disabled={false}
+            loading={false}
+            label="Make top-level"
+          />
+          <Box flexGrow={1}></Box>
+          <Button
+            onClick={() => {
+              onClose();
+            }}
+          >
+            Cancel
+          </Button>
+          <ValidatingSubmitButton
+            loading={false}
+            onClick={() => {
+              const folder = selection.asSet().only.orElseGet(() => {
+                throw new Error("More than one folder is selected");
+              });
+              void moveFiles(selectedFiles)
+                .to({
+                  destination: { key: "folder", folder },
+                  section,
+                })
+                .then(() => {
+                  refreshListing();
+                  onClose();
+                });
+            }}
+            validationResult={Result.Ok(null)}
+          >
+            Move
+          </ValidatingSubmitButton>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+);
+
+export default (
+  props: $Diff<MoveDialogArgs, {| selectedFiles: mixed |}>
+): Node => {
+  const selection = useGallerySelection();
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      onKeyDown={(e) => {
-        e.stopPropagation();
-      }}
-      scroll="paper"
-    >
-      <DialogTitle>Move</DialogTitle>
-      <DialogContent sx={{ overflow: "hidden" }}>
-        <DialogContentText variant="body2">
-          Choose a folder, enter a path, or tap the &quot;top-level&quot;
-          button.
-        </DialogContentText>
-      </DialogContent>
-      <DialogContent sx={{ pt: 0 }}>
-        {FetchingData.match(galleryListing, {
-          loading: () => <></>,
-          error: (error) => <>{error}</>,
-          success: (listing) => (
-            <Box sx={{ overflowY: "auto" }}>
-              <TreeView
-                listing={listing}
-                path={[]}
-                selectedSection="images"
-                refreshListing={refreshListing}
-                filter={(file) => file.isFolder}
-              />
-            </Box>
-          ),
-        })}
-      </DialogContent>
-      <DialogActions>
-        <SubmitSpinnerButton
-          onClick={() => {}}
-          disabled={false}
-          loading={false}
-          label="Make top-level"
-        />
-        <Box flexGrow={1}></Box>
-        <Button
-          onClick={() => {
-            onClose();
-          }}
-        >
-          Cancel
-        </Button>
-        <ValidatingSubmitButton
-          loading={false}
-          onClick={() => {
-            // do move
-          }}
-          validationResult={Result.Ok(null)}
-        >
-          Move
-        </ValidatingSubmitButton>
-      </DialogActions>
-    </Dialog>
+    <GallerySelection>
+      <MoveDialog {...props} selectedFiles={selection.asSet()} />
+    </GallerySelection>
   );
-}
+};

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -20,6 +20,7 @@ import { useGalleryListing, type GalleryFile } from "../useGalleryListing";
 import * as FetchingData from "../../../util/fetchingData";
 import { GallerySelection, useGallerySelection } from "../useGallerySelection";
 import { observer } from "mobx-react-lite";
+import { autorun } from "mobx";
 import {
   useGalleryActions,
   rootDestination,
@@ -50,6 +51,19 @@ const MoveDialog = observer(
     });
     const { moveFiles } = useGalleryActions();
     const selection = useGallerySelection();
+    const [pathString, setPathString] = React.useState("");
+
+    React.useEffect(() => {
+      autorun(() => {
+        selection.asSet().only.do((file) => {
+          setPathString(file.pathAsString());
+        });
+      });
+    }, [selection]);
+
+    React.useEffect(() => {
+      if (!open) setPathString("");
+    }, [open]);
 
     return (
       <Dialog
@@ -76,7 +90,7 @@ const MoveDialog = observer(
                 <TreeView
                   listing={listing}
                   path={[]}
-                  selectedSection="images"
+                  selectedSection={section}
                   refreshListing={refreshListing}
                   filter={(file) => file.isFolder && !file.isSnippetFolder}
                   disableDragAndDrop
@@ -89,6 +103,7 @@ const MoveDialog = observer(
           <Grid container spacing={1} direction="column">
             <Grid item>
               <TextField
+                value={pathString}
                 fullWidth
                 size="small"
                 InputProps={{

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -75,6 +75,7 @@ const MoveDialog = observer(
                   selectedSection="images"
                   refreshListing={refreshListing}
                   filter={(file) => file.isFolder && !file.isSnippetFolder}
+                  disableDragAndDrop
                 />
               </Box>
             ),

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -21,11 +21,7 @@ import * as FetchingData from "../../../util/fetchingData";
 import { GallerySelection, useGallerySelection } from "../useGallerySelection";
 import { observer } from "mobx-react-lite";
 import { autorun } from "mobx";
-import {
-  useGalleryActions,
-  rootDestination,
-  folderDestination,
-} from "../useGalleryActions";
+import { useGalleryActions, rootDestination } from "../useGalleryActions";
 import RsSet from "../../../util/set";
 
 type MoveDialogArgs = {|
@@ -104,6 +100,9 @@ const MoveDialog = observer(
             <Grid item>
               <TextField
                 value={pathString}
+                onChange={({ target: { value } }) => {
+                  setPathString(value);
+                }}
                 fullWidth
                 size="small"
                 InputProps={{
@@ -143,14 +142,8 @@ const MoveDialog = observer(
                 <ValidatingSubmitButton
                   loading={false}
                   onClick={() => {
-                    const folder = selection.asSet().only.orElseGet(() => {
-                      throw new Error("More than one folder is selected");
-                    });
                     void moveFiles(selectedFiles)
-                      .to({
-                        destination: folderDestination(folder),
-                        section,
-                      })
+                      .toDestinationWithPath(section, pathString)
                       .then(() => {
                         refreshListing();
                         onClose();

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -1,0 +1,39 @@
+//@flow
+
+import React, { type Node, type ComponentType } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+
+type MoveDialogArgs = {|
+  open: boolean,
+  onClose: () => void,
+|};
+
+export default function MoveDialog({ open, onClose }: MoveDialogArgs): Node {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+      }}
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          // do move
+        }}
+      >
+        <DialogTitle>Move</DialogTitle>
+        <DialogContent>
+          <DialogContentText variant="body2" sx={{ mb: 2 }}>
+            Choose a folder, enter a path, or tap the &quot;top-level&quot;
+            button.
+          </DialogContentText>
+        </DialogContent>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -58,6 +58,9 @@ const MoveDialog = ({
     if (!open) setPathString("");
   }, [open]);
 
+  const [topLevelLoading, setTopLevelLoading] = React.useState(false);
+  const [submitLoading, setSubmitLoading] = React.useState(false);
+
   return (
     <Dialog
       open={open}
@@ -115,18 +118,20 @@ const MoveDialog = ({
             <Stack direction="row" spacing={1}>
               <SubmitSpinnerButton
                 onClick={() => {
+                  setTopLevelLoading(true);
                   void moveFiles(selectedFiles)
                     .to({
                       destination: rootDestination(),
                       section,
                     })
                     .then(() => {
+                      setTopLevelLoading(false);
                       refreshListing();
                       onClose();
                     });
                 }}
-                disabled={false}
-                loading={false}
+                disabled={topLevelLoading}
+                loading={topLevelLoading}
                 label="Make top-level"
               />
               <Box flexGrow={1}></Box>
@@ -138,11 +143,13 @@ const MoveDialog = ({
                 Cancel
               </Button>
               <ValidatingSubmitButton
-                loading={false}
+                loading={submitLoading}
                 onClick={() => {
+                  setSubmitLoading(true);
                   void moveFiles(selectedFiles)
                     .toDestinationWithPath(section, pathString)
                     .then(() => {
+                      setSubmitLoading(false);
                       refreshListing();
                       onClose();
                     });

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -74,7 +74,7 @@ const MoveDialog = observer(
                   path={[]}
                   selectedSection="images"
                   refreshListing={refreshListing}
-                  filter={(file) => file.isFolder}
+                  filter={(file) => file.isFolder && !file.isSnippetFolder}
                 />
               </Box>
             ),

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -56,6 +56,7 @@ export default function MoveDialog({ open, onClose }: MoveDialogArgs): Node {
                 path={[]}
                 selectedSection="images"
                 refreshListing={refreshListing}
+                filter={(file) => file.isFolder}
               />
             </Box>
           ),

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -16,7 +16,11 @@ import { useGalleryListing, type GalleryFile } from "../useGalleryListing";
 import * as FetchingData from "../../../util/fetchingData";
 import { GallerySelection, useGallerySelection } from "../useGallerySelection";
 import { observer } from "mobx-react-lite";
-import { useGalleryActions } from "../useGalleryActions";
+import {
+  useGalleryActions,
+  rootDestination,
+  folderDestination,
+} from "../useGalleryActions";
 import RsSet from "../../../util/set";
 
 type MoveDialogArgs = {|
@@ -81,7 +85,7 @@ const MoveDialog = observer(
             onClick={() => {
               void moveFiles(selectedFiles)
                 .to({
-                  destination: { key: "root" },
+                  destination: rootDestination(),
                   section,
                 })
                 .then(() => {
@@ -109,7 +113,7 @@ const MoveDialog = observer(
               });
               void moveFiles(selectedFiles)
                 .to({
-                  destination: { key: "folder", folder },
+                  destination: folderDestination(folder),
                   section,
                 })
                 .then(() => {

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveDialog.js
@@ -20,7 +20,6 @@ import { useGalleryListing, type GalleryFile } from "../useGalleryListing";
 import * as FetchingData from "../../../util/fetchingData";
 import { GallerySelection, useGallerySelection } from "../useGallerySelection";
 import { observer } from "mobx-react-lite";
-import { autorun } from "mobx";
 import { useGalleryActions, rootDestination } from "../useGalleryActions";
 import RsSet from "../../../util/set";
 
@@ -46,16 +45,14 @@ const MoveDialog = observer(
       path: [],
     });
     const { moveFiles } = useGalleryActions();
-    const selection = useGallerySelection();
     const [pathString, setPathString] = React.useState("");
-
-    React.useEffect(() => {
-      autorun(() => {
-        selection.asSet().only.do((file) => {
+    const selection = useGallerySelection({
+      onChange: (sel) => {
+        sel.asSet().only.do((file) => {
           setPathString(file.pathAsString());
         });
-      });
-    }, [selection]);
+      },
+    });
 
     React.useEffect(() => {
       if (!open) setPathString("");

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.js
@@ -221,7 +221,13 @@ function MoveCopyDialog({
   };
 
   return (
-    <CustomDialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+    <CustomDialog
+      open={dialogOpen}
+      onClose={() => setDialogOpen(false)}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+      }}
+    >
       <AppBar position="relative" open={true}>
         <Toolbar variant="dense">
           <Typography variant="h6" noWrap component="h2">

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.js
@@ -34,7 +34,7 @@ import Result from "../../../util/result";
 import AccessibilityTips from "../../../components/AccessibilityTips";
 import docLinks from "../../../assets/DocLinks";
 
-const COLOR = {
+export const COLOR = {
   main: {
     hue: 180,
     saturation: 30,

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.js
@@ -2,7 +2,7 @@
 
 import React, { type Node } from "react";
 import { ThemeProvider, styled } from "@mui/material/styles";
-import createAccentedTheme from "../../accentedTheme";
+import createAccentedTheme from "../../../accentedTheme";
 import Dialog from "@mui/material/Dialog";
 import Typography from "@mui/material/Typography";
 import Toolbar from "@mui/material/Toolbar";
@@ -13,26 +13,26 @@ import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
 import Box from "@mui/material/Box";
-import HelpLinkIcon from "../../components/HelpLinkIcon";
-import FormField from "../../components/Inputs/FormField";
+import HelpLinkIcon from "../../../components/HelpLinkIcon";
+import FormField from "../../../components/Inputs/FormField";
 import MenuItem from "@mui/material/MenuItem";
 import Menu from "@mui/material/Menu";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemButton from "@mui/material/ListItemButton";
 import List from "@mui/material/List";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import ChoiceField from "../../components/Inputs/ChoiceField";
+import ChoiceField from "../../../components/Inputs/ChoiceField";
 import TextField from "@mui/material/TextField";
 import { withStyles } from "Styles";
 import Stack from "@mui/material/Stack";
 import useIrods, { type IrodsLocation } from "./useIrods";
 import Alert from "@mui/lab/Alert";
 import AlertTitle from "@mui/lab/AlertTitle";
-import * as FetchingData from "../../util/fetchingData";
-import ValidatingSubmitButton from "../../components/ValidatingSubmitButton";
-import Result from "../../util/result";
-import AccessibilityTips from "../../components/AccessibilityTips";
-import docLinks from "../../assets/DocLinks";
+import * as FetchingData from "../../../util/fetchingData";
+import ValidatingSubmitButton from "../../../components/ValidatingSubmitButton";
+import Result from "../../../util/result";
+import AccessibilityTips from "../../../components/AccessibilityTips";
+import docLinks from "../../../assets/DocLinks";
 
 const COLOR = {
   main: {

--- a/src/main/webapp/ui/src/eln/gallery/components/NewMenuItem.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/NewMenuItem.js
@@ -24,6 +24,7 @@ type NewMenuItemArgs = {|
   onKeyDown?: (KeyboardEvent) => void,
   compact?: boolean,
   disabled?: boolean,
+  "aria-haspopup"?: "menu" | "dialog",
 
   /*
    * These properties are dynamically added by the MUI Menu parent component
@@ -47,6 +48,7 @@ export default (styled(
         disabled,
         autoFocus,
         tabIndex,
+        "aria-haspopup": ariaHasPopup,
         ...props
       }: NewMenuItemArgs,
       ref
@@ -60,6 +62,7 @@ export default (styled(
         //eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={autoFocus}
         tabIndex={tabIndex}
+        aria-haspopup={ariaHasPopup}
       >
         <CardHeader {...props} />
       </MenuItem>

--- a/src/main/webapp/ui/src/eln/gallery/components/NewMenuItem.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/NewMenuItem.js
@@ -44,10 +44,10 @@ export default (styled(
     padding: 0,
     borderRadius: "2px",
     border: prefersMoreContrast ? "2px solid #000" : "none",
-    backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.12),
+    backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.24),
     transition: "background-color ease-in-out .2s",
     "&:hover": {
-      backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.24),
+      backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.36),
     },
     "& .MuiCardHeader-root": {
       padding: theme.spacing(compact ? 1 : 2),

--- a/src/main/webapp/ui/src/eln/gallery/components/NewMenuItem.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/NewMenuItem.js
@@ -31,8 +31,14 @@ export default (styled(
   const prefersMoreContrast = window.matchMedia(
     "(prefers-contrast: more)"
   ).matches;
-  const fg = `hsl(${foregroundColor.hue}deg, ${foregroundColor.saturation}%, ${foregroundColor.lightness}%, 100%)`;
-  const bg = `hsl(${backgroundColor.hue}deg, ${backgroundColor.saturation}%, ${backgroundColor.lightness}%, 100%)`;
+  const fg =
+    typeof foregroundColor === "string"
+      ? foregroundColor
+      : `hsl(${foregroundColor.hue}deg, ${foregroundColor.saturation}%, ${foregroundColor.lightness}%, 100%)`;
+  const bg =
+    typeof backgroundColor === "string"
+      ? backgroundColor
+      : `hsl(${backgroundColor.hue}deg, ${backgroundColor.saturation}%, ${backgroundColor.lightness}%, 100%)`;
   return {
     margin: theme.spacing(compact ? 0.5 : 1),
     padding: 0,
@@ -73,8 +79,12 @@ export default (styled(
   title: string,
   avatar: Node,
   subheader: string,
-  foregroundColor: {| hue: number, saturation: number, lightness: number |},
-  backgroundColor: {| hue: number, saturation: number, lightness: number |},
+  foregroundColor:
+    | string
+    | {| hue: number, saturation: number, lightness: number |},
+  backgroundColor:
+    | string
+    | {| hue: number, saturation: number, lightness: number |},
   onClick?: () => void,
   onKeyDown?: (KeyboardEvent) => void,
   compact?: boolean,

--- a/src/main/webapp/ui/src/eln/gallery/components/NewMenuItem.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/NewMenuItem.js
@@ -1,31 +1,69 @@
 //@flow
 
-import React, { type Node, type ComponentType } from "react";
+import React, {
+  type Node,
+  type ComponentType,
+  type ElementConfig,
+} from "react";
 import { styled } from "@mui/material/styles";
 import MenuItem from "@mui/material/MenuItem";
 import CardHeader from "@mui/material/CardHeader";
 import { alpha } from "@mui/system";
 
+type NewMenuItemArgs = {|
+  title: string,
+  avatar: Node,
+  subheader: string,
+  foregroundColor:
+    | string
+    | {| hue: number, saturation: number, lightness: number |},
+  backgroundColor:
+    | string
+    | {| hue: number, saturation: number, lightness: number |},
+  onClick?: () => void,
+  onKeyDown?: (KeyboardEvent) => void,
+  compact?: boolean,
+  disabled?: boolean,
+
+  /*
+   * These properties are dynamically added by the MUI Menu parent component
+   */
+  autoFocus?: boolean,
+  tabIndex?: number,
+
+  ...ElementConfig<typeof CardHeader>,
+|};
+
 export default (styled(
-  ({
-    foregroundColor: _foregroundColor,
-    backgroundColor: _backgroundColor,
-    compact: _compact,
-    className,
-    onClick,
-    onKeyDown,
-    disabled,
-    ...props
-  }) => (
-    <MenuItem
-      className={className}
-      tabIndex={0}
-      onKeyDown={onKeyDown}
-      onClick={onClick}
-      disabled={disabled}
-    >
-      <CardHeader {...props} />
-    </MenuItem>
+  React.forwardRef(
+    (
+      {
+        foregroundColor: _foregroundColor,
+        backgroundColor: _backgroundColor,
+        compact: _compact,
+        className,
+        onClick,
+        onKeyDown,
+        disabled,
+        autoFocus,
+        tabIndex,
+        ...props
+      }: NewMenuItemArgs,
+      ref
+    ) => (
+      <MenuItem
+        ref={ref}
+        className={className}
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        disabled={disabled}
+        //eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
+        tabIndex={tabIndex}
+      >
+        <CardHeader {...props} />
+      </MenuItem>
+    )
   )
 )(({ theme, backgroundColor, foregroundColor, compact }) => {
   const prefersMoreContrast = window.matchMedia(
@@ -75,18 +113,4 @@ export default (styled(
       fontWeight: 500,
     },
   };
-}): ComponentType<{|
-  title: string,
-  avatar: Node,
-  subheader: string,
-  foregroundColor:
-    | string
-    | {| hue: number, saturation: number, lightness: number |},
-  backgroundColor:
-    | string
-    | {| hue: number, saturation: number, lightness: number |},
-  onClick?: () => void,
-  onKeyDown?: (KeyboardEvent) => void,
-  compact?: boolean,
-  disabled?: boolean,
-|}>);
+}): ComponentType<NewMenuItemArgs>);

--- a/src/main/webapp/ui/src/eln/gallery/components/PlaceholderLabel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/PlaceholderLabel.js
@@ -1,0 +1,36 @@
+//@flow
+
+import React, { type Node, type ComponentType } from "react";
+import Grid from "@mui/material/Grid";
+import { styled } from "@mui/material/styles";
+
+export default (styled(({ children, className }) => (
+  <Grid container className={className}>
+    <Grid
+      item
+      sx={{
+        p: 1,
+        pt: 2,
+        pr: 5,
+      }}
+    >
+      {children}
+    </Grid>
+  </Grid>
+))(() => ({
+  justifyContent: "stretch",
+  alignItems: "stretch",
+  height: "100%",
+  "& > *": {
+    fontSize: "2rem",
+    fontWeight: 700,
+    color: window.matchMedia("(prefers-contrast: more)").matches
+      ? "black"
+      : "hsl(190deg, 20%, 29%, 37%)",
+    flexGrow: 1,
+    textAlign: "center",
+
+    overflowWrap: "anywhere",
+    overflow: "hidden",
+  },
+})): ComponentType<{| children: Node |}>);

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -49,6 +49,7 @@ import { fetchIntegrationInfo } from "../../../common/integrationHelpers";
 import useVerticalRovingTabIndex from "../../../components/useVerticalRovingTabIndex";
 import useViewportDimensions from "../../../util/useViewportDimensions";
 import { observer } from "mobx-react-lite";
+import { autorun } from "mobx";
 library.add(faImage);
 library.add(faFilm);
 library.add(faFile);
@@ -424,6 +425,12 @@ const Sidebar = ({
     React.useState(8);
   const [newMenuAnchorEl, setNewMenuAnchorEl] = React.useState(null);
   const viewport = useViewportDimensions();
+
+  React.useEffect(() => {
+    autorun(() => {
+      setDrawerOpen(!viewport.isViewportSmall);
+    });
+  }, [viewport]);
 
   const { getTabIndex, getRef, eventHandlers } = useVerticalRovingTabIndex<
     typeof ListItemButton

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -258,7 +258,7 @@ const DmpMenuSection = () => {
   if (!argosEnabled && !dmponlineEnabled && !dmptoolEnabled) return null;
   return (
     <>
-      <Divider variant="middle" textAlign="left">
+      <Divider textAlign="left">
         DMPs
       </Divider>
       {argosEnabled && <ArgosNewMenuItem />}

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -72,6 +72,7 @@ const AddButton = styled(({ drawerOpen, ...props }) => (
     {...props}
     fullWidth
     style={{ minWidth: "unset" }}
+    aria-haspopup="menu"
     startIcon={
       <AddIcon
         style={{
@@ -116,10 +117,18 @@ const UploadMenuItem = ({
   path,
   folderId,
   onUploadComplete,
+  autoFocus,
+  tabIndex,
 }: {|
   path: $ReadOnlyArray<GalleryFile>,
   folderId: Id,
   onUploadComplete: () => void,
+
+  /*
+   * These properties are dynamically added by the MUI Menu parent component
+   */
+  autoFocus?: boolean,
+  tabIndex?: number,
 |}) => {
   const { uploadFiles } = useGalleryActions();
   const inputRef = React.useRef<HTMLInputElement | null>(null);
@@ -137,6 +146,9 @@ const UploadMenuItem = ({
         onClick={() => {
           inputRef.current?.click();
         }}
+        //eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
+        tabIndex={tabIndex}
       />
       <input
         ref={inputRef}
@@ -158,10 +170,18 @@ const NewFolderMenuItem = ({
   path,
   folderId,
   onDialogClose,
+  autoFocus,
+  tabIndex,
 }: {|
   path: $ReadOnlyArray<GalleryFile>,
   folderId: Id,
   onDialogClose: (boolean) => void,
+
+  /*
+   * These properties are dynamically added by the MUI Menu parent component
+   */
+  autoFocus?: boolean,
+  tabIndex?: number,
 |}) => {
   const [open, setOpen] = React.useState(false);
   const [name, setName] = React.useState("");
@@ -221,6 +241,9 @@ const NewFolderMenuItem = ({
         onClick={() => {
           setOpen(true);
         }}
+        //eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
+        tabIndex={tabIndex}
       />
     </>
   );
@@ -258,7 +281,9 @@ const DmpMenuSection = () => {
   if (!argosEnabled && !dmponlineEnabled && !dmptoolEnabled) return null;
   return (
     <>
-      <Divider textAlign="left">DMPs</Divider>
+      <Divider textAlign="left" aria-label="DMPs">
+        DMPs
+      </Divider>
       {argosEnabled && <ArgosNewMenuItem />}
       {dmponlineEnabled && <DMPOnlineNewMenuItem />}
       {dmptoolEnabled && <DMPToolNewMenuItem />}
@@ -390,6 +415,7 @@ export default function GallerySidebar({
           MenuListProps={{
             disablePadding: true,
           }}
+          keepMounted
         >
           {FetchingData.getSuccessValue(folderId)
             .map((fId) => (

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -111,15 +111,9 @@ const CustomDrawer = styled(Drawer)(({ open, theme }) => ({
   [theme.breakpoints.down("sm")]: {
     width: open ? "200px" : "200px",
   },
-  transition: window.matchMedia("(prefers-reduced-motion: reduce)").matches
-    ? "none !important"
-    : "width .25s cubic-bezier(0.4, 0, 0.2, 1)",
   "& .MuiPaper-root": {
     position: "relative",
     overflowX: "hidden",
-    transition: window.matchMedia("(prefers-reduced-motion: reduce)").matches
-      ? "none !important"
-      : "width .25s cubic-bezier(0.4, 0, 0.2, 1)",
   },
 }));
 

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -98,7 +98,7 @@ const AddButton = styled(({ drawerOpen, ...props }) => (
     </div>
   </Button>
 ))(() => ({
-  color: `hsl(${COLOR.contrastText.hue}deg, ${COLOR.contrastText.saturation}%, ${COLOR.contrastText.lightness}%, 100%)`,
+  color: `hsl(${COLOR.contrastText.hue}deg, ${COLOR.contrastText.saturation}%, 40%, 100%)`,
 }));
 
 const CustomDrawer = styled(Drawer)(({ open }) => ({
@@ -258,9 +258,7 @@ const DmpMenuSection = () => {
   if (!argosEnabled && !dmponlineEnabled && !dmptoolEnabled) return null;
   return (
     <>
-      <Divider textAlign="left">
-        DMPs
-      </Divider>
+      <Divider textAlign="left">DMPs</Divider>
       {argosEnabled && <ArgosNewMenuItem />}
       {dmponlineEnabled && <DMPOnlineNewMenuItem />}
       {dmptoolEnabled && <DMPToolNewMenuItem />}

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -244,6 +244,7 @@ const NewFolderMenuItem = ({
         //eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={autoFocus}
         tabIndex={tabIndex}
+        aria-haspopup="dialog"
       />
     </>
   );

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -101,6 +101,7 @@ const AddButton = styled(({ drawerOpen, ...props }) => (
     </div>
   </Button>
 ))(() => ({
+  overflowX: "hidden",
   color: `hsl(${COLOR.contrastText.hue}deg, ${COLOR.contrastText.saturation}%, 40%, 100%)`,
 }));
 
@@ -112,8 +113,12 @@ const CustomDrawer = styled(Drawer)(({ open, theme }) => ({
     width: open ? "200px" : "200px",
   },
   "& .MuiPaper-root": {
+    /*
+     * We set this position so that the drawer does not float above the AppBar
+     * and so that the active tab indicator can slide up and down relative to
+     * this bounding box.
+     */
     position: "relative",
-    overflowX: "hidden",
   },
 }));
 

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -126,12 +126,14 @@ const UploadMenuItem = ({
   path,
   folderId,
   onUploadComplete,
+  onCancel,
   autoFocus,
   tabIndex,
 }: {|
   path: $ReadOnlyArray<GalleryFile>,
   folderId: Id,
   onUploadComplete: () => void,
+  onCancel: () => void,
 
   /*
    * These properties are dynamically added by the MUI Menu parent component
@@ -141,6 +143,18 @@ const UploadMenuItem = ({
 |}) => {
   const { uploadFiles } = useGalleryActions();
   const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  /*
+   * This is necessary because React does not yet support the new cancel event
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/cancel_event
+   * https://github.com/facebook/react/issues/27858
+   */
+  React.useEffect(() => {
+    const input = inputRef.current;
+    input?.addEventListener("cancel", onCancel);
+    return () => input?.removeEventListener("cancel", onCancel);
+  }, [inputRef, onCancel]);
+
   return (
     <>
       <NewMenuItem
@@ -259,7 +273,11 @@ const NewFolderMenuItem = ({
   );
 };
 
-const DmpMenuSection = () => {
+type DmpMenuSectionArgs = {|
+  onDialogClose: () => void,
+|};
+
+const DmpMenuSection = ({ onDialogClose }: DmpMenuSectionArgs) => {
   const [argosEnabled, setArgosEnabled] = React.useState(false);
   const [dmponlineEnabled, setDmponlineEnabled] = React.useState(false);
   const [dmptoolEnabled, setDmptoolEnabled] = React.useState(false);
@@ -294,9 +312,11 @@ const DmpMenuSection = () => {
       <Divider textAlign="left" aria-label="DMPs">
         DMPs
       </Divider>
-      {argosEnabled && <ArgosNewMenuItem />}
-      {dmponlineEnabled && <DMPOnlineNewMenuItem />}
-      {dmptoolEnabled && <DMPToolNewMenuItem />}
+      {argosEnabled && <ArgosNewMenuItem onDialogClose={onDialogClose} />}
+      {dmponlineEnabled && (
+        <DMPOnlineNewMenuItem onDialogClose={onDialogClose} />
+      )}
+      {dmptoolEnabled && <DMPToolNewMenuItem onDialogClose={onDialogClose} />}
     </>
   );
 };
@@ -417,7 +437,7 @@ const Sidebar = ({
       anchor="left"
       variant={viewport.isViewportSmall ? "temporary" : "permanent"}
       onClose={() => {
-        setDrawerOpen(false);
+        setDrawerOpen(!viewport.isViewportSmall);
       }}
       aria-label="gallery sections drawer"
     >
@@ -429,7 +449,10 @@ const Sidebar = ({
         <StyledMenu
           open={Boolean(newMenuAnchorEl)}
           anchorEl={newMenuAnchorEl}
-          onClose={() => setNewMenuAnchorEl(null)}
+          onClose={() => {
+            setDrawerOpen(!viewport.isViewportSmall);
+            setNewMenuAnchorEl(null);
+          }}
           MenuListProps={{
             disablePadding: true,
           }}
@@ -444,6 +467,11 @@ const Sidebar = ({
                 onUploadComplete={() => {
                   refreshListing();
                   setNewMenuAnchorEl(null);
+                  setDrawerOpen(!viewport.isViewportSmall);
+                }}
+                onCancel={() => {
+                  setNewMenuAnchorEl(null);
+                  setDrawerOpen(!viewport.isViewportSmall);
                 }}
               />
             ))
@@ -457,11 +485,17 @@ const Sidebar = ({
                 onDialogClose={(success) => {
                   if (success) refreshListing();
                   setNewMenuAnchorEl(null);
+                  setDrawerOpen(!viewport.isViewportSmall);
                 }}
               />
             ))
             .orElse(null)}
-          <DmpMenuSection />
+          <DmpMenuSection
+            onDialogClose={() => {
+              setNewMenuAnchorEl(null);
+              setDrawerOpen(!viewport.isViewportSmall);
+            }}
+          />
         </StyledMenu>
       </Box>
       <Divider />
@@ -487,6 +521,7 @@ const Sidebar = ({
             selected={selectedSection === "Images"}
             onClick={(event) => {
               setSelectedSection("Images");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />
@@ -500,6 +535,7 @@ const Sidebar = ({
             selected={selectedSection === "Audios"}
             onClick={(event) => {
               setSelectedSection("Audios");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />
@@ -513,6 +549,7 @@ const Sidebar = ({
             selected={selectedSection === "Videos"}
             onClick={(event) => {
               setSelectedSection("Videos");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />
@@ -526,6 +563,7 @@ const Sidebar = ({
             selected={selectedSection === "Documents"}
             onClick={(event) => {
               setSelectedSection("Documents");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />
@@ -539,6 +577,7 @@ const Sidebar = ({
             selected={selectedSection === "Chemistry"}
             onClick={(event) => {
               setSelectedSection("Chemistry");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />
@@ -552,6 +591,7 @@ const Sidebar = ({
             selected={selectedSection === "DMPs"}
             onClick={(event) => {
               setSelectedSection("DMPs");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />
@@ -565,6 +605,7 @@ const Sidebar = ({
             selected={selectedSection === "Snippets"}
             onClick={(event) => {
               setSelectedSection("Snippets");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />
@@ -578,6 +619,7 @@ const Sidebar = ({
             selected={selectedSection === "Miscellaneous"}
             onClick={(event) => {
               setSelectedSection("Miscellaneous");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />
@@ -594,6 +636,7 @@ const Sidebar = ({
             selected={selectedSection === "PdfDocuments"}
             onClick={(event) => {
               setSelectedSection("PdfDocuments");
+              setDrawerOpen(!viewport.isViewportSmall);
               setSelectedIndicatorOffset(event.currentTarget.offsetTop);
             }}
           />

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -1,0 +1,408 @@
+//@flow
+
+import React, { type Node, type ComponentType } from "react";
+import Fade from "@mui/material/Fade";
+import { COLOR, SELECTED_OR_FOCUS_BORDER } from "../common";
+import { styled } from "@mui/material/styles";
+import Avatar from "@mui/material/Avatar";
+import FileIcon from "@mui/icons-material/InsertDriveFile";
+import * as FetchingData from "../../../util/fetchingData";
+import * as MapUtils from "../../../util/MapUtils";
+import {
+  useGalleryListing,
+  type GalleryFile,
+  idToString,
+} from "../useGalleryListing";
+import { useGalleryActions } from "../useGalleryActions";
+import { useGallerySelection } from "../useGallerySelection";
+import { doNotAwait } from "../../../util/Util";
+import { SimpleTreeView } from "@mui/x-tree-view/SimpleTreeView";
+import { TreeItem } from "@mui/x-tree-view/TreeItem";
+import { useDroppable, useDraggable, useDndContext } from "@dnd-kit/core";
+import Box from "@mui/material/Box";
+import Collapse from "@mui/material/Collapse";
+import { runInAction } from "mobx";
+import { useLocalObservable, observer } from "mobx-react-lite";
+import { useFileImportDropZone } from "../../../components/useFileImportDragAndDrop";
+import AlertContext, { mkAlert } from "../../../stores/contexts/Alert";
+import RsSet from "../../../util/set";
+import PlaceholderLabel from "./PlaceholderLabel";
+
+const CustomTransition = styled(({ children, in: open, className }) => (
+  <div className={className}>
+    <Collapse
+      in={open}
+      timeout={
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : 200
+      }
+    >
+      {children}
+    </Collapse>
+  </div>
+))(({ in: open }) => ({
+  "& .MuiCollapse-wrapperInner > .MuiBox-root": {
+    transform:
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches || open
+        ? "none"
+        : "translateX(-10px) !important",
+    opacity:
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches || open
+        ? 1
+        : "0 !important",
+    transition: window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      ? "none"
+      : "all .2s ease",
+  },
+}));
+
+type TreeItemContentArgs = {|
+  file: GalleryFile,
+  path: $ReadOnlyArray<GalleryFile>,
+  section: string,
+  idMap: Map<string, GalleryFile>,
+  refreshListing: () => void,
+|};
+
+const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
+  ({
+    path,
+    file,
+    section,
+    idMap,
+    refreshListing,
+  }: TreeItemContentArgs): Node => {
+    const { galleryListing } = useGalleryListing({
+      section,
+      searchTerm: "",
+      path: [...path, file],
+    });
+
+    React.useEffect(() => {
+      FetchingData.getSuccessValue(galleryListing).do((listing) => {
+        if (listing.tag === "empty") return;
+        runInAction(() => {
+          for (const f of listing.list) idMap.set(idToString(f.id), f);
+        });
+      });
+    }, [galleryListing]);
+
+    return FetchingData.match(galleryListing, {
+      /*
+       * nothing is shown whilst loading otherwise the UI ends up being quite
+       * janky when there ends up being nothing in the folder
+       */
+      loading: () => null,
+      error: (error) => <>{error}</>,
+      success: (listing) =>
+        listing.tag === "list"
+          ? listing.list.map((f, i) => (
+              <CustomTreeItem
+                file={f}
+                index={i}
+                path={[...path, file]}
+                section={section}
+                key={idToString(f.id)}
+                idMap={idMap}
+                refreshListing={refreshListing}
+              />
+            ))
+          : null,
+    });
+  }
+);
+
+const CustomTreeItem = observer(
+  ({
+    file,
+    index,
+    path,
+    section,
+    idMap,
+    refreshListing,
+  }: {|
+    file: GalleryFile,
+    index: number,
+    path: $ReadOnlyArray<GalleryFile>,
+    section: string,
+    idMap: Map<string, GalleryFile>,
+    refreshListing: () => void,
+  |}) => {
+    const { uploadFiles } = useGalleryActions();
+    const selection = useGallerySelection();
+    const { onDragEnter, onDragOver, onDragLeave, onDrop, over } =
+      useFileImportDropZone({
+        onDrop: doNotAwait(async (files) => {
+          await uploadFiles([...file.path, file], file.id, files);
+          refreshListing();
+        }),
+        disabled: !file.isFolder,
+      });
+    const { setNodeRef: setDropRef, isOver } = useDroppable({
+      id: file.id,
+      disabled: !file.isFolder,
+      data: {
+        path: file.path,
+        destination: { key: "folder", folder: file },
+      },
+    });
+    const {
+      attributes,
+      listeners,
+      setNodeRef: setDragRef,
+      transform,
+    } = useDraggable({
+      disabled: false,
+      id: file.id,
+      data: {
+        /*
+         * If this `file` is one of the selected files then all of the selected
+         * files are to be moved by the drag operation. If it is not included
+         * then just move this file.
+         */
+        filesBeingMoved: selection.includes(file)
+          ? selection.asSet()
+          : new RsSet([file]),
+      },
+    });
+    const dndContext = useDndContext();
+
+    const dragStyle: { [string]: string | number } = transform
+      ? {
+          transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(1.1)`,
+          zIndex: 1, // just needs to be rendered above Nodes later in the DOM
+          position: "relative",
+          boxShadow: `hsl(${COLOR.main.hue}deg 66% 10% / 20%) 0px 2px 16px 8px`,
+          maxWidth: "max-content",
+        }
+      : {};
+    const dropStyle: { [string]: string | number } = isOver
+      ? {
+          border: SELECTED_OR_FOCUS_BORDER,
+        }
+      : {
+          border: `2px solid hsl(${COLOR.background.hue}deg, ${COLOR.background.saturation}%, 99%)`,
+        };
+    const inGroupBeingDraggedStyle: { [string]: string | number } =
+      (
+        dndContext.active?.data.current?.filesBeingMoved ?? new RsSet()
+      ).hasWithEq(file, (a, b) => a.id === b.id) &&
+      dndContext.active?.id !== file.id
+        ? {
+            opacity: 0.2,
+          }
+        : {};
+    const fileUploadDropping: { [string]: string | number } = over
+      ? {
+          border: SELECTED_OR_FOCUS_BORDER,
+        }
+      : {};
+
+    return (
+      <Box
+        sx={{
+          transitionDelay: `${(index + 1) * 0.04}s !important`,
+        }}
+      >
+        <TreeItem
+          itemId={idToString(file.id)}
+          label={
+            <Box
+              sx={{
+                display: "flex",
+                pointerEvents: "none",
+                userSelect: "none",
+              }}
+            >
+              <Avatar
+                src={file.thumbnailUrl}
+                imgProps={{
+                  role: "presentation",
+                }}
+                variant="rounded"
+                sx={{
+                  width: "24px",
+                  height: "24px",
+                  aspectRatio: "1 / 1",
+                  fontSize: "5em",
+                  margin: "2px 12px 2px 8px",
+                  background: "white",
+                }}
+              >
+                <FileIcon fontSize="inherit" />
+              </Avatar>
+              {file.name}
+            </Box>
+          }
+          slots={{ groupTransition: CustomTransition }}
+          /*
+           * These are for dragging files from outside the browser
+           */
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+          onDragEnter={onDragEnter}
+          onDragLeave={onDragLeave}
+          /*
+           * These are for dragging files between folders within the gallery
+           */
+          ref={(node) => {
+            setDropRef(node);
+            setDragRef(node);
+          }}
+          {...listeners}
+          {...attributes}
+          style={{
+            ...dragStyle,
+            ...dropStyle,
+            ...inGroupBeingDraggedStyle,
+            ...fileUploadDropping,
+            borderRadius: "4px",
+          }}
+        >
+          {file.isFolder && (
+            <TreeItemContent
+              file={file}
+              path={path}
+              section={section}
+              idMap={idMap}
+              refreshListing={refreshListing}
+            />
+          )}
+        </TreeItem>
+      </Box>
+    );
+  }
+);
+
+type TreeViewArgs = {|
+  listing:
+    | {| tag: "empty", reason: string |}
+    | {| tag: "list", list: $ReadOnlyArray<GalleryFile> |},
+  path: $ReadOnlyArray<GalleryFile>,
+  selectedSection: string,
+  refreshListing: () => void,
+|};
+
+const TreeView = ({
+  listing,
+  path,
+  selectedSection,
+  refreshListing,
+}: TreeViewArgs) => {
+  const { addAlert } = React.useContext(AlertContext);
+  const selection = useGallerySelection();
+  const [expandedItems, setExpandedItems] = React.useState<
+    $ReadOnlyArray<GalleryFile["id"]>
+  >([]);
+
+  /*
+   * Problem is, this map only contains the root level files/folders
+   */
+  const idMap = useLocalObservable(() => {
+    const map = new Map<string, GalleryFile>();
+    if (listing.tag === "empty") return map;
+    for (const file of listing.list) map.set(idToString(file.id), file);
+    return map;
+  });
+
+  if (listing.tag === "empty")
+    return (
+      <div key={listing.reason}>
+        <Fade
+          in={true}
+          timeout={
+            window.matchMedia("(prefers-reduced-motion: reduce)").matches
+              ? 0
+              : 300
+          }
+        >
+          <div>
+            <PlaceholderLabel>{listing.reason}</PlaceholderLabel>
+          </div>
+        </Fade>
+      </div>
+    );
+  return (
+    <SimpleTreeView
+      expandedItems={expandedItems}
+      onExpandedItemsChange={(_event, nodeIds) => {
+        setExpandedItems(nodeIds);
+      }}
+      selectedItems={selection
+        .asSet()
+        .map(({ id }) => idToString(id))
+        .toArray()}
+      onItemSelectionToggle={(
+        event,
+        itemId: string | $ReadOnlyArray<string>,
+        selected
+      ) => {
+        /*
+         * If there are multiple files selected and the user taps any file
+         * (already selected or not) then this function is called twice: first
+         * with `itemId` as an array of all of the selected nodes with
+         * `selected` set to false, followed by `itemId` as a string value and
+         * `selected` set to true. The idea being, that you can first clear the
+         * data structure being passed as `selectedItems` and then add back the
+         * singular selected item. However, because we wish to handle ctrl/meta
+         * keys, we ignore this first invocation and instead just consider
+         * whether the tapped file is already selected or not to toggle its
+         * state. As such, we can ignore the first invocation where `itemId` is
+         * an array.
+         */
+        if (Array.isArray(itemId)) return;
+        /*
+         * It's not possible for us to support shift-clicking in tree view
+         * because there's no data structure we can query to find a range of
+         * adjacent nodes. There's simply no way for us to get the itemIds of
+         * the nodes between two selected nodes; even more so if the user were
+         * to attempt to select nodes are different levels of the hierarchy.
+         * SimpleTreeView does have a multiSelect mode but attempting to use it
+         * just results in console errors.
+         */
+        if (event.shiftKey) {
+          if (selected) {
+            addAlert(
+              mkAlert({
+                title: "Shift selection is not supported in tree view.",
+                message:
+                  "Either use command/ctrl to select each in turn, or use grid view.",
+                variant: "warning",
+              })
+            );
+          }
+          return;
+        }
+        if (event.ctrlKey || event.metaKey) {
+          MapUtils.get(idMap, itemId).do((file) => {
+            if (selection.includes(file)) {
+              selection.remove(file);
+            } else {
+              selection.append(file);
+            }
+          });
+        } else {
+          selection.clear();
+          if (selected) {
+            MapUtils.get(idMap, itemId).do((file) => {
+              selection.append(file);
+            });
+          }
+        }
+      }}
+    >
+      {listing.list.map((file, index) => (
+        <CustomTreeItem
+          index={index}
+          file={file}
+          path={path}
+          key={idToString(file.id)}
+          section={selectedSection}
+          idMap={idMap}
+          refreshListing={refreshListing}
+        />
+      ))}
+    </SimpleTreeView>
+  );
+};
+
+export default (observer(TreeView): ComponentType<TreeViewArgs>);

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -13,7 +13,7 @@ import {
   type GalleryFile,
   idToString,
 } from "../useGalleryListing";
-import { useGalleryActions } from "../useGalleryActions";
+import { useGalleryActions, folderDestination } from "../useGalleryActions";
 import { useGallerySelection } from "../useGallerySelection";
 import { doNotAwait } from "../../../util/Util";
 import { SimpleTreeView } from "@mui/x-tree-view/SimpleTreeView";
@@ -149,7 +149,7 @@ const CustomTreeItem = observer(
       disabled: !file.isFolder,
       data: {
         path: file.path,
-        destination: { key: "folder", folder: file },
+        destination: folderDestination(file),
       },
     });
     const {

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -314,7 +314,7 @@ const TreeView = ({
     return map;
   });
 
-  if (listing.tag === "empty")
+  if (listing.tag === "empty" || listing.list.filter(filter).length === 0)
     return (
       <div key={listing.reason}>
         <Fade
@@ -326,7 +326,9 @@ const TreeView = ({
           }
         >
           <div>
-            <PlaceholderLabel>{listing.reason}</PlaceholderLabel>
+            <PlaceholderLabel>
+              {listing.reason ?? "There are no folders."}
+            </PlaceholderLabel>
           </div>
         </Fade>
       </div>

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -61,6 +61,7 @@ type TreeItemContentArgs = {|
   section: string,
   idMap: Map<string, GalleryFile>,
   refreshListing: () => void,
+  filter: (GalleryFile) => boolean,
 |};
 
 const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
@@ -70,6 +71,7 @@ const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
     section,
     idMap,
     refreshListing,
+    filter,
   }: TreeItemContentArgs): Node => {
     const { galleryListing } = useGalleryListing({
       section,
@@ -95,17 +97,20 @@ const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
       error: (error) => <>{error}</>,
       success: (listing) =>
         listing.tag === "list"
-          ? listing.list.map((f, i) => (
-              <CustomTreeItem
-                file={f}
-                index={i}
-                path={[...path, file]}
-                section={section}
-                key={idToString(f.id)}
-                idMap={idMap}
-                refreshListing={refreshListing}
-              />
-            ))
+          ? listing.list.map((f, i) =>
+              filter(f) ? (
+                <CustomTreeItem
+                  file={f}
+                  index={i}
+                  path={[...path, file]}
+                  section={section}
+                  key={idToString(f.id)}
+                  idMap={idMap}
+                  refreshListing={refreshListing}
+                  filter={filter}
+                />
+              ) : null
+            )
           : null,
     });
   }
@@ -119,6 +124,7 @@ const CustomTreeItem = observer(
     section,
     idMap,
     refreshListing,
+    filter,
   }: {|
     file: GalleryFile,
     index: number,
@@ -126,6 +132,7 @@ const CustomTreeItem = observer(
     section: string,
     idMap: Map<string, GalleryFile>,
     refreshListing: () => void,
+    filter: (GalleryFile) => boolean,
   |}) => {
     const { uploadFiles } = useGalleryActions();
     const selection = useGallerySelection();
@@ -265,6 +272,7 @@ const CustomTreeItem = observer(
               section={section}
               idMap={idMap}
               refreshListing={refreshListing}
+              filter={filter}
             />
           )}
         </TreeItem>
@@ -280,6 +288,7 @@ type TreeViewArgs = {|
   path: $ReadOnlyArray<GalleryFile>,
   selectedSection: string,
   refreshListing: () => void,
+  filter?: (GalleryFile) => boolean,
 |};
 
 const TreeView = ({
@@ -287,6 +296,7 @@ const TreeView = ({
   path,
   selectedSection,
   refreshListing,
+  filter = () => true,
 }: TreeViewArgs) => {
   const { addAlert } = React.useContext(AlertContext);
   const selection = useGallerySelection();
@@ -390,17 +400,20 @@ const TreeView = ({
         }
       }}
     >
-      {listing.list.map((file, index) => (
-        <CustomTreeItem
-          index={index}
-          file={file}
-          path={path}
-          key={idToString(file.id)}
-          section={selectedSection}
-          idMap={idMap}
-          refreshListing={refreshListing}
-        />
-      ))}
+      {listing.list.map((file, index) =>
+        filter(file) ? (
+          <CustomTreeItem
+            index={index}
+            file={file}
+            path={path}
+            key={idToString(file.id)}
+            section={selectedSection}
+            idMap={idMap}
+            refreshListing={refreshListing}
+            filter={filter}
+          />
+        ) : null
+      )}
     </SimpleTreeView>
   );
 };

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -62,6 +62,7 @@ type TreeItemContentArgs = {|
   idMap: Map<string, GalleryFile>,
   refreshListing: () => void,
   filter: (GalleryFile) => boolean,
+  disableDragAndDrop?: boolean,
 |};
 
 const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
@@ -72,6 +73,7 @@ const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
     idMap,
     refreshListing,
     filter,
+    disableDragAndDrop,
   }: TreeItemContentArgs): Node => {
     const { galleryListing } = useGalleryListing({
       section,
@@ -108,6 +110,7 @@ const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
                   idMap={idMap}
                   refreshListing={refreshListing}
                   filter={filter}
+                  disableDragAndDrop={disableDragAndDrop}
                 />
               ) : null
             )
@@ -125,6 +128,7 @@ const CustomTreeItem = observer(
     idMap,
     refreshListing,
     filter,
+    disableDragAndDrop,
   }: {|
     file: GalleryFile,
     index: number,
@@ -133,6 +137,7 @@ const CustomTreeItem = observer(
     idMap: Map<string, GalleryFile>,
     refreshListing: () => void,
     filter: (GalleryFile) => boolean,
+    disableDragAndDrop?: boolean,
   |}) => {
     const { uploadFiles } = useGalleryActions();
     const selection = useGallerySelection();
@@ -146,7 +151,7 @@ const CustomTreeItem = observer(
       });
     const { setNodeRef: setDropRef, isOver } = useDroppable({
       id: file.id,
-      disabled: !file.isFolder,
+      disabled: disableDragAndDrop || !file.isFolder,
       data: {
         path: file.path,
         destination: folderDestination(file),
@@ -158,7 +163,7 @@ const CustomTreeItem = observer(
       setNodeRef: setDragRef,
       transform,
     } = useDraggable({
-      disabled: false,
+      disabled: disableDragAndDrop,
       id: file.id,
       data: {
         /*
@@ -273,6 +278,7 @@ const CustomTreeItem = observer(
               idMap={idMap}
               refreshListing={refreshListing}
               filter={filter}
+              disableDragAndDrop={disableDragAndDrop}
             />
           )}
         </TreeItem>
@@ -289,6 +295,7 @@ type TreeViewArgs = {|
   selectedSection: string,
   refreshListing: () => void,
   filter?: (GalleryFile) => boolean,
+  disableDragAndDrop?: boolean,
 |};
 
 const TreeView = ({
@@ -297,6 +304,7 @@ const TreeView = ({
   selectedSection,
   refreshListing,
   filter = () => true,
+  disableDragAndDrop,
 }: TreeViewArgs) => {
   const { addAlert } = React.useContext(AlertContext);
   const selection = useGallerySelection();
@@ -413,6 +421,7 @@ const TreeView = ({
             idMap={idMap}
             refreshListing={refreshListing}
             filter={filter}
+            disableDragAndDrop={disableDragAndDrop}
           />
         ) : null
       )}

--- a/src/main/webapp/ui/src/eln/gallery/components/useIrods.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/useIrods.js
@@ -2,13 +2,16 @@
 
 import axios, { type Axios } from "axios";
 import React from "react";
-import Result from "../../util/result";
-import * as Parsers from "../../util/parsers";
-import * as FetchingData from "../../util/fetchingData";
-import useOauthToken from "../../common/useOauthToken";
-import { Optional } from "../../util/optional";
-import AlertContext, { mkAlert, type Alert } from "../../stores/contexts/Alert";
-import * as ArrayUtils from "../../util/ArrayUtils";
+import Result from "../../../util/result";
+import * as Parsers from "../../../util/parsers";
+import * as FetchingData from "../../../util/fetchingData";
+import useOauthToken from "../../../common/useOauthToken";
+import { Optional } from "../../../util/optional";
+import AlertContext, {
+  mkAlert,
+  type Alert,
+} from "../../../stores/contexts/Alert";
+import * as ArrayUtils from "../../../util/ArrayUtils";
 
 type Link = {| operation: string, href: string |};
 

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -47,6 +47,7 @@ function WholePage() {
           selectedSection={selectedSection}
           setSelectedSection={setSelectedSection}
           drawerOpen={drawerOpen}
+          setDrawerOpen={setDrawerOpen}
           path={path}
           folderId={folderId}
           refreshListing={refreshListing}

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -17,7 +17,7 @@ import useViewportDimensions from "../../util/useViewportDimensions";
 import Alerts from "../../Inventory/components/Alerts";
 import { DisableDragAndDropByDefault } from "../../components/useFileImportDragAndDrop";
 import Analytics from "../../components/Analytics";
-import { GallerySelection } from "./useGalleryActions";
+import { GallerySelection } from "./useGallerySelection";
 
 function WholePage() {
   const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -27,6 +27,7 @@ export function useGalleryActions(): {|
   |},
   deleteFiles: (Set<GalleryFile>) => Promise<void>,
   duplicateFiles: (Set<GalleryFile>) => Promise<void>,
+  rename: (GalleryFile, string) => Promise<void>,
 |} {
   const { addAlert, removeAlert } = React.useContext(AlertContext);
 
@@ -332,5 +333,16 @@ export function useGalleryActions(): {|
     }
   }
 
-  return { uploadFiles, createFolder, moveFiles, deleteFiles, duplicateFiles };
+  function rename(_file: GalleryFile, _newName: string) {
+    return Promise.resolve();
+  }
+
+  return {
+    uploadFiles,
+    createFolder,
+    moveFiles,
+    deleteFiles,
+    duplicateFiles,
+    rename,
+  };
 }

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -33,6 +33,7 @@ export function useGalleryActions(): {|
       destination: Destination,
       section: string,
     |}) => Promise<void>,
+    toDestinationWithPath: (string, string) => Promise<void>,
   |},
   deleteFiles: (RsSet<GalleryFile>) => Promise<void>,
   duplicateFiles: (RsSet<GalleryFile>) => Promise<void>,
@@ -166,7 +167,13 @@ export function useGalleryActions(): {|
     }
   }
 
-  function moveFiles(files: Set<GalleryFile>) {
+  function moveFiles(files: Set<GalleryFile>): {|
+    to: ({|
+      destination: Destination,
+      section: string,
+    |}) => Promise<void>,
+    toDestinationWithPath: (string, string) => Promise<void>,
+  |} {
     return {
       to: async ({
         destination,
@@ -176,7 +183,7 @@ export function useGalleryActions(): {|
           | {| key: "root" |}
           | {| key: "folder", folder: GalleryFile |},
         section: string,
-      |}) => {
+      |}): Promise<void> => {
         if (
           destination.key === "folder" &&
           destination.folder.isSnippetFolder
@@ -191,12 +198,18 @@ export function useGalleryActions(): {|
           );
           return;
         }
-        const target =
+        const path =
           destination.key === "root"
             ? `/${section}/`
             : destination.folder.pathAsString();
+        await moveFiles(files).toDestinationWithPath(section, path);
+      },
+      toDestinationWithPath: async (
+        section: string,
+        path: string
+      ): Promise<void> => {
         const formData = new FormData();
-        formData.append("target", target);
+        formData.append("target", path);
         for (const file of files)
           formData.append("filesId[]", idToString(file.id));
         formData.append("mediaType", section);

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -4,6 +4,7 @@ import React from "react";
 import axios from "axios";
 import * as ArrayUtils from "../../util/ArrayUtils";
 import * as Parsers from "../../util/parsers";
+import RsSet from "../../util/set";
 import Result from "../../util/result";
 import { type GalleryFile, idToString, type Id } from "./useGalleryListing";
 import AlertContext, { mkAlert } from "../../stores/contexts/Alert";
@@ -22,7 +23,7 @@ export function useGalleryActions(): {|
     |}) => Promise<void>,
   |},
   deleteFiles: (Set<GalleryFile>) => Promise<void>,
-  duplicateFiles: (Set<GalleryFile>) => Promise<void>,
+  duplicateFiles: (RsSet<GalleryFile>) => Promise<void>,
   rename: (GalleryFile, string) => Promise<void>,
 |} {
   const { addAlert, removeAlert } = React.useContext(AlertContext);
@@ -277,7 +278,8 @@ export function useGalleryActions(): {|
     }
   }
 
-  async function duplicateFiles(files: Set<GalleryFile>) {
+  async function duplicateFiles(files: RsSet<GalleryFile>) {
+    if (files.some((f) => /System Folder/.test(f.type))) return;
     const formData = new FormData();
     for (const file of files) {
       formData.append("idToCopy[]", idToString(file.id));

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -7,10 +7,6 @@ import * as Parsers from "../../util/parsers";
 import Result from "../../util/result";
 import { type GalleryFile, idToString, type Id } from "./useGalleryListing";
 import AlertContext, { mkAlert } from "../../stores/contexts/Alert";
-import {
-  filenameExceptExtension,
-  justFilenameExtension,
-} from "../../util/files";
 
 export function useGalleryActions(): {|
   uploadFiles: (
@@ -287,9 +283,7 @@ export function useGalleryActions(): {|
       formData.append("idToCopy[]", idToString(file.id));
       formData.append(
         "newName[]",
-        `${filenameExceptExtension(file.name)}_copy.${justFilenameExtension(
-          file.name
-        )}`
+        file.transformFilename((name) => name + "_copy")
       );
     }
     try {
@@ -338,7 +332,7 @@ export function useGalleryActions(): {|
     formData.append("recordId", idToString(file.id));
     formData.append(
       "newName",
-      `${newName}.${justFilenameExtension(file.name)}`
+      file.transformFilename(() => newName)
     );
     try {
       const data = await axios.post<FormData, mixed>(

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -333,8 +333,50 @@ export function useGalleryActions(): {|
     }
   }
 
-  function rename(_file: GalleryFile, _newName: string) {
-    return Promise.resolve();
+  async function rename(file: GalleryFile, newName: string) {
+    const formData = new FormData();
+    formData.append("recordId", idToString(file.id));
+    formData.append(
+      "newName",
+      `${newName}.${justFilenameExtension(file.name)}`
+    );
+    try {
+      const data = await axios.post<FormData, mixed>(
+        "workspace/editor/structuredDocument/ajax/rename",
+        formData,
+        {
+          headers: {
+            "content-type": "multipart/form-data",
+          },
+        }
+      );
+      addAlert(
+        Parsers.objectPath(["data", "exceptionMessage"], data)
+          .flatMap(Parsers.isString)
+          .map((exceptionMessage) =>
+            mkAlert({
+              title: `Failed to rename item.`,
+              message: exceptionMessage,
+              variant: "error",
+            })
+          )
+          .orElse(
+            mkAlert({
+              message: `Successfully renamed item.`,
+              variant: "success",
+            })
+          )
+      );
+    } catch (e) {
+      addAlert(
+        mkAlert({
+          variant: "error",
+          title: `Failed to rename item.`,
+          message: e.message,
+        })
+      );
+      throw e;
+    }
   }
 
   return {

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -279,7 +279,7 @@ export function useGalleryActions(): {|
   }
 
   async function duplicateFiles(files: RsSet<GalleryFile>) {
-    if (files.some((f) => /System Folder/.test(f.type))) return;
+    if (files.some((f) => f.isSystemFolder)) return;
     const formData = new FormData();
     for (const file of files) {
       formData.append("idToCopy[]", idToString(file.id));

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -1,14 +1,12 @@
 //@flow
 
-import React, { type Context, type Node } from "react";
+import React from "react";
 import axios from "axios";
 import * as ArrayUtils from "../../util/ArrayUtils";
 import * as Parsers from "../../util/parsers";
 import Result from "../../util/result";
 import { type GalleryFile, idToString, type Id } from "./useGalleryListing";
 import AlertContext, { mkAlert } from "../../stores/contexts/Alert";
-import { observable, runInAction } from "mobx";
-import RsSet from "../../util/set";
 
 export function useGalleryActions(): {|
   uploadFiles: (
@@ -278,75 +276,4 @@ export function useGalleryActions(): {|
   }
 
   return { uploadFiles, createFolder, moveFiles, deleteFiles };
-}
-
-/*
- * Other modules should not be accessing the context directly, but instead
- * using the custom hook defined below. By not exporting the type flow will
- * complain if the context is accessed directly.
- */
-type Selection = Map<string, GalleryFile>;
-
-function mkSelection(): Selection {
-  // $FlowExpectedError[prop-missing] Difficult to get this library type right
-  return observable.map();
-}
-
-type SelectionContextType = {|
-  selection: Selection,
-|};
-
-const DEFAULT_SELECTION_CONTEXT: SelectionContextType = {
-  selection: mkSelection(),
-};
-
-const SelectionContext: Context<SelectionContextType> = React.createContext(
-  DEFAULT_SELECTION_CONTEXT
-);
-
-export const GallerySelection = ({ children }: {| children: Node |}): Node => (
-  <SelectionContext.Provider
-    value={{
-      selection: mkSelection(),
-    }}
-  >
-    {children}
-  </SelectionContext.Provider>
-);
-
-export function useGallerySelection(): {|
-  isEmpty: () => boolean,
-  clear: () => void,
-  append: (GalleryFile) => void,
-  remove: (GalleryFile) => void,
-  includes: (GalleryFile) => boolean,
-  asSet: () => RsSet<GalleryFile>,
-  asSetOfIds: () => Set<GalleryFile["id"]>,
-  asTreeViewModel: () => $ReadOnlyArray<string>,
-|} {
-  const { selection } = React.useContext(SelectionContext);
-  return {
-    isEmpty: () => selection.size === 0,
-    clear: () => {
-      runInAction(() => {
-        selection.clear();
-      });
-    },
-    append: (file) => {
-      runInAction(() => {
-        selection.set(idToString(file.id), file);
-      });
-    },
-    remove: (file) => {
-      runInAction(() => {
-        selection.delete(idToString(file.id));
-      });
-    },
-    includes: (file) => {
-      return selection.has(idToString(file.id));
-    },
-    asSet: () => new RsSet(selection.values()),
-    asSetOfIds: () => new Set([...selection.values()].map(({ id }) => id)),
-    asTreeViewModel: () => [...selection.keys()],
-  };
 }

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -22,7 +22,7 @@ export function useGalleryActions(): {|
       section: string,
     |}) => Promise<void>,
   |},
-  deleteFiles: (Set<GalleryFile>) => Promise<void>,
+  deleteFiles: (RsSet<GalleryFile>) => Promise<void>,
   duplicateFiles: (RsSet<GalleryFile>) => Promise<void>,
   rename: (GalleryFile, string) => Promise<void>,
 |} {
@@ -235,7 +235,8 @@ export function useGalleryActions(): {|
     };
   }
 
-  async function deleteFiles(files: Set<GalleryFile>) {
+  async function deleteFiles(files: RsSet<GalleryFile>) {
+    if (files.some((f) => f.isSystemFolder)) return;
     const formData = new FormData();
     for (const file of files)
       formData.append("idsToDelete[]", idToString(file.id));

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -208,12 +208,13 @@ export function useGalleryActions(): {|
         section: string,
         path: string
       ): Promise<void> => {
-        const formData = new FormData();
-        formData.append("target", path);
-        for (const file of files)
-          formData.append("filesId[]", idToString(file.id));
-        formData.append("mediaType", section);
         try {
+          if (path === "") throw new Error("Path cannot be empty");
+          const formData = new FormData();
+          formData.append("target", path);
+          for (const file of files)
+            formData.append("filesId[]", idToString(file.id));
+          formData.append("mediaType", section);
           const data = await axios.post<FormData, mixed>(
             "gallery/ajax/moveGalleriesElements",
             formData,

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -331,6 +331,7 @@ export function useGalleryActions(): {|
   }
 
   async function rename(file: GalleryFile, newName: string) {
+    if (file.isSystemFolder) return;
     const formData = new FormData();
     formData.append("recordId", idToString(file.id));
     formData.append(

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -9,6 +9,18 @@ import Result from "../../util/result";
 import { type GalleryFile, idToString, type Id } from "./useGalleryListing";
 import AlertContext, { mkAlert } from "../../stores/contexts/Alert";
 
+export opaque type Destination =
+  | {| key: "root" |}
+  | {| key: "folder", folder: GalleryFile |};
+
+export function rootDestination(): Destination {
+  return { key: "root" };
+}
+
+export function folderDestination(folder: GalleryFile): Destination {
+  return { key: "folder", folder };
+}
+
 export function useGalleryActions(): {|
   uploadFiles: (
     $ReadOnlyArray<GalleryFile>,
@@ -18,7 +30,7 @@ export function useGalleryActions(): {|
   createFolder: ($ReadOnlyArray<GalleryFile>, Id, string) => Promise<void>,
   moveFiles: (Set<GalleryFile>) => {|
     to: ({|
-      destination: {| key: "root" |} | {| key: "folder", folder: GalleryFile |},
+      destination: Destination,
       section: string,
     |}) => Promise<void>,
   |},

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -194,11 +194,7 @@ export function useGalleryActions(): {|
         const target =
           destination.key === "root"
             ? `/${section}/`
-            : `/${[
-                section,
-                ...destination.folder.path.map(({ name }) => name),
-                ...[destination.folder.name],
-              ].join("/")}/`;
+            : destination.folder.pathAsString();
         const formData = new FormData();
         formData.append("target", target);
         for (const file of files)

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -236,9 +236,7 @@ export function useGalleryListing({
       isSystemFolder,
       isSnippetFolder: isSystemFolder && /SNIPPETS/.test(name),
       transformFilename: (f) => {
-        if (/Folder/.test(type)) {
-          return f(name);
-        }
+        if (isFolder) return f(name);
         return `${f(filenameExceptExtension(name))}.${justFilenameExtension(
           name
         )}`;

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -23,7 +23,9 @@ export type GalleryFile = {|
   modificationDate: number,
   type: string,
   thumbnailUrl: string,
+
   path: $ReadOnlyArray<GalleryFile>,
+  pathAsString: () => string,
   open?: () => void,
 
   isFolder: boolean,
@@ -227,6 +229,8 @@ export function useGalleryListing({
         isSystemFolder
       ),
       path,
+      pathAsString: () =>
+        `/${[section, ...path.map(({ name }) => name), name].join("/")}/`,
       ...(isFolder
         ? {
             open: () => {

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -28,6 +28,7 @@ export type GalleryFile = {|
 
   isFolder: boolean,
   isSystemFolder: boolean,
+  isImage: boolean,
   isSnippet: boolean,
   isSnippetFolder: boolean,
 
@@ -235,6 +236,7 @@ export function useGalleryListing({
         : {}),
       isFolder,
       isSystemFolder,
+      isImage: /Image/.test(type),
       isSnippet: /Snippet/.test(type),
       isSnippetFolder: isSystemFolder && /SNIPPETS/.test(name),
       transformFilename: (f) => {

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -28,6 +28,7 @@ export type GalleryFile = {|
 
   isFolder: boolean,
   isSystemFolder: boolean,
+  isSnippet: boolean,
   isSnippetFolder: boolean,
 
   /*
@@ -234,6 +235,7 @@ export function useGalleryListing({
         : {}),
       isFolder,
       isSystemFolder,
+      isSnippet: /Snippet/.test(type),
       isSnippetFolder: isSystemFolder && /SNIPPETS/.test(name),
       transformFilename: (f) => {
         if (isFolder) return f(name);

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -7,6 +7,10 @@ import * as Parsers from "../../util/parsers";
 import AlertContext, { mkAlert } from "../../stores/contexts/Alert";
 import * as FetchingData from "../../util/fetchingData";
 import { gallerySectionCollectiveNoun } from "./common";
+import {
+  filenameExceptExtension,
+  justFilenameExtension,
+} from "../../util/files";
 
 export opaque type Id = number;
 export function idToString(id: Id): string {
@@ -25,6 +29,15 @@ export type GalleryFile = {|
   isFolder: boolean,
   isSystemFolder: boolean,
   isSnippetFolder: boolean,
+
+  /*
+   * There are various places in the UI where the user applies some
+   * transformation to the name of either a folder or file. Mainly the rename
+   * action, but also when duplicating and in other places too. This method
+   * allows the call to generate a new file name by applying a transformation
+   * to the name before the extension, leaving the extension in place.
+   */
+  transformFilename: ((string) => string) => string,
 |};
 
 /**
@@ -222,6 +235,14 @@ export function useGalleryListing({
       isFolder,
       isSystemFolder,
       isSnippetFolder: isSystemFolder && /SNIPPETS/.test(name),
+      transformFilename: (f) => {
+        if (/Folder/.test(type)) {
+          return f(name);
+        }
+        return `${f(filenameExceptExtension(name))}.${justFilenameExtension(
+          name
+        )}`;
+      },
     };
     return ret;
   }

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -197,8 +197,8 @@ export function useGalleryListing({
       return `The folder "${folderName}" is empty.`;
     }
     if (searchTerm !== "")
-      return `There are no root-level ${gallerySectionCollectiveNoun[section]} that match the search term "${searchTerm}".`;
-    return `There are no root-level ${gallerySectionCollectiveNoun[section]}.`;
+      return `There are no top-level ${gallerySectionCollectiveNoun[section]} that match the search term "${searchTerm}".`;
+    return `There are no top-level ${gallerySectionCollectiveNoun[section]}.`;
   }
 
   function mkGalleryFile(

--- a/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
@@ -2,7 +2,7 @@
 
 import React, { type Node, type Context } from "react";
 import { type GalleryFile } from "./useGalleryListing";
-import { makeObservable, action, observable, computed } from "mobx";
+import { makeObservable, action, observable, computed, autorun } from "mobx";
 import RsSet from "../../util/set";
 
 /*
@@ -74,6 +74,16 @@ export const GallerySelection = ({ children }: {| children: Node |}): Node => (
   </SelectionContext.Provider>
 );
 
-export function useGallerySelection(): Selection {
-  return React.useContext(SelectionContext);
+export function useGallerySelection({
+  onChange,
+}: {| onChange?: (Selection) => void |} = {}): Selection {
+  const selection = React.useContext(SelectionContext);
+
+  React.useEffect(() => {
+    autorun(() => {
+      onChange?.(selection);
+    });
+  }, [selection]);
+
+  return selection;
 }

--- a/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
@@ -1,7 +1,7 @@
 //@flow
 
 import React, { type Node, type Context } from "react";
-import { type GalleryFile, idToString } from "./useGalleryListing";
+import { type GalleryFile } from "./useGalleryListing";
 import { observable, runInAction } from "mobx";
 import RsSet from "../../util/set";
 
@@ -9,8 +9,16 @@ import RsSet from "../../util/set";
  * Other modules should not be accessing the context directly, but instead
  * using the custom hook defined below. By not exporting the type flow will
  * complain if the context is accessed directly.
+ *
+ * We use a Map even though the interface exposed by this module is more akin
+ * to a Set because we want to be able to check the inclusion of files based on
+ * their Id. There are various points in the UI where the particular objects in
+ * memory that are modelling the Gallery Files are replaced, and so we must
+ * compare based on their Ids to make sure we don't end up with the same file
+ * added to the Selection twice. We can't use RsSet, even though it has
+ * `hasWithEq` that would suffice, because it is not observable.
  */
-type Selection = Map<string, GalleryFile>;
+type Selection = Map<GalleryFile["id"], GalleryFile>;
 
 function mkSelection(): Selection {
   // $FlowExpectedError[prop-missing] Difficult to get this library type right
@@ -46,8 +54,6 @@ export function useGallerySelection(): {|
   remove: (GalleryFile) => void,
   includes: (GalleryFile) => boolean,
   asSet: () => RsSet<GalleryFile>,
-  asSetOfIds: () => Set<GalleryFile["id"]>,
-  asTreeViewModel: () => $ReadOnlyArray<string>,
 |} {
   const { selection } = React.useContext(SelectionContext);
   return {
@@ -59,19 +65,17 @@ export function useGallerySelection(): {|
     },
     append: (file) => {
       runInAction(() => {
-        selection.set(idToString(file.id), file);
+        selection.set(file.id, file);
       });
     },
     remove: (file) => {
       runInAction(() => {
-        selection.delete(idToString(file.id));
+        selection.delete(file.id);
       });
     },
     includes: (file) => {
-      return selection.has(idToString(file.id));
+      return selection.has(file.id);
     },
     asSet: () => new RsSet(selection.values()),
-    asSetOfIds: () => new Set([...selection.values()].map(({ id }) => id)),
-    asTreeViewModel: () => [...selection.keys()],
   };
 }

--- a/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
@@ -48,7 +48,8 @@ export const GallerySelection = ({ children }: {| children: Node |}): Node => (
 );
 
 export function useGallerySelection(): {|
-  isEmpty: () => boolean,
+  isEmpty: boolean,
+  size: number,
   clear: () => void,
   append: (GalleryFile) => void,
   remove: (GalleryFile) => void,
@@ -57,7 +58,8 @@ export function useGallerySelection(): {|
 |} {
   const { selection } = React.useContext(SelectionContext);
   return {
-    isEmpty: () => selection.size === 0,
+    isEmpty: selection.size === 0,
+    size: selection.size,
     clear: () => {
       runInAction(() => {
         selection.clear();

--- a/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
@@ -1,0 +1,77 @@
+//@flow
+
+import React, { type Node, type Context } from "react";
+import { type GalleryFile, idToString } from "./useGalleryListing";
+import { observable, runInAction } from "mobx";
+import RsSet from "../../util/set";
+
+/*
+ * Other modules should not be accessing the context directly, but instead
+ * using the custom hook defined below. By not exporting the type flow will
+ * complain if the context is accessed directly.
+ */
+type Selection = Map<string, GalleryFile>;
+
+function mkSelection(): Selection {
+  // $FlowExpectedError[prop-missing] Difficult to get this library type right
+  return observable.map();
+}
+
+type SelectionContextType = {|
+  selection: Selection,
+|};
+
+const DEFAULT_SELECTION_CONTEXT: SelectionContextType = {
+  selection: mkSelection(),
+};
+
+const SelectionContext: Context<SelectionContextType> = React.createContext(
+  DEFAULT_SELECTION_CONTEXT
+);
+
+export const GallerySelection = ({ children }: {| children: Node |}): Node => (
+  <SelectionContext.Provider
+    value={{
+      selection: mkSelection(),
+    }}
+  >
+    {children}
+  </SelectionContext.Provider>
+);
+
+export function useGallerySelection(): {|
+  isEmpty: () => boolean,
+  clear: () => void,
+  append: (GalleryFile) => void,
+  remove: (GalleryFile) => void,
+  includes: (GalleryFile) => boolean,
+  asSet: () => RsSet<GalleryFile>,
+  asSetOfIds: () => Set<GalleryFile["id"]>,
+  asTreeViewModel: () => $ReadOnlyArray<string>,
+|} {
+  const { selection } = React.useContext(SelectionContext);
+  return {
+    isEmpty: () => selection.size === 0,
+    clear: () => {
+      runInAction(() => {
+        selection.clear();
+      });
+    },
+    append: (file) => {
+      runInAction(() => {
+        selection.set(idToString(file.id), file);
+      });
+    },
+    remove: (file) => {
+      runInAction(() => {
+        selection.delete(idToString(file.id));
+      });
+    },
+    includes: (file) => {
+      return selection.has(idToString(file.id));
+    },
+    asSet: () => new RsSet(selection.values()),
+    asSetOfIds: () => new Set([...selection.values()].map(({ id }) => id)),
+    asTreeViewModel: () => [...selection.keys()],
+  };
+}

--- a/src/main/webapp/ui/src/util/set.js
+++ b/src/main/webapp/ui/src/util/set.js
@@ -100,6 +100,7 @@ export default class RsSet<A> extends Set<A> {
    */
   get only(): Optional<A> {
     if (this.isEmpty) return Optional.empty();
+    if (this.size > 1) return Optional.empty();
     return Optional.present(this.first);
   }
 

--- a/src/main/webapp/ui/src/util/set.js
+++ b/src/main/webapp/ui/src/util/set.js
@@ -35,6 +35,7 @@ export default class RsSet<A> extends Set<A> {
       isEmpty: computed,
       first: computed,
       last: computed,
+      only: computed,
     });
   }
 
@@ -91,6 +92,15 @@ export default class RsSet<A> extends Set<A> {
    */
   get last(): A {
     return [...this][this.size - 1];
+  }
+
+  /**
+   * If the set contains just one element, then return it wrapped in
+   * Optional.present.
+   */
+  get only(): Optional<A> {
+    if (this.isEmpty) return Optional.empty();
+    return Optional.present(this.first);
   }
 
   /*
@@ -247,14 +257,14 @@ export default class RsSet<A> extends Set<A> {
    */
   unionWithEq(s: RsSet<A>, eq: (A, A) => boolean): RsSet<A> {
     const result = new RsSet<A>();
-    outerA: for (let elementOfThis of this) {
-      for (let alreadyAdded of result) {
+    outerA: for (const elementOfThis of this) {
+      for (const alreadyAdded of result) {
         if (eq(elementOfThis, alreadyAdded)) continue outerA;
       }
       result.add(elementOfThis);
     }
-    outerB: for (let elementOfS of s) {
-      for (let alreadyAdded of result) {
+    outerB: for (const elementOfS of s) {
+      for (const alreadyAdded of result) {
         if (eq(elementOfS, alreadyAdded)) continue outerB;
       }
       result.add(elementOfS);
@@ -264,8 +274,8 @@ export default class RsSet<A> extends Set<A> {
 
   subtractWithEq(s: RsSet<A>, eq: (A, A) => boolean): RsSet<A> {
     const result = new RsSet<A>();
-    outer: for (let elementOfThis of this) {
-      for (let elementOfS of s) {
+    outer: for (const elementOfThis of this) {
+      for (const elementOfS of s) {
         if (eq(elementOfThis, elementOfS)) continue outer;
       }
       result.add(elementOfThis);
@@ -378,15 +388,15 @@ export const flattenWithIntersectionWithEq = <A>(
   const allElements = flattenWithUnion(setOfSets);
   const intersection = new RsSet<A>();
 
-  allElementsLoop: for (let element of allElements) {
+  allElementsLoop: for (const element of allElements) {
     // check if `element` is already in `ret`
-    for (let alreadyAdded of intersection) {
+    for (const alreadyAdded of intersection) {
       if (eqFunc(alreadyAdded, element)) continue allElementsLoop;
     }
 
     // check if `element` is in all `setOfSets`
-    eachSetLoop: for (let set of setOfSets) {
-      for (let elem of set) {
+    eachSetLoop: for (const set of setOfSets) {
+      for (const elem of set) {
         if (eqFunc(elem, element)) {
           // if in this set, then check next set
           continue eachSetLoop;

--- a/src/main/webapp/ui/src/util/table.js
+++ b/src/main/webapp/ui/src/util/table.js
@@ -26,7 +26,10 @@ function desc(a: { ... }, b: { ... }, orderBy: string): -1 | 0 | 1 {
  * but not so for older browsers. For more information, see
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability
  */
-function stableSort<T>(array: Array<T>, cmp: (T, T) => -1 | 0 | 1): Array<T> {
+function stableSort<T>(
+  array: $ReadOnlyArray<T>,
+  cmp: (T, T) => -1 | 0 | 1
+): Array<T> {
   const stabilizedThis = array.map((el, index) => [el, index]);
   stabilizedThis.sort((a, b) => {
     const order = cmp(a[0], b[0]);


### PR DESCRIPTION
This change adds a new menu to the new gallery page, which provides the user with various actions that they can perform on the selected files. It includes all of the actions from the current gallery's menubar, but not all are yet implemented as some require backend development work and others -- such as the export flow -- require their own substantial rework that is best tackled separately.

<img width="357" alt="image" src="https://github.com/rspace-os/rspace-web/assets/8805923/c67ae232-2ccb-4010-9161-4c6ba14e2c0b">

This change also includes
- a different theme colour so that the UI is more distinctive to the iRODS branding
- an additional accessibility tip, describing the support for up to 200% zoom
- on mobile and small windows, the sidebar now full closes and opens above all other content to prevent the page for overflow horizontally.