### PR TITLE
RSDEV-375 Submit ELN's "Create from Template" dialog with enter

### DIFF
--- a/src/main/webapp/scripts/tags/createFromTemplateDlg.js
+++ b/src/main/webapp/scripts/tags/createFromTemplateDlg.js
@@ -4,6 +4,30 @@
 
 var currentFolderId;
 
+function submit() {
+  var $selected = $('#createFromTemplateDlg .active:first');
+  if ($selected.length === 0) {
+    apprise('Please select a template by clicking on it');
+    return;
+  }
+
+  var templateId = $selected.data('id');
+  var docName = $("#createFromTemplateNameInput").val();
+
+  if (!docName || docName.trim().length === 0 || docName.match(/\//) ) {
+    apprise("Please enter a name - excluding '/' characters.");
+    return false;
+  }
+
+  var $form = $('#createFromTemplateForm');
+  $form.attr('action', "/workspace/editor/structuredDocument/createFromTemplate/" + currentFolderId);
+  $form.find('#createFromTemplateId').val(templateId);
+  $form.find('#createFromTemplateNewName').val(docName);
+  $form.submit();
+
+  RS.blockPage('Creating a document...');
+}
+
 function initCreateFromTemplateDlg() {
   $('#createFromTemplateDlg').dialog({
     modal : true,
@@ -17,27 +41,7 @@ function initCreateFromTemplateDlg() {
         text: 'Create',
         id: 'createFromTemplateDlgCreateBtn',
         click: function() { 
-          var $selected = $('#createFromTemplateDlg .active:first');
-          if ($selected.length === 0) {
-            apprise('Please select a template by clicking on it');
-            return;
-          }
-              
-          var templateId = $selected.data('id');
-          var docName = $("#createFromTemplateNameInput").val();
-              
-          if (!docName || docName.trim().length === 0 || docName.match(/\//) ) {
-            apprise("Please enter a name - excluding '/' characters.");
-            return false;
-          }
-              
-          var $form = $('#createFromTemplateForm');
-          $form.attr('action', "/workspace/editor/structuredDocument/createFromTemplate/" + currentFolderId);
-          $form.find('#createFromTemplateId').val(templateId);
-          $form.find('#createFromTemplateNewName').val(docName);                    
-          $form.submit();
-          
-          RS.blockPage('Creating a document...');
+          submit();
         }
       }
     },
@@ -47,6 +51,11 @@ function initCreateFromTemplateDlg() {
   });
     
   $('#templateDlgTabs').tabs();
+
+  $('#createFromTemplateNameForm').submit(function() {
+    submit();
+    return false;
+  });
   
   $('#templateFilterForm').submit(function() {
     var filterTerm = $('#templateFilterInput').val();


### PR DESCRIPTION
The dialog is broken up into three separate forms:
1. One for filtering the template picker
2. One for typing in a name
3. One for actually making the network call

This change wires up the submit event of the second to the third so that pressing the enter key after typing in a name for the template the network call is made and the user is redirected to their new document, just as if they had tapped the 'Create' button