### PR TITLE
RSDEV-277 Improve breadcrumbs on new Gallery page

### DIFF
--- a/src/main/webapp/WEB-INF/decorators.xml
+++ b/src/main/webapp/WEB-INF/decorators.xml
@@ -29,6 +29,8 @@
         <pattern>*/public/inventory/**</pattern>
         <pattern>/apps</pattern>
         <pattern>/newGallery</pattern>
+        <pattern>/newGallery*</pattern>
+        <pattern>/newGallery/**</pattern>
     </excludes>
     <decorator name="public" page="externalPages.jsp">
         <pattern>*/signup*</pattern>

--- a/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -140,6 +140,10 @@
       <from>/newGallery</from>
       <to>/eln/gallery.html</to>
     </rule>
+    <rule>
+      <from>/newGallery/**</from>
+      <to>/eln/gallery.html</to>
+    </rule>
 
     <!-- Backward compatibility: nextcloud/owncloud were not using /apps prefix until RSDEV-105 -->
     <rule>

--- a/src/main/webapp/ui/flow-typed/mui.js
+++ b/src/main/webapp/ui/flow-typed/mui.js
@@ -25,6 +25,14 @@ declare module "@mui/system" {
   declare export function darken(color: string, coefficient: number): string;
 
   /**
+   * Lightens a color.
+   * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color()
+   * @param {number} coefficient - multiplier in the range 0 - 1
+   * @returns {string} A CSS color string. Hex input values are returned as rgb
+   */
+  declare export function lighten(color: string, coefficient: number): string;
+
+  /**
    * Applies a transparency to a color.
    * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color()
    * @param {number} opacity - number in the range 0 - 1

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -211,14 +211,18 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
                   [`&:has(.${inputAdornmentClasses.positionStart})`]: {
                     paddingLeft: 0,
                   },
-                  [`& .${svgIconClasses.root}`]: {
-                    fill: prefersMoreContrast
-                      ? "rgb(0,0,0)"
-                      : contrastTextColor,
+                  [`& .${inputAdornmentClasses.root}`]: {
+                    paddingLeft: baseTheme.spacing(1),
+                    paddingRight: baseTheme.spacing(1),
+                    [`& .${svgIconClasses.root}`]: {
+                      fill: prefersMoreContrast
+                        ? "rgb(0,0,0)"
+                        : contrastTextColor,
+                    },
                   },
                   "& input": {
                     padding: baseTheme.spacing(0.5),
-                    paddingLeft: 0,
+                    paddingLeft: baseTheme.spacing(1),
                     color: prefersMoreContrast
                       ? "rgb(0,0,0)"
                       : contrastTextColor,
@@ -452,19 +456,20 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
                 [`& .${outlinedInputClasses.input}`]: {
                   paddingTop: "5px",
                   paddingBottom: "5px",
+                  paddingLeft: baseTheme.spacing(1.5),
                 },
               },
               [`& .${inputAdornmentClasses.root}`]: {
                 height: "100%",
-                paddingLeft: baseTheme.spacing(1),
-                paddingRight: baseTheme.spacing(1),
+                paddingLeft: baseTheme.spacing(1.5),
+                paddingRight: baseTheme.spacing(1.5),
                 borderRight: accentedBorder,
-                backgroundColor: lighterInteractiveColor,
+                marginRight: 0,
                 [`& .${typographyClasses.root}`]: {
                   textTransform: "uppercase",
                   fontWeight: 700,
-                  fontSize: "0.9rem",
-                  lineHeight: "31px",
+                  fontSize: "0.8125rem",
+                  lineHeight: "20px",
                 },
               },
             },

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -3,7 +3,7 @@
 import { createTheme } from "@mui/material";
 import baseTheme from "./theme";
 import { mergeThemes } from "./util/styles";
-import { darken, alpha } from "@mui/system";
+import { darken, alpha, lighten } from "@mui/system";
 import { toolbarClasses } from "@mui/material/Toolbar";
 import { typographyClasses } from "@mui/material/Typography";
 import { svgIconClasses } from "@mui/material/SvgIcon";
@@ -94,11 +94,17 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
   const mainAccentColor = prefersMoreContrast
     ? "rgb(0,0,0)"
     : `hsl(${accent.main.hue}deg, ${accent.main.saturation}%, ${accent.main.lightness}%)`;
-  const disabledColor = `hsl(${accent.main.hue}deg, 10%, 86%)`;
+  const disabledColor = lighten(
+    `hsl(${accent.main.hue}deg, 10%, ${accent.main.lightness}%)`,
+    0.5
+  );
 
   const linkButtonText = prefersMoreContrast
     ? "rgb(0,0,0)"
-    : `hsl(${accent.main.hue}deg, ${accent.main.saturation}%, 40%)`;
+    : darken(
+        `hsl(${accent.main.hue}deg, ${accent.main.saturation}%, ${accent.main.lightness}%)`,
+        0.5
+      );
 
   /**
    * A background colour that can be used behind headers, toolbars, and other

--- a/src/main/webapp/ui/src/components/EventBoundary.js
+++ b/src/main/webapp/ui/src/components/EventBoundary.js
@@ -1,6 +1,6 @@
 //@flow
 
-import React from "react";
+import React, { type Node } from "react";
 
 /**
  * All of the DOM events that happen inside of a dialog shouldn't propagate
@@ -8,7 +8,7 @@ import React from "react";
  * providing keyboard navigation. See ../../../../QuirksOfMaterialUi.md, secion
  * "Dialogs inside Menus", for more information.
  */
