### PR TITLE
RSDEV-120  Migrate DMPTool dialog to accented theme

### DIFF
--- a/src/main/webapp/ui/flow-typed/mui.js
+++ b/src/main/webapp/ui/flow-typed/mui.js
@@ -62,6 +62,7 @@ declare module "@mui/x-data-grid" {
     sortable?: boolean,
     headerClassName?: string,
     disableExport?: boolean,
+    display?: "text" | "flex",
   |};
 
   declare export function DataGrid<

--- a/src/main/webapp/ui/flow-typed/mui.js
+++ b/src/main/webapp/ui/flow-typed/mui.js
@@ -118,6 +118,7 @@ declare module "@mui/x-data-grid" {
       // https://github.com/mui/mui-x/blob/v7.12.0/packages/x-data-grid/src/constants/localeTextConstants.ts
       noRowsLabel?: string,
     |},
+    onCellKeyDown?: (Row, KeyboardEvent) => void,
   |}): Node;
 
   declare export function GridToolbarContainer({|

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.js
@@ -14,7 +14,6 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import Grid from "@mui/material/Grid";
 import { withStyles } from "Styles";
-import { makeStyles } from "tss-react/mui";
 import { observer } from "mobx-react-lite";
 import SubmitSpinnerButton from "../../components/SubmitSpinnerButton";
 import Typography from "@mui/material/Typography";
@@ -49,6 +48,7 @@ import createAccentedTheme from "../../accentedTheme";
 import { ThemeProvider } from "@mui/material/styles";
 import { DataGrid } from "@mui/x-data-grid";
 import Radio from "@mui/material/Radio";
+import Stack from "@mui/material/Stack";
 
 const COLOR = {
   main: {
@@ -443,7 +443,7 @@ const CustomDialog = withStyles<
 >((theme, { fullScreen }) => ({
   paper: {
     overflow: "hidden",
-    margin: theme.spacing(2.625),
+    margin: fullScreen ? 0 : theme.spacing(2.625),
     maxHeight: "unset",
     minHeight: "unset",
 
@@ -453,23 +453,9 @@ const CustomDialog = withStyles<
   },
 }))(Dialog);
 
-const useStyles = makeStyles()(() => ({
-  contentWrapper: {
-    overscrollBehavior: "contain",
-    WebkitOverflowScrolling: "unset",
-  },
-  barWrapper: {
-    display: "flex",
-    alignSelf: "center",
-    width: "100%",
-    flexDirection: "column",
-    alignItems: "center",
-  },
-  fullWidth: { width: "100%" },
-}));
-
 function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
   const { addAlert } = useContext(AlertContext);
+  const { isViewportSmall } = useViewportDimensions();
 
   const [DMPs, setDMPs]: UseState<Array<PlanSummary>> = useState([]);
   const [totalCount, setTotalCount]: UseState<number> = useState(0);
@@ -502,7 +488,7 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
        * close the dialog.
        */
       setSelectedPlan(null);
-    } catch (e:mixed) {
+    } catch (e) {
       console.error(e);
       addAlert(
         mkAlert({
@@ -515,8 +501,6 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
       setImporting(false);
     }
   };
-
-  const { classes } = useStyles();
 
   return (
     <>
@@ -534,7 +518,7 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
           </Box>
         </Toolbar>
       </AppBar>
-      <DialogContent className={classes.contentWrapper}>
+      <DialogContent>
         <Grid
           container
           direction="column"
@@ -629,6 +613,7 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
               initialState={{
                 columns: {
                   columnVisibilityModel: {
+                    id: !isViewportSmall,
                     grant: false,
                     createdAt: false,
                     modifiedAt: false,
@@ -658,7 +643,7 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
           </Grid>
         </Grid>
       </DialogContent>
-      <DialogActions className={classes.barWrapper}>
+      <DialogActions>
         <Grid container direction="row" spacing={1}>
           <Grid item>
             <CustomTablePagination
@@ -685,24 +670,23 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
               }}
             />
           </Grid>
-          <Grid item sx={{ flexGrow: "1" }}></Grid>
-          <Grid item>
-            <Button onClick={() => setOpen(false)} disabled={importing}>
-              {selectedPlan ? "Cancel" : "Close"}
-            </Button>
-          </Grid>
-          <Grid item>
-            <ValidatingSubmitButton
-              onClick={() => {
-                void handleImport();
-              }}
-              validationResult={
-                !selectedPlan ? IsInvalid("No DMP selected.") : IsValid()
-              }
-              loading={importing}
-            >
-              Import
-            </ValidatingSubmitButton>
+          <Grid item sx={{ ml: "auto" }}>
+            <Stack direction="row" spacing={1}>
+              <Button onClick={() => setOpen(false)} disabled={importing}>
+                {selectedPlan ? "Cancel" : "Close"}
+              </Button>
+              <ValidatingSubmitButton
+                onClick={() => {
+                  void handleImport();
+                }}
+                validationResult={
+                  !selectedPlan ? IsInvalid("No DMP selected.") : IsValid()
+                }
+                loading={importing}
+              >
+                Import
+              </ValidatingSubmitButton>
+            </Stack>
           </Grid>
         </Grid>
       </DialogActions>

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.js
@@ -639,6 +639,12 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
                 }
               }}
               getRowHeight={() => "auto"}
+              onCellKeyDown={({ id }, e) => {
+                if (e.key === " " || e.key === "Enter") {
+                  setSelectedPlan(DMPs.find((d) => d.id === id));
+                  e.stopPropagation();
+                }
+              }}
             />
           </Grid>
         </Grid>

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -15,10 +15,7 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import Grid from "@mui/material/Grid";
 import { withStyles } from "Styles";
-import { makeStyles } from "tss-react/mui";
 import { observer } from "mobx-react-lite";
-import clsx from "clsx";
-import WarningIcon from "@mui/icons-material/Warning";
 import Typography from "@mui/material/Typography";
 import axios from "axios";
 import { type UseState } from "../../util/types";
@@ -90,20 +87,6 @@ const CustomDialog = withStyles<
   },
 }))(Dialog);
 
-const useStyles = makeStyles()((theme) => ({
-  fullWidth: { width: "100%" },
-  warningRow: {
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    alignItems: "center",
-    fontSize: "13px",
-    marginTop: theme.spacing(0.5),
-  },
-  warningMessage: { marginRight: "3vw" },
-  warningRed: { color: theme.palette.warningRed },
-}));
-
 export type Plan = {
   id: number,
   title: string,
@@ -111,22 +94,6 @@ export type Plan = {
   modified: string,
   created: string,
 };
-
-const WarningBar = observer(() => {
-  const { classes } = useStyles();
-  return (
-    <div
-      className={clsx(
-        classes.warningRow,
-        classes.fullWidth,
-        classes.warningRed
-      )}
-    >
-      <WarningIcon />
-      <span className={classes.warningMessage}>Warning text</span>
-    </div>
-  );
-});
 
 function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
   const { addAlert } = useContext(AlertContext);
@@ -223,10 +190,6 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
       setImporting(false);
     }
   };
