### PR TITLE
[#63] specify a different database using deployment properties

### DIFF
--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -261,8 +261,8 @@ alters the logging verbosity for various frameworks or RSpace code.
 
 #### Set deployment properties through command line
 
-`-Djdbc.url=jdbc:mysql://localhost:3306/databasename`
-specifies a specific database different from the default, rspace
+`-Djdbc.url=jdbc:mysql://localhost:3306/another_database -Djdbc.db=another_database`
+specifies to use a different database `another_database` at the url `jdbc:mysql://localhost:3306/another_database`.
 
 `-DRS_FILE_BASE=/path/toFileStore`
 overrides the default filestore location.


### PR DESCRIPTION
update docs explaining additional deployment param required to use a different database than the standard rspace