### PR TITLE
RSDEV-257 Add "Move all to trash" button to error toast when deleting samples

### DIFF
--- a/src/main/webapp/ui/src/components/Alerts/SnackbarContentWrapper.js
+++ b/src/main/webapp/ui/src/components/Alerts/SnackbarContentWrapper.js
@@ -48,6 +48,7 @@ const useStyles = makeStyles()((theme, { verySmallLayout }) => ({
   buttons: {
     margin: -12,
     flexShrink: 0,
+    marginLeft: 0,
   },
   content: {
     width: "100%",
@@ -167,7 +168,8 @@ const SnackbarContentWrapper = forwardRef<
                     alert.onActionClick();
                     onClose();
                   }}
-                  color="primary"
+                  variant="outlined"
+                  sx={{ color: "white", borderColor: "white" }}
                 >
                   {alert.actionLabel.toUpperCase()}
                 </Button>

--- a/src/main/webapp/ui/src/stores/models/Search.js
+++ b/src/main/webapp/ui/src/stores/models/Search.js
@@ -494,6 +494,10 @@ export default class Search implements SearchInterface {
                 sample: s,
               }),
             })),
+            actionLabel: "Move all to trash",
+            onActionClick: () => {
+              alert("delete all");
+            },
           })
         );
       }

--- a/src/main/webapp/ui/src/stores/models/Search.js
+++ b/src/main/webapp/ui/src/stores/models/Search.js
@@ -79,11 +79,15 @@ export const getViewGroup = (
     [() => true, "static"],
   ])(view);
 
-const prepareRecordsForBulkApi = (records: Array<InventoryRecord>) =>
+const prepareRecordsForBulkApi = (
+  records: Array<InventoryRecord>,
+  opts?: {| forceDelete?: boolean |}
+) =>
   records.map((record) => ({
     id: record.id,
     type: record.type,
     owner: { username: record.owner?.username },
+    ...(opts ?? {}),
   }));
 
 type SearchArgs = {|
@@ -421,7 +425,10 @@ export default class Search implements SearchInterface {
    * Deletes the passed records, displays toasts accordingly, and invokes the
    * refreshing of the UI's state.
    */
-  async deleteRecords(records: Array<InventoryRecord>): Promise<void> {
+  async deleteRecords(
+    records: Array<InventoryRecord>,
+    opts?: {| forceDelete?: boolean |}
+  ): Promise<void> {
     this.setProcessingContextActions(true);
     const { uiStore } = getRootStore();
 
@@ -446,7 +453,7 @@ export default class Search implements SearchInterface {
             }>,
             errorCount: number,
           }
-        >(prepareRecordsForBulkApi(records), "DELETE", false)
+        >(prepareRecordsForBulkApi(records, opts), "DELETE", false)
       );
 
       /*
@@ -496,7 +503,7 @@ export default class Search implements SearchInterface {
             })),
             actionLabel: "Move all to trash",
             onActionClick: () => {
-              alert("delete all");
+              void this.deleteRecords(records, { forceDelete: true });
             },
           })
         );

--- a/src/main/webapp/ui/src/stores/models/Search.js
+++ b/src/main/webapp/ui/src/stores/models/Search.js
@@ -494,7 +494,13 @@ export default class Search implements SearchInterface {
               "Some of the samples could not be trashed because the subsamples are in containers.",
             message: "Please move them to the trash first.",
             details: subsamplesThatPreventedSampleDeletion.map(([s, ss]) => ({
-              title: `Could not trash "${ss.name ?? "UNKNOWN"}"`,
+              title: `Could not trash "${ss.name ?? "UNKNOWN"}" ${
+                ss.parentContainers.length > 0
+                  ? `(in ${ss.parentContainers[0].name} ${
+                      ss.parentContainers[0].globalId ?? ""
+                    })`
+                  : ""
+              }`,
               variant: "error",
               record: factory.newRecord({
                 ...ss,


### PR DESCRIPTION
When deleting a sample, if some of the subsamples are in containers then the user is prevented from being able to delete the sample as it is likely that some of the substance is still in use/in freezers/etc. However, in the case where a sample only ever has one subsample, or there happens to only be one subsample left, it would be very useful to be able to delete the sample and subsample both in one operation. Furthermore, there may be edge cases where it is desirable to delete all of the subsamples of a sample in a storage and the system should be flexible enough to support that it even if its is an unusual request.

As such, this change adds a button to the error toast that explains that some of the subsamples are still in containers that allows the user to force the deletion of all of the subsamples and sample even though the subsamples remain in containers.