### PR TITLE
RSDEV-260 Add subsamples details section to sample page

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -3,7 +3,6 @@
 import React, { type Node, type ComponentType } from "react";
 import { observer } from "mobx-react-lite";
 import SubSampleModel from "../../../stores/models/SubSampleModel";
-import { type InventoryRecord } from "../../../stores/definitions/InventoryRecord";
 import Grid from "@mui/material/Grid";
 import Collapse from "@mui/material/Collapse";
 import ExpandCollapseIcon from "../../../components/ExpandCollapseIcon";
@@ -12,13 +11,38 @@ import Toolbar from "@mui/material/Toolbar";
 import AppBar from "@mui/material/AppBar";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
-import { useTheme } from "@mui/material/styles";
+import { styled, useTheme, darken, alpha } from "@mui/material/styles";
 import LocationField from "../../components/Fields/Location";
 import Box from "@mui/material/Box";
 import GlobalId from "../../../components/GlobalId";
 import QuantityField from "../../Subsample/Fields/Quantity";
 import Stack from "@mui/material/Stack";
 import Notes from "../../Subsample/Fields/Notes/Notes";
+import MobileStepper from "@mui/material/MobileStepper";
+import Button from "@mui/material/Button";
+import KeyboardArrowLeft from "@mui/icons-material/KeyboardArrowLeft";
+import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
+import { type Search } from "../../../stores/definitions/Search";
+import { doNotAwait, modulo } from "../../../util/Util";
+
+const CustomStepper = styled(MobileStepper)(({ theme }) => ({
+  backgroundColor: theme.palette.record.subSample.lighter,
+  borderBottomLeftRadius: "4px",
+  borderBottomRightRadius: "4px",
+  border: `2px solid ${theme.palette.record.subSample.bg}`,
+  borderTop: "none",
+  color: alpha(darken(theme.palette.record.subSample.bg, 0.5), 0.7),
+  fontWeight: "700",
+  letterSpacing: "0.03em",
+  "& .MuiButtonBase-root": {
+    "& .MuiSvgIcon-root": {
+      color: theme.palette.record.subSample.bg,
+    },
+    "&.Mui-disabled": {
+      opacity: 0.3,
+    },
+  },
+}));
 
 const Wrapper = ({ children }: {| children: Node |}) => {
   const [sectionOpen, setSectionOpen] = React.useState(true);
@@ -42,54 +66,114 @@ const Wrapper = ({ children }: {| children: Node |}) => {
 };
 
 type SubsampleDetailsArgs = {|
-  subsample: InventoryRecord | null,
+  search: Search,
 |};
 
-function SubsampleDetails({ subsample }: SubsampleDetailsArgs) {
+function SubsampleDetails({ search }: SubsampleDetailsArgs) {
   const theme = useTheme();
 
-  if (subsample === null) return <Wrapper>No subsamples</Wrapper>;
+  const subsample = search.activeResult;
+  if (subsample === null || typeof subsample === "undefined")
+    return <Wrapper>No subsamples</Wrapper>;
+  const index = search.filteredResults.findIndex(
+    (x) => x.globalId === subsample.globalId
+  );
 
   if (!(subsample instanceof SubSampleModel))
     throw new Error("All Subsamples must be instances of SubSampleModel");
+
   return (
     <Wrapper>
-      <Card
-        variant="outlined"
-        sx={{ border: `2px solid ${theme.palette.record.subSample.bg}` }}
-      >
-        <AppBar
-          position="relative"
-          open={true}
+      <>
+        <Card
+          variant="outlined"
           sx={{
-            backgroundColor: theme.palette.record.subSample.bg,
-            boxShadow: "none",
+            border: `2px solid ${theme.palette.record.subSample.bg}`,
+            borderBottomLeftRadius: 0,
+            borderBottomRightRadius: 0,
           }}
         >
-          <Toolbar
-            variant="dense"
-            disableGutters
+          <AppBar
+            position="relative"
+            open={true}
             sx={{
-              px: 1.5,
+              backgroundColor: theme.palette.record.subSample.bg,
+              boxShadow: "none",
             }}
           >
-            {subsample.name}
-            <Box flexGrow={1}></Box>
-            <GlobalId record={subsample} />
-          </Toolbar>
-        </AppBar>
-        <CardContent>
-          <Stack spacing={2}>
-            <LocationField fieldOwner={subsample} />
-            <QuantityField
-              fieldOwner={subsample}
-              quantityCategory={subsample.quantityCategory}
-              onErrorStateChange={() => {}}
-            />
-            <Notes record={subsample} onErrorStateChange={() => {}} />
-          </Stack>
-        </CardContent>
-      </Card>
+            <Toolbar
+              variant="dense"
+              disableGutters
+              sx={{
+                px: 1.5,
+              }}
+            >
+              {subsample.name}
+              <Box flexGrow={1}></Box>
+              <GlobalId record={subsample} />
+            </Toolbar>
+          </AppBar>
+          <CardContent>
+            <Stack spacing={2}>
+              <LocationField fieldOwner={subsample} />
+              <QuantityField
+                fieldOwner={subsample}
+                quantityCategory={subsample.quantityCategory}
+                onErrorStateChange={() => {}}
+              />
+              <Notes record={subsample} onErrorStateChange={() => {}} />
+            </Stack>
+          </CardContent>
+        </Card>
+        <CustomStepper
+          variant="text"
+          steps={search.count}
+          activeStep={
+            index + search.fetcher.pageSize * search.fetcher.pageNumber
+          }
+          position="static"
+          nextButton={
+            <Button
+              size="small"
+              onClick={doNotAwait(async () => {
+                if (index + 1 > search.filteredResults.length - 1)
+                  await search.setPage(search.fetcher.pageNumber + 1);
+                await search.setActiveResult(
+                  search.filteredResults[(index + 1) % search.fetcher.pageSize]
+                );
+              })}
+              disabled={
+                index +
+                  search.fetcher.pageSize * search.fetcher.pageNumber +
+                  1 >=
+                search.count
+              }
+            >
+              <KeyboardArrowRight />
+            </Button>
+          }
+          backButton={
+            <Button
+              size="small"
+              onClick={doNotAwait(async () => {
+                if (index === 0)
+                  await search.setPage(search.fetcher.pageNumber - 1);
+                await search.setActiveResult(
+                  search.filteredResults[
+                    modulo(index - 1, search.fetcher.pageSize)
+                  ]
+                );
+              })}
+              disabled={
+                index + search.fetcher.pageSize * search.fetcher.pageNumber ===
+                0
+              }
+            >
+              <KeyboardArrowLeft />
+            </Button>
+          }
+        />
+      </>
     </Wrapper>
   );
 }

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -11,6 +11,8 @@ import Toolbar from "@mui/material/Toolbar";
 import AppBar from "@mui/material/AppBar";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardActions from "@mui/material/CardActions";
+import Link from "@mui/material/Link";
 import { styled, useTheme, darken, alpha } from "@mui/material/styles";
 import LocationField from "../../components/Fields/Location";
 import Box from "@mui/material/Box";
@@ -25,6 +27,7 @@ import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
 import { type Search } from "../../../stores/definitions/Search";
 import { doNotAwait, modulo } from "../../../util/Util";
 import { svgIconClasses } from "@mui/material/SvgIcon";
+import { Link as ReactRouterLink } from "react-router-dom";
 
 const CustomStepper = styled(MobileStepper)(({ theme }) => ({
   backgroundColor: theme.palette.record.subSample.lighter,
@@ -125,6 +128,11 @@ function SubsampleDetails({ search }: SubsampleDetailsArgs) {
               <Notes record={subsample} onErrorStateChange={() => {}} />
             </Stack>
           </CardContent>
+          <CardActions>
+            <Link component={ReactRouterLink} to={subsample.permalinkURL}>
+              See the full details of <strong>{subsample.name}</strong>
+            </Link>
+          </CardActions>
         </Card>
         <CustomStepper
           variant="text"

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -18,6 +18,7 @@ import Box from "@mui/material/Box";
 import GlobalId from "../../../components/GlobalId";
 import QuantityField from "../../Subsample/Fields/Quantity";
 import Stack from "@mui/material/Stack";
+import Notes from "../../Subsample/Fields/Notes/Notes";
 
 const Wrapper = ({ children }: {| children: Node |}) => {
   const [sectionOpen, setSectionOpen] = React.useState(true);
@@ -85,6 +86,7 @@ function SubsampleDetails({ subsample }: SubsampleDetailsArgs) {
               quantityCategory={subsample.quantityCategory}
               onErrorStateChange={() => {}}
             />
+            <Notes record={subsample} onErrorStateChange={() => {}} />
           </Stack>
         </CardContent>
       </Card>

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -8,6 +8,12 @@ import Grid from "@mui/material/Grid";
 import Collapse from "@mui/material/Collapse";
 import ExpandCollapseIcon from "../../../components/ExpandCollapseIcon";
 import IconButton from "@mui/material/IconButton";
+import Toolbar from "@mui/material/Toolbar";
+import AppBar from "@mui/material/AppBar";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import { useTheme } from "@mui/material/styles";
+import LocationField from "../../components/Fields/Location";
 
 const Wrapper = ({ children }: {| children: Node |}) => {
   const [sectionOpen, setSectionOpen] = React.useState(true);
@@ -21,8 +27,8 @@ const Wrapper = ({ children }: {| children: Node |}) => {
           <ExpandCollapseIcon open={sectionOpen} />
         </IconButton>
       </Grid>
-      <Grid item>
-        <Collapse in={sectionOpen} collapsedSize={44}>
+      <Grid item flexGrow={1}>
+        <Collapse in={sectionOpen} collapsedSize={50}>
           {children}
         </Collapse>
       </Grid>
@@ -35,11 +41,34 @@ type SubsampleDetailsArgs = {|
 |};
 
 function SubsampleDetails({ subsample }: SubsampleDetailsArgs) {
+  const theme = useTheme();
+
   if (subsample === null) return <Wrapper>No subsamples</Wrapper>;
 
-  if (!subsample instanceof SubSampleModel)
+  if (!(subsample instanceof SubSampleModel))
     throw new Error("All Subsamples must be instances of SubSampleModel");
-  return <Wrapper>{subsample.name}</Wrapper>;
+  return (
+    <Wrapper>
+      <Card
+        variant="outlined"
+        sx={{ border: `2px solid ${theme.palette.record.subSample.bg}` }}
+      >
+        <AppBar
+          position="relative"
+          open={true}
+          sx={{
+            backgroundColor: theme.palette.record.subSample.bg,
+            boxShadow: "none",
+          }}
+        >
+          <Toolbar variant="dense">{subsample.name}</Toolbar>
+        </AppBar>
+        <CardContent>
+          <LocationField fieldOwner={subsample} />
+        </CardContent>
+      </Card>
+    </Wrapper>
+  );
 }
 
 export default (observer(

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -28,6 +28,7 @@ import { type Search } from "../../../stores/definitions/Search";
 import { doNotAwait, modulo } from "../../../util/Util";
 import { svgIconClasses } from "@mui/material/SvgIcon";
 import { Link as ReactRouterLink } from "react-router-dom";
+import Typography from "@mui/material/Typography";
 
 const CustomStepper = styled(MobileStepper)(({ theme }) => ({
   backgroundColor: theme.palette.record.subSample.lighter,
@@ -129,9 +130,11 @@ function SubsampleDetails({ search }: SubsampleDetailsArgs) {
             </Stack>
           </CardContent>
           <CardActions>
-            <Link component={ReactRouterLink} to={subsample.permalinkURL}>
-              See the full details of <strong>{subsample.name}</strong>
-            </Link>
+            <Typography align="center" sx={{ width: "100%" }}>
+              <Link component={ReactRouterLink} to={subsample.permalinkURL}>
+                See full details of <strong>{subsample.name}</strong>
+              </Link>
+            </Typography>
           </CardActions>
         </Card>
         <CustomStepper

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -1,0 +1,47 @@
+//@flow
+
+import React, { type Node, type ComponentType } from "react";
+import { observer } from "mobx-react-lite";
+import SubSampleModel from "../../../stores/models/SubSampleModel";
+import { type InventoryRecord } from "../../../stores/definitions/InventoryRecord";
+import Grid from "@mui/material/Grid";
+import Collapse from "@mui/material/Collapse";
+import ExpandCollapseIcon from "../../../components/ExpandCollapseIcon";
+import IconButton from "@mui/material/IconButton";
+
+const Wrapper = ({ children }: {| children: Node |}) => {
+  const [sectionOpen, setSectionOpen] = React.useState(true);
+  return (
+    <Grid container direction="row" flexWrap="nowrap" spacing={1}>
+      <Grid item sx={{ pl: 0, ml: -2 }}>
+        <IconButton
+          onClick={() => setSectionOpen(!sectionOpen)}
+          sx={{ p: 1.25 }}
+        >
+          <ExpandCollapseIcon open={sectionOpen} />
+        </IconButton>
+      </Grid>
+      <Grid item>
+        <Collapse in={sectionOpen} collapsedSize={44}>
+          {children}
+        </Collapse>
+      </Grid>
+    </Grid>
+  );
+};
+
+type SubsampleDetailsArgs = {|
+  subsample: InventoryRecord | null,
+|};
+
+function SubsampleDetails({ subsample }: SubsampleDetailsArgs) {
+  if (subsample === null) return <Wrapper>No subsamples</Wrapper>;
+
+  if (!subsample instanceof SubSampleModel)
+    throw new Error("All Subsamples must be instances of SubSampleModel");
+  return <Wrapper>{subsample.name}</Wrapper>;
+}
+
+export default (observer(
+  SubsampleDetails
+): ComponentType<SubsampleDetailsArgs>);

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -16,6 +16,8 @@ import { useTheme } from "@mui/material/styles";
 import LocationField from "../../components/Fields/Location";
 import Box from "@mui/material/Box";
 import GlobalId from "../../../components/GlobalId";
+import QuantityField from "../../Subsample/Fields/Quantity";
+import Stack from "@mui/material/Stack";
 
 const Wrapper = ({ children }: {| children: Node |}) => {
   const [sectionOpen, setSectionOpen] = React.useState(true);
@@ -76,7 +78,14 @@ function SubsampleDetails({ subsample }: SubsampleDetailsArgs) {
           </Toolbar>
         </AppBar>
         <CardContent>
-          <LocationField fieldOwner={subsample} />
+          <Stack spacing={2}>
+            <LocationField fieldOwner={subsample} />
+            <QuantityField
+              fieldOwner={subsample}
+              quantityCategory={subsample.quantityCategory}
+              onErrorStateChange={() => {}}
+            />
+          </Stack>
         </CardContent>
       </Card>
     </Wrapper>

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -19,11 +19,12 @@ import QuantityField from "../../Subsample/Fields/Quantity";
 import Stack from "@mui/material/Stack";
 import Notes from "../../Subsample/Fields/Notes/Notes";
 import MobileStepper from "@mui/material/MobileStepper";
-import Button from "@mui/material/Button";
+import Button, { buttonClasses } from "@mui/material/Button";
 import KeyboardArrowLeft from "@mui/icons-material/KeyboardArrowLeft";
 import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
 import { type Search } from "../../../stores/definitions/Search";
 import { doNotAwait, modulo } from "../../../util/Util";
+import { svgIconClasses } from "@mui/material/SvgIcon";
 
 const CustomStepper = styled(MobileStepper)(({ theme }) => ({
   backgroundColor: theme.palette.record.subSample.lighter,
@@ -34,11 +35,11 @@ const CustomStepper = styled(MobileStepper)(({ theme }) => ({
   color: alpha(darken(theme.palette.record.subSample.bg, 0.5), 0.7),
   fontWeight: "700",
   letterSpacing: "0.03em",
-  "& .MuiButtonBase-root": {
-    "& .MuiSvgIcon-root": {
+  [`& .${buttonClasses.root}`]: {
+    [`& .${svgIconClasses.root}`]: {
       color: theme.palette.record.subSample.bg,
     },
-    "&.Mui-disabled": {
+    [`&.${buttonClasses.disabled}`]: {
       opacity: 0.3,
     },
   },

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -14,6 +14,8 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import { useTheme } from "@mui/material/styles";
 import LocationField from "../../components/Fields/Location";
+import Box from "@mui/material/Box";
+import GlobalId from "../../../components/GlobalId";
 
 const Wrapper = ({ children }: {| children: Node |}) => {
   const [sectionOpen, setSectionOpen] = React.useState(true);
@@ -61,7 +63,17 @@ function SubsampleDetails({ subsample }: SubsampleDetailsArgs) {
             boxShadow: "none",
           }}
         >
-          <Toolbar variant="dense">{subsample.name}</Toolbar>
+          <Toolbar
+            variant="dense"
+            disableGutters
+            sx={{
+              px: 1.5,
+            }}
+          >
+            {subsample.name}
+            <Box flexGrow={1}></Box>
+            <GlobalId record={subsample} />
+          </Toolbar>
         </AppBar>
         <CardContent>
           <LocationField fieldOwner={subsample} />

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleListing.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleListing.js
@@ -36,6 +36,11 @@ function SubsampleListing({ sample }: SubsampleListingArgs): Node {
     setSearchOpen(sample.subSamples.length > 1);
   }, [sample.subSamples]);
 
+  React.useEffect(() => {
+    if (!sample.search.activeResult && sample.search.filteredResults.length > 0)
+      void sample.search.setActiveResult();
+  }, [sample.search.filteredResults]);
+
   const handleSearch = (query: string) => {
     void sample.search.fetcher.performInitialSearch({
       query,
@@ -62,8 +67,8 @@ function SubsampleListing({ sample }: SubsampleListingArgs): Node {
             value={{
               search: sample.search,
               scopedResult: sample,
-              isChild: true,
-              differentSearchForSettingActiveResult: search,
+              isChild: false,
+              differentSearchForSettingActiveResult: sample.search,
             }}
           >
             <InnerSearchNavigationContext>

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleListing.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleListing.js
@@ -9,6 +9,9 @@ import { menuIDs } from "../../../util/menuIDs";
 import Grid from "@mui/material/Grid";
 import SampleModel from "../../../stores/models/SampleModel";
 import InnerSearchNavigationContext from "../../components/InnerSearchNavigationContext";
+import Collapse from "@mui/material/Collapse";
+import ExpandCollapseIcon from "../../../components/ExpandCollapseIcon";
+import IconButton from "@mui/material/IconButton";
 
 const TABS = ["LIST", "TREE", "CARD"];
 
@@ -25,6 +28,13 @@ type SubsampleListingArgs = {|
  */
 function SubsampleListing({ sample }: SubsampleListingArgs): Node {
   const { search } = React.useContext(SearchContext);
+  const [searchOpen, setSearchOpen] = React.useState(
+    sample.subSamples.length > 1
+  );
+
+  React.useEffect(() => {
+    setSearchOpen(sample.subSamples.length > 1);
+  }, [sample.subSamples]);
 
   const handleSearch = (query: string) => {
     void sample.search.fetcher.performInitialSearch({
@@ -34,25 +44,46 @@ function SubsampleListing({ sample }: SubsampleListingArgs): Node {
   };
 
   return (
-    <SearchContext.Provider
-      value={{
-        search: sample.search,
-        scopedResult: sample,
-        isChild: true,
-        differentSearchForSettingActiveResult: search,
-      }}
-    >
-      <InnerSearchNavigationContext>
-        <Grid container direction="column" spacing={1}>
-          <Grid item>
-            <Search handleSearch={handleSearch} TABS={TABS} size="small" />
-          </Grid>
-          <Grid item>
-            <SearchView contextMenuId={menuIDs.RESULTS} />
-          </Grid>
-        </Grid>
-      </InnerSearchNavigationContext>
-    </SearchContext.Provider>
+    <Grid container direction="row" flexWrap="nowrap" spacing={1}>
+      <Grid item sx={{ pl: 0, ml: -2 }}>
+        <IconButton onClick={() => setSearchOpen(!searchOpen)} sx={{ p: 1.25 }}>
+          <ExpandCollapseIcon open={searchOpen} />
+        </IconButton>
+      </Grid>
+      <Grid item>
+        <Collapse
+          in={searchOpen}
+          collapsedSize={44}
+          onClick={() => {
+            setSearchOpen(true);
+          }}
+        >
+          <SearchContext.Provider
+            value={{
+              search: sample.search,
+              scopedResult: sample,
+              isChild: true,
+              differentSearchForSettingActiveResult: search,
+            }}
+          >
+            <InnerSearchNavigationContext>
+              <Grid container direction="column" spacing={1}>
+                <Grid item>
+                  <Search
+                    handleSearch={handleSearch}
+                    TABS={TABS}
+                    size="small"
+                  />
+                </Grid>
+                <Grid item>
+                  <SearchView contextMenuId={menuIDs.RESULTS} />
+                </Grid>
+              </Grid>
+            </InnerSearchNavigationContext>
+          </SearchContext.Provider>
+        </Collapse>
+      </Grid>
+    </Grid>
   );
 }
 

--- a/src/main/webapp/ui/src/Inventory/Sample/Form.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Form.js
@@ -31,6 +31,7 @@ import {
 import LimitedAccessAlert from "../components/LimitedAccessAlert";
 import type { Person } from "../../stores/definitions/Person";
 import SubsampleDetails from "./Content/SubsampleDetails";
+import Typography from "@mui/material/Typography";
 
 const OverviewSection = observer(
   ({ activeResult }: { activeResult: SampleModel }) => {
@@ -225,6 +226,15 @@ function Form(): Node {
               sectionName="subsamples"
               recordType="sample"
             >
+              {/*
+               * We say "one of the {plural}" here instead of "a {alias}"
+               * because adding the logic to get the grammar of "a" versus
+               * "an" right would be too much of a pain.
+               */}
+              <Typography variant="body1">
+                Tap one of the {activeResult.subSampleAlias.plural} in the
+                search section to preview it below.
+              </Typography>
               <SubsampleListing sample={activeResult} />
               <SubsampleDetails search={activeResult.search} />
             </StepperPanel>

--- a/src/main/webapp/ui/src/Inventory/Sample/Form.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Form.js
@@ -226,7 +226,7 @@ function Form(): Node {
               recordType="sample"
             >
               <SubsampleListing sample={activeResult} />
-              <SubsampleDetails subsample={activeResult.search.activeResult} />
+              <SubsampleDetails search={activeResult.search} />
             </StepperPanel>
           ) : null}
         </>

--- a/src/main/webapp/ui/src/Inventory/Sample/Form.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Form.js
@@ -30,6 +30,7 @@ import {
 } from "../components/Stepper/StepperPanelHeader";
 import LimitedAccessAlert from "../components/LimitedAccessAlert";
 import type { Person } from "../../stores/definitions/Person";
+import SubsampleDetails from "./Content/SubsampleDetails";
 
 const OverviewSection = observer(
   ({ activeResult }: { activeResult: SampleModel }) => {
@@ -225,6 +226,7 @@ function Form(): Node {
               recordType="sample"
             >
               <SubsampleListing sample={activeResult} />
+              <SubsampleDetails subsample={activeResult.search.activeResult} />
             </StepperPanel>
           ) : null}
         </>

--- a/src/main/webapp/ui/src/Inventory/Search/ResultsTable.js
+++ b/src/main/webapp/ui/src/Inventory/Search/ResultsTable.js
@@ -65,7 +65,7 @@ function ResultsTable({ contextMenuId }: ResultsTableArgs): Node {
   };
 
   const handleChangePage = (newPage: number) => {
-    search.setPage(newPage);
+    void search.setPage(newPage);
   };
 
   const toggleAll = () => {

--- a/src/main/webapp/ui/src/Inventory/Search/components/ResultRow.js
+++ b/src/main/webapp/ui/src/Inventory/Search/components/ResultRow.js
@@ -57,16 +57,16 @@ function ResultRow({ result, adjustableColumns }: ResultRowArgs): Node {
   const { classes } = useStyles();
 
   /*
-   * Whilst card view uses `searchStore`, here we use
-   * `differentSearchForSettingActiveResult` because there are various places
-   * where list view is used for selecting records where slightly different
-   * actions are taken. In the right panel, tapping a row will set that record
-   * as the `activeResult` of `searchStore` (thereby changing the contents of
-   * the right panel). In the move dialog, the right panel of the dialog is
-   * updated to show the current contents of the container. In the template
-   * picker, tapping the row will set the `activeResult` of the picker's search
-   * which will ultimately change the `template` of the new sample that is the
-   * `searchStore`'s `activeResult`. Ultimately, this means that replacing
+   * Here we use `differentSearchForSettingActiveResult` because there are
+   * various places where list view is used for selecting records where
+   * slightly different actions are taken. In the right panel, tapping a row
+   * will set that record as the `activeResult` of `searchStore` (thereby
+   * changing the contents of the right panel). In the move dialog, the right
+   * panel of the dialog is updated to show the current contents of the
+   * container. In the template picker, tapping the row will set the
+   * `activeResult` of the picker's search which will ultimately change the
+   * `template` of the new sample that is the `searchStore`'s `activeResult`.
+   * Ultimately, this means that replacing
    * `differentSearchForSettingActiveResult` with a solution that just looks at
    * the current search context and its parent is not sufficiently flexible.
    */

--- a/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/NewNote.js
+++ b/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/NewNote.js
@@ -12,6 +12,7 @@ import Typography from "@mui/material/Typography";
 import TextField from "../../../../components/Inputs/TextField";
 import SubSampleModel from "../../../../stores/models/SubSampleModel";
 import FormField from "../../../../components/Inputs/FormField";
+import Stack from "@mui/material/Stack";
 
 const emptyNote = {
   content: "",
@@ -91,24 +92,31 @@ function NewNote({ record, onErrorStateChange }: NewNoteArgs): Node {
         )}
         disabled={!record.isFieldEditable("notes")}
       />
-      <Typography variant="caption">
-        Please note that once created, notes can be neither edited nor deleted.
-      </Typography>
-      <Button
-        style={{ marginTop: "15px" }}
-        disableElevation
-        disabled={
-          !record.isFieldEditable("notes") || error || note.content === ""
-        }
-        variant="contained"
-        id="add-note"
-        data-test-id="add-note-button"
-        aria-label="Add new note"
-        onClick={createNote}
-        color="primary"
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="flex-start"
       >
-        Create note
-      </Button>
+        <Typography variant="caption">
+          Please note that once created, notes can be neither edited nor
+          deleted.
+        </Typography>
+        <Button
+          style={{ minWidth: "unset", whiteSpace: "nowrap" }}
+          disableElevation
+          disabled={
+            !record.isFieldEditable("notes") || error || note.content === ""
+          }
+          variant="contained"
+          id="add-note"
+          data-test-id="add-note-button"
+          aria-label="Add new note"
+          onClick={createNote}
+          color="primary"
+        >
+          Create note
+        </Button>
+      </Stack>
     </>
   );
 }

--- a/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/NewNote.js
+++ b/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/NewNote.js
@@ -89,6 +89,7 @@ function NewNote({ record, onErrorStateChange }: NewNoteArgs): Node {
         renderInput={({ error: _error, ...props }) => (
           <TextField onChange={handleChange} name="content" {...props} />
         )}
+        disabled={!record.isFieldEditable("notes")}
       />
       <Typography variant="caption">
         Please note that once created, notes can be neither edited nor deleted.
@@ -96,7 +97,9 @@ function NewNote({ record, onErrorStateChange }: NewNoteArgs): Node {
       <Button
         style={{ marginTop: "15px" }}
         disableElevation
-        disabled={error || note.content === ""}
+        disabled={
+          !record.isFieldEditable("notes") || error || note.content === ""
+        }
         variant="contained"
         id="add-note"
         data-test-id="add-note-button"

--- a/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/Notes.js
+++ b/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/Notes.js
@@ -16,7 +16,7 @@ function Notes({ record, onErrorStateChange }: NotesArgs): Node {
   return (
     <FormControl>
       {record.isFieldVisible("notes") && <NotesList record={record} />}
-      {record.isFieldEditable("notes") && record.isFieldVisible("notes") && (
+      {record.isFieldVisible("notes") && (
         <NewNote record={record} onErrorStateChange={onErrorStateChange} />
       )}
     </FormControl>

--- a/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/Notes.js
+++ b/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/Notes.js
@@ -6,15 +6,22 @@ import NotesList from "./NotesList";
 import NewNote from "./NewNote";
 import FormControl from "../../../../components/Inputs/FormControl";
 import SubSampleModel from "../../../../stores/models/SubSampleModel";
+import FormLabel from "@mui/material/FormLabel";
 
 type NotesArgs = {|
   record: SubSampleModel,
   onErrorStateChange: (boolean) => void,
+  hideLabel?: boolean,
 |};
 
-function Notes({ record, onErrorStateChange }: NotesArgs): Node {
+function Notes({
+  record,
+  onErrorStateChange,
+  hideLabel = false,
+}: NotesArgs): Node {
   return (
     <FormControl>
+      {!hideLabel && <FormLabel>Notes</FormLabel>}
       {record.isFieldVisible("notes") && <NotesList record={record} />}
       {record.isFieldVisible("notes") && (
         <NewNote record={record} onErrorStateChange={onErrorStateChange} />

--- a/src/main/webapp/ui/src/Inventory/Subsample/Form.js
+++ b/src/main/webapp/ui/src/Inventory/Subsample/Form.js
@@ -270,6 +270,7 @@ const NotesSection = observer(
           onErrorStateChange={(value) =>
             setFormSectionError(formSectionError, "notes", value)
           }
+          hideLabel
         />
       </StepperPanel>
     );

--- a/src/main/webapp/ui/src/Inventory/components/DetailedListing/Card.js
+++ b/src/main/webapp/ui/src/Inventory/components/DetailedListing/Card.js
@@ -208,14 +208,20 @@ type CardArgs = {|
 |};
 
 function RecordCard({ record }: CardArgs): Node {
-  const { search, disabled, isChild, scopedResult } = useContext(SearchContext);
+  const {
+    search,
+    disabled,
+    isChild,
+    scopedResult,
+    differentSearchForSettingActiveResult,
+  } = useContext(SearchContext);
   const { searchStore, uiStore } = useStores();
   const { useNavigate } = useContext(NavigateContext);
   const navigate = useNavigate();
   const theme = useTheme();
 
   const activateResult = (r: InventoryRecord) => {
-    searchStore.search
+    differentSearchForSettingActiveResult
       .setActiveResult(r)
       .then(() => {
         uiStore.setVisiblePanel("right");

--- a/src/main/webapp/ui/src/stores/definitions/Search.js
+++ b/src/main/webapp/ui/src/stores/definitions/Search.js
@@ -212,7 +212,7 @@ export interface CoreFetcher {
    */
   pageNumber: number;
   pageSize: number;
-  setPage(number): void;
+  setPage(number): Promise<void>;
   setPageSize(number): void;
 
   /*
@@ -364,7 +364,7 @@ export interface Search {
    * pagination) and reperform the search.
    */
   setPageSize(number): void;
-  setPage(number): void;
+  setPage(number): Promise<void>;
 
   /*
    * The UI MAY provide a mechanism to select multiple search results that can

--- a/src/main/webapp/ui/src/stores/models/Fetcher/CacheFetcher.js
+++ b/src/main/webapp/ui/src/stores/models/Fetcher/CacheFetcher.js
@@ -46,7 +46,7 @@ export default class CacheFetcher
     // do nothing; status filter is not allowed in grid and image view
   }
 
-  setPage(pageNumber: number): void {
+  async setPage(pageNumber: number): Promise<void> {
     this.pageNumber = pageNumber;
   }
 

--- a/src/main/webapp/ui/src/stores/models/Fetcher/CoreFetcher.js
+++ b/src/main/webapp/ui/src/stores/models/Fetcher/CoreFetcher.js
@@ -216,15 +216,15 @@ export default class CoreFetcher {
     Object.assign(this, params);
   }
 
-  setPage(pageNumber: number): void {
+  async setPage(pageNumber: number): Promise<void> {
     this.pageNumber = pageNumber;
-    void this.reperformCurrentSearch();
+    await this.reperformCurrentSearch();
   }
 
   setOrder(order: Order, orderBy: string): void {
     this.order = order;
     this.orderBy = orderBy;
-    this.setPage(0);
+    void this.setPage(0);
   }
 
   setPageSize(pageSize: number): void {

--- a/src/main/webapp/ui/src/stores/models/Fetcher/DynamicFetcher.js
+++ b/src/main/webapp/ui/src/stores/models/Fetcher/DynamicFetcher.js
@@ -31,15 +31,15 @@ export default class DynamicFetcher
     this.pageSize = DYNAMIC_PAGE_SIZE;
   }
 
-  setPage(pageNumber: number) {
+  async setPage(pageNumber: number): Promise<void> {
     this.pageNumber = pageNumber;
-    void this.search(null, (results: Array<InventoryRecord>) =>
+    await this.search(null, (results: Array<InventoryRecord>) =>
       pageNumber === 0 ? this.setResults(results) : this.addResults([], results)
     );
   }
 
   dynamicSearch() {
-    this.setPage(this.pageNumber + 1);
+    void this.setPage(this.pageNumber + 1);
   }
 
   get nextDynamicPageSize(): number {

--- a/src/main/webapp/ui/src/stores/models/Search.js
+++ b/src/main/webapp/ui/src/stores/models/Search.js
@@ -1157,8 +1157,8 @@ export default class Search implements SearchInterface {
     this.performSearch();
   }
 
-  setPage(pageNumber: number) {
-    this.fetcher.setPage(pageNumber);
+  async setPage(pageNumber: number) {
+    await this.fetcher.setPage(pageNumber);
   }
 
   setOwner(user: ?Person, doSearch: ?boolean = true) {

--- a/src/main/webapp/ui/src/stores/models/__tests__/Search/setBench.test.js
+++ b/src/main/webapp/ui/src/stores/models/__tests__/Search/setBench.test.js
@@ -31,7 +31,7 @@ describe("action: setBench", () => {
           Promise.resolve({ data: { containers: [] } })
         );
 
-      search.setPage(1);
+      void search.setPage(1);
       expect(querySpy).toHaveBeenCalledTimes(1);
       expect(querySpy).toHaveBeenCalledWith(
         "containers",

--- a/src/main/webapp/ui/src/stores/models/__tests__/Search/setDeletedItems.test.js
+++ b/src/main/webapp/ui/src/stores/models/__tests__/Search/setDeletedItems.test.js
@@ -31,7 +31,7 @@ describe("action: setDeletedItems", () => {
           Promise.resolve({ data: { containers: [] } })
         );
 
-      search.setPage(1);
+      void search.setPage(1);
       expect(querySpy).toHaveBeenCalledTimes(1);
       expect(querySpy).toHaveBeenCalledWith(
         "containers",

--- a/src/main/webapp/ui/src/stores/models/__tests__/Search/setOwner.test.js
+++ b/src/main/webapp/ui/src/stores/models/__tests__/Search/setOwner.test.js
@@ -31,7 +31,7 @@ describe("action: setOwner", () => {
           Promise.resolve({ data: { containers: [] } })
         );
 
-      search.setPage(1);
+      void search.setPage(1);
       expect(querySpy).toHaveBeenCalledTimes(1);
       expect(querySpy).toHaveBeenCalledWith(
         "containers",

--- a/src/main/webapp/ui/src/stores/models/__tests__/Search/setPageSize.test.js
+++ b/src/main/webapp/ui/src/stores/models/__tests__/Search/setPageSize.test.js
@@ -31,7 +31,7 @@ describe("action: setPageSize", () => {
           Promise.resolve({ data: { containers: [] } })
         );
 
-      search.setPage(1);
+      void search.setPage(1);
       expect(querySpy).toHaveBeenCalledTimes(1);
       expect(querySpy).toHaveBeenCalledWith(
         "containers",

--- a/src/main/webapp/ui/src/stores/models/__tests__/Search/setTypeFilter.test.js
+++ b/src/main/webapp/ui/src/stores/models/__tests__/Search/setTypeFilter.test.js
@@ -31,7 +31,7 @@ describe("action: setTypeFilter", () => {
           Promise.resolve({ data: { containers: [] } })
         );
 
-      search.setPage(1);
+      void search.setPage(1);
       expect(querySpy).toHaveBeenCalledTimes(1);
       expect(querySpy).toHaveBeenCalledWith(
         "containers",


### PR DESCRIPTION
This change adds a new section to the sample page, showing some details of each subsample. This is to make it easier to browse those details without having to click around each subsample page, particularly useful when samples regularly only have one subsample.

![image](https://github.com/rspace-os/rspace-web/assets/8805923/aaeaa258-11de-4c4e-9750-754ed39160c4)

This new panel appears below the subsample listing table, with the subsample theme colours to distinguish it from the sample itself. The user can browse back and forward between the subsample with the arrow buttons, or just to a specific subsample by tapping a row in the table (viewing the subsample's own page is now reachable by tapping the Global ID link or the link at the end of the new panel). The location, quantity, and notes fields are shown; fields that are specific to the subsample and detail what is unique about this physical quantity of some substance.

Moreover, the table listing all of the subsamples now defaults to being closed when there is only one subsample. We still must keep it available as there are some operations on the subsample that can only be performed from the search mechanism, but it is unlikely to be of interest most of the time for users who typically have samples with only one subsample. Interacting with the search mechanism in any way causes it to open.

In terms of implementation details of note, the `activeResult` of the `Search` mechanism scoped to the `SampleModel` is being used for fetching the full details of the subsample, and it is that allows us to change the displayed subsample when the rows of the table are tapped. As such, when the user presses the next and previous buttons we have to fetch the previous or next page of results if the record in question is not yet known to the `Search` mechanism. Up until now, we've not used the `activeResult` of the searches scoped to each record type (container contents, sample subsamples, and template samples), but the `activeResult` is in use in the move dialog, the template picker, and of course the whole page-wide search. The abstraction afforded by the `Search` and `CoreFetcher` et al. classes continues to pay dividends.