-
-  const { classes } = useStyles();
-
-  const showWarning = false; // intentionally left, may be used later
 
   function statusText() {
     if (errorFetching) return Optional.present(errorFetching);
@@ -393,7 +356,6 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
           </Grid>
         </Grid>
       </DialogContent>
-      {showWarning && <WarningBar />}
       <DialogActions>
         <Grid container direction="row" spacing={1}>
           <Grid item sx={{ ml: "auto" }}>

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -191,13 +191,6 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
     }
   };
 
-  function statusText() {
-    if (errorFetching) return Optional.present(errorFetching);
-    if (fetching) return Optional.present("Fetching DMPs...");
-    if (DMPs.length === 0) return Optional.present("No items to display");
-    return Optional.empty<string>();
-  }
-
   return (
     <>
       <AppBar position="relative" open={true}>
@@ -340,19 +333,6 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
               }}
               getRowHeight={() => "auto"}
             />
-            {statusText()
-              .map((sText) => (
-                <Typography
-                  key={null}
-                  component="div"
-                  variant="body2"
-                  color="textPrimary"
-                  align="center"
-                >
-                  {sText}
-                </Typography>
-              ))
-              .orElse(null)}
           </Grid>
         </Grid>
       </DialogContent>

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -29,10 +29,40 @@ import { Optional } from "../../util/optional";
 import useViewportDimensions from "../../util/useViewportDimensions";
 import AlertContext, { mkAlert } from "../../stores/contexts/Alert";
 import Portal from "@mui/material/Portal";
+import createAccentedTheme from "../../accentedTheme";
+import { ThemeProvider } from "@mui/material/styles";
 import ValidatingSubmitButton, {
   IsInvalid,
   IsValid,
 } from "../../components/ValidatingSubmitButton";
