### PR TITLE
Documentation about debugging public pages

### DIFF
--- a/src/main/webapp/ui/.dependency-cruiser.js
+++ b/src/main/webapp/ui/.dependency-cruiser.js
@@ -214,6 +214,18 @@ module.exports = {
       to: {
         pathNot: "src/util|babel|jest-dom|fast-check|mobx|react",
       }
+    },
+
+    {
+      name: "Public pages must not use stores",
+      comment: "Users may not be authenticated on the public pages and so we must not depend on the global stores as they assume the user is.",
+      from: {
+        path: "src/components/PublicPages",
+      },
+      to: {
+        path: "src/stores/stores",
+        reachable: true
+      },
     }
 
   ],

--- a/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.js
+++ b/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.js
@@ -1,5 +1,17 @@
 // @flow
 
+/*
+ * ====  A POINT ABOUT THE IMPORTS  ===========================================
+ *
+ *  This is a public page, so the user may not be authenticated. As such, this
+ *  module, and any module that is imported, MUST NOT import anything from the
+ *  global Inventory stores (i.e. from ../../stores/stores/*). If it does, then
+ *  the page will be rendered as a blank screen and there will be an unhelpful
+ *  error message on the browser's console saying that webpack export could not
+ *  be initialised. For more information, see the README in this directory.
+ *
+ * ============================================================================
+ */
 import React, {
   useState,
   useEffect,

--- a/src/main/webapp/ui/src/components/PublicPages/README.md
+++ b/src/main/webapp/ui/src/components/PublicPages/README.md
@@ -8,12 +8,36 @@ published more widely if their deployment is not behind a firewall.
 This comes with some complexity due to the way that the Inventory frontend is
 architected. There is a global state object that is defined in the various
 files in ../../stores/stores which are all highly coupled together. As such,
-some of simpler capabilities such as storing the list of alert toast that are
-currently being shown can't be used without also being able to check the
-contents of the current user's bench. Worse still, most of the model classes
-(../../stores/models/) and many of the react components depend on this global
-state either directly or indirectly.
+some of simpler capabilities such as displaying an alert toasts can't be used
+without also being able to check the contents of the current user's bench.
+Worse still, most of the model classes (../../stores/models/) and many of the
+react components depend on this global state either directly or indirectly.
 
 *None of this code can be used on the public pages.*
 
 ## But what if I accidentally do?
+
+If anyone accidentally adds a dependency on the stores to a class or component
+that these public pages have an indirect dependency on then the public page
+will break. Now, this will hopefully be caught by the cypress test for that
+public page (so do make sure any new public pages have a cypress test!) but
+the error message that you get wont necessarily help you in identifying what
+exactly the cause of the issue is. For example, the following error message was
+to be found in the JavaScript console after IdentifierModel
+(../../stores/models/IdentifierModel.js) imported InvApiService
+(../../common/InvApiService.js) as the latter has a dependency on getRootStore
+(../../stores/stores/RootStore.js):
+
+```
+Uncaught ReferenceError: Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initialization
+    at Module.default (ApiServiceBase.js:3:42)
+    at eval (ElnApiService.js:7:71)
+    at ./src/common/ElnApiService.js (inventoryRecordIdentifierPublicPage.js:4213:1)
+    at __webpack_require__ (runtime.js:31:42)
+    at eval (AuthStore.js:9:79)
+    at ./src/stores/stores/AuthStore.js (inventoryRecordIdentifierPublicPage.js:4906:1)
+    at __webpack_require__ (runtime.js:31:42)
+    at eval (RootStore.js:6:68)
+    at ./src/stores/stores/RootStore.js (inventoryRecordIdentifierPublicPage.js:4983:1)
+    at __webpack_require__ (runtime.js:31:42)
+```

--- a/src/main/webapp/ui/src/components/PublicPages/README.md
+++ b/src/main/webapp/ui/src/components/PublicPages/README.md
@@ -13,7 +13,7 @@ without also being able to check the contents of the current user's bench.
 Worse still, most of the model classes (../../stores/models/) and many of the
 react components depend on this global state either directly or indirectly.
 
-*None of this code can be used on the public pages.*
+**None of this code can be used on the public pages.**
 
 ## But what if I accidentally do?
 
@@ -23,10 +23,10 @@ will break. Now, this will hopefully be caught by the cypress test for that
 public page (so do make sure any new public pages have a cypress test!) but
 the error message that you get wont necessarily help you in identifying what
 exactly the cause of the issue is. For example, the following error message was
-to be found in the JavaScript console after IdentifierModel
-(../../stores/models/IdentifierModel.js) imported InvApiService
-(../../common/InvApiService.js) as the latter has a dependency on getRootStore
-(../../stores/stores/RootStore.js):
+to be found in the JavaScript console after
+[IdentifierModel](../../stores/models/IdentifierModel.js) imported
+[InvApiService](../../common/InvApiService.js) as the latter has a dependency
+on [getRootStore](../../stores/stores/RootStore.js):
 
 ```
 Uncaught ReferenceError: Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initialization

--- a/src/main/webapp/ui/src/components/PublicPages/README.md
+++ b/src/main/webapp/ui/src/components/PublicPages/README.md
@@ -41,3 +41,12 @@ Uncaught ReferenceError: Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initi
     at ./src/stores/stores/RootStore.js (inventoryRecordIdentifierPublicPage.js:4983:1)
     at __webpack_require__ (runtime.js:31:42)
 ```
+
+Things you can try:
+
+  1. Find the recent change that broke the page, and that it is small and thus
+     the new import obvious. `git bisect` is your friend.
+
+  2. Chase each of the imports, starting in the component that is used as the
+     entry point in the Webpack config. This will be tedious, and there might
+     be an automated way to generate the import tree.

--- a/src/main/webapp/ui/src/components/PublicPages/README.md
+++ b/src/main/webapp/ui/src/components/PublicPages/README.md
@@ -1,0 +1,19 @@
+# Public Pages
+
+This directory contains react components that render whole webpages that are
+public, which is to say that the user may not be authenticated. This is
+typically so that someone who is a user can send a link to a colleague, or even
+published more widely if their deployment is not behind a firewall.
+
+This comes with some complexity due to the way that the Inventory frontend is
+architected. There is a global state object that is defined in the various
+files in ../../stores/stores which are all highly coupled together. As such,
+some of simpler capabilities such as storing the list of alert toast that are
+currently being shown can't be used without also being able to check the
+contents of the current user's bench. Worse still, most of the model classes
+(../../stores/models/) and many of the react components depend on this global
+state either directly or indirectly.
+
+*None of this code can be used on the public pages.*
+
+## But what if I accidentally do?

--- a/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
+++ b/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
@@ -1,5 +1,19 @@
 //@flow
 
+/*
+ * ====  A POINT ABOUT THE IMPORTS  ===========================================
+ *
+ *  This class is used, amongst other places, on the IdentifierPublicPage[1]
+ *  where the user may not be authenticated. As such, this module, and any
+ *  module that is imported, MUST NOT import anything from the global Inventory
+ *  stores (i.e. from ../stores/*). If it does, then the page will be rendered
+ *  as a blank screen and there will be an unhelpful error message on the
+ *  browser's console saying that webpack export could not be initialised.
+ *
+ *  [1]: ../../components/PublicPage/IdentifierPublicPage.js
+ *
+ * ============================================================================
+ */
 import { observable, computed, action, makeObservable } from "mobx";
 import {
   type GeoLocationAttrs,

--- a/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
+++ b/src/main/webapp/ui/src/stores/models/GeoLocationModel.js
@@ -23,13 +23,6 @@ import {
   type PolygonPoint,
 } from "../definitions/GeoLocation";
 
-/**
- * GeoLocation validation.
- * "error" state and helperText to be displayed when:
- * some values for a GL element are given (incomplete), and that value empty.
- * incomplete status is not empty, and empty may be acceptable (for Place)
- */
-
 export const pointComplete = (point: PolygonPoint): boolean => {
   return Object.values(point).every((v) => v !== "");
 };
@@ -136,10 +129,11 @@ export default class GeoLocationModel implements GeoLocation {
     this.geoLocationBox = attrs.geoLocationBox;
 
     /*
-     * Polygons are a series of points, where the first and last point are the same.
-     * Rather than have all code which mutates these points synchronise the two ends,
-     * we have them point to the same object in memory. The validation is just to
-     * ensure we're not erasing data before doing so.
+     * Polygons are a series of points, where the first and last point are the
+     * same; GeoLocationPolygonModel ensures that this invariant is maintained.
+     * The validation is just to ensure we're not erasing data before doing so,
+     * because mutations of the first or last points inside the
+     * GeoLocationPolygonModel will over write the other.
      */
     const lastIndex = attrs.geoLocationPolygon.length - 1;
     if (
@@ -148,13 +142,11 @@ export default class GeoLocationModel implements GeoLocation {
       attrs.geoLocationPolygon[0].polygonPoint.pointLongitude ===
         attrs.geoLocationPolygon[lastIndex].polygonPoint.pointLongitude
     ) {
-      //TODO remove the last one
       this.geoLocationPolygon = new GeoLocationPolygonModel(
         attrs.geoLocationPolygon.map(({ polygonPoint }) => ({
           polygonPoint: observable(polygonPoint),
         }))
       );
-      // this.geoLocationPolygon[lastIndex] = this.geoLocationPolygon[0];
     } else {
       throw new Error(
         "Polygon data is invalid: the first and last points are not the same."

--- a/src/main/webapp/ui/src/stores/models/IdentifierModel.js
+++ b/src/main/webapp/ui/src/stores/models/IdentifierModel.js
@@ -1,5 +1,21 @@
 //@flow
 
+/*
+ * ====  A POINT ABOUT THE IMPORTS  ===========================================
+ *
+ *  This class is used, amongst other places, on the IdentifierPublicPage[1]
+ *  where the user may not be authenticated. As such, this module, and any
+ *  module that is imported, MUST NOT import anything from the global Inventory
+ *  stores (i.e. from ../stores/*). If it does, then the page will be rendered
+ *  as a blank screen and there will be an unhelpful error message on the
+ *  browser's console saying that webpack export could not be initialised. To
+ *  avoid this, dependency injection is used to pass references that have been
+ *  created in code that can depend on the global stores.
+ *
+ *  [1]: ../../components/PublicPage/IdentifierPublicPage.js
+ *
+ * ============================================================================
+ */
 import {
   observable,
   action,


### PR DESCRIPTION
After dealing with a bug about how public pages must not import the global stores (commit 21e8f97), I have expanded on the in-code documentation and written a guide on debugging such issues with the addition of a dependency-cruiser rule to aid such debugging.