### PR TITLE
PRT-794 Define GeoLocationPolygon class to enforce bounding region

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/GeoLocationField.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/GeoLocationField.js
@@ -8,9 +8,7 @@ import React, {
   lazy,
 } from "react";
 import { observer } from "mobx-react-lite";
-import GeoLocationModel, {
-  polygonComplete,
-} from "../../../../stores/models/GeoLocationModel";
+import GeoLocationModel from "../../../../stores/models/GeoLocationModel";
 import InputWrapper from "../../../../components/Inputs/InputWrapper";
 import Alert from "@mui/material/Alert";
 import Grid from "@mui/material/Grid";
@@ -384,7 +382,7 @@ const GeoLocationField = ({
             </Grid>
             <PolygonStateAlert
               polygonEmpty={polygonEmpty}
-              polygonComplete={polygonComplete(geoLocation.geoLocationPolygon)}
+              polygonComplete={geoLocation.geoLocationPolygon.isValid}
               textMessages={POLYGON_FIELD_MESSAGES}
             />
           </CustomFieldset>
@@ -569,9 +567,7 @@ const GeoLocationField = ({
                   </Grid>
                   <PolygonStateAlert
                     polygonEmpty={polygonEmpty}
-                    polygonComplete={polygonComplete(
-                      geoLocation.geoLocationPolygon
-                    )}
+                    polygonComplete={geoLocation.geoLocationPolygon.isValid}
                     textMessages={POLYGON_FIELD_MESSAGES}
                   />
                 </CustomFieldset>

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/Identifiers.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/Identifiers.js
@@ -324,6 +324,7 @@ export const IdentifiersList: ComponentType<IdentifiersListArgs> = observer(
     const { classes } = useStyles();
     const editable = activeResult.isFieldEditable("identifiers");
     const { addAlert } = useContext(AlertContext);
+    const { uiStore } = useStores();
 
     const StateInfo = ({
       identifierState,
@@ -405,7 +406,10 @@ export const IdentifiersList: ComponentType<IdentifiersListArgs> = observer(
     };
 
     const handleRetract = (id: Identifier) => {
-      void id.retract();
+      void id.retract({
+        confirm: (...args) => uiStore.confirm(...args),
+        addAlert: (...args) => addAlert(...args),
+      });
     };
 
     const handleDelete = (id: Identifier) => {

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MapViewer.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MapViewer.js
@@ -98,7 +98,7 @@ export default function MapViewer({
   }
   if (polygon.isValid) {
     const sum = polygon
-      .map(({ polygonPoint }) => parseFloat(polygonPoint.pointLatitude))
+      .mapPoints((polygonPoint) => parseFloat(polygonPoint.pointLatitude))
       .reduce((acc, lat) => acc + lat, 0);
     latitudeCenter += sum * (1 / polygon.length);
     latitudeDataPoints++;
@@ -126,7 +126,7 @@ export default function MapViewer({
   }
   if (polygon.isValid) {
     const sum = polygon
-      .map(({ polygonPoint }) => parseFloat(polygonPoint.pointLongitude))
+      .mapPoints((polygonPoint) => parseFloat(polygonPoint.pointLongitude))
       .reduce((acc, lat) => acc + lat, 0);
     longitudeCenter += sum * (1 / polygon.length);
     longitudeDataPoints++;
@@ -182,10 +182,8 @@ export default function MapViewer({
               fillOpacity: 0.5,
               stroke: false,
             }}
-            positions={polygon.map(
-              ({
-                polygonPoint: { pointLatitude: lat, pointLongitude: long },
-              }) => [lat, long]
+            positions={polygon.mapPoints(
+              ({ pointLatitude: lat, pointLongitude: long }) => [lat, long]
             )}
           />
         )}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MapViewer.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MapViewer.js
@@ -5,7 +5,6 @@ import "leaflet/dist/leaflet.css";
 import {
   boxComplete,
   pointComplete,
-  polygonComplete,
 } from "../../../../stores/models/GeoLocationModel";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Grid from "@mui/material/Grid";
@@ -56,9 +55,7 @@ export default function MapViewer({
 
   const [showPoint, setShowPoint] = useState<boolean>(pointComplete(point));
   const [showBox, setShowBox] = useState<boolean>(boxComplete(box));
-  const [showPolygon, setShowPolygon] = useState<boolean>(
-    polygonComplete(polygon)
-  );
+  const [showPolygon, setShowPolygon] = useState<boolean>(polygon.isValid);
 
   const {
     eastBoundLongitude,
@@ -99,18 +96,12 @@ export default function MapViewer({
       latitudeDataPoints++;
     }
   }
-  if (polygonComplete(polygon)) {
-    if (
-      polygon.every(
-        ({ polygonPoint }) => !isNaN(parseFloat(polygonPoint.pointLatitude))
-      )
-    ) {
-      const sum = polygon
-        .map(({ polygonPoint }) => parseFloat(polygonPoint.pointLatitude))
-        .reduce((acc, lat) => acc + lat, 0);
-      latitudeCenter += sum * (1 / polygon.length);
-      latitudeDataPoints++;
-    }
+  if (polygon.isValid) {
+    const sum = polygon
+      .map(({ polygonPoint }) => parseFloat(polygonPoint.pointLatitude))
+      .reduce((acc, lat) => acc + lat, 0);
+    latitudeCenter += sum * (1 / polygon.length);
+    latitudeDataPoints++;
   }
   latitudeCenter /= latitudeDataPoints;
 
@@ -133,18 +124,12 @@ export default function MapViewer({
       longitudeDataPoints++;
     }
   }
-  if (polygonComplete(polygon)) {
-    if (
-      polygon.every(
-        ({ polygonPoint }) => !isNaN(parseFloat(polygonPoint.pointLongitude))
-      )
-    ) {
-      const sum = polygon
-        .map(({ polygonPoint }) => parseFloat(polygonPoint.pointLongitude))
-        .reduce((acc, lat) => acc + lat, 0);
-      longitudeCenter += sum * (1 / polygon.length);
-      longitudeDataPoints++;
-    }
+  if (polygon.isValid) {
+    const sum = polygon
+      .map(({ polygonPoint }) => parseFloat(polygonPoint.pointLongitude))
+      .reduce((acc, lat) => acc + lat, 0);
+    longitudeCenter += sum * (1 / polygon.length);
+    longitudeDataPoints++;
   }
   longitudeCenter /= longitudeDataPoints;
 
@@ -242,7 +227,7 @@ export default function MapViewer({
                 <Switch
                   color="tertiary"
                   checked={showPolygon}
-                  disabled={!polygonComplete(polygon)}
+                  disabled={!polygon.isValid}
                   onChange={() => setShowPolygon(!showPolygon)}
                   inputProps={{ "aria-label": "show GL Polygon" }}
                 />

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MultipleInputHandler.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MultipleInputHandler.js
@@ -22,6 +22,7 @@ import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import { capitaliseJustFirstChar } from "../../../../util/Util";
+import { GeoLocationPolygonModel } from "../../../../stores/models/GeoLocationModel";
 
 export const isEmpty = (v: string): boolean => v === "";
 
@@ -54,7 +55,12 @@ const MultipleInputHandler = ({
 
   const newItem = () => {
     return field.key === "Geolocations"
-      ? newGeoLocation
+      ? {
+          ...newGeoLocation,
+          geoLocationPolygon: new GeoLocationPolygonModel(
+            newGeoLocation.geoLocationPolygon
+          ),
+        }
       : {
           value: field.key === "Dates" ? new Date() : "",
           ...(field.options ? { type: field.options[0].value } : null),

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MultipleInputHandler.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MultipleInputHandler.js
@@ -22,7 +22,7 @@ import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import { capitaliseJustFirstChar } from "../../../../util/Util";
-import { GeoLocationPolygonModel } from "../../../../stores/models/GeoLocationModel";
+import GeoLocationModel from "../../../../stores/models/GeoLocationModel";
 
 export const isEmpty = (v: string): boolean => v === "";
 
@@ -55,12 +55,9 @@ const MultipleInputHandler = ({
 
   const newItem = () => {
     return field.key === "Geolocations"
-      ? {
+      ? new GeoLocationModel({
           ...newGeoLocation,
-          geoLocationPolygon: new GeoLocationPolygonModel(
-            newGeoLocation.geoLocationPolygon
-          ),
-        }
+        })
       : {
           value: field.key === "Dates" ? new Date() : "",
           ...(field.options ? { type: field.options[0].value } : null),

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PolygonCard.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PolygonCard.js
@@ -61,13 +61,11 @@ const PolygonEditor = observer(
       editable && i < geoLocationPolygon.length - 1;
 
     const handleAddPoint = (i: number): void => {
-      geoLocationPolygon.splice(i + 1, 0, {
-        polygonPoint: { pointLatitude: "", pointLongitude: "" },
-      });
+      geoLocationPolygon.addAnotherPoint(i);
       doUpdateIdentifiers();
     };
     const handleRemovePoint = (i: number): void => {
-      geoLocationPolygon.splice(i, 1);
+      geoLocationPolygon.removePoint(i);
       doUpdateIdentifiers();
     };
 

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PolygonCard.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PolygonCard.js
@@ -75,105 +75,101 @@ const PolygonEditor = observer(
       (isEmpty(point.pointLongitude) && !polygonEmpty) ||
       isOutOfRangeX(Number(point.pointLongitude));
 
-    return geoLocationPolygon
-      .map((item) => item.polygonPoint)
-      .map((point, i) => (
-        <Grid
-          key={i}
-          container
-          direction="row"
-          spacing={1}
-          sx={{
-            alignItems: "center",
-            width: "100%",
-          }}
-        >
-          <Grid item md={5}>
-            <InputWrapper label={`Point ${i + 1} Latitude`}>
-              {editable && i < geoLocationPolygon.length - 1 ? (
-                <AmberNumberField
-                  inputProps={{ ...COORD_RANGE_Y }}
-                  size="small"
-                  variant="standard"
-                  fullWidth
-                  datatestid={`Polygon-point-${i}-latitude`}
-                  disabled={false}
-                  value={point.pointLatitude ?? ""}
-                  placeholder="Enter Point Latitude"
-                  onChange={({ target: { value } }) => {
-                    geoLocationPolygon.set(i, "pointLatitude", value);
-                    doUpdateIdentifiers();
-                  }}
-                  /* value is required for any polygon point (if at least another value is specified) */
-                  error={polygonPointLatitudeError(point)}
-                  helperText={
-                    polygonPointLatitudeError(point) ? (
-                      <>Between &minus;90.0˚ and 90.0˚.</>
-                    ) : null
-                  }
-                />
-              ) : (
-                /* last point is edited by editing first */
-                point.pointLatitude || (
-                  <span style={{ color: "#949494" }}>-</span>
-                )
-              )}
-            </InputWrapper>
-          </Grid>
-          <Grid item md={5}>
-            <InputWrapper label={`Point ${i + 1} Longitude`}>
-              {editable && i < geoLocationPolygon.length - 1 ? (
-                <AmberNumberField
-                  inputProps={{ ...COORD_RANGE_X }}
-                  size="small"
-                  variant="standard"
-                  fullWidth
-                  datatestid={`Polygon-point-${i + 1}-longitude`}
-                  disabled={false}
-                  value={point.pointLongitude ?? ""}
-                  placeholder="Enter Point Longitude"
-                  onChange={({ target: { value } }) => {
-                    geoLocationPolygon.set(i, "pointLongitude", value);
-                    doUpdateIdentifiers();
-                  }}
-                  /* value is required for any polygon point (if at least another value is specified) */
-                  error={polygonPointLongitudeError(point)}
-                  helperText={
-                    polygonPointLongitudeError(point) ? (
-                      <>Between &minus;180.0˚ and 180.0˚.</>
-                    ) : null
-                  }
-                />
-              ) : (
-                /* last point is edited by editing first */
-                point.pointLongitude || (
-                  <span style={{ color: "#949494" }}>-</span>
-                )
-              )}
-            </InputWrapper>
-          </Grid>
-          <Grid item md={1}>
-            {canBeAdded(i) ? (
-              <AddButton
-                onClick={() => handleAddPoint(i)}
-                title={`Add Point after ${i + 1}`}
+    return geoLocationPolygon.mapPoints((point, i) => (
+      <Grid
+        key={i}
+        container
+        direction="row"
+        spacing={1}
+        sx={{
+          alignItems: "center",
+          width: "100%",
+        }}
+      >
+        <Grid item md={5}>
+          <InputWrapper label={`Point ${i + 1} Latitude`}>
+            {editable && i < geoLocationPolygon.length - 1 ? (
+              <AmberNumberField
+                inputProps={{ ...COORD_RANGE_Y }}
+                size="small"
+                variant="standard"
+                fullWidth
+                datatestid={`Polygon-point-${i}-latitude`}
+                disabled={false}
+                value={point.pointLatitude ?? ""}
+                placeholder="Enter Point Latitude"
+                onChange={({ target: { value } }) => {
+                  geoLocationPolygon.set(i, "pointLatitude", value);
+                  doUpdateIdentifiers();
+                }}
+                /* value is required for any polygon point (if at least another value is specified) */
+                error={polygonPointLatitudeError(point)}
+                helperText={
+                  polygonPointLatitudeError(point) ? (
+                    <>Between &minus;90.0˚ and 90.0˚.</>
+                  ) : null
+                }
               />
             ) : (
-              <>&nbsp;</>
+              /* last point is edited by editing first */
+              point.pointLatitude || <span style={{ color: "#949494" }}>-</span>
             )}
-          </Grid>
-          <Grid item md={1}>
-            {canBeRemoved(i) ? (
-              <RemoveButton
-                onClick={() => handleRemovePoint(i)}
-                title={`Remove Point ${i + 1}`}
-              />
-            ) : (
-              <>&nbsp;</>
-            )}
-          </Grid>
+          </InputWrapper>
         </Grid>
-      ));
+        <Grid item md={5}>
+          <InputWrapper label={`Point ${i + 1} Longitude`}>
+            {editable && i < geoLocationPolygon.length - 1 ? (
+              <AmberNumberField
+                inputProps={{ ...COORD_RANGE_X }}
+                size="small"
+                variant="standard"
+                fullWidth
+                datatestid={`Polygon-point-${i + 1}-longitude`}
+                disabled={false}
+                value={point.pointLongitude ?? ""}
+                placeholder="Enter Point Longitude"
+                onChange={({ target: { value } }) => {
+                  geoLocationPolygon.set(i, "pointLongitude", value);
+                  doUpdateIdentifiers();
+                }}
+                /* value is required for any polygon point (if at least another value is specified) */
+                error={polygonPointLongitudeError(point)}
+                helperText={
+                  polygonPointLongitudeError(point) ? (
+                    <>Between &minus;180.0˚ and 180.0˚.</>
+                  ) : null
+                }
+              />
+            ) : (
+              /* last point is edited by editing first */
+              point.pointLongitude || (
+                <span style={{ color: "#949494" }}>-</span>
+              )
+            )}
+          </InputWrapper>
+        </Grid>
+        <Grid item md={1}>
+          {canBeAdded(i) ? (
+            <AddButton
+              onClick={() => handleAddPoint(i)}
+              title={`Add Point after ${i + 1}`}
+            />
+          ) : (
+            <>&nbsp;</>
+          )}
+        </Grid>
+        <Grid item md={1}>
+          {canBeRemoved(i) ? (
+            <RemoveButton
+              onClick={() => handleRemovePoint(i)}
+              title={`Remove Point ${i + 1}`}
+            />
+          ) : (
+            <>&nbsp;</>
+          )}
+        </Grid>
+      </Grid>
+    ));
   }
 );
 

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PolygonCard.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PolygonCard.js
@@ -104,9 +104,7 @@ const PolygonEditor = observer(
                   value={point.pointLatitude ?? ""}
                   placeholder="Enter Point Latitude"
                   onChange={({ target: { value } }) => {
-                    runInAction(() => {
-                      point.pointLatitude = value;
-                    });
+                    geoLocationPolygon.set(i, "pointLatitude", value);
                     doUpdateIdentifiers();
                   }}
                   /* value is required for any polygon point (if at least another value is specified) */
@@ -138,9 +136,7 @@ const PolygonEditor = observer(
                   value={point.pointLongitude ?? ""}
                   placeholder="Enter Point Longitude"
                   onChange={({ target: { value } }) => {
-                    runInAction(() => {
-                      point.pointLongitude = value;
-                    });
+                    geoLocationPolygon.set(i, "pointLongitude", value);
                     doUpdateIdentifiers();
                   }}
                   /* value is required for any polygon point (if at least another value is specified) */

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PolygonCard.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PolygonCard.js
@@ -29,7 +29,6 @@ import {
   PolygonStateAlert,
   type PolygonMessages,
 } from "./GeoLocationField";
-import { polygonComplete } from "../../../../stores/models/GeoLocationModel";
 
 const POLYGON_CARD_MESSAGES: PolygonMessages = {
   empty: "An empty Polygon will not be included in the Geolocation.",
@@ -311,7 +310,7 @@ function PolygonCard({
           <Box sx={{ my: 1 }}>
             <PolygonStateAlert
               polygonEmpty={polygonEmpty}
-              polygonComplete={polygonComplete(geoLocation.geoLocationPolygon)}
+              polygonComplete={geoLocation.geoLocationPolygon.isValid}
               textMessages={POLYGON_CARD_MESSAGES}
             />
           </Box>

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PublicPreviewDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PublicPreviewDialog.js
@@ -111,7 +111,7 @@ const PublicPreviewDialog = ({
                  * public page were the user to tap the "Publish" button right now.
                  */}
                 <IdentifierDataGrid
-                  identifier={id.publicData}
+                  identifier={id}
                   record={{
                     description: record.description,
                     tags: record.tags,

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PublishButton.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/PublishButton.js
@@ -4,6 +4,7 @@ import React, { type Node } from "react";
 import { type Identifier } from "../../../../stores/definitions/Identifier";
 import SubmitSpinnerButton from "../../../../components/SubmitSpinnerButton";
 import { doNotAwait } from "../../../../util/Util";
+import useStores from "../../../../stores/use-stores";
 
 export default function PublishButton({
   identifier,
@@ -13,6 +14,7 @@ export default function PublishButton({
   disabled?: boolean,
 |}): Node {
   const [publishing, setPublishing] = React.useState(false);
+  const { uiStore } = useStores();
 
   /*
    * if the identifier has already been published, i.e. it is findable
@@ -29,9 +31,14 @@ export default function PublishButton({
         try {
           setPublishing(true);
           if (republish) {
-            await identifier.republish();
+            await identifier.republish({
+              addAlert: (...args) => uiStore.addAlert(...args),
+            });
           } else {
-            await identifier.publish();
+            await identifier.publish({
+              confirm: (...args) => uiStore.confirm(...args),
+              addAlert: (...args) => uiStore.addAlert(...args),
+            });
           }
         } finally {
           setPublishing(false);

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/__tests__/mocking.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/__tests__/mocking.js
@@ -103,39 +103,8 @@ export const mockIGSNIdentifier = (recordType: TestRecordType): Identifier => {
     retract: async (): Promise<void> => {},
     republish: async (): Promise<void> => {},
 
-    publicData: {
-      id: 1,
-      rsPublicId: "WywYf6xh2FRTisfMx0y4BA",
-      doi: "/10.82316/2z52-vx20",
-      doiType: "DATACITE_IGSN",
-      creatorName: "User 1",
-      creatorType: "Personal",
-      creatorAffiliation:
-        "Association of Asian Pacific Community Health Organizations",
-      creatorAffiliationIdentifier: "https://ror.org/03zsq2967",
-      title: "Item one",
-      publicUrl: "https://doi.org/10.82316/2z52-vx20",
-      publisher: "ResearchSpace at http://localhost:8080",
-      publicationYear: 2023,
-      resourceType: "Material Sample",
-      resourceTypeGeneral: "PhysicalObject",
-      url: "http://localhost:8080/public/inventory/WywYf6xh2FRTisfMx0y4BA",
-      state: "findable",
-      subjects: [
-        {
-          classificationCode: "a code",
-          schemeURI: "https://uri.one",
-          subjectScheme: "test scheme",
-          value: "Subject one",
-          valueURI: "https://uri.two",
-        },
-      ],
-      descriptions: [{ value: "My test description text", type: "ABSTRACT" }],
-      alternateIdentifiers: [{ value: "SS4", freeType: "a-type" }],
-      dates: [{ value: new Date("2023-08-09T16:32:17.853Z"), type: "Created" }],
-      geoLocations: [],
-      _links: [],
-      customFieldsOnPublicPage: false,
+    toJson() {
+      return {};
     },
   };
 };

--- a/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.js
+++ b/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.js
@@ -27,7 +27,6 @@ import {
   type Identifier,
   type IdentifierAttrs,
 } from "../../stores/definitions/Identifier";
-import { type GeoLocationPolygon } from "../../stores/definitions/GeoLocation";
 import Description from "../../Inventory/components/Fields/Description";
 import Tags from "../../Inventory/components/Fields/Tags";
 import { Optional } from "../../util/optional";
@@ -173,10 +172,6 @@ const glPointComplete = (point: PolygonPoint): boolean => {
 
 const glBoxComplete = (box: GeoLocationBox): boolean => {
   return Object.values(box).every((v) => v !== "");
-};
-
-const glPolygonComplete = (polygon: GeoLocationPolygon): boolean => {
-  return polygon.every((el) => glPointComplete(el.polygonPoint));
 };
 
 type IdentifierDataGridArgs = {|
@@ -617,7 +612,7 @@ export const IdentifierDataGrid = ({
                               </dl>
                             </>
                           )}
-                          {glPolygonComplete(gl.geoLocationPolygon) && (
+                          {gl.geoLocationPolygon.isValid && (
                             <>
                               <Typography component="h4" variant="h6">
                                 Polygon

--- a/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.js
+++ b/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.js
@@ -618,8 +618,8 @@ export const IdentifierDataGrid = ({
                                 Polygon
                               </Typography>
                               <dl className={classes.styledDescriptionList}>
-                                {gl.geoLocationPolygon.map(
-                                  ({ polygonPoint: point }, index) => (
+                                {gl.geoLocationPolygon.mapPoints(
+                                  (point, index) => (
                                     <DividedPair key={index}>
                                       <dt>Point {index + 1} Latitude</dt>
                                       <dd>{point.pointLatitude}˚</dd>

--- a/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.js
+++ b/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.js
@@ -23,7 +23,11 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
 import Divider from "@mui/material/Divider";
-import type { IdentifierAttrs } from "../../stores/definitions/Identifier";
+import {
+  type Identifier,
+  type IdentifierAttrs,
+} from "../../stores/definitions/Identifier";
+import { type GeoLocationPolygon } from "../../stores/definitions/GeoLocation";
 import Description from "../../Inventory/components/Fields/Description";
 import Tags from "../../Inventory/components/Fields/Tags";
 import { Optional } from "../../util/optional";
@@ -38,6 +42,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import NoValue from "../NoValue";
 import VisuallyHiddenHeading from "../VisuallyHiddenHeading";
+import IdentifierModel from "../../stores/models/IdentifierModel";
 
 const useStyles = makeStyles()((theme) => ({
   styledDescriptionList: {
@@ -162,8 +167,6 @@ type GeoLocationBox = {
   westBoundLongitude: string,
 };
 
-type GeoLocationPolygon = Array<{ polygonPoint: PolygonPoint }>;
-
 const glPointComplete = (point: PolygonPoint): boolean => {
   return Object.values(point).every((v) => v !== "");
 };
@@ -177,7 +180,7 @@ const glPolygonComplete = (polygon: GeoLocationPolygon): boolean => {
 };
 
 type IdentifierDataGridArgs = {|
-  identifier: IdentifierAttrs,
+  identifier: Identifier,
   record: {
     description: ?string,
     tags: Array<Tag>,
@@ -825,7 +828,7 @@ type IdentifierPublicPageArgs = {|
 const IdentifierPublicPage = ({ publicId }: IdentifierPublicPageArgs): Node => {
   const [fetching, setFetching] = useState(false);
   const [publicData, setPublicData] = useState<?{
-    identifiers: Array<IdentifierAttrs>,
+    identifiers: Array<Identifier>,
     description: ?string,
     tags: Array<Tag>,
     fields?: Array<{
@@ -870,6 +873,9 @@ const IdentifierPublicPage = ({ publicId }: IdentifierPublicPageArgs): Node => {
         }>(`/api/inventory/v1/public/view/${publicId}`);
         setPublicData({
           ...data,
+          identifiers: data.identifiers.map(
+            (x) => new IdentifierModel(x, publicId)
+          ),
           tags: data.tags.map((tag) => ({
             value: decodeTagString(tag.value),
             uri:

--- a/src/main/webapp/ui/src/stores/definitions/Factory.js
+++ b/src/main/webapp/ui/src/stores/definitions/Factory.js
@@ -12,6 +12,7 @@ import { type InventoryRecord } from "./InventoryRecord";
 import { type DocumentAttrs, type Document } from "./Document";
 import { type IdentifierAttrs, type Identifier } from "./Identifier";
 import { type GlobalId } from "./BaseRecord";
+import InvApiService from "../../common/InvApiService";
 
 /*
  * Objects which implement this interface provide an abstraction layer over the
@@ -30,7 +31,7 @@ export interface Factory {
 
   newPerson(PersonAttrs): Person;
   newBarcode(PersistedBarcodeAttrs): BarcodeRecord;
-  newIdentifier(IdentifierAttrs, GlobalId): Identifier;
+  newIdentifier(IdentifierAttrs, GlobalId, typeof InvApiService): Identifier;
   newDocument(DocumentAttrs): Document;
 
   /*

--- a/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
+++ b/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
@@ -33,6 +33,7 @@ export interface GeoLocationPolygon {
     count: number,
     ...items: $ReadOnlyArray<{| polygonPoint: PolygonPoint |}>
   ): $ReadOnlyArray<{| polygonPoint: PolygonPoint |}>;
+  toJson(): mixed;
 }
 
 /*
@@ -134,4 +135,6 @@ export interface GeoLocation {
    */
   +polygonEmpty: boolean;
   +inPolygonPointIncomplete: boolean;
+
+  toJson(): { ... };
 }

--- a/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
+++ b/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
@@ -26,10 +26,11 @@ export interface GeoLocationPolygon {
   +length: number;
   get(i: number): ?{| polygonPoint: PolygonPoint |};
   set(i: number, key: $Keys<PolygonPoint>, value: string): void;
-  every(f: ({| polygonPoint: PolygonPoint |}) => boolean): boolean;
   map<T>(f: ({| polygonPoint: PolygonPoint |}, i: number) => T): Array<T>;
   addAnotherPoint(i: number): void;
   removePoint(i: number): void;
+  +isValid: boolean;
+  +empty: boolean;
   toJson(): mixed;
 }
 

--- a/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
+++ b/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
@@ -28,11 +28,8 @@ export interface GeoLocationPolygon {
   set(i: number, key: $Keys<PolygonPoint>, value: string): void;
   every(f: ({| polygonPoint: PolygonPoint |}) => boolean): boolean;
   map<T>(f: ({| polygonPoint: PolygonPoint |}, i: number) => T): Array<T>;
-  splice(
-    i: number,
-    count: number,
-    ...items: $ReadOnlyArray<{| polygonPoint: PolygonPoint |}>
-  ): $ReadOnlyArray<{| polygonPoint: PolygonPoint |}>;
+  addAnotherPoint(i: number): void;
+  removePoint(i: number): void;
   toJson(): mixed;
 }
 

--- a/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
+++ b/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
@@ -26,7 +26,7 @@ export interface GeoLocationPolygon {
   +length: number;
   get(i: number): ?{| polygonPoint: PolygonPoint |};
   set(i: number, key: $Keys<PolygonPoint>, value: string): void;
-  map<T>(f: ({| polygonPoint: PolygonPoint |}, i: number) => T): Array<T>;
+  mapPoints<T>(f: (PolygonPoint, number) => T): Array<T>;
   addAnotherPoint(i: number): void;
   removePoint(i: number): void;
   +isValid: boolean;

--- a/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
+++ b/src/main/webapp/ui/src/stores/definitions/GeoLocation.js
@@ -21,7 +21,19 @@ export type SimplePoint = {
   latitude: string,
   longitude: string,
 };
-export type GeoLocationPolygon = Array<{ polygonPoint: PolygonPoint }>;
+
+export interface GeoLocationPolygon {
+  +length: number;
+  get(i: number): ?{| polygonPoint: PolygonPoint |};
+  set(i: number, key: $Keys<PolygonPoint>, value: string): void;
+  every(f: ({| polygonPoint: PolygonPoint |}) => boolean): boolean;
+  map<T>(f: ({| polygonPoint: PolygonPoint |}, i: number) => T): Array<T>;
+  splice(
+    i: number,
+    count: number,
+    ...items: $ReadOnlyArray<{| polygonPoint: PolygonPoint |}>
+  ): $ReadOnlyArray<{| polygonPoint: PolygonPoint |}>;
+}
 
 /*
  * This is the shape of the data output by the server to model a geoLocation that has been persisted
@@ -31,7 +43,7 @@ export type GeoLocationAttrs = {|
   geoLocationBox: GeoLocationBox,
   geoLocationPlace: string,
   geoLocationPoint: PolygonPoint,
-  geoLocationPolygon: GeoLocationPolygon,
+  geoLocationPolygon: Array<{| polygonPoint: PolygonPoint |}>,
   geoLocationInPolygonPoint: PolygonPoint,
 |};
 

--- a/src/main/webapp/ui/src/stores/definitions/Identifier.js
+++ b/src/main/webapp/ui/src/stores/definitions/Identifier.js
@@ -4,6 +4,8 @@ import { type GeoLocation, type GeoLocationAttrs } from "./GeoLocation";
 import { type URL } from "../../util/types";
 import { type _LINK } from "../../common/ApiServiceBase";
 import { type RadioOption } from "../../components/Inputs/RadioField";
+import { type Node } from "react";
+import { type Alert } from "../contexts/Alert";
 
 export type IGSNDateType =
   | "Accepted"
@@ -123,9 +125,17 @@ export interface Identifier {
   +recommendedFields: Array<IdentifierField>;
   +anyRecommendedGiven: boolean;
 
-  publish(): Promise<void>;
-  retract(): Promise<void>;
-  republish(): Promise<void>;
+  publish({|
+    confirm: (Node, Node, string, string) => Promise<boolean>,
+    addAlert: (Alert) => void,
+  |}): Promise<void>;
+  retract({|
+    confirm: (Node, Node, string, string) => Promise<boolean>,
+    addAlert: (Alert) => void,
+  |}): Promise<void>;
+  republish({|
+    addAlert: (Alert) => void,
+  |}): Promise<void>;
 
   /*
    * This computed property is for showing the Identifier in the public page

--- a/src/main/webapp/ui/src/stores/definitions/Identifier.js
+++ b/src/main/webapp/ui/src/stores/definitions/Identifier.js
@@ -133,5 +133,5 @@ export interface Identifier {
    * compatible any implementations of this interface must expose an object
    * with the same type.
    */
-  +publicData: IdentifierAttrs;
+  //  +publicData: IdentifierAttrs;
 }

--- a/src/main/webapp/ui/src/stores/definitions/Identifier.js
+++ b/src/main/webapp/ui/src/stores/definitions/Identifier.js
@@ -137,12 +137,5 @@ export interface Identifier {
     addAlert: (Alert) => void,
   |}): Promise<void>;
 
-  /*
-   * This computed property is for showing the Identifier in the public page
-   * preview dialog. The public page itself renders IdentifierAttrs so to be
-   * compatible any implementations of this interface must expose an object
-   * with the same type.
-   */
-  //  +publicData: IdentifierAttrs;
   toJson(): { ... };
 }

--- a/src/main/webapp/ui/src/stores/definitions/Identifier.js
+++ b/src/main/webapp/ui/src/stores/definitions/Identifier.js
@@ -113,7 +113,7 @@ export interface Identifier {
   descriptions: ?Array<IdentifierDescription>;
   alternateIdentifiers: ?Array<AlternateIdentifier>;
   dates: ?Array<IdentifierDate>;
-  geoLocations: ?Array<GeoLocation>;
+  geoLocations: ?$ReadOnlyArray<GeoLocation>;
   customFieldsOnPublicPage: boolean;
   _links: Array<_LINK>;
 
@@ -134,4 +134,5 @@ export interface Identifier {
    * with the same type.
    */
   //  +publicData: IdentifierAttrs;
+  toJson(): { ... };
 }

--- a/src/main/webapp/ui/src/stores/definitions/__tests__/Factory/mocking.js
+++ b/src/main/webapp/ui/src/stores/definitions/__tests__/Factory/mocking.js
@@ -12,13 +12,18 @@ import { type DocumentAttrs, type Document } from "../../Document";
 import { type InventoryRecord } from "../../InventoryRecord";
 import { type IdentifierAttrs, type Identifier } from "../../Identifier";
 import { type GlobalId } from "../../BaseRecord";
+import InvApiService from "../../../../common/InvApiService";
 
 type FactoryOverrides = {|
   newRecord?: (any) => InventoryRecord,
   newPerson?: (PersonAttrs) => PersonModel,
   newBarcode?: (BarcodeAttrs) => BarcodeRecord,
   newDocument?: (DocumentAttrs) => Document,
-  newIdentifier?: (IdentifierAttrs, GlobalId) => Identifier,
+  newIdentifier?: (
+    IdentifierAttrs,
+    GlobalId,
+    typeof InvApiService
+  ) => Identifier,
   newFactory?: () => Factory,
 |};
 
@@ -29,7 +34,10 @@ export const mockFactory: (?FactoryOverrides) => Factory = (
     newRecord: jest.fn<[any], InventoryRecord>(),
     newPerson: jest.fn<[PersonAttrs], PersonModel>(),
     newBarcode: jest.fn<[BarcodeAttrs], BarcodeRecord>(),
-    newIdentifier: jest.fn<[IdentifierAttrs, GlobalId], Identifier>(),
+    newIdentifier: jest.fn<
+      [IdentifierAttrs, GlobalId, typeof InvApiService],
+      Identifier
+    >(),
     newDocument: jest.fn<[DocumentAttrs], Document>(),
     newFactory: jest.fn<[], Factory>().mockImplementation(f),
     ...overrides,

--- a/src/main/webapp/ui/src/stores/models/Factory/AlwaysNewFactory.js
+++ b/src/main/webapp/ui/src/stores/models/Factory/AlwaysNewFactory.js
@@ -18,6 +18,7 @@ import { type IdentifierAttrs } from "../../definitions/Identifier";
 import IdentifierModel from "../IdentifierModel";
 import { type DocumentAttrs, type Document } from "../../definitions/Document";
 import { newDocument } from "../Document";
+import InvApiService from "../../../common/InvApiService";
 
 /*
  * A Factory that has no state and always instantiates a new object whenever it
@@ -53,9 +54,10 @@ export default class AlwaysNewFactory implements Factory {
 
   newIdentifier(
     attrs: IdentifierAttrs,
-    parentGlobalId: GlobalId
+    parentGlobalId: GlobalId,
+    ApiService: typeof InvApiService
   ): IdentifierModel {
-    return new IdentifierModel(attrs, parentGlobalId);
+    return new IdentifierModel(attrs, parentGlobalId, ApiService);
   }
 
   newDocument(attrs: DocumentAttrs): Document {

--- a/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
+++ b/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
@@ -43,8 +43,9 @@ export class GeoLocationPolygonModel implements GeoLocationPolygon {
     makeObservable(this, {
       points: observable,
       length: computed,
-      splice: action,
       set: action,
+      addAnotherPoint: action,
+      removePoint: action,
     });
     this.points = points;
   }
@@ -70,12 +71,14 @@ export class GeoLocationPolygonModel implements GeoLocationPolygon {
     return this.points.map(f);
   }
 
-  splice(
-    i: number,
-    count: number,
-    ...items: $ReadOnlyArray<{| polygonPoint: PolygonPoint |}>
-  ): $ReadOnlyArray<{| polygonPoint: PolygonPoint |}> {
-    return this.points.splice(i, count, ...items);
+  addAnotherPoint(i: number): void {
+    this.points.splice(i + 1, 0, {
+      polygonPoint: { pointLatitude: "", pointLongitude: "" },
+    });
+  }
+
+  removePoint(i: number): void {
+    this.points.splice(i, 1);
   }
 
   toJson(): mixed {

--- a/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
+++ b/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
@@ -59,8 +59,8 @@ export class GeoLocationPolygonModel implements GeoLocationPolygon {
     if (i === 0) this.points[this.length - 1].polygonPoint[key] = value;
   }
 
-  map<T>(f: ({| polygonPoint: PolygonPoint |}, i: number) => T): Array<T> {
-    return this.points.map(f);
+  mapPoints<T>(f: (PolygonPoint, number) => T): Array<T> {
+    return this.points.map(({ polygonPoint }, i) => f(polygonPoint, i));
   }
 
   addAnotherPoint(i: number): void {

--- a/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
+++ b/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
@@ -77,6 +77,10 @@ export class GeoLocationPolygonModel implements GeoLocationPolygon {
   ): $ReadOnlyArray<{| polygonPoint: PolygonPoint |}> {
     return this.points.splice(i, count, ...items);
   }
+
+  toJson(): mixed {
+    return this.points;
+  }
 }
 
 export default class GeoLocationModel implements GeoLocation {
@@ -110,7 +114,6 @@ export default class GeoLocationModel implements GeoLocation {
      * we have them point to the same object in memory. The validation is just to
      * ensure we're not erasing data before doing so.
      */
-    console.debug("new GeoLocationModel");
     const lastIndex = attrs.geoLocationPolygon.length - 1;
     if (
       attrs.geoLocationPolygon[0].polygonPoint.pointLatitude ===
@@ -118,7 +121,6 @@ export default class GeoLocationModel implements GeoLocation {
       attrs.geoLocationPolygon[0].polygonPoint.pointLongitude ===
         attrs.geoLocationPolygon[lastIndex].polygonPoint.pointLongitude
     ) {
-      console.debug("polygon data is correct");
       //TODO remove the last one
       this.geoLocationPolygon = new GeoLocationPolygonModel(
         attrs.geoLocationPolygon.map(({ polygonPoint }) => ({
@@ -172,5 +174,15 @@ export default class GeoLocationModel implements GeoLocation {
       !this.boxIncomplete &&
       !this.polygonIncomplete
     );
+  }
+
+  toJson(): { ... } {
+    return {
+      geoLocationBox: this.geoLocationBox,
+      geoLocationPlace: this.geoLocationPlace,
+      geoLocationPoint: this.geoLocationPoint,
+      geoLocationPolygon: this.geoLocationPolygon.toJson(),
+      geoLocationInPolygonPoint: this.geoLocationInPolygonPoint,
+    };
   }
 }

--- a/src/main/webapp/ui/src/stores/models/IdentifierModel.js
+++ b/src/main/webapp/ui/src/stores/models/IdentifierModel.js
@@ -10,9 +10,7 @@ import {
 import ApiService from "../../common/InvApiService";
 import getRootStore from "../stores/RootStore";
 import React from "react";
-import GeoLocationModel, {
-  GeoLocationPolygonModel,
-} from "../models/GeoLocationModel";
+import GeoLocationModel from "../models/GeoLocationModel";
 import { type Id, type GlobalId } from "../definitions/BaseRecord";
 import { type URL } from "../../util/types";
 import { type _LINK } from "../../common/ApiServiceBase";
@@ -34,7 +32,7 @@ import {
   type GeoLocationPolygon,
 } from "../definitions/GeoLocation";
 import { mkAlert } from "../contexts/Alert";
-import { parseInteger } from "../../util/parsers";
+import * as ArrayUtils from "../../util/ArrayUtils";
 
 type GeoLocationBox = {
   eastBoundLongitude: string,
@@ -182,7 +180,7 @@ export default class IdentifierModel implements Identifier {
   descriptions: ?Array<IdentifierDescription> = [];
   alternateIdentifiers: ?Array<AlternateIdentifier> = [];
   dates: ?Array<IdentifierDate> = [];
-  geoLocations: ?Array<GeoLocation> = [];
+  geoLocations: ?$ReadOnlyArray<GeoLocation> = [];
   _links: Array<_LINK> = [];
   editing: boolean = false;
   customFieldsOnPublicPage: boolean;
@@ -374,8 +372,10 @@ export default class IdentifierModel implements Identifier {
       {
         key: "Geolocations",
         value: this.geoLocations,
-        // $FlowFixMe[incompatible-call]
-        handler: (v) => this.setGeoLocations(v),
+        handler: (v) => {
+          if (Array.isArray(v))
+            this.setGeoLocations(ArrayUtils.filterClass(GeoLocationModel, v));
+        },
       },
     ];
   }
@@ -445,8 +445,7 @@ export default class IdentifierModel implements Identifier {
     this.dates = dates;
   }
 
-  setGeoLocations(geoLocations: Array<GeoLocation>) {
-    // this breaks the loop
+  setGeoLocations(geoLocations: $ReadOnlyArray<GeoLocation>) {
     this.geoLocations = geoLocations;
   }
 
@@ -677,6 +676,35 @@ export default class IdentifierModel implements Identifier {
         );
       }
     }
+  }
+
+  toJson(): { ... } {
+    return {
+      parentGlobalId: this.parentGlobalId,
+      id: this.id,
+      rsPublicId: this.rsPublicId,
+      doi: this.doi,
+      doiType: this.doiType,
+      creatorName: this.creatorName,
+      creatorType: this.creatorType,
+      creatorAffiliation: this.creatorAffiliation,
+      creatorAffiliationIdentifier: this.creatorAffiliationIdentifier,
+      title: this.title,
+      publicUrl: this.publicUrl,
+      publisher: this.publisher,
+      publicationYear: this.publicationYear,
+      resourceType: this.resourceType,
+      resourceTypeGeneral: this.resourceTypeGeneral,
+      url: this.url,
+      state: this.state,
+      subjects: this.subjects,
+      descriptions: this.descriptions,
+      alternateIdentifiers: this.alternateIdentifiers,
+      dates: this.dates,
+      geoLocations: this.geoLocations?.map((g) => g.toJson()),
+      editing: this.editing,
+      customFieldsOnPublicPage: this.customFieldsOnPublicPage,
+    };
   }
 
   //  get publicData(): IdentifierAttrs {

--- a/src/main/webapp/ui/src/stores/models/IdentifierModel.js
+++ b/src/main/webapp/ui/src/stores/models/IdentifierModel.js
@@ -234,7 +234,6 @@ export default class IdentifierModel implements Identifier {
       updateState: action,
       publish: action,
       retract: action,
-      //      publicData: computed,
     });
 
     this.parentGlobalId = parentGlobalId;
@@ -736,38 +735,4 @@ export default class IdentifierModel implements Identifier {
       customFieldsOnPublicPage: this.customFieldsOnPublicPage,
     };
   }
-
-  //  get publicData(): IdentifierAttrs {
-  //    return {
-  //      id: this.id,
-  //      rsPublicId: this.rsPublicId,
-  //      doi: this.doi,
-  //      doiType: this.doiType,
-  //      creatorName: this.creatorName,
-  //      creatorType: this.creatorType,
-  //      creatorAffiliation: this.creatorAffiliation,
-  //      creatorAffiliationIdentifier: this.creatorAffiliationIdentifier,
-  //      title: this.title,
-  //      publicUrl: this.publicUrl,
-  //      publisher: this.publisher,
-  //      publicationYear: parseInteger(this.publicationYear).orElse(0),
-  //      resourceType: this.resourceType,
-  //      resourceTypeGeneral: this.resourceTypeGeneral,
-  //      url: this.url,
-  //      state: this.state,
-  //      subjects: this.subjects,
-  //      descriptions: this.descriptions,
-  //      alternateIdentifiers: this.alternateIdentifiers,
-  //      dates: this.dates,
-  //      geoLocations: this.geoLocations?.map((g) => ({
-  //        geoLocationBox: g.geoLocationBox,
-  //        geoLocationPlace: g.geoLocationPlace,
-  //        geoLocationPoint: g.geoLocationPoint,
-  //        geoLocationPolygon: new GeoLocationPolygonModel(g.geoLocationPolygon),
-  //        geoLocationInPolygonPoint: g.geoLocationInPolygonPoint,
-  //      })),
-  //      _links: this._links,
-  //      customFieldsOnPublicPage: this.customFieldsOnPublicPage,
-  //    };
-  //  }
 }

--- a/src/main/webapp/ui/src/stores/models/IdentifierModel.js
+++ b/src/main/webapp/ui/src/stores/models/IdentifierModel.js
@@ -7,7 +7,7 @@ import {
   makeObservable,
   runInAction,
 } from "mobx";
-import ApiService from "../../common/InvApiService";
+import axios from "axios";
 import React, { type Node } from "react";
 import GeoLocationModel from "../models/GeoLocationModel";
 import { type Id, type GlobalId } from "../definitions/BaseRecord";
@@ -484,7 +484,7 @@ export default class IdentifierModel implements Identifier {
         )
       ) {
         if (!this.id) throw new Error("DOI Id must be known.");
-        const response = await ApiService.post<
+        const response = await axios.post<
           {||},
           {
             state: IGSNPublishingState,
@@ -569,10 +569,10 @@ export default class IdentifierModel implements Identifier {
         )
       ) {
         if (!this.id) throw new Error("DOI Id must be known.");
-        const response = await ApiService.post<
-          {||},
-          { state: IGSNPublishingState }
-        >(`/identifiers/${this.id}/retract`, {});
+        const response = await axios.post<{||}, { state: IGSNPublishingState }>(
+          `/identifiers/${this.id}/retract`,
+          {}
+        );
         this.updateState(response.data.state);
         addAlert(
           mkAlert({
@@ -629,10 +629,10 @@ export default class IdentifierModel implements Identifier {
 
       // retract
       try {
-        const response = await ApiService.post<
-          {||},
-          { state: IGSNPublishingState }
-        >(`/identifiers/${id}/retract`, {});
+        const response = await axios.post<{||}, { state: IGSNPublishingState }>(
+          `/identifiers/${id}/retract`,
+          {}
+        );
         this.updateState(response.data.state);
       } catch (error) {
         const serverErrorResponse = error.response.data;
@@ -651,7 +651,7 @@ export default class IdentifierModel implements Identifier {
 
       // publish
       try {
-        const response = await ApiService.post<
+        const response = await axios.post<
           {||},
           {
             state: IGSNPublishingState,

--- a/src/main/webapp/ui/src/stores/models/IdentifierModel.js
+++ b/src/main/webapp/ui/src/stores/models/IdentifierModel.js
@@ -7,7 +7,7 @@ import {
   makeObservable,
   runInAction,
 } from "mobx";
-import axios from "axios";
+import ApiService from "../../common/InvApiService";
 import React, { type Node } from "react";
 import GeoLocationModel from "../models/GeoLocationModel";
 import { type Id, type GlobalId } from "../definitions/BaseRecord";
@@ -483,7 +483,7 @@ export default class IdentifierModel implements Identifier {
         )
       ) {
         if (!this.id) throw new Error("DOI Id must be known.");
-        const response = await axios.post<
+        const response = await ApiService.post<
           {||},
           {
             state: IGSNPublishingState,
@@ -568,10 +568,10 @@ export default class IdentifierModel implements Identifier {
         )
       ) {
         if (!this.id) throw new Error("DOI Id must be known.");
-        const response = await axios.post<{||}, { state: IGSNPublishingState }>(
-          `/identifiers/${this.id}/retract`,
-          {}
-        );
+        const response = await ApiService.post<
+          {||},
+          { state: IGSNPublishingState }
+        >(`/identifiers/${this.id}/retract`, {});
         this.updateState(response.data.state);
         addAlert(
           mkAlert({
@@ -628,10 +628,10 @@ export default class IdentifierModel implements Identifier {
 
       // retract
       try {
-        const response = await axios.post<{||}, { state: IGSNPublishingState }>(
-          `/identifiers/${id}/retract`,
-          {}
-        );
+        const response = await ApiService.post<
+          {||},
+          { state: IGSNPublishingState }
+        >(`/identifiers/${id}/retract`, {});
         this.updateState(response.data.state);
       } catch (error) {
         const serverErrorResponse = error.response.data;
@@ -650,7 +650,7 @@ export default class IdentifierModel implements Identifier {
 
       // publish
       try {
-        const response = await axios.post<
+        const response = await ApiService.post<
           {||},
           {
             state: IGSNPublishingState,

--- a/src/main/webapp/ui/src/stores/models/IdentifierModel.js
+++ b/src/main/webapp/ui/src/stores/models/IdentifierModel.js
@@ -10,7 +10,9 @@ import {
 import ApiService from "../../common/InvApiService";
 import getRootStore from "../stores/RootStore";
 import React from "react";
-import GeoLocationModel from "../models/GeoLocationModel";
+import GeoLocationModel, {
+  GeoLocationPolygonModel,
+} from "../models/GeoLocationModel";
 import { type Id, type GlobalId } from "../definitions/BaseRecord";
 import { type URL } from "../../util/types";
 import { type _LINK } from "../../common/ApiServiceBase";
@@ -27,7 +29,10 @@ import {
   type IdentifierDate,
 } from "../definitions/Identifier";
 import type { RadioOption } from "../../components/Inputs/RadioField";
-import type { GeoLocation } from "../definitions/GeoLocation";
+import {
+  type GeoLocation,
+  type GeoLocationPolygon,
+} from "../definitions/GeoLocation";
 import { mkAlert } from "../contexts/Alert";
 import { parseInteger } from "../../util/parsers";
 
@@ -41,7 +46,6 @@ type PolygonPoint = {
   pointLatitude: string,
   pointLongitude: string,
 };
-export type GeoLocationPolygon = Array<{ polygonPoint: PolygonPoint }>;
 
 export type IdentifierGeoLocation = {
   geoLocationBox: GeoLocationBox,
@@ -232,7 +236,7 @@ export default class IdentifierModel implements Identifier {
       updateState: action,
       publish: action,
       retract: action,
-      publicData: computed,
+      //      publicData: computed,
     });
 
     this.parentGlobalId = parentGlobalId;
@@ -442,6 +446,7 @@ export default class IdentifierModel implements Identifier {
   }
 
   setGeoLocations(geoLocations: Array<GeoLocation>) {
+    // this breaks the loop
     this.geoLocations = geoLocations;
   }
 
@@ -674,37 +679,37 @@ export default class IdentifierModel implements Identifier {
     }
   }
 
-  get publicData(): IdentifierAttrs {
-    return {
-      id: this.id,
-      rsPublicId: this.rsPublicId,
-      doi: this.doi,
-      doiType: this.doiType,
-      creatorName: this.creatorName,
-      creatorType: this.creatorType,
-      creatorAffiliation: this.creatorAffiliation,
-      creatorAffiliationIdentifier: this.creatorAffiliationIdentifier,
-      title: this.title,
-      publicUrl: this.publicUrl,
-      publisher: this.publisher,
-      publicationYear: parseInteger(this.publicationYear).orElse(0),
-      resourceType: this.resourceType,
-      resourceTypeGeneral: this.resourceTypeGeneral,
-      url: this.url,
-      state: this.state,
-      subjects: this.subjects,
-      descriptions: this.descriptions,
-      alternateIdentifiers: this.alternateIdentifiers,
-      dates: this.dates,
-      geoLocations: this.geoLocations?.map((g) => ({
-        geoLocationBox: g.geoLocationBox,
-        geoLocationPlace: g.geoLocationPlace,
-        geoLocationPoint: g.geoLocationPoint,
-        geoLocationPolygon: g.geoLocationPolygon,
-        geoLocationInPolygonPoint: g.geoLocationInPolygonPoint,
-      })),
-      _links: this._links,
-      customFieldsOnPublicPage: this.customFieldsOnPublicPage,
-    };
-  }
+  //  get publicData(): IdentifierAttrs {
+  //    return {
+  //      id: this.id,
+  //      rsPublicId: this.rsPublicId,
+  //      doi: this.doi,
+  //      doiType: this.doiType,
+  //      creatorName: this.creatorName,
+  //      creatorType: this.creatorType,
+  //      creatorAffiliation: this.creatorAffiliation,
+  //      creatorAffiliationIdentifier: this.creatorAffiliationIdentifier,
+  //      title: this.title,
+  //      publicUrl: this.publicUrl,
+  //      publisher: this.publisher,
+  //      publicationYear: parseInteger(this.publicationYear).orElse(0),
+  //      resourceType: this.resourceType,
+  //      resourceTypeGeneral: this.resourceTypeGeneral,
+  //      url: this.url,
+  //      state: this.state,
+  //      subjects: this.subjects,
+  //      descriptions: this.descriptions,
+  //      alternateIdentifiers: this.alternateIdentifiers,
+  //      dates: this.dates,
+  //      geoLocations: this.geoLocations?.map((g) => ({
+  //        geoLocationBox: g.geoLocationBox,
+  //        geoLocationPlace: g.geoLocationPlace,
+  //        geoLocationPoint: g.geoLocationPoint,
+  //        geoLocationPolygon: new GeoLocationPolygonModel(g.geoLocationPolygon),
+  //        geoLocationInPolygonPoint: g.geoLocationInPolygonPoint,
+  //      })),
+  //      _links: this._links,
+  //      customFieldsOnPublicPage: this.customFieldsOnPublicPage,
+  //    };
+  //  }
 }

--- a/src/main/webapp/ui/src/stores/models/Result.js
+++ b/src/main/webapp/ui/src/stores/models/Result.js
@@ -508,7 +508,7 @@ export default class Result
       |}>,
       newBase64Image?: ?string,
       barcodes?: Array<{ ... }>,
-      identifiers?: Array<Identifier>,
+      identifiers?: mixed,
       sharingMode?: SharingMode,
       sharedWith?: ?Array<SharedWithGroup>,
       ...
@@ -538,7 +538,7 @@ export default class Result
         this.barcodes
       ).map((b) => b.paramsForBackend);
     if (this.currentlyEditableFields.has("identifiers"))
-      params.identifiers = this.identifiers;
+      params.identifiers = this.identifiers.map(i => i.toJson());
     if (this.currentlyEditableFields.has("sharingMode"))
       params.sharingMode = this.sharingMode;
     if (this.currentlyEditableFields.has("sharedWith"))

--- a/src/main/webapp/ui/src/stores/models/Result.js
+++ b/src/main/webapp/ui/src/stores/models/Result.js
@@ -390,7 +390,7 @@ export default class Result
 
       this.identifiers = params.identifiers.map((idAttrs) => {
         if (!this.globalId) throw new Error("Global Id must be known.");
-        return factory.newIdentifier(idAttrs, this.globalId);
+        return factory.newIdentifier(idAttrs, this.globalId, ApiService);
       });
       void this.fetchImage("thumbnail");
     } else {
@@ -1321,7 +1321,7 @@ export default class Result
         >(`/identifiers`, {
           parentGlobalId: globalId,
         });
-        const newIGSN = new IdentifierModel(response.data, globalId);
+        const newIGSN = new IdentifierModel(response.data, globalId, ApiService);
         this.identifiers = this.identifiers.concat(newIGSN);
         getRootStore().uiStore.addAlert(
           mkAlert({

--- a/src/main/webapp/ui/src/util/ArrayUtils.js
+++ b/src/main/webapp/ui/src/util/ArrayUtils.js
@@ -98,7 +98,7 @@ export const partition = <T>(
  */
 export const filterClass = <T, U>(
   clazz: Class<T>,
-  array: Array<U>
+  array: $ReadOnlyArray<U>
 ): Array<T> => {
   const arrayOft = ([]: Array<T>);
   for (const a of array) {


### PR DESCRIPTION
The first and last points of a GeoLocation polygon must be the same to enclose a region. This invariant was not sufficiently being enforced and so this change defines a new class and accompanying interface to ensure all code that creates and modifies GeoLocation polygons enforces this invariant.

Further changes were necessary because the GeoLocation classes could not be used on the public page due to transitive dependencies on AuthStore, which this change fixes with a little dependency injection. This makes `publicData` unnecessary.