### PR TITLE
RSDEV-302 Shrink size of generated PyRAT table

### DIFF
--- a/src/main/webapp/ui/src/tinyMCE/pyrat/Pyrat.js
+++ b/src/main/webapp/ui/src/tinyMCE/pyrat/Pyrat.js
@@ -477,6 +477,7 @@ parent.tinymce.activeEditor.on("pyrat-insert", function () {
 function createTinyMceTable() {
   let pyratTable = document.createElement("table");
   pyratTable.setAttribute("data-tableSource", "pyrat");
+  pyratTable.style = "font-size: 0.7em";
 
   let tableHeader = document.createElement("tr");
   VISIBLE_HEADER_CELLS.forEach((cell) => {


### PR DESCRIPTION
This change reduces to the font size of the generated PyRAT table that is inserted into the rich text fields of documents by the PyRAT integration. This is done to reduced the probability of horizontal scrolling being required most of the time.

This image shows the new font-size at the top and the old size just below it.

![image](https://github.com/user-attachments/assets/f84c9cd2-f93c-461a-9985-cf80a9b8c5d9)
