### PR TITLE
RSDEV-270 Some improvements to the export dialog

### DIFF
--- a/src/main/webapp/ui/src/Export/ExportDialog.js
+++ b/src/main/webapp/ui/src/Export/ExportDialog.js
@@ -35,6 +35,7 @@ import Result from "../util/result";
 import { parseEncodedTags } from "../components/Tags/ParseEncodedTagStrings";
 import Divider from "@mui/material/Divider";
 import AlertContext, { mkAlert } from "../stores/contexts/Alert";
+import useViewportDimensions from "../util/useViewportDimensions";
 
 const DEFAULT_REPO_CONFIG = {
   repoChoice: 0,
@@ -138,6 +139,7 @@ function ExportDialog({
   allowFileStores,
 }: ExportDialogArgs): Node {
   const { addAlert } = React.useContext(AlertContext);
+  const { isViewportSmall } = useViewportDimensions();
 
   const [state, setState] = useState<typeof DEFAULT_STATE>(
     observable(DEFAULT_STATE)
@@ -401,6 +403,7 @@ function ExportDialog({
             fullWidth={true}
             maxWidth="sm"
             onClose={handleClose}
+            fullScreen={isViewportSmall}
           >
             <DialogTitle data-test-id="modalTitle">
               {activePane.title}

--- a/src/main/webapp/ui/src/Export/ExportDialog.js
+++ b/src/main/webapp/ui/src/Export/ExportDialog.js
@@ -8,8 +8,7 @@ import Button from "@mui/material/Button";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import Dialog from "@mui/material/Dialog";
-import IconButton from "@mui/material/IconButton";
-import CloseIcon from "@mui/icons-material/Close";
+import DialogActions from "@mui/material/DialogActions";
 import MobileStepper from "@mui/material/MobileStepper";
 import axios from "axios";
 import FormatChoice, { type ArchiveType } from "./FormatChoice";
@@ -36,6 +35,7 @@ import * as ArrayUtils from "../util/ArrayUtils";
 import * as Parsers from "../util/parsers";
 import Result from "../util/result";
 import { parseEncodedTags } from "../components/Tags/ParseEncodedTagStrings";
+import Divider from "@mui/material/Divider";
 
 const DEFAULT_REPO_CONFIG = {
   repoChoice: 0,
@@ -410,17 +410,14 @@ function ExportDialog({
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={materialTheme}>
         <Confirm>
-          <Dialog open={state.open} fullWidth={true} maxWidth="sm">
+          <Dialog
+            open={state.open}
+            fullWidth={true}
+            maxWidth="sm"
+            onClose={handleClose}
+          >
             <DialogTitle data-test-id="modalTitle">
               {activePane.title}
-              <IconButton
-                aria-label="Close"
-                data-test-id="closeModal"
-                style={styles.closeButton}
-                onClick={handleClose}
-              >
-                <CloseIcon />
-              </IconButton>
             </DialogTitle>
             <DialogContent>
               {activePane.key === "FormatChoice" && (
@@ -471,31 +468,44 @@ function ExportDialog({
               )}
             </DialogContent>
             <LoadingFade loading={state.loading} />
-            <MobileStepper
-              steps={numberOfPanes(firstPane)}
-              position="static"
-              activeStep={getIndexOfPane(firstPane, activePane)}
-              backButton={
-                <Button
-                  size="small"
-                  data-test-id="createGroupBackButton"
-                  onClick={handleBack}
-                  disabled={!activePane.prev}
-                >
-                  Back
-                </Button>
-              }
-              nextButton={
-                <Button
-                  size="small"
-                  data-test-id="createGroupNextButton"
-                  onClick={() => handleNext()}
-                  disabled={state.exportConfig.archiveType === ""}
-                >
-                  {activePane.next ? "Next" : "Export"}
-                </Button>
-              }
-            />
+            <DialogActions>
+              <Button size="small" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Divider orientation="vertical" sx={{ height: "2em" }} />
+              <MobileStepper
+                sx={{
+                  m: -1,
+                  ml: "0 !important",
+                  flexGrow: 1,
+                  background: "transparent",
+                  pl: 0,
+                }}
+                steps={numberOfPanes(firstPane)}
+                position="static"
+                activeStep={getIndexOfPane(firstPane, activePane)}
+                backButton={
+                  <Button
+                    size="small"
+                    data-test-id="createGroupBackButton"
+                    onClick={handleBack}
+                    disabled={!activePane.prev}
+                  >
+                    Back
+                  </Button>
+                }
+                nextButton={
+                  <Button
+                    size="small"
+                    data-test-id="createGroupNextButton"
+                    onClick={() => handleNext()}
+                    disabled={state.exportConfig.archiveType === ""}
+                  >
+                    {activePane.next ? "Next" : "Export"}
+                  </Button>
+                }
+              />
+            </DialogActions>
           </Dialog>
           <Snackbar
             anchorOrigin={{

--- a/src/main/webapp/ui/src/Export/ExportDialog.js
+++ b/src/main/webapp/ui/src/Export/ExportDialog.js
@@ -208,7 +208,7 @@ function ExportDialog({
         docConfig.pageSize = format;
         docConfig.defaultPageSize = format;
       })
-      .catch(function (error) {
+      .catch((error) => {
         console.log(error);
       });
   }, []);
@@ -263,7 +263,7 @@ function ExportDialog({
           })
         );
       })
-      .catch(function (error) {
+      .catch((error) => {
         console.log(error);
       });
   };
@@ -553,13 +553,13 @@ const xmlConfig = {
   allVersions: false,
 };
 
-let pdfConfig = {
+const pdfConfig = {
   exportFormat: "PDF",
   exportName: "",
   provenance: true,
   comments: true,
   annotations: true,
-        restartPageNumberPerDoc: true,
+  restartPageNumberPerDoc: true,
   pageSize: "A4",
   defaultPageSize: "A4",
   dateType: "EXP",
@@ -568,7 +568,7 @@ let pdfConfig = {
   includeFieldLastModifiedDate: true,
 };
 
-let docConfig = {
+const docConfig = {
   exportFormat: "WORD",
   exportName: "",
   pageSize: "A4",

--- a/src/main/webapp/ui/src/Export/ExportModal.js
+++ b/src/main/webapp/ui/src/Export/ExportModal.js
@@ -3,6 +3,7 @@
 import ExportDialog from "./ExportDialog";
 import { createRoot } from "react-dom/client";
 import React from "react";
+import Alerts from "../components/Alerts/Alerts";
 
 /*
  * This module initialises the ExportDialog react component within the
@@ -16,16 +17,18 @@ import React from "react";
 const domContainer = document.getElementById("exportModal");
 const root = createRoot(domContainer);
 root.render(
-  <ExportDialog
-    exportSelection={{
-      type: "selection",
-      exportTypes: [],
-      exportNames: [],
-      exportIds: [],
-    }}
-    open={false}
-    allowFileStores={RS.netFileStoresExportEnabled}
-  />
+  <Alerts>
+    <ExportDialog
+      exportSelection={{
+        type: "selection",
+        exportTypes: [],
+        exportNames: [],
+        exportIds: [],
+      }}
+      open={false}
+      allowFileStores={RS.netFileStoresExportEnabled}
+    />
+  </Alerts>
 );
 
 RS.exportModal = {
@@ -55,11 +58,13 @@ RS.exportModal = {
       exportIds: exportSelection.exportIds || [],
     };
     root.render(
-      <ExportDialog
-        exportSelection={adjustedSelection}
-        open={true}
-        allowFileStores={RS.netFileStoresExportEnabled}
-      />
+      <Alerts>
+        <ExportDialog
+          exportSelection={adjustedSelection}
+          open={true}
+          allowFileStores={RS.netFileStoresExportEnabled}
+        />
+      </Alerts>
     );
   },
 };

--- a/src/main/webapp/ui/src/Export/FormatChoice.js
+++ b/src/main/webapp/ui/src/Export/FormatChoice.js
@@ -6,6 +6,7 @@ import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
 import axios from "axios";
 import { type ExportSelection } from "./ExportDialog";
 import { type Validator } from "../util/Validator";
@@ -15,6 +16,10 @@ import { Optional } from "../util/optional";
 import { useDeploymentProperty } from "../eln/useDeploymentProperty";
 import * as FetchingData from "../util/fetchingData";
 import * as Parsers from "../util/parsers";
+import {
+  OptionHeading,
+  OptionExplanation,
+} from "../components/Inputs/RadioField";
 
 export type ArchiveType = "pdf" | "doc" | "xml" | "html" | "eln";
 
@@ -202,74 +207,96 @@ function FormatChoice({
         value={archiveType}
         onChange={handleChange}
       >
-        <FormControlLabel
-          value="html"
-          control={<Radio data-test-id="zip-html" color="primary" />}
-          label={
-            <span>
-              <strong>.ZIP bundle containing .HTML files</strong> - Exported
-              data, notebooks and attached files can be accessed offline with a
-              browser
-            </span>
-          }
-        />
-        <FormControlLabel
-          value="xml"
-          control={<Radio data-test-id="zip-xml" color="primary" />}
-          label={
-            <span>
-              <strong>.ZIP bundle containing .XML files</strong> - Exported data
-              is machine readable. Good for archiving, or transferring data from
-              one RSpace server or user to another
-            </span>
-          }
-        />
-        <FormControlLabel
-          value="pdf"
-          disabled={!pdfAvailable}
-          control={<Radio data-test-id="pdf" color="primary" />}
-          label={
-            pdfAvailable ? (
-              <span>
-                <strong>PDF file</strong> - A read-only version of your RSpace
-                documents will be placed in the &apos;Exports&apos; area of the
-                Gallery
-              </span>
-            ) : (
-              "All selected items are attachments - there are no RSpace documents to export."
-            )
-          }
-        />
-        <FormControlLabel
-          value="eln"
-          control={<Radio data-test-id="zip-eln" color="primary" />}
-          label={
-            <span>
-              <strong>RO-Crate</strong> - an XML bundle with an RO-Crate
-              metadata file, zipped into a .eln archive
-            </span>
-          }
-        />
-        {FetchingData.getSuccessValue(asposeEnabled)
-          .flatMap(Parsers.isBoolean)
-          .orElse(false) && (
+        <Stack spacing={2}>
           <FormControlLabel
-            value="doc"
-            disabled={!wordAvailable}
-            control={<Radio data-test-id="doc" color="primary" />}
+            value="html"
+            control={<Radio data-test-id="zip-html" color="primary" />}
             label={
-              wordAvailable ? (
-                <span>
-                  <strong>.DOC file</strong> - MS Word version of your RSpace
-                  documents will be placed in the &apos;Exports&apos; area of the
-                  Gallery
-                </span>
-              ) : (
-                wordAvailabilityMessage
-              )
+              <>
+                <OptionHeading>
+                  .ZIP bundle containing .HTML files
+                </OptionHeading>
+                <OptionExplanation>
+                  Exported data, notebooks and attached files can be accessed
+                  offline with a browser.
+                </OptionExplanation>
+              </>
             }
           />
-        )}
+          <FormControlLabel
+            value="xml"
+            control={<Radio data-test-id="zip-xml" color="primary" />}
+            label={
+              <>
+                <OptionHeading>.ZIP bundle containing .XML files</OptionHeading>
+                <OptionExplanation>
+                  Exported data is machine readable. Good for archiving, or
+                  transferring data from one RSpace server or user to another.
+                </OptionExplanation>
+              </>
+            }
+          />
+          <FormControlLabel
+            value="pdf"
+            disabled={!pdfAvailable}
+            control={<Radio data-test-id="pdf" color="primary" />}
+            label={
+              <>
+                <OptionHeading>PDF file</OptionHeading>
+                <OptionExplanation>
+                  {pdfAvailable ? (
+                    <>
+                      A read-only version of your RSpace documents will be
+                      placed in the &apos;Exports&apos; area of the Gallery
+                    </>
+                  ) : (
+                    <>
+                      All selected items are attachments &mdash; there are no
+                      RSpace documents to export.
+                    </>
+                  )}
+                </OptionExplanation>
+              </>
+            }
+          />
+          <FormControlLabel
+            value="eln"
+            control={<Radio data-test-id="zip-eln" color="primary" />}
+            label={
+              <>
+                <OptionHeading>RO-Crate</OptionHeading>
+                <OptionExplanation>
+                  An XML bundle with an RO-Crate metadata file, zipped into a
+                  .eln archive.
+                </OptionExplanation>
+              </>
+            }
+          />
+          {FetchingData.getSuccessValue(asposeEnabled)
+            .flatMap(Parsers.isBoolean)
+            .orElse(false) && (
+            <FormControlLabel
+              value="doc"
+              disabled={!wordAvailable}
+              control={<Radio data-test-id="doc" color="primary" />}
+              label={
+                <>
+                  <OptionHeading>.DOC file</OptionHeading>
+                  <OptionExplanation>
+                    {wordAvailable ? (
+                      <>
+                        MS Word version of your RSpace documents will be placed
+                        in the &apos;Exports&apos; area of the Gallery.
+                      </>
+                    ) : (
+                      wordAvailabilityMessage
+                    )}
+                  </OptionExplanation>
+                </>
+              }
+            />
+          )}
+        </Stack>
       </RadioGroup>
 
       <h3 style={{ marginTop: "20px" }}>Choose additional destinations</h3>

--- a/src/main/webapp/ui/src/Export/FormatChoice.js
+++ b/src/main/webapp/ui/src/Export/FormatChoice.js
@@ -122,7 +122,7 @@ function FormatChoice({
     let allMedia = false;
     let isSystem = false;
     // $FlowExpectedError[cannot-resolve-name] Global variable
-    let isGallery = typeof isGalleryPage !== "undefined" && isGalleryPage;
+    const isGallery = typeof isGalleryPage !== "undefined" && isGalleryPage;
 
     if (exportSelection.type === "selection") {
       // if all are media, there's nothing to export in this format: RSpac1333
@@ -148,7 +148,7 @@ function FormatChoice({
       exportSelection.type === "selection" &&
       exportSelection.exportIds.length === 1
     ) {
-      let selectedType = exportSelection.exportTypes[0];
+      const selectedType = exportSelection.exportTypes[0];
       if (selectedType.indexOf("FOLDER") >= 0) {
         disabledBecauseFolder = true;
       } else if (selectedType === "NOTEBOOK") {
@@ -163,7 +163,7 @@ function FormatChoice({
       );
     }
 
-    let wordExportAllowed =
+    const wordExportAllowed =
       !disabledBecauseMultiple &&
       !disabledBecauseFolder &&
       !disabledBecauseNotebook &&

--- a/src/main/webapp/ui/src/Export/FormatChoice.js
+++ b/src/main/webapp/ui/src/Export/FormatChoice.js
@@ -27,7 +27,7 @@ const WORD_ERRORS = [
   "Word export is only available for a single document, and you have selected more than one.",
   "Word export is only available for a single document, and you've selected a folder.",
   "Word export is only available for a single document or notebook entry, and you've selected a Notebook.",
-  "All selected items are attachments - there are no RSpace documents to export.",
+  "All selected items are attachments — there are no RSpace documents to export.",
 ];
 
 type FormatChoiceArgs = {|

--- a/src/main/webapp/ui/src/Export/__tests__/ExportDialog.test.js
+++ b/src/main/webapp/ui/src/Export/__tests__/ExportDialog.test.js
@@ -19,9 +19,9 @@ import fc from "fast-check";
 import MockAdapter from "axios-mock-adapter";
 import * as axios from "axios";
 import CREATE_QUICK_EXPORT_PLAN from "./createQuickExportPlan";
-import CREATE_FULL_EXPORT_PLAN from "./createFullExportPlan";
 import each from "jest-each";
 import { type UseState } from "../../util/types";
+import Alerts from "../../components/Alerts/Alerts";
 
 const mockAxios = new MockAdapter(axios);
 
@@ -100,11 +100,13 @@ function renderExportDialog({
       setOpen(o);
     };
     return (
-      <ExportDialog
-        exportSelection={selection}
-        open={open}
-        allowFileStores={allowFileStores ?? false}
-      />
+      <Alerts>
+        <ExportDialog
+          exportSelection={selection}
+          open={open}
+          allowFileStores={allowFileStores ?? false}
+        />
+      </Alerts>
     );
   };
   render(<Wrapper />);

--- a/src/main/webapp/ui/src/Export/__tests__/FormatChoice.test.js
+++ b/src/main/webapp/ui/src/Export/__tests__/FormatChoice.test.js
@@ -202,7 +202,7 @@ describe("FormatChoice", () => {
 
       expect(
         screen.getByRole("radio", {
-          name: "Word export is only available for a single document, and you have selected more than one.",
+          name: ".DOC file Word export is only available for a single document, and you have selected more than one.",
         })
       ).toBeDisabled();
     });
@@ -234,7 +234,7 @@ describe("FormatChoice", () => {
 
       expect(
         screen.getByRole("radio", {
-          name: "Word export is only available for a single document, and you've selected a folder.",
+          name: ".DOC file Word export is only available for a single document, and you've selected a folder.",
         })
       ).toBeDisabled();
     });
@@ -266,7 +266,7 @@ describe("FormatChoice", () => {
 
       expect(
         screen.getByRole("radio", {
-          name: "Word export is only available for a single document or notebook entry, and you've selected a Notebook.",
+          name: ".DOC file Word export is only available for a single document or notebook entry, and you've selected a Notebook.",
         })
       ).toBeDisabled();
     });
@@ -298,9 +298,8 @@ describe("FormatChoice", () => {
 
       expect(
         screen.getAllByRole("radio", {
-          name: "All selected items are attachments - there are no RSpace documents to export.",
-          // selecting second such radio because first will be for .pdf export
-        })[1]
+          name: ".DOC file All selected items are attachments — there are no RSpace documents to export.",
+        })[0]
       ).toBeDisabled();
     });
   });
@@ -329,7 +328,7 @@ describe("FormatChoice", () => {
 
       expect(
         screen.getAllByRole("radio", {
-          name: "All selected items are attachments - there are no RSpace documents to export.",
+          name: "PDF file All selected items are attachments — there are no RSpace documents to export.",
           // selecting first such radio because second will be for .doc export
         })[0]
       ).toBeDisabled();

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -32,6 +32,8 @@ import IrodsLogo from "./IrodsLogo.svg";
 import Avatar from "@mui/material/Avatar";
 import Typography from "@mui/material/Typography";
 import MoveDialog from "./MoveDialog";
+import ExportDialog from "../../../Export/ExportDialog";
+import EventBoundary from "../../../components/EventBoundary";
 
 const RenameDialog = ({
   open,
@@ -126,6 +128,7 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
   const [renameOpen, setRenameOpen] = React.useState(false);
   const [moveOpen, setMoveOpen] = React.useState(false);
   const [irodsOpen, setIrodsOpen] = React.useState(false);
+  const [exportOpen, setExportOpen] = React.useState(false);
 
   const duplicateAllowed = (): Result<null> => {
     if (selection.isEmpty)
@@ -183,7 +186,7 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
   const exportAllowed = (): Result<null> => {
     if (selection.isEmpty)
       return Result.Error([new Error("Nothing selected.")]);
-    return Result.Error([new Error("Not yet available.")]);
+    return Result.Ok(null);
   };
 
   const downloadAllowed = (): Result<null> => {
@@ -328,11 +331,36 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
           foregroundColor={COLOR.contrastText}
           avatar={<FileDownloadIcon />}
           onClick={() => {
-            setActionsMenuAnchorEl(null);
+            setExportOpen(true);
           }}
           compact
           disabled={exportAllowed().isError}
         />
+        <EventBoundary>
+          <ExportDialog
+            open={exportOpen}
+            onClose={() => {
+              setExportOpen(false);
+              setActionsMenuAnchorEl(null);
+            }}
+            exportSelection={{
+              type: "selection",
+              exportTypes: selection
+                .asSet()
+                .map(() => "MEDIA_FILE")
+                .toArray(),
+              exportNames: selection
+                .asSet()
+                .map(({ name }) => name)
+                .toArray(),
+              exportIds: selection
+                .asSet()
+                .map(({ id }) => idToString(id))
+                .toArray(),
+            }}
+            allowFileStores={false}
+          />
+        </EventBoundary>
         <NewMenuItem
           title="Edit"
           subheader={imageEditingAllowed()


### PR DESCRIPTION
This change makes a few stylistic changes to the export dialog to make it more consistent with the rest of the product, including
- Replacing the 'X' in the top right corner, with a 'Cancel' button at the bottom
- Make the dialog fullscreen on mobile devices
- Arrange the initial radio buttons with a short label and a smaller explanation below, rather than all on the same line.

<img width="619" alt="image" src="https://github.com/user-attachments/assets/91cc5d90-bb1e-44cf-b388-7dd374e47497">

This change also makes the export dialog work on the new gallery