### PR TITLE
RSPAC-2209: option to utf8-recode first name/last name coming from SAML response

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/SignupController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SignupController.java
@@ -18,7 +18,10 @@ import com.researchspace.service.UserEnablementUtils;
 import com.researchspace.service.UserExistsException;
 import com.researchspace.webapp.filter.RemoteUserRetrievalPolicy;
 import com.researchspace.webapp.filter.SSOShiroFormAuthFilterExt;
+import java.io.UnsupportedEncodingException;
 import javax.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.Setter;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -44,7 +47,10 @@ public class SignupController extends BaseController {
       "cloud/signup/accountActivationFail";
 
   private @Autowired RoleManager roleManager;
-  private @Autowired RemoteUserRetrievalPolicy remoteUserPolicy;
+
+  @Autowired
+  @Setter(AccessLevel.PACKAGE) // for testing
+  private RemoteUserRetrievalPolicy remoteUserPolicy;
   private @Autowired UserValidator userValidator;
   private @Autowired SignupCaptchaVerifier captchaVerifier;
   private @Autowired UserEnablementUtils userEnablementUtils;
@@ -68,7 +74,12 @@ public class SignupController extends BaseController {
   private IPostUserSignup postSignup;
 
   @Value("${user.signup.acceptedDomains}")
+  @Setter(AccessLevel.PACKAGE) // for testing
   private String acceptedSignupDomains;
+
+  @Value("${deployment.sso.recodeIncomingFirstNameLastNameToUtf8}")
+  @Setter(AccessLevel.PACKAGE) // for testing
+  private Boolean deploymentSsoRecodeNamesToUft8;
 
   public SignupController() {
     setCancelView("redirect:login");
@@ -124,14 +135,28 @@ public class SignupController extends BaseController {
     return emailString == null ? "" : emailString;
   }
 
-  private String getLastnameFromRemote(HttpServletRequest req) {
+  protected String getLastnameFromRemote(HttpServletRequest req) {
     String rc = remoteUserPolicy.getOtherRemoteAttributes(req).get("Shib-surName");
-    return rc == null ? "" : rc;
+    return rc == null ? "" : ensureUtf8EncodingForSAMLAttributeValue(rc);
   }
 
-  private String getFirstNameFromRemote(HttpServletRequest req) {
+  protected String getFirstNameFromRemote(HttpServletRequest req) {
     String rc = remoteUserPolicy.getOtherRemoteAttributes(req).get("Shib-givenName");
-    return rc == null ? "" : rc;
+    return rc == null ? "" : ensureUtf8EncodingForSAMLAttributeValue(rc);
+  }
+
+  private String ensureUtf8EncodingForSAMLAttributeValue(String rc) {
+    if (deploymentSsoRecodeNamesToUft8) {
+      try {
+        String recodedFromIso = new String(rc.getBytes("ISO-8859-1"), "UTF-8");
+        if (recodedFromIso.length() < rc.length()) {
+          return recodedFromIso;
+        }
+      } catch (UnsupportedEncodingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return rc;
   }
 
   private boolean getIsAllowedPiRoleFromRemote(HttpServletRequest req) {
@@ -281,13 +306,4 @@ public class SignupController extends BaseController {
     return (new ModelAndView("usernameReminder/remindUsernameEmailSent")).addObject("email", email);
   }
 
-  /*
-   * ================
-   * for testing
-   * ================
-   */
-
-  void setAcceptedSignupDomains(String acceptedDomains) {
-    this.acceptedSignupDomains = acceptedDomains;
-  }
 }

--- a/src/main/java/com/researchspace/webapp/controller/SignupController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SignupController.java
@@ -51,6 +51,7 @@ public class SignupController extends BaseController {
   @Autowired
   @Setter(AccessLevel.PACKAGE) // for testing
   private RemoteUserRetrievalPolicy remoteUserPolicy;
+
   private @Autowired UserValidator userValidator;
   private @Autowired SignupCaptchaVerifier captchaVerifier;
   private @Autowired UserEnablementUtils userEnablementUtils;

--- a/src/main/java/com/researchspace/webapp/filter/SAMLRemoteUserPolicy.java
+++ b/src/main/java/com/researchspace/webapp/filter/SAMLRemoteUserPolicy.java
@@ -46,7 +46,7 @@ public class SAMLRemoteUserPolicy implements RemoteUserRetrievalPolicy {
     log.debug("SAML attributes: {}", logSamlAttributes(httpRequest).toString());
     log.debug("Remote user:  {}", httpRequest.getRemoteUser());
     Object username = httpRequest.getAttribute(SHIBBOLETH_ID_ATTRIBUTE);
-    log.info("SAML [{}] attribute from HttpRequest: ", SHIBBOLETH_ID_ATTRIBUTE, username);
+    log.info("SAML [{}] attribute from HttpRequest: {}", SHIBBOLETH_ID_ATTRIBUTE, username);
 
     if (username == null) {
       username = httpRequest.getAttribute("eppn");

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -328,6 +328,8 @@ deployment.sso.backdoorUserCreation.enabled=false
 deployment.sso.selfDeclarePI.enabled=false
 # email address that users should be referred to on problems with their SSO account. See RSPAC-2710
 deployment.sso.adminEmail=support@<your_server>.com
+# enables mechanism for correcting encoding of names within SSO-SAML response. See RSPAC-2209
+deployment.sso.recodeIncomingFirstNameLastNameToUtf8=true
 
 ## Must be set if running with Aspose at all.
 aspose.enabled=true

--- a/src/test/java/com/researchspace/api/v1/controller/SysadminUsersAPIController2MVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SysadminUsersAPIController2MVCIT.java
@@ -12,8 +12,6 @@ import com.researchspace.core.util.JacksonUtil;
 import com.researchspace.model.User;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MvcResult;

--- a/src/test/java/com/researchspace/api/v1/controller/SysadminUsersAPIControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SysadminUsersAPIControllerMVCIT.java
@@ -42,9 +42,9 @@ import org.springframework.validation.BindException;
 // test that this property is used.
 @TestPropertySource(
     properties = {
-        "sysadmin.apikey.generation=true",
-        "sysadmin.nodeletenewerthan.days=7",
-        "api.beta.enabled=true"
+      "sysadmin.apikey.generation=true",
+      "sysadmin.nodeletenewerthan.days=7",
+      "api.beta.enabled=true"
     })
 public class SysadminUsersAPIControllerMVCIT extends API_MVC_TestBase {
 

--- a/src/test/java/com/researchspace/webapp/controller/SignupControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SignupControllerTest.java
@@ -3,6 +3,7 @@ package com.researchspace.webapp.controller;
 import static com.researchspace.model.record.TestFactory.createAnyUser;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,6 +12,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.dtos.UserValidator;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.SignupCaptchaVerifier;
+import com.researchspace.webapp.filter.SAMLRemoteUserPolicy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -78,11 +80,39 @@ public class SignupControllerTest {
   }
 
   @Test
-  public void ssoSignupAllowedREquiresGeneralUseRSignup() {
+  public void ssoSignupAllowedRequiresGeneralUseRSignup() {
     when(properties.isUserSignup()).thenReturn(Boolean.FALSE);
     signupCtrller.setAcceptedSignupDomains("@xyz, abc, def");
     assertFalse(signupCtrller.isSsoSignupAllowed("any.somwhere@abc"));
     assertFalse(signupCtrller.isSsoSignupAllowed("any.somwhere@xyz"));
     assertFalse(signupCtrller.isSsoSignupAllowed("any.somwhere@def"));
   }
+
+  @Test
+  public void testIncomingSAMLFirstNameLastNameUtfRecoding() {
+
+    // enable encoding
+    signupCtrller.setRemoteUserPolicy(new SAMLRemoteUserPolicy());
+    signupCtrller.setDeploymentSsoRecodeNamesToUft8(true);
+
+    // check iso-encoded chars
+    MockHttpServletRequest mockIso8859Request = new MockHttpServletRequest();
+    mockIso8859Request.setAttribute("Shib-givenName", "MÃ¦ck");
+    mockIso8859Request.setAttribute("Shib-surName", "SchÃ¸dt-Å»Ä\u0099bski");
+    assertEquals("Mæck", signupCtrller.getFirstNameFromRemote(mockIso8859Request));
+    assertEquals("Schødt-Żębski", signupCtrller.getLastnameFromRemote(mockIso8859Request));
+
+    // check if still works for utf8 chars
+    MockHttpServletRequest mockUtf8Request = new MockHttpServletRequest();
+    mockUtf8Request.setAttribute("Shib-givenName", "Mæck");
+    mockUtf8Request.setAttribute("Shib-surName", "Schødt-Żębski");
+    assertEquals("Mæck", signupCtrller.getFirstNameFromRemote(mockUtf8Request));
+    assertEquals("Schødt-Żębski", signupCtrller.getLastnameFromRemote(mockUtf8Request));
+
+    // confirm not conversion when encoding disabled in deployment property
+    signupCtrller.setDeploymentSsoRecodeNamesToUft8(false);
+    assertEquals("MÃ¦ck", signupCtrller.getFirstNameFromRemote(mockIso8859Request));
+    assertEquals("SchÃ¸dt-Å»Ä\u0099bski", signupCtrller.getLastnameFromRemote(mockIso8859Request));
+  }
+
 }

--- a/src/test/java/com/researchspace/webapp/controller/SignupControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SignupControllerTest.java
@@ -1,9 +1,9 @@
 package com.researchspace.webapp.controller;
 
 import static com.researchspace.model.record.TestFactory.createAnyUser;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,7 +80,7 @@ public class SignupControllerTest {
   }
 
   @Test
-  public void ssoSignupAllowedRequiresGeneralUseRSignup() {
+  public void ssoSignupAllowedRequiresGeneralUserSignup() {
     when(properties.isUserSignup()).thenReturn(Boolean.FALSE);
     signupCtrller.setAcceptedSignupDomains("@xyz, abc, def");
     assertFalse(signupCtrller.isSsoSignupAllowed("any.somwhere@abc"));
@@ -109,10 +109,9 @@ public class SignupControllerTest {
     assertEquals("Mæck", signupCtrller.getFirstNameFromRemote(mockUtf8Request));
     assertEquals("Schødt-Żębski", signupCtrller.getLastnameFromRemote(mockUtf8Request));
 
-    // confirm not conversion when encoding disabled in deployment property
+    // confirm no conversion if encoding is disabled in deployment property
     signupCtrller.setDeploymentSsoRecodeNamesToUft8(false);
     assertEquals("MÃ¦ck", signupCtrller.getFirstNameFromRemote(mockIso8859Request));
     assertEquals("SchÃ¸dt-Å»Ä\u0099bski", signupCtrller.getLastnameFromRemote(mockIso8859Request));
   }
-
 }


### PR DESCRIPTION
adds deployment property that enables re-coding of first name and last name coming from SAML response from iso-8859-1 to utf8 response