### PR TITLE
RSDEV-286 On new gallery, move "upload new version" to actions menu

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -35,6 +35,7 @@ import Typography from "@mui/material/Typography";
 import MoveDialog from "./MoveDialog";
 import ExportDialog from "../../../Export/ExportDialog";
 import EventBoundary from "../../../components/EventBoundary";
+import * as Parsers from "../../../util/parsers";
 
 const RenameDialog = ({
   open,
@@ -346,11 +347,13 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
         />
         {selection
           .asSet()
-          .only.map((file) => (
+          .only.map((file) => file.extension)
+          .flatMap((f) => Parsers.isNotNull(f).toOptional())
+          .map((extension) => (
             <input
               key={null}
               ref={newVersionInputRef}
-              accept={".png"}
+              accept={`.${extension}`}
               hidden
               onChange={({ target: { files } }) => {
                 console.debug(files);

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -203,7 +203,25 @@ function ActionsMenu({ refreshListing, section }: ActionsMenuArgs): Node {
   const uploadNewVersionAllowed = (): Result<null> => {
     if (selection.isEmpty)
       return Result.Error([new Error("Nothing selected.")]);
-    return Result.Ok(null);
+    return selection
+      .asSet()
+      .only.toResult(
+        () =>
+          new Error("Only one item may be updated with a new version at once.")
+      )
+      .flatMap((file) => {
+        if (file.isFolder)
+          return Result.Error([
+            new Error("Cannot update folders with a new version."),
+          ]);
+        if (!file.extension)
+          return Result.Error([
+            new Error(
+              "An extension is required to be able to update the file with a new version"
+            ),
+          ]);
+        return Result.Ok(null);
+      });
   };
 
   const exportAllowed = (): Result<null> => {

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1108,6 +1108,7 @@ function GalleryMainPanel({
                 <ActionsMenu
                   refreshListing={refreshListing}
                   section={selectedSection}
+                  folderId={folderId}
                 />
                 <Box sx={{ flexGrow: 1 }}></Box>
                 <Button

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -38,7 +38,20 @@ export function useGalleryActions(): {|
   deleteFiles: (RsSet<GalleryFile>) => Promise<void>,
   duplicateFiles: (RsSet<GalleryFile>) => Promise<void>,
   rename: (GalleryFile, string) => Promise<void>,
-  uploadNewVersion: (Id, GalleryFile, File) => Promise<void>,
+
+  /**
+   * The contents of `file` is replaced with `newFile`. The filename is also
+   * replaced and the version number incremented.
+   *
+   * @arg folderId The Id of the folder that `file` currently resides in.
+   * @arg file     The file whose contents are being updated.
+   * @arg newFile  The contents that `file` is being updated to.
+   */
+  uploadNewVersion: (
+    folderId: Id,
+    file: GalleryFile,
+    newFile: File
+  ) => Promise<void>,
 |} {
   const { addAlert, removeAlert } = React.useContext(AlertContext);
 

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryActions.js
@@ -409,10 +409,7 @@ export function useGalleryActions(): {|
     const formData = new FormData();
     formData.append("selectedMediaId", idToString(file.id));
     formData.append("xfile", newFile);
-    const targetFolderId = ArrayUtils.last(file.path)
-      .map(({ id }) => idToString(id))
-      .orElse(idToString(folderId));
-    formData.append("targetFolderId", targetFolderId);
+    formData.append("targetFolderId", idToString(folderId));
     try {
       const { data } = await axios.post<FormData, mixed>(
         "gallery/ajax/uploadFile",

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -21,6 +21,7 @@ export function idToString(id: Id): string {
 export type GalleryFile = {|
   id: Id,
   name: string,
+  extension: string | null,
   modificationDate: number,
   type: string,
   thumbnailUrl: string,
@@ -223,6 +224,7 @@ export function useGalleryListing({
     const ret: GalleryFile = {
       id,
       name,
+      extension,
       modificationDate,
       type,
       thumbnailUrl: generateIconSrc(

--- a/src/main/webapp/ui/src/util/result.js
+++ b/src/main/webapp/ui/src/util/result.js
@@ -161,6 +161,15 @@ export default class Result<T> {
   }
 
   /**
+   * Simply hand-off the error handling to try/catch logic.
+   * The first error will be thrown and all others discarded.
+   */
+  elseThrow(): T {
+    if (this.#state.key === "error") throw this.#state.errors[0];
+    return this.#state.value;
+  }
+
+  /**
    * To modify/accumulate the errors collected in the Error branch.  The most
    * common reason to do this is to take a generic error message and convert it
    * into a specific one for the use-case at hand. Some tips:


### PR DESCRIPTION
On the current gallery, this button sits on the info panel but to streamline the info panel and place all buttons that perform actions in one place this is being moved to the actions menu -- the equivalent of the menu bar -- on the new gallery page.