+
+const COLOR = {
+  main: {
+    hue: 208,
+    saturation: 46,
+    lightness: 70,
+  },
+  darker: {
+    hue: 208,
+    saturation: 93,
+    lightness: 33,
+  },
+  contrastText: {
+    hue: 208,
+    saturation: 35,
+    lightness: 26,
+  },
+  background: {
+    hue: 208,
+    saturation: 25,
+    lightness: 71,
+  },
+  backgroundContrastText: {
+    hue: 208,
+    saturation: 11,
+    lightness: 24,
+  },
+};
 
 const CustomDialog = withStyles<
   {| fullScreen: boolean, ...ElementProps<typeof Dialog> |},
@@ -295,21 +325,23 @@ function DMPDialog({ open, setOpen }: DMPDialogArgs): Node {
    */
 
   return (
-    <Portal>
-      <DialogBoundary>
-        <CustomDialog
-          onClose={() => {
-            setOpen(false);
-          }}
-          open={open}
-          maxWidth="lg"
-          fullWidth
-          fullScreen={isViewportSmall}
-        >
-          <DMPDialogContent setOpen={setOpen} />
-        </CustomDialog>
-      </DialogBoundary>
-    </Portal>
+    <ThemeProvider theme={createAccentedTheme(COLOR)}>
+      <Portal>
+        <DialogBoundary>
+          <CustomDialog
+            onClose={() => {
+              setOpen(false);
+            }}
+            open={open}
+            maxWidth="lg"
+            fullWidth
+            fullScreen={isViewportSmall}
+          >
+            <DMPDialogContent setOpen={setOpen} />
+          </CustomDialog>
+        </DialogBoundary>
+      </Portal>
+    </ThemeProvider>
   );
 }
 

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -13,7 +13,6 @@ import Button from "@mui/material/Button";
 import { Dialog, DialogBoundary } from "../../components/DialogBoundary";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
-import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import DMPTable from "./DMPTable";
 import { withStyles } from "Styles";
@@ -35,6 +34,13 @@ import ValidatingSubmitButton, {
   IsInvalid,
   IsValid,
 } from "../../components/ValidatingSubmitButton";
