### PR TITLE
RSDEV-196 Have dependency cruiser check for incompatible licenses

### DIFF
--- a/src/main/webapp/ui/.dependency-cruiser.js
+++ b/src/main/webapp/ui/.dependency-cruiser.js
@@ -1,6 +1,15 @@
 /** @type {import('dependency-cruiser').IConfiguration} */
 module.exports = {
   forbidden: [
+    {
+      name: "compatible-licenses",
+      comment: "Third-party code should adhere to a license that is compatible with our own",
+      severity: "error",
+      from: {},
+      to: {
+        licenseNot: ["MIT", "BSD", "Apache", "Hippocratic"]
+      }
+    },
     // {
     //   name: 'no-circular',
     //   severity: 'warn',


### PR DESCRIPTION
This dependency cruiser rule encodes a whitelist of strings of which at least one must appear in the license string of every third-party library we install from npm. As such, by running dependency cruiser, any violations will be reported.