### PR TITLE
issue-73: reworking API key display logic and ways for sysadmin to access it

### DIFF
--- a/src/main/java/com/researchspace/api/v1/UserDetailsSysAdminApi.java
+++ b/src/main/java/com/researchspace/api/v1/UserDetailsSysAdminApi.java
@@ -11,15 +11,18 @@ import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-/** returns user details available to sysadmins - only sysadmins will be allowed to use this API */
-@RequestMapping("/api/v1/syadmin/userDetails")
-public interface UserDetailsSyadminApi {
+/**
+ * returns user details available to sysadmins - only sysadmins will be allowed to use this API, and
+ * only if sysadmin.apikey.access deployment property is set to true
+ */
+@RequestMapping("/api/v1/sysadmin/userDetails")
+public interface UserDetailsSysAdminApi {
 
+  /**
+   * returns a map of all users usernames to api keys. Request user must be a sysadmin, and
+   * sysadmin.apikey.access deployment property must be set to 'true', or request will be rejected
+   */
   @GetMapping("/apiKeyInfo/all")
   @ResponseBody
-  /**
-   * returns a map of all users usernames to api keys. Request user must be a sysadmin or request
-   * will not be authorised
-   */
   Map<String, String> getAllApiKeyInfo(@RequestAttribute(name = "user") User user);
 }

--- a/src/main/java/com/researchspace/api/v1/controller/UserDetailsSysAdminApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/UserDetailsSysAdminApiController.java
@@ -1,6 +1,6 @@
 package com.researchspace.api.v1.controller;
 
-import com.researchspace.api.v1.UserDetailsSyadminApi;
+import com.researchspace.api.v1.UserDetailsSysAdminApi;
 import com.researchspace.model.SignupSource;
 import com.researchspace.model.User;
 import com.researchspace.model.UserApiKey;
@@ -11,18 +11,24 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.shiro.authz.AuthorizationException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.RequestAttribute;
 
 @ApiController
-public class UserDetailsSysAdminApiController implements UserDetailsSyadminApi {
+public class UserDetailsSysAdminApiController implements UserDetailsSysAdminApi {
   @Autowired private UserManager userManager;
   @Autowired private UserApiKeyManager apiKeyMgr;
 
+  @Value("${sysadmin.apikey.access}")
+  private boolean sysadminApiKeyAccess;
+
   @Override
   public Map<String, String> getAllApiKeyInfo(@RequestAttribute(name = "user") User user) {
-    boolean isSysadmin = user.hasSysadminRole();
-    if (!isSysadmin) {
+    if (!user.hasSysadminRole()) {
       throw new AuthorizationException("Only sysadmin can use this API");
+    }
+    if (!sysadminApiKeyAccess) {
+      throw new AuthorizationException("Reading apiKeys by sysadmin is not enabled on this server");
     }
     Map<String, String> allUserInfo = new HashMap<>();
     for (User aUser : userManager.getUsers()) {

--- a/src/main/java/com/researchspace/webapp/controller/UserProfileController.java
+++ b/src/main/java/com/researchspace/webapp/controller/UserProfileController.java
@@ -773,7 +773,7 @@ public class UserProfileController extends BaseController {
           "API key details cannot be accessed when 'operating' as another user");
     }
     User user = userManager.getAuthenticatedUserInSession();
-    SECURITY_LOG.info("User [{}] asked to see their apiKey", user.getUsername());
+    SECURITY_LOG.info("User [{}] asked to see their API key", user.getUsername());
 
     Optional<UserApiKey> optKey = apiKeyMgr.getKeyForUser(user);
     if (!optKey.isPresent()) {

--- a/src/main/java/com/researchspace/webapp/controller/UserProfileController.java
+++ b/src/main/java/com/researchspace/webapp/controller/UserProfileController.java
@@ -106,7 +106,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.authz.AuthorizationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -769,8 +768,8 @@ public class UserProfileController extends BaseController {
   @GetMapping("/ajax/apiKeyValue")
   public @ResponseBody AjaxReturnObject<String> getApiKeyValue() {
     if (SecurityUtils.getSubject().isRunAs()) {
-      throw new AuthorizationException(
-          "API key details cannot be accessed when 'operating' as another user");
+      return new AjaxReturnObject<>(
+          null, ErrorList.of("API key value cannot be accessed when 'operating as' another user"));
     }
     User user = userManager.getAuthenticatedUserInSession();
     SECURITY_LOG.info("User [{}] asked to see their API key", user.getUsername());

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -121,6 +121,8 @@ sysadmin.delete.user=false
 sysadmin.delete.user.resourceList.folder=archive/deletedUserResourceListings
 # whether successful user deletion from DB should be immediately followed by filestore resources deletion
 sysadmin.delete.user.deleteResourcesImmediately=true
+# whether sysadmin should be able to see users' API keys. this shouldn't be changed unless in very specific scenarios
+sysadmin.apikey.access=false
 
 #Path to error log file
 sysadmin.errorfile.path=src/test/resources/TestResources/sampleLogs/RSLogs.txt

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -121,7 +121,7 @@ sysadmin.delete.user=false
 sysadmin.delete.user.resourceList.folder=archive/deletedUserResourceListings
 # whether successful user deletion from DB should be immediately followed by filestore resources deletion
 sysadmin.delete.user.deleteResourcesImmediately=true
-# whether sysadmin should be able to see users' API keys. this shouldn't be changed unless in very specific scenarios
+# whether sysadmin should be able to see users' API keys; this shouldn't be changed unless in very specific scenarios
 sysadmin.apikey.access=false
 
 #Path to error log file

--- a/src/main/resources/deployments/dev/deployment.properties
+++ b/src/main/resources/deployments/dev/deployment.properties
@@ -13,7 +13,6 @@ archive.folder.storagetime=1
 importArchiveFromServer.enabled=true
 
 sysadmin.delete.user=true
-sysadmin.apikey.access=true
 rs.dev.groupcreation=true
 ui.bannerImage.url=/workspace
 ui.bannerImage.loggedOutUrl=https://www.bbc.com/

--- a/src/main/resources/deployments/dev/deployment.properties
+++ b/src/main/resources/deployments/dev/deployment.properties
@@ -63,6 +63,9 @@ nextcloud.secret=
 egnyte.client.id=
 egnyte.internal.app.client.id=
 
+pyrat.url=
+pyrat.client.token=
+
 # clustermarket
 clustermarket.client.id=
 clustermarket.secret=

--- a/src/main/resources/deployments/dev/deployment.properties
+++ b/src/main/resources/deployments/dev/deployment.properties
@@ -13,6 +13,7 @@ archive.folder.storagetime=1
 importArchiveFromServer.enabled=true
 
 sysadmin.delete.user=true
+sysadmin.apikey.access=true
 rs.dev.groupcreation=true
 ui.bannerImage.url=/workspace
 ui.bannerImage.loggedOutUrl=https://www.bbc.com/
@@ -62,9 +63,6 @@ nextcloud.secret=
 # egnyte integration that redirects to https://localhost:8443 after authentication
 egnyte.client.id=
 egnyte.internal.app.client.id=
-
-pyrat.url=
-pyrat.client.token=
 
 # clustermarket
 clustermarket.client.id=

--- a/src/main/webapp/WEB-INF/pages/userform.jsp
+++ b/src/main/webapp/WEB-INF/pages/userform.jsp
@@ -299,7 +299,7 @@
 <div class="bootstrap-custom-flat">
 	<div class="col-xs-9" style="padding: 0px">
 		<hr />
-		<c:if test="${canEdit and !sessionScope['rs.IS_RUN_AS']}">
+		<c:if test="${canEdit}">
 			<div class="api-menu__header col-xs-12">
 				<fmt:message key="user.apikey.label" />
 			</div>
@@ -561,14 +561,14 @@
 <script type="text/template" id="apiKeyDetailsTemplate">
 	{{#enabled}}
     <div class="api-menu__key col-xs-8">
-      {{#key}}
-        <strong>Key</strong>: <span id="api-menu__keyValue">{{key}}</span>
+      {{#revokable}}
+        <strong>Key</strong>: <span id="api-menu__keyValue"> ... </span>
           <a href="#" id="api-menu__showKey" onclick="return false;">Show Key</a>
           <a href="#" id="api-menu__hideKey" onclick="return false;">Hide Key</a>
-      {{/key}}
-      {{^key}}
+      {{/revokable}}
+      {{^revokable}}
         <strong>Key</strong>: Empty.
-      {{/key}}
+      {{/revokable}}
 
       <br />
       See <a href="/public/apiDocs" target="_blank">API Documentation</a>.

--- a/src/main/webapp/WEB-INF/pages/userform.jsp
+++ b/src/main/webapp/WEB-INF/pages/userform.jsp
@@ -14,12 +14,6 @@
 
 <input type="hidden" name="from" value="<c:out value=" ${param.from}" />" />
 
-<%-- commenting as seems unused (mk - 22/09/16) --%>
-<%-- <c:if test="${cookieLogin == 'true'}"> --%>
-<%-- 	<form:hidden path="password" /> --%>
-<%-- 	<form:hidden path="confirmPassword" /> --%>
-<%-- </c:if> --%>
-
 <c:if test="${empty user.version}">
 	<input type="hidden" name="encryptPass" value="true" />
 </c:if>
@@ -305,7 +299,7 @@
 <div class="bootstrap-custom-flat">
 	<div class="col-xs-9" style="padding: 0px">
 		<hr />
-		<c:if test="${canEdit}">
+		<c:if test="${canEdit and !sessionScope['rs.IS_RUN_AS']}">
 			<div class="api-menu__header col-xs-12">
 				<fmt:message key="user.apikey.label" />
 			</div>

--- a/src/main/webapp/WEB-INF/pages/userform.jsp
+++ b/src/main/webapp/WEB-INF/pages/userform.jsp
@@ -562,7 +562,7 @@
 	{{#enabled}}
     <div class="api-menu__key col-xs-8">
       {{#revokable}}
-        <strong>Key</strong>: <span id="api-menu__keyValue"> ... </span>
+        <strong>Key</strong>: <span id="api-menu__keyValue"> &lt;hidden&gt; </span>
           <a href="#" id="api-menu__showKey" onclick="return false;">Show Key</a>
           <a href="#" id="api-menu__hideKey" onclick="return false;">Hide Key</a>
       {{/revokable}}

--- a/src/main/webapp/scripts/pages/userform.js
+++ b/src/main/webapp/scripts/pages/userform.js
@@ -521,7 +521,6 @@ function initApiKeyDisplay () {
 
   $(document).on("click", "#apiKeyRegenerateBtn", function(e) {
     e.preventDefault();
-    e.stopPropagation();
 
 	  $.get('/vfpwd/ajax/checkVerificationPasswordNeeded', function(response) {  
       	if (response.data) {
@@ -532,7 +531,9 @@ function initApiKeyDisplay () {
 	  });
   });
   
-  $(document).on("click", "#apiKeyRevokeBtn", function(e) { 
+  $(document).on("click", "#apiKeyRevokeBtn", function(e) {
+    e.preventDefault();
+
     $.post('/userform/ajax/apiKey', {"_method":"DELETE"}, function (intDeleted){
       if (intDeleted > 0) {
         RS.defaultConfirm("Key deleted");

--- a/src/main/webapp/scripts/pages/userform.js
+++ b/src/main/webapp/scripts/pages/userform.js
@@ -500,6 +500,11 @@ function renderApiKeyMenu(serverResponse) {
 }
 
 function initApiKeyDisplay () {
+
+  if ($('#apiKeyInfo').size() == 0) {
+    return; // fragment not displayed
+  }
+
   function updateApiKeyMenu() {
     $.get('/userform/ajax/apiKeyInfo')
      .then(renderApiKeyMenu);

--- a/src/main/webapp/scripts/pages/userform.js
+++ b/src/main/webapp/scripts/pages/userform.js
@@ -389,7 +389,7 @@ function initPwdConfirmDlg () {
           var jqxhr = $.post('/userform/ajax/apiKey', {"password":pwd})
                        .done(function(data) {
                            showRSApiKey = true;
-                           renderApiKeyMenu(data); 
+                           renderApiKeyMenu(data);
                        })
                        .fail(function() {
                           RS.ajaxFailed("Creating a new API key", false, jqxhr);
@@ -495,21 +495,30 @@ function renderApiKeyMenu(serverResponse) {
   var keyInfoData = serverResponse.data;
   var htmlData = Mustache.render(apiKeyInfoTemplate, keyInfoData);
   $apiKeyInfo.html(htmlData);
+  if (keyInfoData.key) {
+    $('#api-menu__keyValue').text(keyInfoData.key);
+  }
+  $('#api-menu__keyValue, #api-menu__hideKey').toggle(showRSApiKey);
+  $('#api-menu__showKey').toggle(!showRSApiKey);
+}
+
+function showApiKeyValue(serverResponse) {
+  if (!serverResponse.data) {
+    apprise(getValidationErrorString(serverResponse.errorMsg));
+    return;
+  }
+  $('#api-menu__keyValue').text(serverResponse.data);
   $('#api-menu__keyValue, #api-menu__hideKey').toggle(showRSApiKey);
   $('#api-menu__showKey').toggle(!showRSApiKey);
 }
 
 function initApiKeyDisplay () {
 
-  if ($('#apiKeyInfo').size() == 0) {
-    return; // fragment not displayed
+  function updateApiKeyMenu() {
+    $.get('/userform/ajax/apiKeyDisplayInfo')
+     .then(renderApiKeyMenu);
   }
 
-  function updateApiKeyMenu() {
-    $.get('/userform/ajax/apiKeyInfo')
-     .then(renderApiKeyMenu);
-  }  
-  
   $(document).on("click", "#apiKeyRegenerateBtn", function(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -535,8 +544,13 @@ function initApiKeyDisplay () {
   });
   
   $(document).on("click", "#api-menu__showKey, #api-menu__hideKey", function() {
-	  showRSApiKey = !showRSApiKey;
-	  updateApiKeyMenu();
+    showRSApiKey = !showRSApiKey;
+    if (showRSApiKey) {
+      $.get('/userform/ajax/apiKeyValue')
+        .then(showApiKeyValue);
+    }
+    $('#api-menu__keyValue, #api-menu__hideKey').toggle(showRSApiKey);
+    $('#api-menu__showKey').toggle(!showRSApiKey);
   });
 
   updateApiKeyMenu();


### PR DESCRIPTION
This PR consists of multiple changes that should make retrieval of API key more secure and traceable.

The changes in behaviour:
- for user who generated API key the value of their key is no longer sent to front-end whenever 'My Profile' page is displayed, but only after user explicitly clicks on 'Show Key' link
- when System Admin user 'operates as' they can no longer see user's API key ('Show Key' returns an error); System Admin can still generate new API key or revoke the old one, as there may be valid reasons for these actions (similarly how we do allow System Admin to reset user's password)
- the `/apiKeyInfo/all` endpoint within `UserDetailsSysAdminApi` is now only available when deployment property `sysadmin.apikey.access` is set to `true` (it's `false` by default)