+import Link from "@mui/material/Link";
+import Toolbar from "@mui/material/Toolbar";
+import AppBar from "@mui/material/AppBar";
+import docLinks from "../../assets/DocLinks";
+import Box from "@mui/material/Box";
+import HelpLinkIcon from "../../components/HelpLinkIcon";
+import AccessibilityTips from "../../components/AccessibilityTips";
 
 const COLOR = {
   main: {
@@ -70,12 +76,13 @@ const CustomDialog = withStyles<
 >((theme, { fullScreen }) => ({
   paper: {
     overflow: "hidden",
+    margin: fullScreen ? 0 : theme.spacing(2.625),
+    maxHeight: "unset",
+    minHeight: "unset",
 
-    // this is to avoid intercom help button
-    maxHeight: fullScreen ? "unset" : "86vh",
-
-    // this is to ensure the picker has enough height even when list is empty
-    minHeight: "86vh",
+    // this is so that the hights of the dialog's content of constrained and scrollbars appear
+    // 24px margin above and below, 3px border above and below
+    height: fullScreen ? "100%" : "calc(100% - 48px)",
   },
 }))(Dialog);
 
@@ -243,11 +250,43 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
 
   return (
     <>
-      <DialogTitle className={classes.dialogTitle}>
-        Data Management Plans (DMPs) from DMPTool
-      </DialogTitle>
+      <AppBar position="relative" open={true}>
+        <Toolbar variant="dense">
+          <Typography variant="h6" noWrap component="h2">
+            DMPTool
+          </Typography>
+          <Box flexGrow={1}></Box>
+          <Box ml={1}>
+            <AccessibilityTips supportsHighContrastMode elementType="dialog" />
+          </Box>
+          <Box ml={1} sx={{ transform: "translateY(2px)" }}>
+            <HelpLinkIcon title="DMPTool help" link={docLinks.dmptool} />
+          </Box>
+        </Toolbar>
+      </AppBar>
       <DialogContent className={classes.contentWrapper}>
-        <Grid container>
+        <Grid
+          container
+          direction="column"
+          spacing={2}
+          flexWrap="nowrap"
+          // this is so that just the table is scrollable
+          height="calc(100% + 16px)"
+        >
+          <Grid item>
+            <Typography variant="h3">Import a DMP into the Gallery</Typography>
+          </Grid>
+          <Grid item>
+            <Typography variant="body2">
+              Importing a DMP will make it available to view and reference
+              within RSpace.
+            </Typography>
+            <Typography variant="body2">
+              See <Link href="https://dmptool.org">dmptool.org</Link> and our{" "}
+              <Link href={docLinks.dmptool}>DMPTool integration docs</Link> for
+              more.
+            </Typography>
+          </Grid>
           <Grid item xs={12}>
             <ScopeField getDMPs={getDMPs} />
             <DMPTable

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -91,12 +91,7 @@ const CustomDialog = withStyles<
 }))(Dialog);
 
 const useStyles = makeStyles()((theme) => ({
-  contentWrapper: {
-    overscrollBehavior: "contain",
-    WebkitOverflowScrolling: "unset",
-  },
   fullWidth: { width: "100%" },
-  sideSpaced: { marginRight: theme.spacing(1), marginLeft: theme.spacing(1) },
   warningRow: {
     display: "flex",
     flexDirection: "row",
@@ -107,9 +102,6 @@ const useStyles = makeStyles()((theme) => ({
   },
   warningMessage: { marginRight: "3vw" },
   warningRed: { color: theme.palette.warningRed },
-  dialogTitle: {
-    paddingBottom: theme.spacing(0.5),
-  },
 }));
 
 export type Plan = {
@@ -259,7 +251,7 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
           </Box>
         </Toolbar>
       </AppBar>
-      <DialogContent className={classes.contentWrapper}>
+      <DialogContent>
         <Grid
           container
           direction="column"
@@ -406,11 +398,7 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
         <Grid container direction="row" spacing={1}>
           <Grid item sx={{ ml: "auto" }}>
             <Stack direction="row" spacing={1}>
-              <Button
-                className={classes.sideSpaced}
-                onClick={() => setOpen(false)}
-                disabled={importing}
-              >
+              <Button onClick={() => setOpen(false)} disabled={importing}>
                 {selectedPlan ? "Cancel" : "Close"}
               </Button>
               <ValidatingSubmitButton

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -39,6 +39,7 @@ import Toolbar from "@mui/material/Toolbar";
 import AppBar from "@mui/material/AppBar";
 import docLinks from "../../assets/DocLinks";
 import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
 import HelpLinkIcon from "../../components/HelpLinkIcon";
 import AccessibilityTips from "../../components/AccessibilityTips";
 
@@ -91,20 +92,8 @@ const useStyles = makeStyles()((theme) => ({
     overscrollBehavior: "contain",
     WebkitOverflowScrolling: "unset",
   },
-  barWrapper: {
-    display: "flex",
-    alignSelf: "center",
-    width: "95%",
-    flexDirection: "column",
-    alignItems: "center",
-  },
   fullWidth: { width: "100%" },
   sideSpaced: { marginRight: theme.spacing(1), marginLeft: theme.spacing(1) },
-  flexEndRow: {
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-end",
-  },
   warningRow: {
     display: "flex",
     flexDirection: "row",
@@ -311,29 +300,31 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
         </Grid>
       </DialogContent>
       {showWarning && <WarningBar />}
-      <DialogActions className={clsx(classes.barWrapper)}>
-        <div className={clsx(classes.flexEndRow, classes.fullWidth)}>
-          <div>
-            <Button
-              className={classes.sideSpaced}
-              onClick={() => setOpen(false)}
-              disabled={importing}
-            >
-              {selectedPlan ? "Cancel" : "Close"}
-            </Button>
-            <ValidatingSubmitButton
-              onClick={() => {
-                void handleImport();
-              }}
-              validationResult={
-                !selectedPlan?.id ? IsInvalid("No DMP selected.") : IsValid()
-              }
-              loading={importing}
-            >
-              Import
-            </ValidatingSubmitButton>
-          </div>
-        </div>
+      <DialogActions>
+        <Grid container direction="row" spacing={1}>
+          <Grid item sx={{ ml: "auto" }}>
+            <Stack direction="row" spacing={1}>
+              <Button
+                className={classes.sideSpaced}
+                onClick={() => setOpen(false)}
+                disabled={importing}
+              >
+                {selectedPlan ? "Cancel" : "Close"}
+              </Button>
+              <ValidatingSubmitButton
+                onClick={() => {
+                  void handleImport();
+                }}
+                validationResult={
+                  !selectedPlan?.id ? IsInvalid("No DMP selected.") : IsValid()
+                }
+                loading={importing}
+              >
+                Import
+              </ValidatingSubmitButton>
+            </Stack>
+          </Grid>
+        </Grid>
       </DialogActions>
     </>
   );

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -232,6 +232,8 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
           </Grid>
           <Grid item>
             <ScopeField getDMPs={getDMPs} />
+          </Grid>
+          <Grid item sx={{ overflowY: "auto" }} flexGrow={1}>
             <DataGrid
               columns={[
                 {

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -237,7 +237,7 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
               more.
             </Typography>
           </Grid>
-          <Grid item xs={12}>
+          <Grid item>
             <ScopeField getDMPs={getDMPs} />
             <DataGrid
               columns={[

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -128,7 +128,6 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
                 title: "Fetch failed.",
                 message: r.data.error?.errorMessages[0] ?? "Could not get DMPs",
                 variant: "error",
-                isInfinite: false,
               })
             );
           }

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -334,6 +334,12 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
                 }
               }}
               getRowHeight={() => "auto"}
+              onCellKeyDown={({ id }, e) => {
+                if (e.key === " " || e.key === "Enter") {
+                  setSelectedPlan(DMPs.find((d) => d.id === id));
+                  e.stopPropagation();
+                }
+              }}
             />
           </Grid>
         </Grid>

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/ScopeField.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/ScopeField.js
@@ -34,7 +34,7 @@ export default function ScopeField({ getDMPs }: ScopeFieldArgs): Node {
   };
 
   return (
-    <Grid container spacing={2} sx={{ mb: 1 }}>
+    <Grid container direction="row" spacing={2}>
       <Grid item>
         <RadioField
           value={currentScope}

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/ScopeField.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/ScopeField.js
@@ -5,6 +5,7 @@ import Grid from "@mui/material/Grid";
 import RadioField, {
   type RadioOption,
 } from "../../components/Inputs/RadioField";
+import Typography from "@mui/material/Typography";
 
 export type Scope = "MINE" | "PUBLIC" | "BOTH";
 
@@ -48,11 +49,11 @@ export default function ScopeField({ getDMPs }: ScopeFieldArgs): Node {
       </Grid>
 
       <Grid item>
-        <p>
+        <Typography variant="body2">
           Select a scope to get the latest plans.
           <br /> Select a plan and click &quot;Import&quot; to add it to the
           Gallery.
-        </p>
+        </Typography>
       </Grid>
     </Grid>
   );

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/__tests__/DMPDialog.test.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/__tests__/DMPDialog.test.js
@@ -3,6 +3,7 @@
  */
 //@flow
 /* eslint-env jest */
+import "../../../../__mocks__/matchMedia.js";
 import React from "react";
 import {
   render,

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/__tests__/DMPDialog.test.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/__tests__/DMPDialog.test.js
@@ -41,7 +41,7 @@ describe("DMPDialog", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("No items to display")).toBeVisible();
+      expect(screen.getByText("No DMPs")).toBeVisible();
     });
   });
 
@@ -89,7 +89,7 @@ describe("DMPDialog", () => {
     await sleep(2000);
 
     await waitFor(() => {
-      expect(screen.getByText("very mine")).toBeVisible();
+      expect(screen.getByText("mine")).toBeVisible();
     });
   });
 });

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/__tests__/DMPToolMenuItem.test.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/__tests__/DMPToolMenuItem.test.js
@@ -3,6 +3,7 @@
  */
 //@flow
 /* eslint-env jest */
