### PR TITLE
RSDEV-364 Fix setting attachments on new record as the preview image

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Container/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Container/NewRecordForm.js
@@ -152,7 +152,7 @@ export default function NewRecordForm(): Node {
           sectionName="attachments"
           recordType="container"
         >
-          <AttachmentsField />
+          <AttachmentsField fieldOwner={activeResult} />
         </StepperPanel>
         <StepperPanel
           title="Access Permissions"

--- a/src/main/webapp/ui/src/Inventory/Sample/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/NewRecordForm.js
@@ -238,7 +238,7 @@ function NewRecordForm(): Node {
           sectionName="attachments"
           recordType="sample"
         >
-          <AttachmentsField />
+          <AttachmentsField fieldOwner={activeResult} />
         </StepperPanel>
         <StepperPanel
           icon="sample"


### PR DESCRIPTION
When attaching a file to an Inventory record, there is a button to use that file as the preview image for the record. This button, however, was not working when creating new records as `fieldOwner` was not being passed to `AttachmentsField` in the two NewRecordForms that support Attachments (subsamples have no NewRecordForm and templates do not support attachments)