### PR TITLE
RSDEV-357 Allow searching for names that contain diacritics by using characters that don't have them

### DIFF
--- a/src/main/webapp/ui/src/my-rspace/directory/groups/UserList.js
+++ b/src/main/webapp/ui/src/my-rspace/directory/groups/UserList.js
@@ -40,7 +40,7 @@ class UserList extends React.Component {
         }`
       )
         .toUpperCase()
-        .includes(this.state.searchTerm.toUpperCase())
+        .includes(stripDiacritics(this.state.searchTerm.toUpperCase()))
     );
   };
 

--- a/src/main/webapp/ui/src/my-rspace/directory/groups/UserList.js
+++ b/src/main/webapp/ui/src/my-rspace/directory/groups/UserList.js
@@ -9,6 +9,7 @@ import Checkbox from "@mui/material/Checkbox";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
 import CardContent from "@mui/material/CardContent";
+import { stripDiacritics } from "../../../util/StringUtils";
 
 class UserList extends React.Component {
   constructor(props) {
@@ -33,7 +34,11 @@ class UserList extends React.Component {
 
   visibleUsers = () => {
     return this.props.users.filter((user) =>
-      `${user.username} ${user.displayName ? user.displayName : user.fullName}`
+      stripDiacritics(
+        `${user.username} ${
+          user.displayName ? user.displayName : user.fullName
+        }`
+      )
         .toUpperCase()
         .includes(this.state.searchTerm.toUpperCase())
     );

--- a/src/main/webapp/ui/src/system-groups/UserList.js
+++ b/src/main/webapp/ui/src/system-groups/UserList.js
@@ -61,8 +61,10 @@ export default function UserList(props): Node {
   }
 
   function filterVisibleUsers(search) {
-    let visible = props.users.filter((u) =>
-      stripDiacritics(userLabel(u)).toUpperCase().includes(search.toUpperCase())
+    const visible = props.users.filter((u) =>
+      stripDiacritics(userLabel(u))
+        .toUpperCase()
+        .includes(stripDiacritics(search.toUpperCase()))
     );
     setVisibleUsers(visible);
     unselectFilteredUsers(visible);

--- a/src/main/webapp/ui/src/system-groups/UserList.js
+++ b/src/main/webapp/ui/src/system-groups/UserList.js
@@ -9,6 +9,7 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Checkbox from "@mui/material/Checkbox";
 import UserDetails from "../components/UserDetails";
+import { stripDiacritics } from "../util/StringUtils";
 
 export default function UserList(props): Node {
   const [searchTerm, setSearchTerm] = React.useState("");
@@ -61,7 +62,7 @@ export default function UserList(props): Node {
 
   function filterVisibleUsers(search) {
     let visible = props.users.filter((u) =>
-      userLabel(u).toUpperCase().includes(search.toUpperCase())
+      stripDiacritics(userLabel(u)).toUpperCase().includes(search.toUpperCase())
     );
     setVisibleUsers(visible);
     unselectFilteredUsers(visible);

--- a/src/main/webapp/ui/src/util/StringUtils.js
+++ b/src/main/webapp/ui/src/util/StringUtils.js
@@ -1,0 +1,22 @@
+//@flow strict
+
+/**
+ * This function takes a string and removes any diacritics (accents). This is
+ * useful where we want to compare people's names with a query string inputted
+ * using anglo-centric keyboard, and any other use cases should be carefully
+ * considered to make sure that the resulting string is used correctly as it
+ * will no longer match the original.
+
+ * It does this by performing a Unicode decomposition to separate any code
+ * points that are latin characters and a diacritic into two code points, the
+ * character followed by the diacritic, and removing all of the code points
+ * within the Comblining Diacritical Marks Unicode block, leaving just the
+ * latin characters.
+ *
+ * Note that the resulting string may have a greater length than the original
+ * as the Unicode decomposition will convert ligatures into a sequence of latin
+ * characters.
+ */
+export function stripDiacritics(str: string): string {
+  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}

--- a/src/main/webapp/ui/src/util/__tests__/StringUtils/stripDiacritics.test.js
+++ b/src/main/webapp/ui/src/util/__tests__/StringUtils/stripDiacritics.test.js
@@ -1,0 +1,12 @@
+/*
+ * @jest-environment jsdom
+ */
+//@flow
+/* eslint-env jest */
+import { stripDiacritics } from "../../StringUtils";
+
+describe("stripDiacritics", () => {
+  test("Example", () => {
+    expect(stripDiacritics("Zoë")).toEqual("Zoe");
+  });
+});


### PR DESCRIPTION
This changes adds a little logic to the two places where searching for people's names is performed in the frontend code, allowing for a searcher to provide a query string that does not contain diacritics and still get results for names that do not contain such marks.