+import "../../../../__mocks__/matchMedia.js";
 import React from "react";
 import { render, cleanup, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";

--- a/src/main/webapp/ui/src/util/table.js
+++ b/src/main/webapp/ui/src/util/table.js
@@ -119,6 +119,7 @@ type ColumnProps<Row: { ... }, Value> = {|
   sortable?: boolean,
   headerClassName?: string,
   disableExport?: boolean,
+  display?: "text" | "flex",
 |};
 
 const DataGridColumn = {


### PR DESCRIPTION
This means the DMPTool dialog for importing DMPs into the Gallery has consistent styling with the new Gallery, utilising an accented theme to mimic the DMPTool branding. Moreover, it supports the high contrast mode that comes with the theme. The dialog also now uses MUI's DataGrid, allowing the user to choose additional columns of data. This change applies to both the existing and new gallery.

Current gallery before
<img width="925" alt="image" src="https://github.com/user-attachments/assets/e032f2a2-dca3-48c4-ba4d-cacf5e18d4d5">

Current gallery after
<img width="926" alt="image" src="https://github.com/user-attachments/assets/67523510-d244-4894-9f6b-3379de05b345">

New gallery before
<img width="945" alt="image" src="https://github.com/user-attachments/assets/31953a7c-e2f0-4b84-945e-82f1b0e5ddea">

New gallery after
<img width="938" alt="image" src="https://github.com/user-attachments/assets/6beb48ef-c730-4034-9b99-dc2de74bae3c">

This change also includes keyboard controls for selecting a row of the table in the Argos dialog as that was not included in its recent change.
