### PR TITLE
RSDEV-325 Use UI preferences to persist UI state in React-land

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Search/SearchRouter.js
+++ b/src/main/webapp/ui/src/Inventory/Search/SearchRouter.js
@@ -37,6 +37,7 @@ import { UserCancelledAction } from "../../util/error";
 import ExpandCollapseIcon from "../../components/ExpandCollapseIcon";
 import IconButtonWithTooltip from "../../components/IconButtonWithTooltip";
 import MainSearchNavigationContext from "./MainSearchNavigationContext";
+import { UiPreferences } from "../../util/useUiPreference";
 
 const useStyles = makeStyles()((theme, { alwaysVisibleSidebar }) => ({
   grid: {
@@ -280,16 +281,18 @@ const SearchRouter = observer(({ paramsOverride }: SearchRouterArgs) => {
 function SearchRouterWrapper({ paramsOverride }: SearchRouterArgs): Node {
   const { searchStore } = useStores();
   return (
-    <SearchContext.Provider
-      value={{
-        search: searchStore.search,
-        differentSearchForSettingActiveResult: searchStore.search,
-      }}
-    >
-      <MainSearchNavigationContext>
-        <SearchRouter paramsOverride={paramsOverride} />
-      </MainSearchNavigationContext>
-    </SearchContext.Provider>
+    <UiPreferences>
+      <SearchContext.Provider
+        value={{
+          search: searchStore.search,
+          differentSearchForSettingActiveResult: searchStore.search,
+        }}
+      >
+        <MainSearchNavigationContext>
+          <SearchRouter paramsOverride={paramsOverride} />
+        </MainSearchNavigationContext>
+      </SearchContext.Provider>
+    </UiPreferences>
   );
 }
 

--- a/src/main/webapp/ui/src/Inventory/components/Stepper/StepperPanelHeader.js
+++ b/src/main/webapp/ui/src/Inventory/components/Stepper/StepperPanelHeader.js
@@ -118,7 +118,8 @@ function StepperPanelHeader_({
         <Grid item>
           <IconButtonWithTooltip
             title={open ? "Collapse section" : "Expand section"}
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               onToggle(!open);
               setAllBtn(true);
             }}

--- a/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.js
+++ b/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.js
@@ -1,8 +1,9 @@
 //@flow
 
-import React, { type Node, useState } from "react";
+import React, { type Node } from "react";
 import FormSectionsContext from "../../../stores/contexts/FormSections";
 import { mapObject } from "../../../util/Util";
+import useUiPreference, { PREFERENCES } from "../../../util/useUiPreference";
 
 const defaultFormSectionExpandedState = () =>
   Object.freeze({
@@ -71,9 +72,10 @@ type SynchroniseFormSectionsArgs = {|
 export default function SynchroniseFormSections({
   children,
 }: SynchroniseFormSectionsArgs): Node {
-  const [formSectionExpandedState, setFormSectionExpandedState] = useState(
-    defaultFormSectionExpandedState()
-  );
+  const [formSectionExpandedState, setFormSectionExpandedState] =
+    useUiPreference(PREFERENCES.INVENTORY_FORM_SECTIONS_EXPANDED, {
+      defaultValue: defaultFormSectionExpandedState(),
+    });
   return (
     <FormSectionsContext.Provider
       value={{

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -71,6 +71,7 @@ import { Link as ReactRouterLink } from "react-router-dom";
 import useOneDimensionalRovingTabIndex from "../../../components/useOneDimensionalRovingTabIndex";
 import Box from "@mui/material/Box";
 import Fab from "@mui/material/Fab";
+import useUiPreference, { PREFERENCES } from "../../../util/useUiPreference";
 
 const DragCancelFab = () => {
   const dndContext = useDndContext();
@@ -1016,7 +1017,12 @@ function GalleryMainPanel({
       },
     });
   const [viewMenuAnchorEl, setViewMenuAnchorEl] = React.useState(null);
-  const [viewMode, setViewMode] = React.useState("grid");
+  const [viewMode, setViewMode] = useUiPreference(
+    PREFERENCES.GALLERY_VIEW_MODE,
+    {
+      defaultValue: "grid",
+    }
+  );
   const [sortMenuAnchorEl, setSortMenuAnchorEl] = React.useState(null);
   const { moveFiles } = useGalleryActions();
   const selection = useGallerySelection();

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -15,7 +15,7 @@ import AppBar from "./components/AppBar";
 import Sidebar from "./components/Sidebar";
 import MainPanel from "./components/MainPanel";
 import Box from "@mui/material/Box";
-import { useGalleryListing, type GalleryFile } from "./useGalleryListing";
+import { useGalleryListing } from "./useGalleryListing";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import CssBaseline from "@mui/material/CssBaseline";
 import useViewportDimensions from "../../util/useViewportDimensions";
@@ -25,7 +25,10 @@ import Analytics from "../../components/Analytics";
 import { GallerySelection } from "./useGallerySelection";
 import { BrowserRouter, Navigate, useSearchParams } from "react-router-dom";
 import { Routes, Route } from "react-router";
-import useUiPreference, { PREFERENCES } from "../../util/useUiPreference";
+import useUiPreference, {
+  PREFERENCES,
+  UiPreferences,
+} from "../../util/useUiPreference";
 
 const WholePage = styled(() => {
   const [searchParams] = useSearchParams();
@@ -41,10 +44,13 @@ const WholePage = styled(() => {
   }, [searchParams]);
 
   const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");
-  const [orderBy, setOrderBy] = useUiPreference(PREFERENCES.GALLERY_SORT_BY, {
-    defaultValue: "name",
-  });
-  const [sortOrder, setSortOrder] = useUiPreference(
+  const [orderBy, setOrderBy] = useUiPreference<"name" | "modificationDate">(
+    PREFERENCES.GALLERY_SORT_BY,
+    {
+      defaultValue: "name",
+    }
+  );
+  const [sortOrder, setSortOrder] = useUiPreference<"DESC" | "ASC">(
     PREFERENCES.GALLERY_SORT_ORDER,
     {
       defaultValue: "ASC",
@@ -131,22 +137,24 @@ window.addEventListener("load", () => {
               <CssBaseline />
               <ThemeProvider theme={createAccentedTheme(COLOR)}>
                 <Analytics>
-                  <DisableDragAndDropByDefault>
-                    <Routes>
-                      <Route
-                        path="/newGallery"
-                        element={
-                          <GallerySelection>
-                            <WholePage />
-                          </GallerySelection>
-                        }
-                      />
-                      <Route
-                        path="*"
-                        element={<Navigate to="/newGallery" replace />}
-                      />
-                    </Routes>
-                  </DisableDragAndDropByDefault>
+                  <UiPreferences>
+                    <DisableDragAndDropByDefault>
+                      <Routes>
+                        <Route
+                          path="/newGallery"
+                          element={
+                            <GallerySelection>
+                              <WholePage />
+                            </GallerySelection>
+                          }
+                        />
+                        <Route
+                          path="*"
+                          element={<Navigate to="/newGallery" replace />}
+                        />
+                      </Routes>
+                    </DisableDragAndDropByDefault>
+                  </UiPreferences>
                 </Analytics>
               </ThemeProvider>
             </StyledEngineProvider>

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -25,6 +25,7 @@ import Analytics from "../../components/Analytics";
 import { GallerySelection } from "./useGallerySelection";
 import { BrowserRouter, Navigate, useSearchParams } from "react-router-dom";
 import { Routes, Route } from "react-router";
+import useUiPreference, { PREFERENCES } from "../../util/useUiPreference";
 
 const WholePage = styled(() => {
   const [searchParams] = useSearchParams();
@@ -40,8 +41,15 @@ const WholePage = styled(() => {
   }, [searchParams]);
 
   const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");
-  const [orderBy, setOrderBy] = React.useState("name");
-  const [sortOrder, setSortOrder] = React.useState("ASC");
+  const [orderBy, setOrderBy] = useUiPreference(PREFERENCES.GALLERY_SORT_BY, {
+    defaultValue: "name",
+  });
+  const [sortOrder, setSortOrder] = useUiPreference(
+    PREFERENCES.GALLERY_SORT_ORDER,
+    {
+      defaultValue: "ASC",
+    }
+  );
   const { galleryListing, path, clearPath, folderId, refreshListing } =
     useGalleryListing({
       section: selectedSection,

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -1,6 +1,7 @@
 //@flow
 
 import { type UseState } from "./types";
+import React from "react";
 
 /*
  * This constant ensures that we don't end up with clashing keys
@@ -15,5 +16,15 @@ export default function useUiPreference(
     defaultValue: mixed,
   |}
 ): UseState<mixed> {
-  return ["tree", () => {}];
+  const [value, setValue] = React.useState(opts.defaultValue);
+
+  // fetch from server
+
+  return [
+    value,
+    (newValue) => {
+      setValue(newValue);
+      // update server
+    },
+  ];
 }

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -7,7 +7,7 @@ import axios from "axios";
 /*
  * This constant ensures that we don't end up with clashing keys
  */
-export const PREFERENCES: { [Preferences]: symbol } = {
+export const PREFERENCES: { [string]: symbol } = {
   GALLERY_VIEW_MODE: Symbol.for("GALLERY_VIEW_MODE"),
 };
 

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -1,0 +1,19 @@
+//@flow
+
+import { type UseState } from "./types";
+
+/*
+ * This constant ensures that we don't end up with clashing keys
+ */
+export const PREFERENCES: { [Preferences]: symbol } = {
+  GALLERY_VIEW_MODE: Symbol("GALLERY_VIEW_MODE"),
+};
+
+export default function useUiPreference(
+  preference: $Values<typeof PREFERENCES>,
+  opts: {|
+    defaultValue: mixed,
+  |}
+): UseState<mixed> {
+  return ["tree", () => {}];
+}

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -37,6 +37,8 @@ export function UiPreferences({ children }: {| children: Node |}): Node {
   React.useEffect(() => {
     void fetchPreferences().then((data) => {
       setUiPreferences(data);
+    }).catch(() => {
+      setUiPreferences({});
     });
   }, []);
 

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -26,9 +26,9 @@ const UiPreferencesContext: Context<UiPreferencesContextType> = React.createCont
   DEFAULT_UI_PREFERENCES_CONTEXT
 );
 
-function fetchPreferences(): Promise<{ ... }> {
+function fetchPreferences(): Promise<UiPreferencesContextType | ""> {
   return axios
-    .get<UiPreferencesContextType>("/userform/ajax/preference?preference=UI_JSON_SETTINGS")
+    .get<UiPreferencesContextType | "">("/userform/ajax/preference?preference=UI_JSON_SETTINGS")
     .then(({ data }) => data);
 }
 
@@ -109,7 +109,7 @@ export default function useUiPreference<T>(
         formData.append(
           "value",
           JSON.stringify({
-            ...preferences,
+            ...(typeof preferences === "object" ? preferences : {}),
             [key]: {
               value: newValue,
               // we save the time so that we have the option of implementing an

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -11,6 +11,12 @@ export const PREFERENCES: { [Preferences]: symbol } = {
   GALLERY_VIEW_MODE: Symbol.for("GALLERY_VIEW_MODE"),
 };
 
+function fetchPreferences(): Promise<{ ... }> {
+  return axios
+    .get<{ ... }>("/userform/ajax/preference?preference=UI_JSON_SETTINGS")
+    .then(({ data }) => data);
+}
+
 export default function useUiPreference(
   preference: $Values<typeof PREFERENCES>,
   opts: {|
@@ -20,12 +26,10 @@ export default function useUiPreference(
   const [value, setValue] = React.useState(opts.defaultValue);
 
   React.useEffect(() => {
-    void axios
-      .get("/userform/ajax/preference?preference=UI_JSON_SETTINGS")
-      .then(({ data }) => {
-        if (Symbol.keyFor(preference) in data)
-          setValue(data[Symbol.keyFor(preference)]);
-      });
+    void fetchPreferences().then((data) => {
+      if (Symbol.keyFor(preference) in data)
+        setValue(data[Symbol.keyFor(preference)]);
+    });
   }, []);
 
   return [
@@ -33,19 +37,27 @@ export default function useUiPreference(
     (newValue) => {
       setValue(newValue);
 
-      const formData = new FormData();
-      formData.append("preference", "UI_JSON_SETTINGS");
-      formData.append(
-        "value",
-        JSON.stringify({
-          [Symbol.keyFor(preference)]: newValue,
-        })
-      );
-      void axios.post("/userform/ajax/preference", formData, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      });
+      void (async () => {
+        const preferences = await fetchPreferences();
+        const formData = new FormData();
+        formData.append("preference", "UI_JSON_SETTINGS");
+        formData.append(
+          "value",
+          JSON.stringify({
+            ...preferences,
+            [Symbol.keyFor(preference)]: newValue,
+          })
+        );
+        await axios.post<FormData, mixed>(
+          "/userform/ajax/preference",
+          formData,
+          {
+            headers: {
+              "Content-Type": "multipart/form-data",
+            },
+          }
+        );
+      })();
     },
   ];
 }

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -86,8 +86,8 @@ export default function useUiPreference<T>(
   const key = Symbol.keyFor(preference);
   let v = opts.defaultValue;
   if (key && typeof uiPreferences[key] !== "undefined") {
-    // $FlowExpectedError[incompatible-type] We assume the server responds with the right type
-    v = uiPreferences[key];
+    // $FlowExpectedError[incompatible-use] We assume the server responds with the right type
+    v = uiPreferences[key].value;
   }
   const [value, setValue] = React.useState(v);
 
@@ -105,7 +105,12 @@ export default function useUiPreference<T>(
           "value",
           JSON.stringify({
             ...preferences,
-            [key]: newValue,
+            [key]: {
+              value: newValue,
+              // we save the time so that we have the option of implementing an
+              // eviction polciy in the future
+              time: new Date().getTime()
+            },
           })
         );
         await axios.post<FormData, mixed>(

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -10,6 +10,8 @@ import * as Parsers from "./parsers";
  */
 export const PREFERENCES: { [string]: symbol } = {
   GALLERY_VIEW_MODE: Symbol.for("GALLERY_VIEW_MODE"),
+  GALLERY_SORT_BY: Symbol.for("GALLERY_SORT_BY"),
+  GALLERY_SORT_ORDER: Symbol.for("GALLERY_SORT_ORDER"),
 };
 
 function fetchPreferences(): Promise<{ ... }> {

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -59,7 +59,7 @@ export default function useUiPreference<T>(
   const uiPreferences = React.useContext(UiPreferencesContext);
   const key = Symbol.keyFor(preference);
   let v = opts.defaultValue;
-  if (key && uiPreferences[key]) {
+  if (key && typeof uiPreferences[key] !== "undefined") {
     // $FlowExpectedError[incompatible-type] We assume the server responds with the right type
     v = uiPreferences[key];
   }

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -12,6 +12,7 @@ export const PREFERENCES: { [string]: symbol } = {
   GALLERY_VIEW_MODE: Symbol.for("GALLERY_VIEW_MODE"),
   GALLERY_SORT_BY: Symbol.for("GALLERY_SORT_BY"),
   GALLERY_SORT_ORDER: Symbol.for("GALLERY_SORT_ORDER"),
+  INVENTORY_FORM_SECTIONS_EXPANDED: Symbol.for("INVENTORY_FORM_SECTIONS_EXPANDED"),
 };
 
 type UiPreferencesContextType = {[key in keyof (typeof PREFERENCES)]: mixed};
@@ -45,9 +46,13 @@ export function UiPreferences({ children }: {| children: Node |}): Node {
 
   React.useEffect(() => {
     void fetchPreferences().then((data) => {
+      if (data === "") {
+        setUiPreferences(mapObject(() => null, PREFERENCES));
+        return;
+      }
       setUiPreferences(data);
     }).catch(() => {
-      setUiPreferences({});
+      setUiPreferences(mapObject(() => null, PREFERENCES));
     });
   }, []);
 
@@ -87,7 +92,7 @@ export default function useUiPreference<T>(
   let v = opts.defaultValue;
   if (key && typeof uiPreferences[key] !== "undefined") {
     // $FlowExpectedError[incompatible-use] We assume the server responds with the right type
-    v = uiPreferences[key].value;
+    v = uiPreferences[key]?.value ?? opts.defaultValue;
   }
   const [value, setValue] = React.useState(v);
 
@@ -113,14 +118,9 @@ export default function useUiPreference<T>(
             },
           })
         );
-        await axios.post<FormData, mixed>(
+        await axios.post<mixed, mixed>(
           "/userform/ajax/preference",
-          formData,
-          {
-            headers: {
-              "Content-Type": "multipart/form-data",
-            },
-          }
+          formData
         );
       })();
     },

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -1,9 +1,9 @@
 //@flow
 
 import { type UseState } from "./types";
-import React from "react";
+import React, { type Node, type Context } from "react";
 import axios from "axios";
-import * as Parsers from "./parsers";
+import { mapObject } from "./Util";
 
 /*
  * This constant ensures that we don't end up with clashing keys
@@ -14,36 +14,60 @@ export const PREFERENCES: { [string]: symbol } = {
   GALLERY_SORT_ORDER: Symbol.for("GALLERY_SORT_ORDER"),
 };
 
+type UiPreferencesContextType = {[key in keyof (typeof PREFERENCES)]: mixed};
+
+const DEFAULT_UI_PREFERENCES_CONTEXT: UiPreferencesContextType = mapObject(
+  () => null,
+  PREFERENCES
+);
+
+const UiPreferencesContext: Context<UiPreferencesContextType> = React.createContext(
+  DEFAULT_UI_PREFERENCES_CONTEXT
+);
+
 function fetchPreferences(): Promise<{ ... }> {
   return axios
-    .get<{ ... }>("/userform/ajax/preference?preference=UI_JSON_SETTINGS")
+    .get<UiPreferencesContextType>("/userform/ajax/preference?preference=UI_JSON_SETTINGS")
     .then(({ data }) => data);
 }
 
-export default function useUiPreference(
-  preference: $Values<typeof PREFERENCES>,
-  opts: {|
-    defaultValue: mixed,
-  |}
-): UseState<mixed> {
-  const [value, setValue] = React.useState(opts.defaultValue);
+export function UiPreferences({ children }: {| children: Node |}): Node {
+  const [uiPreferences, setUiPreferences] = React.useState<UiPreferencesContextType | null>(null);
 
   React.useEffect(() => {
     void fetchPreferences().then((data) => {
-      const key = Symbol.keyFor(preference);
-      if (!key) return;
-      Parsers.getValueWithKey(key)(data).do((v) => {
-        setValue(v);
-      });
+      setUiPreferences(data);
     });
   }, []);
+
+  if (!uiPreferences) return null;
+  return (
+    <UiPreferencesContext.Provider value={uiPreferences}>
+      {children}
+    </UiPreferencesContext.Provider>
+  );
+}
+
+export default function useUiPreference<T>(
+  preference: $Values<typeof PREFERENCES>,
+  opts: {|
+    defaultValue: T,
+  |}
+): UseState<T> {
+  const uiPreferences = React.useContext(UiPreferencesContext);
+  const key = Symbol.keyFor(preference);
+  let v = opts.defaultValue;
+  if (key && uiPreferences[key]) {
+    // $FlowExpectedError[incompatible-type] We assume the server responds with the right type
+    v = uiPreferences[key];
+  }
+  const [value, setValue] = React.useState(v);
 
   return [
     value,
     (newValue) => {
       setValue(newValue);
 
-      const key = Symbol.keyFor(preference);
       if (!key) return;
       void (async () => {
         const preferences = await fetchPreferences();

--- a/src/main/webapp/ui/src/util/useUiPreference.js
+++ b/src/main/webapp/ui/src/util/useUiPreference.js
@@ -31,6 +31,15 @@ function fetchPreferences(): Promise<{ ... }> {
     .then(({ data }) => data);
 }
 
+/**
+ * This page-wide contexts fetches the UI Preferences and makes the current
+ * values available to all calls to useUiPreference in child components.
+ *
+ * Whilst the data is being fetched, the child nodes are not rendered and so
+ * calls to useUiPreference do not need to consider ongoing network activity.
+ * If the network call fails, the UI Preferences default to an empty object
+ * and all calls to useUiPreference will use the passed default value.
+ */
 export function UiPreferences({ children }: {| children: Node |}): Node {
   const [uiPreferences, setUiPreferences] = React.useState<UiPreferencesContextType | null>(null);
 
@@ -42,6 +51,10 @@ export function UiPreferences({ children }: {| children: Node |}): Node {
     });
   }, []);
 
+  /*
+   * If it turns out that loading this data will likely take a while,
+   * then we will want to replace this null with a loading spinner.
+   */
   if (!uiPreferences) return null;
   return (
     <UiPreferencesContext.Provider value={uiPreferences}>
@@ -50,6 +63,19 @@ export function UiPreferences({ children }: {| children: Node |}): Node {
   );
 }
 
+/**
+ * Use this custom hook to get the value of a UI Preference from the page-wide
+ * context. The returned tuple has the same shape as a call to React.useState,
+ * so that the value can be updated and persisted across page loads.
+ *
+ * @arg preference The UI Preference in question
+ *
+ * @arg opts Various options, including
+ *
+ *      defaultValue  If the current state of UI Preferences does not include
+ *                    `preference` then `defaultValue` will be returned as the
+ *                    value instead.
+ */
 export default function useUiPreference<T>(
   preference: $Values<typeof PREFERENCES>,
   opts: {|


### PR DESCRIPTION
There are various small bits of the UI that would be good to persist across user sessions: sort ordering, views, draft text.

This change adds a custom react hook for using bits of persisted state in the same way that React.useState is used. The state is stored with its timestamp so that in future we could implement a retention policy/flush the oldest state when necessary. Finally, this change uses this new hook to provide persistence for:
  * New Gallery's sorting
  * New Gallery's view
  * Inventory's form sections