### PR TITLE
Improve image retrieval performance 

### DIFF
--- a/src/main/java/com/researchspace/dao/FileMetadataDao.java
+++ b/src/main/java/com/researchspace/dao/FileMetadataDao.java
@@ -126,4 +126,8 @@ public interface FileMetadataDao extends GenericDao<FileProperty, Long> {
    * @return
    */
   FileStoreRoot getCurrentFileStoreRoot(boolean external);
+
+  boolean doesUserOwnDocWithHash(User user, String contentsHash);
+
+  FileProperty getImageFileByHash(String contentsHash);
 }

--- a/src/main/java/com/researchspace/dao/SampleDao.java
+++ b/src/main/java/com/researchspace/dao/SampleDao.java
@@ -101,4 +101,6 @@ public interface SampleDao extends GenericDao<Sample, Long> {
   void resetDefaultTemplateOwner();
 
   List<Sample> getAllUsingImage(FileProperty fileProperty);
+
+  List<Sample> getAllTemplatesUsingImage(FileProperty fileProperty);
 }

--- a/src/main/java/com/researchspace/dao/hibernate/FileMetadataHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FileMetadataHibernate.java
@@ -391,6 +391,7 @@ public class FileMetadataHibernate extends GenericDaoHibernate<FileProperty, Lon
     return getSession()
         .createQuery("from FileProperty where contentsHash = :contentsHash", FileProperty.class)
         .setParameter("contentsHash", contentsHash)
+        .setMaxResults(1)
         .getSingleResult();
   }
 }

--- a/src/main/java/com/researchspace/dao/hibernate/FileMetadataHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FileMetadataHibernate.java
@@ -337,4 +337,60 @@ public class FileMetadataHibernate extends GenericDaoHibernate<FileProperty, Lon
             .list();
     return results.isEmpty() ? null : results.get(0);
   }
+
+  @Override
+  public boolean doesUserOwnDocWithHash(User user, String contentsHash) {
+    long sampleHits =
+        (long)
+            getSession()
+                .createQuery(
+                    "select count(*) from Sample where owner = :user and"
+                        + " (imageFileProperty.contentsHash = :contentsHash or"
+                        + " thumbnailFileProperty.contentsHash = :contentsHash) ")
+                .setParameter("user", user)
+                .setParameter("contentsHash", contentsHash)
+                .getSingleResult();
+    if (sampleHits > 0) {
+      return true;
+    }
+
+    long subSampleHits =
+        (long)
+            getSession()
+                .createQuery(
+                    "select count(*) from SubSample where sample.owner = :user and"
+                        + " (imageFileProperty.contentsHash = :contentsHash or"
+                        + " thumbnailFileProperty.contentsHash = :contentsHash) ")
+                .setParameter("user", user)
+                .setParameter("contentsHash", contentsHash)
+                .getSingleResult();
+    if (subSampleHits > 0) {
+      return true;
+    }
+
+    long containerHits =
+        (long)
+            getSession()
+                .createQuery(
+                    "select count(*) from Container where owner = :user and"
+                        + " (imageFileProperty.contentsHash = :contentsHash or"
+                        + " thumbnailFileProperty.contentsHash = :contentsHash or"
+                        + " locationsImageFileProperty.contentsHash = :contentsHash) ")
+                .setParameter("user", user)
+                .setParameter("contentsHash", contentsHash)
+                .getSingleResult();
+    if (containerHits > 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public FileProperty getImageFileByHash(String contentsHash) {
+    return getSession()
+        .createQuery("from FileProperty where contentsHash = :contentsHash", FileProperty.class)
+        .setParameter("contentsHash", contentsHash)
+        .getSingleResult();
+  }
 }

--- a/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
@@ -311,6 +311,18 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
         .list();
   }
 
+  @Override
+  public List<Sample> getAllTemplatesUsingImage(FileProperty fileProperty) {
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery(
+            "from Sample where STemplate.imageFileProperty=:fileProperty OR"
+                + " STemplate.thumbnailFileProperty=:fileProperty",
+            Sample.class)
+        .setParameter("fileProperty", fileProperty)
+        .list();
+  }
+
   /*
    * ============
    *  for tests

--- a/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
@@ -316,8 +316,8 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
     return sessionFactory
         .getCurrentSession()
         .createQuery(
-            "from Sample where STemplate.imageFileProperty=:fileProperty OR"
-                + " STemplate.thumbnailFileProperty=:fileProperty",
+            "from Sample where template = true and (imageFileProperty=:fileProperty OR "
+                + "thumbnailFileProperty=:fileProperty)",
             Sample.class)
         .setParameter("fileProperty", fileProperty)
         .list();

--- a/src/main/java/com/researchspace/service/FileStoreMetaManager.java
+++ b/src/main/java/com/researchspace/service/FileStoreMetaManager.java
@@ -2,6 +2,7 @@ package com.researchspace.service;
 
 import com.researchspace.model.FileProperty;
 import com.researchspace.model.FileStoreRoot;
+import com.researchspace.model.User;
 import java.util.List;
 import java.util.Map;
 
@@ -17,4 +18,8 @@ public interface FileStoreMetaManager extends GenericManager<FileProperty, Long>
    * @return List of FileProperty matching wheres
    */
   List<FileProperty> findProperties(Map<String, String> wheres);
+
+  boolean doesUserOwnDocWithHash(User user, String contentsHash);
+
+  FileProperty getByHash(String contentsHash);
 }

--- a/src/main/java/com/researchspace/service/impl/FileStoreMetaManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/FileStoreMetaManagerImpl.java
@@ -3,6 +3,7 @@ package com.researchspace.service.impl;
 import com.researchspace.dao.FileMetadataDao;
 import com.researchspace.model.FileProperty;
 import com.researchspace.model.FileStoreRoot;
+import com.researchspace.model.User;
 import com.researchspace.service.FileStoreMetaManager;
 import java.util.List;
 import java.util.Map;
@@ -39,5 +40,15 @@ public class FileStoreMetaManagerImpl extends GenericManagerImpl<FileProperty, L
   @Override
   public List<FileProperty> findProperties(Map<String, String> searchCriteria) {
     return fileDao.findProperties(searchCriteria);
+  }
+
+  @Override
+  public boolean doesUserOwnDocWithHash(User user, String contentsHash) {
+    return fileDao.doesUserOwnDocWithHash(user, contentsHash);
+  }
+
+  @Override
+  public FileProperty getByHash(String contentsHash) {
+    return fileDao.getImageFileByHash(contentsHash);
   }
 }


### PR DESCRIPTION
As suggested and as a performance fix, check first if the user owns any record which references the image file being retrieved. 

If not split the next check for user having permissions to view (when they aren't owner) up by `InventoryRecord` type, starting with sample template which is the most likely way a user will access a file they do not own.