### PR TITLE
RSDEV-174 Refactor AttachmentModel in anticipation of attaching Gallery files

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Fields/Attachments/AttachmentTableRow.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Attachments/AttachmentTableRow.js
@@ -9,8 +9,7 @@ import Grid from "@mui/material/Grid";
 import NameWithBadge from "../../NameWithBadge";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSpinner } from "@fortawesome/free-solid-svg-icons";
-import { faAtom } from "@fortawesome/free-solid-svg-icons";
+import { faSpinner, faAtom } from "@fortawesome/free-solid-svg-icons";
 library.add(faSpinner);
 import ChemicalViewerDialog from "../../../../eln-inventory-integration/ChemicalViewer/ChemicalViewerDialog";
 import { type Attachment } from "../../../../stores/definitions/Attachment";
@@ -25,44 +24,49 @@ import { type HasEditableFields } from "../../../../stores/definitions/Editable"
 import { type BlobUrl } from "../../../../stores/stores/ImageStore";
 import { doNotAwait } from "../../../../util/Util";
 
-const ChemicalPreview = observer(({ attachment }: { attachment: Attachment }) => {
-  const loadingString = attachment.loadingString;
-  const chemicalString = attachment.chemicalString;
-  const isChemicalFile = attachment.isChemicalFile;
-  const chemistrySupported = attachment.chemistrySupported;
+const ChemicalPreview = observer(
+  ({ attachment }: { attachment: Attachment }) => {
+    const loadingString = attachment.loadingString;
+    const chemicalString = attachment.chemicalString;
+    const isChemicalFile = attachment.isChemicalFile;
+    const chemistrySupported = attachment.chemistrySupported;
 
-  return (
-    <>
-      <IconButtonWithTooltip
-        title={
-          chemicalString
-            ? ""
-            : loadingString
-            ? "Loading file"
-            : chemistrySupported
-            ? "Preview file as 3D structure"
-            : isChemicalFile && !attachment.id
-            ? "Save first to enable 3D preview"
-            : "3D Preview is not supported for this file type"
-        }
-        size="small"
-        color="primary"
-        onClick={doNotAwait(() => attachment.createChemicalPreview())}
-        disabled={loadingString || !chemistrySupported}
-        icon={
-          loadingString ? (
-            <FontAwesomeIcon icon="spinner" spin size="lg" />
-          ) : (
+    return (
+      <>
+        <IconButtonWithTooltip
+          title={
+            chemicalString
+              ? ""
+              : loadingString
+              ? "Loading file"
+              : chemistrySupported
+              ? "Preview file as 3D structure"
+              : isChemicalFile && !attachment.id
+              ? "Save first to enable 3D preview"
+              : "3D Preview is not supported for this file type"
+          }
+          size="small"
+          color="primary"
+          onClick={doNotAwait(() => attachment.createChemicalPreview())}
+          disabled={loadingString || !chemistrySupported}
+          icon={
+            loadingString ? (
+              <FontAwesomeIcon icon="spinner" spin size="lg" />
+            ) : (
               <FontAwesomeIcon icon={faAtom} size="lg" />
-          )
-        }
-      />
-      {!loadingString && Boolean(chemicalString) && (
-        <ChemicalViewerDialog attachment={attachment} open={Boolean(chemicalString)} />
-      )}
-    </>
-  );
-});
+            )
+          }
+        />
+        {!loadingString && Boolean(chemicalString) && (
+          <ChemicalViewerDialog
+            attachment={attachment}
+            open={Boolean(chemicalString)}
+          />
+        )}
+      </>
+    );
+  }
+);
 
 const Download = ({ attachment }: { attachment: Attachment }) => (
   <IconButtonWithTooltip

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Attachments/AttachmentTableRow.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Attachments/AttachmentTableRow.js
@@ -119,7 +119,7 @@ const SetAsPreviewImage = <
   const setAsPreviewImage = async () => {
     try {
       await attachment.setImageLink();
-      await storeImage(attachment.imageLink, attachment.file);
+      await storeImage(attachment.imageLink, await attachment.getFile());
     } catch (e) {
       uiStore.addAlert(
         mkAlert({

--- a/src/main/webapp/ui/src/components/Inputs/__tests__/AttachmentField.test.js
+++ b/src/main/webapp/ui/src/components/Inputs/__tests__/AttachmentField.test.js
@@ -10,13 +10,14 @@ import "@testing-library/jest-dom";
 import AttachmentField from "../AttachmentField";
 import TextField from "@mui/material/TextField";
 import FileField from "../FileField";
-import AttachmentModel from "../../../stores/models/AttachmentModel";
+import { ExistingAttachment } from "../../../stores/models/AttachmentModel";
 import each from "jest-each";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../theme";
 import { containerAttrs } from "../../../stores/models/__tests__/ContainerModel/mocking";
 import ContainerModel from "../../../stores/models/ContainerModel";
 import MemoisedFactory from "../../../stores/models/Factory/MemoisedFactory";
+import { type Attachment } from "../../../stores/definitions/Attachment";
 
 jest.mock("@mui/material/TextField", () => jest.fn(() => <div></div>));
 jest.mock("../FileField", () => jest.fn(() => <div></div>));
@@ -42,7 +43,7 @@ const activeResult = new ContainerModel(new MemoisedFactory(), {
 });
 
 const makeAttachment = (attrs: ?{| name: string |}) =>
-  new AttachmentModel(
+  new ExistingAttachment(
     {
       id: 0,
       name: "",
@@ -158,7 +159,7 @@ describe("AttachmentField", () => {
         showNoAttachmentLabel,
       }: {|
         disableFileUpload: typeof undefined | boolean,
-        attachment: ?AttachmentModel,
+        attachment: ?Attachment,
         showFileField: boolean,
         showNoAttachmentLabel: boolean,
       |}) => {
@@ -202,7 +203,7 @@ describe("AttachmentField", () => {
     );
   });
   describe("File viewer", () => {
-    describe("attachment = AttachmentModel", () => {
+    describe("attachment = ExistingAttachment", () => {
       test("Attachment's filename should be shown.", () => {
         const { container } = render(
           <ThemeProvider theme={materialTheme}>

--- a/src/main/webapp/ui/src/stores/definitions/Attachment.js
+++ b/src/main/webapp/ui/src/stores/definitions/Attachment.js
@@ -2,6 +2,7 @@
 
 import { type Record } from "./Record";
 import { type URL } from "../../util/types";
+import { type GlobalId } from "./BaseRecord";
 
 /*
  * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
@@ -23,7 +24,6 @@ export interface Attachment extends Record {
   loadingImage: boolean;
   loadingString: boolean;
   chemicalString: string;
-  file: ?File;
 
   /*
    * Indicates that the user has chosen to remove the Attachment, but that
@@ -76,4 +76,21 @@ export interface Attachment extends Record {
   +isChemicalFile: boolean;
   +chemistrySupported: boolean;
   +previewSupported: boolean;
+
+  /**
+   * Save any changes to the attachment; uploading new attachments, or deletion
+   * ones that have been marked for removal. Is called after edits to a
+   * sample/container/subsample/template have been saved, and is called for
+   * each attachment of those records and for each field of type attachment,
+   * if a sample or template is being saved.
+   *
+   * @param parentGlobalId This is the Global Id of the record with which the
+   *                       attachment is associated: this could be a
+   *                       container/sample/subsample/template or it could be a
+   *                       field of a sample or template that is of type
+   *                       attachment. When saving new attachments the server
+   *                       needs to know where to attach them.
+   * @return Promise resolves when the network activity has finished.
+   */
+  save(parentGlobalId: GlobalId): Promise<void>;
 }

--- a/src/main/webapp/ui/src/stores/definitions/__tests__/Attachment/mocking.js
+++ b/src/main/webapp/ui/src/stores/definitions/__tests__/Attachment/mocking.js
@@ -38,5 +38,6 @@ export const mockAttachment = ({
     isChemicalFile: true,
     chemistrySupported: true,
     previewSupported: true,
+    save: () => Promise.resolve(),
   };
 };

--- a/src/main/webapp/ui/src/stores/models/AttachmentModel.js
+++ b/src/main/webapp/ui/src/stores/models/AttachmentModel.js
@@ -73,7 +73,7 @@ export class ExistingAttachment implements Attachment {
   removed: boolean;
   loadingImage: boolean = false;
   loadingString: boolean = false;
-  contentMimeType: ?string;
+  contentMimeType: string;
   onRemoveCallback: (Attachment) => void;
   permalinkURL: ?Url;
   owner: ?Person; // For the info button
@@ -132,7 +132,6 @@ export class ExistingAttachment implements Attachment {
       true
     );
     return runInAction(() => {
-      if (!this.contentMimeType) throw new Error("ContentMimeType is missing");
       const file = new File([data], this.name, { type: this.contentMimeType });
       this.file = file;
       return file;
@@ -284,18 +283,7 @@ export class ExistingAttachment implements Attachment {
   }
 
   get isImageFile(): boolean {
-    if (typeof this.contentMimeType === "string") {
-      return /^image/.test(this.contentMimeType);
-    }
-    if (this.file) {
-      return /^image/.test(this.file.type);
-    }
-    /*
-     * This can't happen because if attachment is loaded from the server
-     * then it will have a contentMimeType whereas if it is a new
-     * attachment then it will have a file. Included to satisfy flow.
-     */
-    throw new Error("Should not happen.");
+    return /^image/.test(this.contentMimeType);
   }
 
   get isChemicalFile(): boolean {
@@ -347,7 +335,6 @@ export class NewlyUploadedAttachment implements Attachment {
   removed: boolean;
   loadingImage: boolean = false;
   loadingString: boolean = false;
-  contentMimeType: ?string;
   onRemoveCallback: (Attachment) => void;
   permalinkURL: ?Url;
   owner: ?Person; // For the info button

--- a/src/main/webapp/ui/src/stores/models/AttachmentModel.js
+++ b/src/main/webapp/ui/src/stores/models/AttachmentModel.js
@@ -396,20 +396,11 @@ export class NewlyUploadedAttachment implements Attachment {
     this.permalinkURL = permalinkURL;
   }
 
-  async getFile(): Promise<File> {
-    if (this.file) return this.file;
-    if (!this.link) throw new Error("No file specified");
-    const { data } = await ApiService.query<{||}, Blob>(
-      this.link,
-      new URLSearchParams(),
-      true
+  getFile(): Promise<File> {
+    if (this.file) return Promise.resolve(this.file);
+    throw new Error(
+      "Impossible because the user already selected a file to upload"
     );
-    return runInAction(() => {
-      if (!this.contentMimeType) throw new Error("ContentMimeType is missing");
-      const file = new File([data], this.name, { type: this.contentMimeType });
-      this.file = file;
-      return file;
-    });
   }
 
   setLoadingImage(value: boolean): void {
@@ -421,8 +412,11 @@ export class NewlyUploadedAttachment implements Attachment {
   }
 
   async setImageLink(): Promise<void> {
-    const file = await this.getFile();
-    if (!file) throw new Error("File is not yet known.");
+    const file = this.file;
+    if (!file)
+      throw new Error(
+        "Impossible because the user already selected a file to upload"
+      );
     let imageFile;
     if (this.isChemicalFile) imageFile = await this.fetchChemicalImage();
     runInAction(() => {
@@ -557,18 +551,10 @@ export class NewlyUploadedAttachment implements Attachment {
   }
 
   get isImageFile(): boolean {
-    if (typeof this.contentMimeType === "string") {
-      return /^image/.test(this.contentMimeType);
-    }
-    if (this.file) {
-      return /^image/.test(this.file.type);
-    }
-    /*
-     * This can't happen because if attachment is loaded from the server
-     * then it will have a contentMimeType whereas if it is a new
-     * attachment then it will have a file. Included to satisfy flow.
-     */
-    throw new Error("Should not happen.");
+    if (this.file) return /^image/.test(this.file.type);
+    throw new Error(
+      "Impossible because the user already selected a file to upload"
+    );
   }
 
   get isChemicalFile(): boolean {

--- a/src/main/webapp/ui/src/stores/models/AttachmentModel.js
+++ b/src/main/webapp/ui/src/stores/models/AttachmentModel.js
@@ -57,7 +57,11 @@ const chemExtensions = new Set([
   "smiles",
 ]);
 
-export default class AttachmentModel implements Attachment {
+/**
+ * This is an attachment that is already associated with a particular
+ * container/sample/subsample/template, having previously been uploaded.
+ */
+export class ExistingAttachment implements Attachment {
   id: AttachmentId;
   globalId: ?GlobalId;
   name: string;
@@ -75,7 +79,7 @@ export default class AttachmentModel implements Attachment {
   owner: ?Person; // For the info button
 
   constructor(
-    attrs: AttachmentAttrs,
+    attrs: FromServer,
     permalinkURL: ?Url,
     onRemoveCallback: (Attachment) => void
   ) {
@@ -111,16 +115,274 @@ export default class AttachmentModel implements Attachment {
     this.name = attrs.name;
     this.owner = null;
     this.size = attrs.size;
-    // if from upload, else from server
-    if ("file" in attrs) {
-      this.file = attrs.file;
-      this.globalId = null;
-    } else {
-      this.globalId = attrs.globalId;
-      this.contentMimeType = attrs.contentMimeType;
-      // $FlowFixMe[incompatible-use] FromServer
-      this.link = attrs._links.find(({ rel }) => rel === "enclosure")?.link;
+    this.globalId = attrs.globalId;
+    this.contentMimeType = attrs.contentMimeType;
+    this.link = attrs._links.find(({ rel }) => rel === "enclosure")?.link;
+    this.removed = false;
+    this.onRemoveCallback = onRemoveCallback;
+    this.permalinkURL = permalinkURL;
+  }
+
+  async getFile(): Promise<File> {
+    if (this.file) return this.file;
+    if (!this.link) throw new Error("No file specified");
+    const { data } = await ApiService.query<{||}, Blob>(
+      this.link,
+      new URLSearchParams(),
+      true
+    );
+    return runInAction(() => {
+      if (!this.contentMimeType) throw new Error("ContentMimeType is missing");
+      const file = new File([data], this.name, { type: this.contentMimeType });
+      this.file = file;
+      return file;
+    });
+  }
+
+  setLoadingImage(value: boolean): void {
+    this.loadingImage = value;
+  }
+
+  setLoadingString(value: boolean): void {
+    this.loadingString = value;
+  }
+
+  async setImageLink(): Promise<void> {
+    const file = await this.getFile();
+    if (!file) throw new Error("File is not yet known.");
+    let imageFile;
+    if (this.isChemicalFile) imageFile = await this.fetchChemicalImage();
+    runInAction(() => {
+      this.imageLink = URL.createObjectURL(imageFile || file);
+    });
+  }
+
+  async createAuthenticatedLink(): Promise<Url> {
+    const file = await this.getFile();
+    if (!file) throw new Error("File is not yet known.");
+    return URL.createObjectURL(file);
+  }
+
+  revokeAuthenticatedLink(link: Url): void {
+    if (this.imageLink) {
+      this.imageLink = null;
     }
+    return URL.revokeObjectURL(link);
+  }
+
+  setChemicalString(chemicalString: string): void {
+    this.chemicalString = chemicalString;
+  }
+
+  async createChemicalPreview(): Promise<void> {
+    await this.fetchChemicalString();
+  }
+
+  revokeChemicalPreview(): void {
+    this.setChemicalString("");
+  }
+
+  remove() {
+    this.removed = true;
+    this.onRemoveCallback(this);
+    getRootStore().trackingStore.trackEvent("RemovedAttachment");
+  }
+
+  async download() {
+    const anchor = document.createElement("a");
+    anchor.href = await this.createAuthenticatedLink();
+    anchor.download = this.name;
+    if (document.body) document.body.appendChild(anchor);
+    anchor.click();
+    getRootStore().trackingStore.trackEvent("DownloadAttachment");
+    this.revokeAuthenticatedLink(anchor.download);
+    if (document.body) document.body.removeChild(anchor);
+  }
+
+  fetchChemicalImage(): Promise<Blob> {
+    if (!this.id) {
+      throw new Error("Cannot get chemical image without file id");
+    } else {
+      const id = this.id;
+      this.setLoadingImage(true);
+      return ApiService.query<
+        {| imageParams: { width: ?number, height: ?number } |},
+        Blob
+      >(
+        `/files/${id}/file/image`,
+        new URLSearchParams({
+          imageParams: JSON.stringify({
+            width: 800,
+            height: null, // optional (h equals w if missing)
+            // scale: 1.0, // optional
+          }),
+        }),
+        true
+      )
+        .then((r) => {
+          return r.data;
+        })
+        .finally(() => {
+          this.setLoadingImage(false);
+        });
+    }
+  }
+
+  fetchChemicalString(): Promise<void> {
+    const id = this.id;
+    if (!id) {
+      throw new Error("Cannot generate chemical preview without file id");
+    } else {
+      this.setLoadingString(true);
+      const response = ApiService.get<
+        void,
+        {| data: { chemElements: string } |}
+      >(`/files/${id}/chemFileDetails`);
+      return response
+        .then((r) => {
+          if (r.status === 200) {
+            const chemicalString = r.data.data.chemElements;
+            this.setChemicalString(chemicalString);
+          }
+        })
+        .catch((error) => {
+          getRootStore().uiStore.addAlert(
+            mkAlert({
+              title: "Fetching chemical file failed.",
+              message:
+                error?.response?.data.message ??
+                error.message ??
+                "Unknown reason.",
+              variant: "error",
+            })
+          );
+          console.error(
+            `Could not get a string representation of chemical file ${id}.`,
+            error
+          );
+        })
+        .finally(() => {
+          this.setLoadingString(false);
+        });
+    }
+  }
+
+  get cardTypeLabel(): string {
+    return "Attachment";
+  }
+
+  get deleted(): boolean {
+    return this.removed;
+  }
+
+  get recordTypeLabel(): string {
+    return this.cardTypeLabel;
+  }
+
+  get iconName(): string {
+    return "attachment";
+  }
+
+  get isImageFile(): boolean {
+    if (typeof this.contentMimeType === "string") {
+      return /^image/.test(this.contentMimeType);
+    }
+    if (this.file) {
+      return /^image/.test(this.file.type);
+    }
+    /*
+     * This can't happen because if attachment is loaded from the server
+     * then it will have a contentMimeType whereas if it is a new
+     * attachment then it will have a file. Included to satisfy flow.
+     */
+    throw new Error("Should not happen.");
+  }
+
+  get isChemicalFile(): boolean {
+    const fileExt = justFilenameExtension(this.name);
+    return chemExtensions.has(fileExt);
+  }
+
+  get hasId(): boolean {
+    return Boolean(this.id);
+  }
+
+  get chemistrySupported(): boolean {
+    return this.isChemicalFile && this.hasId;
+  }
+
+  get previewSupported(): boolean {
+    return this.isImageFile;
+  }
+
+  get recordDetails(): RecordDetails {
+    return {
+      size: this.size,
+    };
+  }
+}
+
+/**
+ * This is a new attachment that is to be associated with a particular
+ * container/sample/subsample/template, as a result of the user uploading a
+ * file.
+ */
+export class NewlyUploadedAttachment implements Attachment {
+  id: AttachmentId;
+  globalId: ?GlobalId;
+  name: string;
+  size: Bytes;
+  link: ?Url;
+  file: ?File;
+  imageLink: ?Url;
+  chemicalString: string = "";
+  removed: boolean;
+  loadingImage: boolean = false;
+  loadingString: boolean = false;
+  contentMimeType: ?string;
+  onRemoveCallback: (Attachment) => void;
+  permalinkURL: ?Url;
+  owner: ?Person; // For the info button
+
+  constructor(
+    attrs: FromUpload,
+    permalinkURL: ?Url,
+    onRemoveCallback: (Attachment) => void
+  ) {
+    makeObservable(this, {
+      name: observable,
+      size: observable,
+      link: observable,
+      file: observable,
+      imageLink: observable,
+      chemicalString: observable,
+      removed: observable,
+      loadingImage: observable,
+      loadingString: observable,
+      permalinkURL: observable,
+      cardTypeLabel: computed,
+      deleted: computed,
+      recordTypeLabel: computed,
+      iconName: computed,
+      isImageFile: computed,
+      isChemicalFile: computed,
+      hasId: computed,
+      previewSupported: computed,
+      chemistrySupported: computed,
+      recordDetails: computed,
+      fetchChemicalImage: action,
+      fetchChemicalString: action,
+      setLoadingImage: action,
+      setLoadingString: action,
+      setImageLink: action,
+      setChemicalString: action,
+    });
+    this.id = attrs.id;
+    this.name = attrs.name;
+    this.owner = null;
+    this.size = attrs.size;
+    this.file = attrs.file;
+    this.globalId = null;
     this.removed = false;
     this.onRemoveCallback = onRemoveCallback;
     this.permalinkURL = permalinkURL;
@@ -329,8 +591,8 @@ export const newAttachment = (
   file: File,
   permalinkURL: ?Url,
   onRemoveCallback: (Attachment) => void
-): AttachmentModel => {
-  return new AttachmentModel(
+): NewlyUploadedAttachment => {
+  return new NewlyUploadedAttachment(
     {
       id: null,
       name: file.name,

--- a/src/main/webapp/ui/src/stores/models/FieldModel.js
+++ b/src/main/webapp/ui/src/stores/models/FieldModel.js
@@ -2,7 +2,8 @@
 
 import { action, observable, computed, makeObservable } from "mobx";
 import * as ArrayUtils from "../../util/ArrayUtils";
-import AttachmentModel, {
+import {
+  ExistingAttachment,
   type AttachmentAttrs,
   newAttachment,
 } from "./AttachmentModel";
@@ -169,7 +170,7 @@ export default class FieldModel implements Field {
     // have to do this setAttributes after because this.permalinkURL needs to be set
     if (attachment)
       this.setAttributes({
-        attachment: new AttachmentModel(
+        attachment: new ExistingAttachment(
           attachment,
           this.owner.id ? this.permalinkURL : "",
           (a) => {

--- a/src/main/webapp/ui/src/stores/models/Result.js
+++ b/src/main/webapp/ui/src/stores/models/Result.js
@@ -31,7 +31,7 @@ import {
 import { type BlobUrl } from "../stores/ImageStore";
 import getRootStore from "../stores/RootStore";
 import { mkAlert, type Alert } from "../contexts/Alert";
-import AttachmentModel from "./AttachmentModel";
+import { ExistingAttachment } from "./AttachmentModel";
 import ExtraFieldModel from "./ExtraFieldModel";
 import {
   type ExtraFieldAttrs,
@@ -363,7 +363,7 @@ export default class Result
     this.permittedActions = new Set(params.permittedActions);
     this.attachments = (params.attachments ?? []).map(
       (a) =>
-        new AttachmentModel(a, this.permalinkURL, () =>
+        new ExistingAttachment(a, this.permalinkURL, () =>
           this.setAttributesDirty({})
         )
     );

--- a/src/main/webapp/ui/src/stores/models/Result.js
+++ b/src/main/webapp/ui/src/stores/models/Result.js
@@ -1604,34 +1604,9 @@ export default class Result
   }
 
   async submitAttachmentChanges(): Promise<void> {
-    const toFormData = async (attachment: Attachment) => {
-      const fd = new FormData();
-      if (!attachment.file) throw new Error("File is not specified.");
-      const file = await attachment.getFile();
-      fd.append("file", file);
-      fd.append(
-        "fileSettings",
-        JSON.stringify({
-          fileName: attachment.name,
-          parentGlobalId: this.globalId,
-        })
-      );
-      return fd;
-    };
-
-    const newFiles = this.attachments
-      .filter((a) => !a.id && !a.removed)
-      .map((a) =>
-        toFormData(a).then((formData) => ApiService.post("files", formData))
-      );
-
-    await Promise.all([
-      ...newFiles,
-      ...this.attachments
-        .filter((a) => a.removed && a.id)
-        // $FlowExpectedError[incompatible-call] all have non-null id
-        .map((a) => ApiService.delete("files", a.id)),
-    ]);
+    if (!this.globalId) throw new Error("Global Id not known");
+    const g = this.globalId;
+    await Promise.all(this.attachments.map(a => a.save(g)));
   }
 
   get iconName(): string {

--- a/src/main/webapp/ui/src/stores/models/__tests__/AttachmentModel/getFile.test.js
+++ b/src/main/webapp/ui/src/stores/models/__tests__/AttachmentModel/getFile.test.js
@@ -4,14 +4,14 @@
 //@flow
 /* eslint-env jest */
 import "@testing-library/jest-dom";
-import AttachmentModel from "../../AttachmentModel";
+import { ExistingAttachment } from "../../AttachmentModel";
 import ApiService from "../../../../common/InvApiService";
 
 jest.mock("../../../stores/RootStore", () => {}); // break import cycle
 
 describe("getFile", () => {
   test("Should memoise the result, i.e. only fetch the file once.", async () => {
-    const attachment = new AttachmentModel(
+    const attachment = new ExistingAttachment(
       {
         id: 1,
         name: "foo.txt",


### PR DESCRIPTION
This is a completely non-functional change that refactors AttachmentModel into two separate classes to remove the conditional logic that toggles the behaviour based on whether the attachment has been persisted in the database or not.

This is in anticipation of the change to allow attachments to be chosen from the Gallery, which further adds permutations of the state that attachments can be in and thus more conditional logic.