-export default ({ children }: { children: Node }) => (
+export default ({ children }: { children: Node }): Node => (
   /*
    * The eslint suppression is required because `div`s should not ordinarilly
    * have event handlers as they cannot be focussed. However, in this case, we

--- a/src/main/webapp/ui/src/components/useOneDimensionalRovingTabIndex.js
+++ b/src/main/webapp/ui/src/components/useOneDimensionalRovingTabIndex.js
@@ -12,10 +12,11 @@ import { modulo } from "../util/Util";
  * than tabbing through them all.
  *
  * This custom hook provides an abstraction over implementing a roving tab
- * index for a vertical list of elements, so that the up and down arrow keys
- * provide navigation between the elements in the list. Tab and shift-tab move
- * the user's focus out of the list, and when they return the focus resumes on
- * the last element in the list that had focus.
+ * index for a one-dimensional list of elements, so that either the up and down
+ * arrow keys provide navigation between the elements in the list, or the left
+ * and right arrow keys dow. Tab and shift-tab move the user's focus out of the
+ * list, and when they return the focus resumes on the last element in the list
+ * that had focus.
  *
  * There are two parts to how this custom hook is to be used:
  *
@@ -31,14 +32,22 @@ import { modulo } from "../util/Util";
  *  - https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio/
  *  - https://www.youtube.com/watch?v=uCIC2LNt0bk
  */
-export default function useVerticalRovingTabIndex<RefComponent: HTMLElement>({
+export default function useOneDimensionalRovingTabIndex<
+  RefComponent: HTMLElement
+>({
   max,
+  direction = "column",
 }: {|
   /**
    * The index of the last element of the vertical list, where the indexing is
    * 0-based.
    */
   max: number,
+
+  /**
+   * The dimension in which the elements of the list are laid out. Defaults to "column"
+   */
+  direction?: "row" | "column",
 |}): {|
   /**
    * The set of the event handlers that must be attached to the container
@@ -92,9 +101,13 @@ export default function useVerticalRovingTabIndex<RefComponent: HTMLElement>({
      * By using modulo rather than min and max the user's focus wraps around
      * when reaching the end.
      */
-    if (e.key === "ArrowUp") {
+    if (e.key === "ArrowUp" && direction === "column") {
       setRovingTabIndex(modulo(rovingTabIndex - 1, max + 1));
-    } else if (e.key === "ArrowDown") {
+    } else if (e.key === "ArrowDown" && direction === "column") {
+      setRovingTabIndex(modulo(rovingTabIndex + 1, max + 1));
+    } else if (e.key === "ArrowLeft" && direction === "row") {
+      setRovingTabIndex(modulo(rovingTabIndex - 1, max + 1));
+    } else if (e.key === "ArrowRight" && direction === "row") {
       setRovingTabIndex(modulo(rovingTabIndex + 1, max + 1));
     }
   }

--- a/src/main/webapp/ui/src/eln/gallery/common.js
+++ b/src/main/webapp/ui/src/eln/gallery/common.js
@@ -1,8 +1,10 @@
 //@flow
 
 import { COLORS as baseThemeColors } from "../../theme";
+import Result from "../../util/result";
+import * as Parsers from "../../util/parsers";
 
-export type GallerySection = 
+export type GallerySection =
   | "Images"
   | "Audios"
   | "Videos"
@@ -12,7 +14,41 @@ export type GallerySection =
   | "NetworkFiles"
   | "Snippets"
   | "Miscellaneous"
-  | "PdfDocuments"
+  | "PdfDocuments";
+
+export const GALLERY_SECTION = {
+  IMAGES: "Images",
+  AUDIOS: "Audios",
+  VIDEOS: "Videos",
+  DOCUMENTS: "Documents",
+  CHEMISTRY: "Chemistry",
+  DMPS: "DMPs",
+  NETWORKFILES: "NetworkFiles",
+  SNIPPETS: "Snippets",
+  MISCELLANEOUS: "Miscellaneous",
+  PDFDOCUMENTS: "PdfDocuments",
+};
+
+export const parseGallerySectionFromUrlSearchParams = (
+  searchParams: URLSearchParams
+): Result<GallerySection> =>
+  Result.fromNullable(
+    searchParams.get("mediaType"),
+    new Error("No search parameter with name 'mediaType'")
+  ).flatMap((mediaType) =>
+    Result.first(
+      Parsers.parseString(GALLERY_SECTION.IMAGES, mediaType),
+      Parsers.parseString(GALLERY_SECTION.AUDIOS, mediaType),
+      Parsers.parseString(GALLERY_SECTION.VIDEOS, mediaType),
+      Parsers.parseString(GALLERY_SECTION.DOCUMENTS, mediaType),
+      Parsers.parseString(GALLERY_SECTION.CHEMISTRY, mediaType),
+      Parsers.parseString(GALLERY_SECTION.DMPS, mediaType),
+      Parsers.parseString(GALLERY_SECTION.NETWORKFILES, mediaType),
+      Parsers.parseString(GALLERY_SECTION.SNIPPETS, mediaType),
+      Parsers.parseString(GALLERY_SECTION.MISCELLANEOUS, mediaType),
+      Parsers.parseString(GALLERY_SECTION.PDFDOCUMENTS, mediaType)
+    )
+  );
 
 export const gallerySectionLabel = {
   Images: "Images",

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -216,6 +216,7 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
         onClick={(e) => {
           setActionsMenuAnchorEl(e.target);
         }}
+        sx={{ flexGrow: 1 }}
       >
         Actions
       </Button>

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -209,8 +209,10 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
   return (
     <>
       <Button
-        variant="outlined"
+        variant="contained"
+        color="primary"
         size="small"
+        disabled={selection.isEmpty}
         aria-haspopup="menu"
         startIcon={<ChecklistIcon />}
         onClick={(e) => {

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -30,6 +30,7 @@ import Result from "../../../util/result";
 import MoveToIrods, { COLOR as IRODS_COLOR } from "./MoveToIrods";
 import IrodsLogo from "./IrodsLogo.svg";
 import Avatar from "@mui/material/Avatar";
+import Typography from "@mui/material/Typography";
 import MoveDialog from "./MoveDialog";
 
 const RenameDialog = ({
@@ -419,6 +420,22 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
           disabled={deleteAllowed().isError}
         />
       </StyledMenu>
+      <Typography
+        variant="body2"
+        sx={{
+          p: 0,
+          pl: 1,
+          fontWeight: 500,
+          display: { xs: "none", sm: "initial" },
+          ...(selection.isEmpty
+            ? {
+                color: "grey",
+              }
+            : {}),
+        }}
+      >
+        {selection.label}
+      </Typography>
     </>
   );
 }

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -216,7 +216,6 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
         onClick={(e) => {
           setActionsMenuAnchorEl(e.target);
         }}
-        sx={{ flexGrow: 1 }}
       >
         Actions
       </Button>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -374,7 +374,8 @@ const GridView = observer(
   ({
     listing,
   }: {|
-    listing: | {| tag: "empty", reason: string |}
+    listing:
+      | {| tag: "empty", reason: string |}
       | {| tag: "list", list: $ReadOnlyArray<GalleryFile> |},
   |}) => {
     const dndContext = useDndContext();
@@ -937,7 +938,8 @@ type GalleryMainPanelArgs = {|
   clearPath: () => void,
   galleryListing: FetchingData.Fetched<
     | {| tag: "empty", reason: string |}
-    | {| tag: "list", list: $ReadOnlyArray<GalleryFile> |}>,
+    | {| tag: "list", list: $ReadOnlyArray<GalleryFile> |}
+  >,
   folderId: FetchingData.Fetched<Id>,
   refreshListing: () => void,
   sortOrder: "DESC" | "ASC",

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -66,6 +66,44 @@ import SwapVertIcon from "@mui/icons-material/SwapVert";
 import HorizontalRuleIcon from "@mui/icons-material/HorizontalRule";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import * as ArrayUtils from "../../../util/ArrayUtils";
+
+const Path = styled(({ className, section, path }) => {
+  const str = ArrayUtils.last(path)
+    .map((folder) => folder.pathAsString())
+    .orElse(`/${section}/`);
+  return (
+    <TextField
+      className={className}
+      value={str}
+      onChange={() => {}}
+      fullWidth
+      size="small"
+      InputProps={{
+        startAdornment: <InputAdornment position="start">Path</InputAdornment>,
+      }}
+    />
+  );
+})(({ theme }) => ({
+  "& .MuiOutlinedInput-root": {
+    "& .MuiInputAdornment-root": {
+      paddingLeft: theme.spacing(1.5),
+      paddingRight: theme.spacing(1.5),
+      backgroundColor: "unset",
+      marginRight: 0,
+      "& .MuiTypography-root": {
+        lineHeight: "20px",
+        fontSize: "0.8125rem",
+      },
+    },
+  },
+  "& input": {
+    height: "21px",
+    paddingLeft: theme.spacing(1.5),
+  },
+}));
 
 const StyledMenu = styled(Menu)(({ open }) => ({
   "& .MuiPaper-root": {
@@ -946,34 +984,9 @@ function GalleryMainPanel({
             item
             container
             direction="row"
-            justifyContent="space-between"
             alignItems="flex-start"
-            flexWrap="nowrap"
+            spacing={1}
           >
-            <Grid item>
-              <CustomBreadcrumbs
-                separator="›"
-                aria-label="breadcrumb"
-                sx={{ mt: 0.5 }}
-              >
-                <Breadcrumb
-                  label={gallerySectionLabel[selectedSection]}
-                  onClick={() => clearPath()}
-                  path={[]}
-                  selectedSection={selectedSection}
-                />
-                {path.map((folder) => (
-                  <Breadcrumb
-                    folder={folder}
-                    label={folder.name}
-                    key={idToString(folder.id)}
-                    onClick={() => folder.open?.()}
-                    path={folder.path}
-                    selectedSection={selectedSection}
-                  />
-                ))}
-              </CustomBreadcrumbs>
-            </Grid>
             <Grid item sx={{ mt: 0.5 }}>
               <Stack direction="row" spacing={1}>
                 <Button
@@ -1130,6 +1143,9 @@ function GalleryMainPanel({
                   />
                 </StyledMenu>
               </Stack>
+            </Grid>
+            <Grid item sx={{ mt: 0.5 }} flexGrow={1}>
+              <Path section={selectedSection} path={path} />
             </Grid>
           </Grid>
           <Grid

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -75,9 +75,11 @@ import { Link as ReactRouterLink } from "react-router-dom";
 const BreadcrumbLink = ({
   folder,
   section,
+  clearPath,
 }: {|
   folder?: GalleryFile,
   section: string,
+  clearPath: () => void,
 |}) => {
   const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: `/${[
@@ -110,6 +112,11 @@ const BreadcrumbLink = ({
     <Link
       component={ReactRouterLink}
       to={""}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        (folder?.open ?? clearPath)();
+      }}
       ref={(node) => {
         setDropRef(node);
       }}
@@ -127,7 +134,7 @@ const BreadcrumbLink = ({
   );
 };
 
-const Path = styled(({ className, section, path }) => {
+const Path = styled(({ className, section, path, clearPath }) => {
   const str = ArrayUtils.last(path)
     .map((folder) => folder.pathAsString())
     .orElse(`/${section}/`);
@@ -184,11 +191,15 @@ const Path = styled(({ className, section, path }) => {
               cursor: "text",
             }}
           >
-            <BreadcrumbLink section={section} />
+            <BreadcrumbLink section={section} clearPath={clearPath} />
             {path.map((f) => (
               <>
                 <span>›</span>
-                <BreadcrumbLink folder={f} section={section} />
+                <BreadcrumbLink
+                  folder={f}
+                  section={section}
+                  clearPath={clearPath}
+                />
               </>
             ))}
           </Stack>
@@ -1252,7 +1263,11 @@ function GalleryMainPanel({
              * above, they each take up 1/3 of the row.
              */}
             <Grid item flexGrow={99999} sx={{ position: "relative" }}>
-              <Path section={selectedSection} path={path} />
+              <Path
+                section={selectedSection}
+                path={path}
+                clearPath={clearPath}
+              />
             </Grid>
           </Grid>
           <Grid

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -69,6 +69,8 @@ import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import TextField from "@mui/material/TextField";
 import InputAdornment from "@mui/material/InputAdornment";
 import * as ArrayUtils from "../../../util/ArrayUtils";
+import Link from "@mui/material/Link";
+import { Link as ReactRouterLink } from "react-router-dom";
 
 const BreadcrumbLink = ({
   folder,
@@ -105,7 +107,9 @@ const BreadcrumbLink = ({
         border: "2px solid transparent",
       };
   return (
-    <span
+    <Link
+      component={ReactRouterLink}
+      to={""}
       ref={(node) => {
         setDropRef(node);
       }}
@@ -117,7 +121,7 @@ const BreadcrumbLink = ({
       }}
     >
       {folder?.name ?? section}
-    </span>
+    </Link>
   );
 };
 

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -132,6 +132,7 @@ const Path = styled(({ className, section, path }) => {
     .map((folder) => folder.pathAsString())
     .orElse(`/${section}/`);
   const [hasFocus, setHasFocus] = React.useState(false);
+  const textFieldRef = React.useRef();
   return (
     <>
       <TextField
@@ -145,6 +146,9 @@ const Path = styled(({ className, section, path }) => {
         }}
         onBlur={() => {
           setHasFocus(false);
+        }}
+        inputProps={{
+          ref: textFieldRef,
         }}
         InputProps={{
           startAdornment: (
@@ -167,6 +171,9 @@ const Path = styled(({ className, section, path }) => {
           }}
         >
           <Stack
+            onClick={() => {
+              textFieldRef.current?.focus();
+            }}
             direction="row"
             spacing={0.25}
             sx={{
@@ -174,6 +181,7 @@ const Path = styled(({ className, section, path }) => {
               overflowX: "auto",
               marginBottom: "-50px",
               paddingBottom: "50px",
+              cursor: "text",
             }}
           >
             <BreadcrumbLink section={section} />

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -118,6 +118,8 @@ const BreadcrumbLink = ({
         borderRadius: "6px",
         paddingLeft: "1px",
         paddingRight: "1px",
+        paddingTop: "1px",
+        fontSize: "0.885rem",
       }}
     >
       {folder?.name ?? section}
@@ -174,15 +176,13 @@ const Path = styled(({ className, section, path }) => {
               paddingBottom: "50px",
             }}
           >
-            <span style={{ marginTop: "2px" }}>/</span>
             <BreadcrumbLink section={section} />
             {path.map((f) => (
               <>
-                <span style={{ marginTop: "2px" }}>/</span>
+                <span>›</span>
                 <BreadcrumbLink folder={f} section={section} />
               </>
             ))}
-            <span style={{ marginTop: "2px" }}>/</span>
           </Stack>
         </div>
       )}

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -70,6 +70,49 @@ import Link from "@mui/material/Link";
 import { Link as ReactRouterLink } from "react-router-dom";
 import useOneDimensionalRovingTabIndex from "../../../components/useOneDimensionalRovingTabIndex";
 import Box from "@mui/material/Box";
+import Fab from "@mui/material/Fab";
+
+const DragCancelFab = () => {
+  const dndContext = useDndContext();
+  const dndInProgress = Boolean(dndContext.active);
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: "cancel",
+    disabled: false,
+    data: null,
+  });
+  const dropStyle: { [string]: string | number } = isOver
+    ? {
+        border: SELECTED_OR_FOCUS_BORDER,
+      }
+    : {
+        border: "2px solid white",
+        animation: "drop 2s linear infinite",
+      };
+  return (
+    <>
+      {dndInProgress && (
+        <div
+          style={{
+            position: "fixed",
+            right: "16px",
+            bottom: "16px",
+          }}
+        >
+          <Fab
+            variant="extended"
+            color="primary"
+            ref={(node) => {
+              setDropRef(node);
+            }}
+            style={dropStyle}
+          >
+            Cancel
+          </Fab>
+        </div>
+      )}
+    </>
+  );
+};
 
 const BreadcrumbLink = React.forwardRef<
   ElementConfig<typeof Link>,
@@ -668,8 +711,8 @@ const FileCard = styled(
       const dragStyle: { [string]: string | number } = transform
         ? {
             transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(1.1)`,
-            zIndex: 1, // just needs to be rendered above Nodes later in the DOM
-            position: "relative",
+            zIndex: 1400, // Above the sidebar
+            position: "fixed",
             boxShadow: `hsl(${COLOR.main.hue}deg 66% 10% / 20%) 0px 2px 16px 8px`,
           }
         : {};
@@ -1248,6 +1291,7 @@ function GalleryMainPanel({
             refreshListing={refreshListing}
           />
         </Slide>
+        <DragCancelFab />
       </DndContext>
     </DialogContent>
   );

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -69,7 +69,7 @@ import InputAdornment from "@mui/material/InputAdornment";
 import * as ArrayUtils from "../../../util/ArrayUtils";
 import Link from "@mui/material/Link";
 import { Link as ReactRouterLink } from "react-router-dom";
-import useVerticalRovingTabIndex from "../../../components/useVerticalRovingTabIndex";
+import useOneDimensionalRovingTabIndex from "../../../components/useOneDimensionalRovingTabIndex";
 
 const BreadcrumbLink = React.forwardRef<
   ElementConfig<typeof Link>,
@@ -161,7 +161,10 @@ const Path = styled(({ className, section, path, clearPath }) => {
     eventHandlers: { onFocus, onBlur, onKeyDown },
     getTabIndex,
     getRef,
-  } = useVerticalRovingTabIndex<typeof Link>({ max: path.length });
+  } = useOneDimensionalRovingTabIndex<typeof Link>({
+    max: path.length,
+    direction: "row",
+  });
 
   return (
     <div

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -980,6 +980,50 @@ function GalleryMainPanel({
                 <Button
                   variant="outlined"
                   size="small"
+                  startIcon={<TreeIcon />}
+                  onClick={(e) => {
+                    setViewMenuAnchorEl(e.target);
+                  }}
+                  aria-haspopup="menu"
+                >
+                  Views
+                </Button>
+                <StyledMenu
+                  open={Boolean(viewMenuAnchorEl)}
+                  anchorEl={viewMenuAnchorEl}
+                  onClose={() => setViewMenuAnchorEl(null)}
+                  MenuListProps={{
+                    disablePadding: true,
+                  }}
+                >
+                  <NewMenuItem
+                    title="Grid"
+                    subheader="Browse by thumbnail previews"
+                    backgroundColor={COLOR.background}
+                    foregroundColor={COLOR.contrastText}
+                    avatar={<GridIcon />}
+                    onClick={() => {
+                      setViewMode("grid");
+                      setViewMenuAnchorEl(null);
+                      selection.clear();
+                    }}
+                  />
+                  <NewMenuItem
+                    title="Tree"
+                    subheader="View and manage folder hierarchy"
+                    backgroundColor={COLOR.background}
+                    foregroundColor={COLOR.contrastText}
+                    avatar={<TreeIcon />}
+                    onClick={() => {
+                      setViewMode("tree");
+                      setViewMenuAnchorEl(null);
+                      selection.clear();
+                    }}
+                  />
+                </StyledMenu>
+                <Button
+                  variant="outlined"
+                  size="small"
                   startIcon={<SwapVertIcon />}
                   onClick={(e) => {
                     setSortMenuAnchorEl(e.target);
@@ -1086,50 +1130,6 @@ function GalleryMainPanel({
                   refreshListing={refreshListing}
                   section={selectedSection}
                 />
-                <Button
-                  variant="outlined"
-                  size="small"
-                  startIcon={<TreeIcon />}
-                  onClick={(e) => {
-                    setViewMenuAnchorEl(e.target);
-                  }}
-                  aria-haspopup="menu"
-                >
-                  Views
-                </Button>
-                <StyledMenu
-                  open={Boolean(viewMenuAnchorEl)}
-                  anchorEl={viewMenuAnchorEl}
-                  onClose={() => setViewMenuAnchorEl(null)}
-                  MenuListProps={{
-                    disablePadding: true,
-                  }}
-                >
-                  <NewMenuItem
-                    title="Grid"
-                    subheader="Browse by thumbnail previews"
-                    backgroundColor={COLOR.background}
-                    foregroundColor={COLOR.contrastText}
-                    avatar={<GridIcon />}
-                    onClick={() => {
-                      setViewMode("grid");
-                      setViewMenuAnchorEl(null);
-                      selection.clear();
-                    }}
-                  />
-                  <NewMenuItem
-                    title="Tree"
-                    subheader="View and manage folder hierarchy"
-                    backgroundColor={COLOR.background}
-                    foregroundColor={COLOR.contrastText}
-                    avatar={<TreeIcon />}
-                    onClick={() => {
-                      setViewMode("tree");
-                      setViewMenuAnchorEl(null);
-                      selection.clear();
-                    }}
-                  />
-                </StyledMenu>
               </Stack>
             </Grid>
             <Grid item flexGrow={1}>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -197,12 +197,20 @@ const Breadcrumb = ({
       destination: folder ? folderDestination(folder) : rootDestination(),
     },
   });
+  const dndContext = useDndContext();
+  const dndInProgress = Boolean(dndContext.active);
   const dropStyle: { [string]: string | number } = isOver
     ? {
         border: SELECTED_OR_FOCUS_BORDER,
       }
-    : {
+    : dndInProgress
+    ? {
         border: "2px solid white",
+        borderWidth: "2px",
+        animation: "drop 2s linear infinite",
+      }
+    : {
+        border: "2px solid transparent",
       };
 
   return (
@@ -548,6 +556,7 @@ const FileCard = styled(
       delete attributes.role;
 
       const dndContext = useDndContext();
+      const dndInProgress = Boolean(dndContext.active);
 
       const dragStyle: { [string]: string | number } = transform
         ? {
@@ -560,6 +569,13 @@ const FileCard = styled(
       const dropStyle: { [string]: string | number } = isOver
         ? {
             borderColor: SELECTED_OR_FOCUS_BLUE,
+          }
+        : dndInProgress && file.isFolder
+        ? {
+            border: "2px solid white",
+            borderWidth: "2px",
+            borderRadius: "8px",
+            animation: "drop 2s linear infinite",
           }
         : {};
       const inGroupBeingDraggedStyle: { [string]: string | number } =

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -65,7 +65,6 @@ import HorizontalRuleIcon from "@mui/icons-material/HorizontalRule";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import TextField from "@mui/material/TextField";
-import InputAdornment from "@mui/material/InputAdornment";
 import * as ArrayUtils from "../../../util/ArrayUtils";
 import Link from "@mui/material/Link";
 import { Link as ReactRouterLink } from "react-router-dom";
@@ -203,11 +202,10 @@ const Path = styled(({ className, section, path, clearPath }) => {
         }}
         inputProps={{
           ref: textFieldRef,
-        }}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">Path</InputAdornment>
-          ),
+          style: {
+            paddingTop: "5px",
+            paddingBottom: "5px",
+          },
         }}
       />
       {/*
@@ -217,10 +215,10 @@ const Path = styled(({ className, section, path, clearPath }) => {
       {!hasFocus && (
         <div
           style={{
-            width: "calc(100% - 75px)",
+            width: "calc(100% - 16px)",
             position: "absolute",
             top: "2px",
-            right: "10px",
+            right: "8px",
             overflow: "hidden",
           }}
         >

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -972,10 +972,11 @@ function GalleryMainPanel({
             container
             direction="row"
             alignItems="flex-start"
-            spacing={1}
+            spacing={0.5}
+            sx={{ mt: 0 }}
           >
-            <Grid item sx={{ mt: 0.5 }}>
-              <Stack direction="row" spacing={1}>
+            <Grid item>
+              <Stack direction="row" spacing={0.5}>
                 <Button
                   variant="outlined"
                   size="small"
@@ -1131,7 +1132,7 @@ function GalleryMainPanel({
                 </StyledMenu>
               </Stack>
             </Grid>
-            <Grid item sx={{ mt: 0.5 }} flexGrow={1}>
+            <Grid item flexGrow={1}>
               <Path section={selectedSection} path={path} />
             </Grid>
           </Grid>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -70,6 +70,57 @@ import TextField from "@mui/material/TextField";
 import InputAdornment from "@mui/material/InputAdornment";
 import * as ArrayUtils from "../../../util/ArrayUtils";
 
+const BreadcrumbLink = ({
+  folder,
+  section,
+}: {|
+  folder?: GalleryFile,
+  section: string,
+|}) => {
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: `/${[
+      section,
+      ...(folder?.path.map(({ name }) => name) ?? []),
+      folder?.name ?? "",
+    ].join("/")}/`,
+    disabled: false,
+    data: {
+      path: folder?.path ?? [],
+      destination: folder ? folderDestination(folder) : rootDestination(),
+    },
+  });
+  const dndContext = useDndContext();
+  const dndInProgress = Boolean(dndContext.active);
+  const dropStyle: { [string]: string | number } = isOver
+    ? {
+        border: SELECTED_OR_FOCUS_BORDER,
+      }
+    : dndInProgress
+    ? {
+        border: "2px solid white",
+        borderWidth: "2px",
+        animation: "drop 2s linear infinite",
+      }
+    : {
+        border: "2px solid transparent",
+      };
+  return (
+    <span
+      ref={(node) => {
+        setDropRef(node);
+      }}
+      style={{
+        ...dropStyle,
+        borderRadius: "6px",
+        paddingLeft: "1px",
+        paddingRight: "1px",
+      }}
+    >
+      {folder?.name ?? section}
+    </span>
+  );
+};
+
 const Path = styled(({ className, section, path }) => {
   const str = ArrayUtils.last(path)
     .map((folder) => folder.pathAsString())
@@ -104,7 +155,7 @@ const Path = styled(({ className, section, path }) => {
           style={{
             width: "calc(100% - 85px)",
             position: "absolute",
-            top: "8px",
+            top: "5px",
             right: "10px",
             overflow: "hidden",
           }}
@@ -119,15 +170,15 @@ const Path = styled(({ className, section, path }) => {
               paddingBottom: "50px",
             }}
           >
-            <span>/</span>
-            <span>{section}</span>
+            <span style={{ marginTop: "2px" }}>/</span>
+            <BreadcrumbLink section={section} />
             {path.map((f) => (
               <>
-                <span>/</span>
-                <span>{f.name}</span>
+                <span style={{ marginTop: "2px" }}>/</span>
+                <BreadcrumbLink folder={f} section={section} />
               </>
             ))}
-            <span>/</span>
+            <span style={{ marginTop: "2px" }}>/</span>
           </Stack>
         </div>
       )}

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -938,8 +938,6 @@ type GalleryMainPanelArgs = {|
   galleryListing: FetchingData.Fetched<
     | {| tag: "empty", reason: string |}
     | {| tag: "list", list: $ReadOnlyArray<GalleryFile> |}>,
-  selectedFile: null | GalleryFile,
-  setSelectedFile: (null | GalleryFile) => void,
   folderId: FetchingData.Fetched<Id>,
   refreshListing: () => void,
   sortOrder: "DESC" | "ASC",

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -95,26 +95,41 @@ const Path = styled(({ className, section, path }) => {
           ),
         }}
       />
+      {/*
+       * These two divs create a horizonally scrolling box without a scrollbar,
+       * mimicing the standard behaviour of a text field.
+       */}
       {!hasFocus && (
-        <Stack
-          direction="row"
-          spacing={0.25}
-          sx={{
+        <div
+          style={{
+            width: "calc(100% - 85px)",
             position: "absolute",
             top: "8px",
-            left: "75px",
+            right: "10px",
+            overflow: "hidden",
           }}
         >
-          <span>/</span>
-          <span>{section}</span>
-          {path.map((f) => (
-            <>
-              <span>/</span>
-              <span>{f.name}</span>
-            </>
-          ))}
-          <span>/</span>
-        </Stack>
+          <Stack
+            direction="row"
+            spacing={0.25}
+            sx={{
+              whiteSpace: "nowrap",
+              overflowX: "auto",
+              marginBottom: "-50px",
+              paddingBottom: "50px",
+            }}
+          >
+            <span>/</span>
+            <span>{section}</span>
+            {path.map((f) => (
+              <>
+                <span>/</span>
+                <span>{f.name}</span>
+              </>
+            ))}
+            <span>/</span>
+          </Stack>
+        </div>
       )}
     </>
   );

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1055,7 +1055,7 @@ function GalleryMainPanel({
                 path={path}
                 clearPath={clearPath}
               />
-              <Stack direction="row" spacing={0.5}>
+              <Stack direction="row" spacing={0.5} alignItems="center">
                 <ActionsMenu
                   refreshListing={refreshListing}
                   section={selectedSection}

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -70,6 +70,7 @@ import * as ArrayUtils from "../../../util/ArrayUtils";
 import Link from "@mui/material/Link";
 import { Link as ReactRouterLink } from "react-router-dom";
 import useOneDimensionalRovingTabIndex from "../../../components/useOneDimensionalRovingTabIndex";
+import Box from "@mui/material/Box";
 
 const BreadcrumbLink = React.forwardRef<
   ElementConfig<typeof Link>,
@@ -173,6 +174,7 @@ const Path = styled(({ className, section, path, clearPath }) => {
       onKeyDown={(e) => {
         onKeyDown(e);
       }}
+      style={{ position: "relative" }}
     >
       <TextField
         className={className}
@@ -215,9 +217,9 @@ const Path = styled(({ className, section, path, clearPath }) => {
       {!hasFocus && (
         <div
           style={{
-            width: "calc(100% - 85px)",
+            width: "calc(100% - 75px)",
             position: "absolute",
-            top: "5px",
+            top: "2px",
             right: "10px",
             overflow: "hidden",
           }}
@@ -1048,15 +1050,13 @@ function GalleryMainPanel({
               </Fade>
             </Typography>
           </Grid>
-          <Grid
-            item
-            container
-            direction="row"
-            alignItems="flex-start"
-            spacing={0.5}
-            sx={{ mt: 0 }}
-          >
-            <Grid item flexGrow={1}>
+          <Grid item sx={{ marginTop: 0.5 }}>
+            <Stack spacing={0.5}>
+              <Path
+                section={selectedSection}
+                path={path}
+                clearPath={clearPath}
+              />
               <Stack direction="row" spacing={0.5}>
                 <Button
                   variant="outlined"
@@ -1066,7 +1066,6 @@ function GalleryMainPanel({
                     setViewMenuAnchorEl(e.target);
                   }}
                   aria-haspopup="menu"
-                  sx={{ flexGrow: 1 }}
                 >
                   Views
                 </Button>
@@ -1111,7 +1110,6 @@ function GalleryMainPanel({
                     setSortMenuAnchorEl(e.target);
                   }}
                   aria-haspopup="menu"
-                  sx={{ flexGrow: 1 }}
                 >
                   Sort
                 </Button>
@@ -1209,26 +1207,13 @@ function GalleryMainPanel({
                     }}
                   />
                 </StyledMenu>
+                <Box sx={{ flexGrow: 1 }}></Box>
                 <ActionsMenu
                   refreshListing={refreshListing}
                   section={selectedSection}
                 />
               </Stack>
-            </Grid>
-            {/*
-             * We use an arbitrarily large number here so that when the buttons
-             * and path field are rendered on the same row, the path field
-             * takes up as much space as possible. We still apply a flexGrow of
-             * 1 to each of buttons so that when they are on their own row
-             * above, they each take up 1/3 of the row.
-             */}
-            <Grid item flexGrow={99999} sx={{ position: "relative" }}>
-              <Path
-                section={selectedSection}
-                path={path}
-                clearPath={clearPath}
-              />
-            </Grid>
+            </Stack>
           </Grid>
           <Grid
             item

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -975,7 +975,7 @@ function GalleryMainPanel({
             spacing={0.5}
             sx={{ mt: 0 }}
           >
-            <Grid item>
+            <Grid item flexGrow={1}>
               <Stack direction="row" spacing={0.5}>
                 <Button
                   variant="outlined"
@@ -985,6 +985,7 @@ function GalleryMainPanel({
                     setViewMenuAnchorEl(e.target);
                   }}
                   aria-haspopup="menu"
+                  sx={{ flexGrow: 1 }}
                 >
                   Views
                 </Button>
@@ -1029,6 +1030,7 @@ function GalleryMainPanel({
                     setSortMenuAnchorEl(e.target);
                   }}
                   aria-haspopup="menu"
+                  sx={{ flexGrow: 1 }}
                 >
                   Sort
                 </Button>
@@ -1132,7 +1134,14 @@ function GalleryMainPanel({
                 />
               </Stack>
             </Grid>
-            <Grid item flexGrow={1}>
+            {/*
+             * We use an arbitrarily large number here so that when the buttons
+             * and path field are rendered on the same row, the path field
+             * takes up as much space as possible. We still apply a flexGrow of
+             * 1 to each of buttons so that when they are on their own row
+             * above, they each take up 1/3 of the row.
+             */}
+            <Grid item flexGrow={99999}>
               <Path section={selectedSection} path={path} />
             </Grid>
           </Grid>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1058,6 +1058,11 @@ function GalleryMainPanel({
                 clearPath={clearPath}
               />
               <Stack direction="row" spacing={0.5}>
+                <ActionsMenu
+                  refreshListing={refreshListing}
+                  section={selectedSection}
+                />
+                <Box sx={{ flexGrow: 1 }}></Box>
                 <Button
                   variant="outlined"
                   size="small"
@@ -1207,11 +1212,6 @@ function GalleryMainPanel({
                     }}
                   />
                 </StyledMenu>
-                <Box sx={{ flexGrow: 1 }}></Box>
-                <ActionsMenu
-                  refreshListing={refreshListing}
-                  section={selectedSection}
-                />
               </Stack>
             </Stack>
           </Grid>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -86,22 +86,9 @@ const Path = styled(({ className, section, path }) => {
       }}
     />
   );
-})(({ theme }) => ({
-  "& .MuiOutlinedInput-root": {
-    "& .MuiInputAdornment-root": {
-      paddingLeft: theme.spacing(1.5),
-      paddingRight: theme.spacing(1.5),
-      backgroundColor: "unset",
-      marginRight: 0,
-      "& .MuiTypography-root": {
-        lineHeight: "20px",
-        fontSize: "0.8125rem",
-      },
-    },
-  },
+})(() => ({
   "& input": {
     height: "21px",
-    paddingLeft: theme.spacing(1.5),
   },
 }));
 

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -74,17 +74,49 @@ const Path = styled(({ className, section, path }) => {
   const str = ArrayUtils.last(path)
     .map((folder) => folder.pathAsString())
     .orElse(`/${section}/`);
+  const [hasFocus, setHasFocus] = React.useState(false);
   return (
-    <TextField
-      className={className}
-      value={str}
-      onChange={() => {}}
-      fullWidth
-      size="small"
-      InputProps={{
-        startAdornment: <InputAdornment position="start">Path</InputAdornment>,
-      }}
-    />
+    <>
+      <TextField
+        className={className}
+        value={hasFocus ? str : ""}
+        onChange={() => {}}
+        fullWidth
+        size="small"
+        onFocus={() => {
+          setHasFocus(true);
+        }}
+        onBlur={() => {
+          setHasFocus(false);
+        }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">Path</InputAdornment>
+          ),
+        }}
+      />
+      {!hasFocus && (
+        <Stack
+          direction="row"
+          spacing={0.25}
+          sx={{
+            position: "absolute",
+            top: "8px",
+            left: "75px",
+          }}
+        >
+          <span>/</span>
+          <span>{section}</span>
+          {path.map((f) => (
+            <>
+              <span>/</span>
+              <span>{f.name}</span>
+            </>
+          ))}
+          <span>/</span>
+        </Stack>
+      )}
+    </>
   );
 })(() => ({
   "& input": {
@@ -1141,7 +1173,7 @@ function GalleryMainPanel({
              * 1 to each of buttons so that when they are on their own row
              * above, they each take up 1/3 of the row.
              */}
-            <Grid item flexGrow={99999}>
+            <Grid item flexGrow={99999} sx={{ position: "relative" }}>
               <Path section={selectedSection} path={path} />
             </Grid>
           </Grid>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1,16 +1,9 @@
 //@flow
 
-import React, {
-  type Node,
-  Children,
-  type ElementConfig,
-  type ComponentType,
-} from "react";
+import React, { type Node, type ComponentType } from "react";
 import DialogContent from "@mui/material/DialogContent";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
-import Breadcrumbs from "@mui/material/Breadcrumbs";
-import Chip from "@mui/material/Chip";
 import Fade from "@mui/material/Fade";
 import {
   gallerySectionLabel,
@@ -317,98 +310,6 @@ const ImportDropzone = styled(
     color: "inherit",
   },
 }));
-
-const Breadcrumb = ({
-  label,
-  onClick,
-  path,
-  selectedSection,
-  folder,
-}: {|
-  label: string,
-  onClick: () => void,
-  path: $ReadOnlyArray<GalleryFile>,
-  selectedSection: string,
-  folder?: GalleryFile,
-|}) => {
-  const { setNodeRef: setDropRef, isOver } = useDroppable({
-    id: `/${[
-      selectedSection,
-      ...path.map(({ name }) => name),
-      folder?.name ?? "",
-    ].join("/")}/`,
-    disabled: false,
-    data: {
-      path,
-      destination: folder ? folderDestination(folder) : rootDestination(),
-    },
-  });
-  const dndContext = useDndContext();
-  const dndInProgress = Boolean(dndContext.active);
-  const dropStyle: { [string]: string | number } = isOver
-    ? {
-        border: SELECTED_OR_FOCUS_BORDER,
-      }
-    : dndInProgress
-    ? {
-        border: "2px solid white",
-        borderWidth: "2px",
-        animation: "drop 2s linear infinite",
-      }
-    : {
-        border: "2px solid transparent",
-      };
-
-  return (
-    <Chip
-      ref={(node) => {
-        setDropRef(node);
-      }}
-      style={{
-        ...dropStyle,
-      }}
-      size="small"
-      clickable
-      label={label}
-      onClick={onClick}
-      sx={{ mt: 0.5 }}
-    />
-  );
-};
-
-const CustomBreadcrumbs = ({
-  children,
-  ...props
-}: ElementConfig<typeof Breadcrumbs>) => {
-  const [open, setOpen] = React.useState(false);
-  let contents = Children.toArray<typeof Breadcrumb | typeof Chip>(children);
-  if (!open && contents.length > 2) {
-    contents = [
-      contents[0],
-      <Chip
-        size="small"
-        clickable
-        label="..."
-        sx={{ mt: 0.5 }}
-        key="..."
-        onMouseEnter={() => {
-          setOpen(true);
-        }}
-      />,
-      contents[contents.length - 1],
-    ];
-  }
-  return (
-    <Breadcrumbs
-      {...props}
-      onMouseLeave={() => {
-        setOpen(false);
-      }}
-    >
-      {contents}
-    </Breadcrumbs>
-  );
-};
 
 const GridView = observer(
   ({

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -51,6 +51,7 @@ import useViewportDimensions from "../../../util/useViewportDimensions";
 import { observer } from "mobx-react-lite";
 import { autorun } from "mobx";
 import EventBoundary from "../../../components/EventBoundary";
+import { useSearchParams } from "react-router-dom";
 library.add(faImage);
 library.add(faFilm);
 library.add(faFile);
@@ -415,6 +416,18 @@ type SidebarArgs = {|
   refreshListing: () => void,
 |};
 
+const offsets = {
+  Images: 8,
+  Audios: 51,
+  Videos: 94,
+  Documents: 137,
+  Chemistry: 180,
+  DMPs: 223,
+  Snippets: 266,
+  Miscellaneous: 309,
+  PdfDocuments: 372,
+};
+
 const Sidebar = ({
   selectedSection,
   setSelectedSection,
@@ -424,8 +437,10 @@ const Sidebar = ({
   folderId,
   refreshListing,
 }: SidebarArgs): Node => {
-  const [selectedIndicatorOffset, setSelectedIndicatorOffset] =
-    React.useState(8);
+  const [, setSearchParams] = useSearchParams();
+  const [selectedIndicatorOffset, setSelectedIndicatorOffset] = React.useState(
+    offsets[selectedSection] ?? 8
+  );
   const [newMenuAnchorEl, setNewMenuAnchorEl] = React.useState(null);
   const viewport = useViewportDimensions();
 
@@ -531,7 +546,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "Images"}
               onClick={(event) => {
-                setSelectedSection("Images");
+                setSearchParams({ mediaType: "Images" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}
@@ -545,7 +560,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "Audios"}
               onClick={(event) => {
-                setSelectedSection("Audios");
+                setSearchParams({ mediaType: "Audios" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}
@@ -559,7 +574,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "Videos"}
               onClick={(event) => {
-                setSelectedSection("Videos");
+                setSearchParams({ mediaType: "Videos" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}
@@ -573,7 +588,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "Documents"}
               onClick={(event) => {
-                setSelectedSection("Documents");
+                setSearchParams({ mediaType: "Documents" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}
@@ -587,7 +602,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "Chemistry"}
               onClick={(event) => {
-                setSelectedSection("Chemistry");
+                setSearchParams({ mediaType: "Chemistry" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}
@@ -601,7 +616,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "DMPs"}
               onClick={(event) => {
-                setSelectedSection("DMPs");
+                setSearchParams({ mediaType: "DMPs" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}
@@ -615,7 +630,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "Snippets"}
               onClick={(event) => {
-                setSelectedSection("Snippets");
+                setSearchParams({ mediaType: "Snippets" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}
@@ -629,7 +644,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "Miscellaneous"}
               onClick={(event) => {
-                setSelectedSection("Miscellaneous");
+                setSearchParams({ mediaType: "Miscellaneous" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}
@@ -646,7 +661,7 @@ const Sidebar = ({
               drawerOpen={drawerOpen}
               selected={selectedSection === "PdfDocuments"}
               onClick={(event) => {
-                setSelectedSection("PdfDocuments");
+                setSearchParams({ mediaType: "PdfDocuments" });
                 if (viewport.isViewportSmall) setDrawerOpen(false);
                 setSelectedIndicatorOffset(event.currentTarget.offsetTop);
               }}

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -4,7 +4,12 @@ import React, { type Node, type ComponentType } from "react";
 import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
 import { styled } from "@mui/material/styles";
-import { COLOR, gallerySectionLabel, type GallerySection } from "../common";
+import {
+  COLOR,
+  gallerySectionLabel,
+  type GallerySection,
+  GALLERY_SECTION,
+} from "../common";
 import List from "@mui/material/List";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItem from "@mui/material/ListItem";
@@ -417,16 +422,16 @@ type SidebarArgs = {|
 |};
 
 const offsets = {
-  Images: 8,
-  Audios: 51,
-  Videos: 94,
-  Documents: 137,
-  Chemistry: 180,
-  DMPs: 223,
-  NetworkFiles: null,
-  Snippets: 266,
-  Miscellaneous: 309,
-  PdfDocuments: 372,
+  [GALLERY_SECTION.IMAGES]: 8,
+  [GALLERY_SECTION.AUDIOS]: 51,
+  [GALLERY_SECTION.VIDEOS]: 94,
+  [GALLERY_SECTION.DOCUMENTS]: 137,
+  [GALLERY_SECTION.CHEMISTRY]: 180,
+  [GALLERY_SECTION.DMPS]: 223,
+  [GALLERY_SECTION.NETWORKFILES]: null,
+  [GALLERY_SECTION.SNIPPETS]: 266,
+  [GALLERY_SECTION.MISCELLANEOUS]: 309,
+  [GALLERY_SECTION.PDFDOCUMENTS]: 372,
 };
 
 const Sidebar = ({

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -51,7 +51,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogActions from "@mui/material/DialogActions";
 import SubmitSpinnerButton from "../../../components/SubmitSpinnerButton";
 import { fetchIntegrationInfo } from "../../../common/integrationHelpers";
-import useVerticalRovingTabIndex from "../../../components/useVerticalRovingTabIndex";
+import useOneDimensionalRovingTabIndex from "../../../components/useOneDimensionalRovingTabIndex";
 import useViewportDimensions from "../../../util/useViewportDimensions";
 import { observer } from "mobx-react-lite";
 import { autorun } from "mobx";
@@ -456,11 +456,10 @@ const Sidebar = ({
     });
   }, [viewport]);
 
-  const { getTabIndex, getRef, eventHandlers } = useVerticalRovingTabIndex<
-    typeof ListItemButton
-  >({
-    max: 8,
-  });
+  const { getTabIndex, getRef, eventHandlers } =
+    useOneDimensionalRovingTabIndex<typeof ListItemButton>({
+      max: 8,
+    });
 
   return (
     <CustomDrawer

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -4,7 +4,7 @@ import React, { type Node, type ComponentType } from "react";
 import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
 import { styled } from "@mui/material/styles";
-import { COLOR, gallerySectionLabel } from "../common";
+import { COLOR, gallerySectionLabel, type GallerySection } from "../common";
 import List from "@mui/material/List";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItem from "@mui/material/ListItem";
@@ -407,7 +407,7 @@ const DrawerTab = styled(
 }));
 
 type SidebarArgs = {|
-  selectedSection: string,
+  selectedSection: GallerySection,
   setSelectedSection: (string) => void,
   drawerOpen: boolean,
   setDrawerOpen: (boolean) => void,
@@ -423,6 +423,7 @@ const offsets = {
   Documents: 137,
   Chemistry: 180,
   DMPs: 223,
+  NetworkFiles: null,
   Snippets: 266,
   Miscellaneous: 309,
   PdfDocuments: 372,

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -2,7 +2,11 @@
 
 import React, { type Node, type ComponentType } from "react";
 import Fade from "@mui/material/Fade";
-import { COLOR, SELECTED_OR_FOCUS_BORDER, type GallerySection } from "../common";
+import {
+  COLOR,
+  SELECTED_OR_FOCUS_BORDER,
+  type GallerySection,
+} from "../common";
 import { styled } from "@mui/material/styles";
 import Avatar from "@mui/material/Avatar";
 import FileIcon from "@mui/icons-material/InsertDriveFile";
@@ -194,8 +198,8 @@ const CustomTreeItem = observer(
     const dragStyle: { [string]: string | number } = transform
       ? {
           transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(1.1)`,
-          zIndex: 1, // just needs to be rendered above Nodes later in the DOM
-          position: "relative",
+          zIndex: 1400, // Above the sidebar
+          position: "fixed",
           boxShadow: `hsl(${COLOR.main.hue}deg 66% 10% / 20%) 0px 2px 16px 8px`,
           maxWidth: "max-content",
         }
@@ -366,6 +370,7 @@ const TreeView = ({
     );
   return (
     <SimpleTreeView
+      sx={{ maxWidth: `calc(100% - 200px)` }}
       expandedItems={expandedItems}
       onExpandedItemsChange={(_event, nodeIds) => {
         setExpandedItems(nodeIds);

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -189,6 +189,7 @@ const CustomTreeItem = observer(
       },
     });
     const dndContext = useDndContext();
+    const dndInProgress = Boolean(dndContext.active);
 
     const dragStyle: { [string]: string | number } = transform
       ? {
@@ -202,6 +203,11 @@ const CustomTreeItem = observer(
     const dropStyle: { [string]: string | number } = isOver
       ? {
           border: SELECTED_OR_FOCUS_BORDER,
+        }
+      : dndInProgress && file.isFolder
+      ? {
+          border: "2px solid white",
+          animation: "drop 2s linear infinite",
         }
       : {
           border: `2px solid hsl(${COLOR.background.hue}deg, ${COLOR.background.saturation}%, 99%)`,

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -18,6 +18,7 @@ import Alerts from "../../Inventory/components/Alerts";
 import { DisableDragAndDropByDefault } from "../../components/useFileImportDragAndDrop";
 import Analytics from "../../components/Analytics";
 import { GallerySelection } from "./useGallerySelection";
+import { BrowserRouter } from "react-router-dom";
 
 const WholePage = styled(() => {
   const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");
@@ -106,18 +107,20 @@ window.addEventListener("load", () => {
     root.render(
       <React.StrictMode>
         <ErrorBoundary>
-          <StyledEngineProvider injectFirst>
-            <CssBaseline />
-            <ThemeProvider theme={createAccentedTheme(COLOR)}>
-              <Analytics>
-                <DisableDragAndDropByDefault>
-                  <GallerySelection>
-                    <WholePage />
-                  </GallerySelection>
-                </DisableDragAndDropByDefault>
-              </Analytics>
-            </ThemeProvider>
-          </StyledEngineProvider>
+          <BrowserRouter>
+            <StyledEngineProvider injectFirst>
+              <CssBaseline />
+              <ThemeProvider theme={createAccentedTheme(COLOR)}>
+                <Analytics>
+                  <DisableDragAndDropByDefault>
+                    <GallerySelection>
+                      <WholePage />
+                    </GallerySelection>
+                  </DisableDragAndDropByDefault>
+                </Analytics>
+              </ThemeProvider>
+            </StyledEngineProvider>
+          </BrowserRouter>
         </ErrorBoundary>
       </React.StrictMode>
     );

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -18,13 +18,27 @@ import Alerts from "../../Inventory/components/Alerts";
 import { DisableDragAndDropByDefault } from "../../components/useFileImportDragAndDrop";
 import Analytics from "../../components/Analytics";
 import { GallerySelection } from "./useGallerySelection";
-import { BrowserRouter } from "react-router-dom";
+import {
+  BrowserRouter,
+  Navigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
+import { Routes, Route } from "react-router";
 
 const WholePage = styled(() => {
+  const [searchParams] = useSearchParams();
+  const [selectedSection, setSelectedSection] = React.useState(
+    searchParams.get("mediaType") ?? "Images"
+  );
+  React.useEffect(() => {
+    const mediaType = searchParams.get("mediaType");
+    if (mediaType) setSelectedSection(mediaType);
+  }, [searchParams]);
+
   const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");
   const [orderBy, setOrderBy] = React.useState("name");
   const [sortOrder, setSortOrder] = React.useState("ASC");
-  const [selectedSection, setSelectedSection] = React.useState("Images");
   const { galleryListing, path, clearPath, folderId, refreshListing } =
     useGalleryListing({
       section: selectedSection,
@@ -113,9 +127,20 @@ window.addEventListener("load", () => {
               <ThemeProvider theme={createAccentedTheme(COLOR)}>
                 <Analytics>
                   <DisableDragAndDropByDefault>
-                    <GallerySelection>
-                      <WholePage />
-                    </GallerySelection>
+                    <Routes>
+                      <Route
+                        path="/newGallery"
+                        element={
+                          <GallerySelection>
+                            <WholePage />
+                          </GallerySelection>
+                        }
+                      />
+                      <Route
+                        path="*"
+                        element={<Navigate to="/newGallery" replace />}
+                      />
+                    </Routes>
                   </DisableDragAndDropByDefault>
                 </Analytics>
               </ThemeProvider>

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -5,7 +5,12 @@ import { createRoot } from "react-dom/client";
 import ErrorBoundary from "../../components/ErrorBoundary";
 import { ThemeProvider, styled, lighten } from "@mui/material/styles";
 import createAccentedTheme from "../../accentedTheme";
-import { COLOR, SELECTED_OR_FOCUS_BLUE } from "./common";
+import {
+  COLOR,
+  SELECTED_OR_FOCUS_BLUE,
+  parseGallerySectionFromUrlSearchParams,
+  GALLERY_SECTION,
+} from "./common";
 import AppBar from "./components/AppBar";
 import Sidebar from "./components/Sidebar";
 import MainPanel from "./components/MainPanel";
@@ -18,22 +23,20 @@ import Alerts from "../../Inventory/components/Alerts";
 import { DisableDragAndDropByDefault } from "../../components/useFileImportDragAndDrop";
 import Analytics from "../../components/Analytics";
 import { GallerySelection } from "./useGallerySelection";
-import {
-  BrowserRouter,
-  Navigate,
-  useParams,
-  useSearchParams,
-} from "react-router-dom";
+import { BrowserRouter, Navigate, useSearchParams } from "react-router-dom";
 import { Routes, Route } from "react-router";
 
 const WholePage = styled(() => {
   const [searchParams] = useSearchParams();
   const [selectedSection, setSelectedSection] = React.useState(
-    searchParams.get("mediaType") ?? "Images"
+    parseGallerySectionFromUrlSearchParams(searchParams).orElse(
+      GALLERY_SECTION.IMAGES
+    )
   );
   React.useEffect(() => {
-    const mediaType = searchParams.get("mediaType");
-    if (mediaType) setSelectedSection(mediaType);
+    parseGallerySectionFromUrlSearchParams(searchParams).do((mediaType) => {
+      setSelectedSection(mediaType);
+    });
   }, [searchParams]);
 
   const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -3,9 +3,9 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import ErrorBoundary from "../../components/ErrorBoundary";
-import { ThemeProvider } from "@mui/material/styles";
+import { ThemeProvider, styled, lighten } from "@mui/material/styles";
 import createAccentedTheme from "../../accentedTheme";
-import { COLOR } from "./common";
+import { COLOR, SELECTED_OR_FOCUS_BLUE } from "./common";
 import AppBar from "./components/AppBar";
 import Sidebar from "./components/Sidebar";
 import MainPanel from "./components/MainPanel";
@@ -19,7 +19,7 @@ import { DisableDragAndDropByDefault } from "../../components/useFileImportDragA
 import Analytics from "../../components/Analytics";
 import { GallerySelection } from "./useGallerySelection";
 
-function WholePage() {
+const WholePage = styled(() => {
   const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");
   const [orderBy, setOrderBy] = React.useState("name");
   const [sortOrder, setSortOrder] = React.useState("ASC");
@@ -83,7 +83,19 @@ function WholePage() {
       </Box>
     </Alerts>
   );
-}
+})(() => ({
+  "@keyframes drop": {
+    "0%": {
+      borderColor: lighten(SELECTED_OR_FOCUS_BLUE, 0.6),
+    },
+    "50%": {
+      borderColor: lighten(SELECTED_OR_FOCUS_BLUE, 0.8),
+    },
+    "100%": {
+      borderColor: lighten(SELECTED_OR_FOCUS_BLUE, 0.6),
+    },
+  },
+}));
 
 window.addEventListener("load", () => {
   const domContainer = document.getElementById("app");

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -50,9 +50,6 @@ const WholePage = styled(() => {
       orderBy,
       sortOrder,
     });
-  const [selectedFile, setSelectedFile] = React.useState<GalleryFile | null>(
-    null
-  );
   const viewport = useViewportDimensions();
   const [drawerOpen, setDrawerOpen] = React.useState(!viewport.isViewportSmall);
 
@@ -87,8 +84,6 @@ const WholePage = styled(() => {
             path={path}
             clearPath={clearPath}
             galleryListing={galleryListing}
-            selectedFile={selectedFile}
-            setSelectedFile={setSelectedFile}
             folderId={folderId}
             refreshListing={refreshListing}
             key={null}

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -129,7 +129,7 @@ function getIconPathForExtension(extension: string) {
       txt: "/images/icons/txt.png",
       text: "/images/icons/txt.png",
       md: "/images/icons/txt.png",
-    }: {[string]: string})[ext] ?? "/images/icons/unknownDocument.png"
+    }: { [string]: string })[ext] ?? "/images/icons/unknownDocument.png"
   );
 }
 
@@ -179,7 +179,8 @@ export function useGalleryListing({
 |}): {|
   galleryListing: FetchingData.Fetched<
     | {| tag: "empty", reason: string |}
-    | {| tag: "list", list: $ReadOnlyArray<GalleryFile> |}>,
+    | {| tag: "list", list: $ReadOnlyArray<GalleryFile> |}
+  >,
   refreshListing: () => void,
   path: $ReadOnlyArray<GalleryFile>,
   clearPath: () => void,

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -369,7 +369,7 @@ export function useGalleryListing({
   if (loading)
     return {
       galleryListing: { tag: "loading" },
-      path: [],
+      path,
       clearPath: () => {},
       folderId: { tag: "loading" },
       refreshListing: () => {},

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -11,6 +11,7 @@ import {
   filenameExceptExtension,
   justFilenameExtension,
 } from "../../util/files";
+import { useGallerySelection } from "./useGallerySelection";
 
 export opaque type Id = number;
 export function idToString(id: Id): string {
@@ -195,6 +196,7 @@ export function useGalleryListing({
     defaultPath ?? []
   );
   const [parentId, setParentId] = React.useState<Result<Id>>(Result.Error([]));
+  const selection = useGallerySelection();
 
   function emptyReason(): string {
     if (path.length > 0) {
@@ -261,6 +263,7 @@ export function useGalleryListing({
   }
 
   async function getGalleryFiles(): Promise<void> {
+    selection.clear();
     setGalleryListing([]);
     setLoading(true);
     try {

--- a/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGallerySelection.js
@@ -26,6 +26,7 @@ class Selection {
       _state: observable,
       isEmpty: computed,
       size: computed,
+      label: computed,
       clear: action,
       append: action,
       remove: action,
@@ -59,6 +60,20 @@ class Selection {
 
   asSet(): RsSet<GalleryFile> {
     return new RsSet(this._state.values());
+  }
+
+  get label(): string {
+    if (this.isEmpty) return "No selection";
+    const folderCount = this.asSet().filter((f) => f.isFolder).size;
+    const fileCount = this.size - folderCount;
+    return [
+      fileCount > 0 ? `${fileCount} file${fileCount > 1 ? "s" : ""}` : "",
+      fileCount > 0 && folderCount > 0 ? ", " : "",
+      folderCount > 0
+        ? `${folderCount} folder${folderCount > 1 ? "s" : ""}`
+        : "",
+      " selected",
+    ].join("");
   }
 }
 


### PR DESCRIPTION
This change alters how the breadcrumbs and other buttons and menus at the top of the new gallery page are rendered.

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/b6b79dbb-c526-4d60-9419-fb6e0e3dd128">

The breadcrumbs, a series of links allowing the users to navigate back up the folder hierarchy, is now rendered within a horizontally scrolling box. When tapped, it transforms into a read-only text field that allows users to select and copy the path, which would not otherwise be possible. Keyboard controls are fully supported, with a roving tab index employed for moving the focus between the links and tab correctly triggering the read-only text field. Being able to drag-and-drop onto the breadcrumbs is retained, with the animated added whilst dragging to make it clear which UI elements are dropzones. Note the blue outline:

<img width="798" alt="Screenshot 2024-07-16 at 11 25 40" src="https://github.com/user-attachments/assets/3b859743-4285-439b-acaf-addf142804d9">

The remaining buttons and menus -- actions, sorting, and views -- have been re-arranged to be consistent with the other newly designed pages (e.g. sysadmin users page) where the primary action in placed in the top left whilst the other buttons and menus are placed in the top right corner. Also similar to the sysadmin users page, a label describing what is selected is also added by this change.

Finally, react-router is used to synchronise the URL search parameter of `mediaType` with the selected gallery section. This means that the new gallery remains backwards compatible with links to the various gallery sections of the old gallery and when `/newGallery` becomes `/gallery` all those existing links will continue to work. I attempted to extended this further by capturing the entire breadcrumb in the URL so that users could use the browser back and forwards buttons to navigate around in addition to the breadcrumb links but this would require some backend changes as the current API endpoints require a folder id to get the listing of a folder's contents; the folder's path is not sufficient given that two folders distinct may have the same name, and thus same path.