### PR TITLE
RSDEV-284: support for OpenID Connect as SSO provider

### DIFF
--- a/DevDocs/public/RSpaceConfiguration.md
+++ b/DevDocs/public/RSpaceConfiguration.md
@@ -410,7 +410,7 @@ These optional settings will enable you to import user data from LDAP, or enable
 ### SSO configuration
 Set these properties to configure RSpace to run in SSO mode e.g. for Shibboleth integration. There may be further integration work needed with Apache headers/redirects etc. to get this working.
 * **deployment.standalone** true /false. Set to false to enable SSO integration. Default is true.
-* **deployment.sso.type=SAML** if single sign-on is configured (if deployment.standalone=false) , this property switches authentication filter to SAML.
+* **deployment.sso.type** if single sign-on is configured (if deployment.standalone=false), this property must switch authentication filter to 'SAML' (default) or 'openid'.
 * **deployment.sso.logout.url** the URL to redirect to after logout from RSpace. There is no default. If this is not set, users will get an error page after logging out.
 * **user.signup.acceptedDomains**  restricts self sign-up for users in SSO environments.
 * **deployment.sso.ssoInfoVariant** Sets a custom "RSpace doesn't know you " page when self-signup is disabled. Default is unset. Requires custom page for RSpace.

--- a/DevDocs/public/RSpaceConfiguration.md
+++ b/DevDocs/public/RSpaceConfiguration.md
@@ -411,7 +411,8 @@ These optional settings will enable you to import user data from LDAP, or enable
 Set these properties to configure RSpace to run in SSO mode e.g. for Shibboleth integration. There may be further integration work needed with Apache headers/redirects etc. to get this working.
 * **deployment.standalone** true /false. Set to false to enable SSO integration. Default is true.
 * **deployment.sso.type** if single sign-on is configured (if deployment.standalone=false), this property must switch authentication filter to 'SAML' (default) or 'openid'.
-* **deployment.sso.logout.url** the URL to redirect to after logout from RSpace. There is no default. If this is not set, users will get an error page after logging out.
+* **deployment.sso.logout.url** the URL to redirect to after logout from RSpace. Default is 'You're logged out' page.
+* **deployment.sso.idp.logout.url** the URL presented to the user on 'You're logged out' page, which should point to a link that ends the global SSO session with IDP. No default. 
 * **user.signup.acceptedDomains**  restricts self sign-up for users in SSO environments.
 * **deployment.sso.ssoInfoVariant** Sets a custom "RSpace doesn't know you " page when self-signup is disabled. Default is unset. Requires custom page for RSpace.
 * **deployment.sso.adminEmail** Sets the support email address for matters relating to accounts managed by SSO.

--- a/src/main/java/com/axiope/service/cfg/ProductionConfig.java
+++ b/src/main/java/com/axiope/service/cfg/ProductionConfig.java
@@ -33,6 +33,7 @@ import com.researchspace.service.impl.license.NoCheckLicenseService;
 import com.researchspace.spring.taskexecutors.ShiroThreadBindingSubjectThreadPoolExecutor;
 import com.researchspace.webapp.filter.EASERemoteUserPolicy;
 import com.researchspace.webapp.filter.MockRemoteUserPolicy;
+import com.researchspace.webapp.filter.OpenIdRemoteUserPolicy;
 import com.researchspace.webapp.filter.RemoteUserRetrievalPolicy;
 import com.researchspace.webapp.filter.SAMLRemoteUserPolicy;
 import java.nio.file.Files;
@@ -282,6 +283,8 @@ public class ProductionConfig extends BaseConfig {
   protected RemoteUserRetrievalPolicy remoteUserRetrievalPolicy() {
     if ("SAML".equals(deploymentSsoType)) {
       return new SAMLRemoteUserPolicy();
+    } else if ("openid".equals(deploymentSsoType)) {
+      return new OpenIdRemoteUserPolicy();
     } else if ("TEST".equals(deploymentSsoType)) {
       return new MockRemoteUserPolicy();
     } else {

--- a/src/main/java/com/axiope/service/cfg/ProductionConfig.java
+++ b/src/main/java/com/axiope/service/cfg/ProductionConfig.java
@@ -281,11 +281,11 @@ public class ProductionConfig extends BaseConfig {
 
   @Bean
   protected RemoteUserRetrievalPolicy remoteUserRetrievalPolicy() {
-    if ("SAML".equals(deploymentSsoType)) {
+    if ("SAML".equalsIgnoreCase(deploymentSsoType)) {
       return new SAMLRemoteUserPolicy();
-    } else if ("openid".equals(deploymentSsoType)) {
+    } else if ("openid".equalsIgnoreCase(deploymentSsoType)) {
       return new OpenIdRemoteUserPolicy();
-    } else if ("TEST".equals(deploymentSsoType)) {
+    } else if ("TEST".equalsIgnoreCase(deploymentSsoType)) {
       return new MockRemoteUserPolicy();
     } else {
       return new EASERemoteUserPolicy();

--- a/src/main/java/com/researchspace/auth/MaintenanceLoginAuthorizer.java
+++ b/src/main/java/com/researchspace/auth/MaintenanceLoginAuthorizer.java
@@ -6,6 +6,7 @@ import com.researchspace.model.User;
 import java.io.IOException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class MaintenanceLoginAuthorizer extends AbstractLoginAuthorizer implements LoginAuthorizer {
@@ -13,7 +14,8 @@ public class MaintenanceLoginAuthorizer extends AbstractLoginAuthorizer implemen
   public static final String REDIRECT_FOR_MAINTENANCE = "/public/maintenanceInProgress";
   public static final String MAINTENANCE_LOGIN_REQUEST_PARAM = "maintenanceLogin";
 
-  private @Autowired MaintenanceManager maintenanceMgr;
+  @Autowired @Setter // for testing
+  private MaintenanceManager maintenanceMgr;
 
   @Override
   public boolean isLoginPermitted(ServletRequest request, ServletResponse response, User subject)
@@ -34,13 +36,5 @@ public class MaintenanceLoginAuthorizer extends AbstractLoginAuthorizer implemen
 
   private boolean containsMaintenanceLoginParameter(ServletRequest request) {
     return request.getParameter(MAINTENANCE_LOGIN_REQUEST_PARAM) != null;
-  }
-
-  /* ======================
-   *     for tests
-   * ===================== */
-
-  public void setMaintenanceMgr(MaintenanceManager maintenanceMgr) {
-    this.maintenanceMgr = maintenanceMgr;
   }
 }

--- a/src/main/java/com/researchspace/properties/IPropertyHolder.java
+++ b/src/main/java/com/researchspace/properties/IPropertyHolder.java
@@ -52,6 +52,11 @@ public interface IPropertyHolder extends Versionable {
   String getSSOLogoutUrl();
 
   /**
+   * @return address which completely logs user out of their SSO IDP
+   */
+  String getSSOIdpLogoutUrl();
+
+  /**
    * Returns boolean value of <code>deployment.sso.adminLogin.enabled</code> property.
    *
    * @return

--- a/src/main/java/com/researchspace/properties/PropertyHolder.java
+++ b/src/main/java/com/researchspace/properties/PropertyHolder.java
@@ -143,6 +143,9 @@ public class PropertyHolder implements IMutablePropertyHolder {
   @Value("${deployment.sso.logout.url}")
   private String ssoLogoutUrl;
 
+  @Value("${deployment.sso.idp.logout.url}")
+  private String ssoIdpLogoutUrl;
+
   @Value("${deployment.sso.adminLogin.enabled}")
   private Boolean ssoAdminLoginEnabled;
 
@@ -390,6 +393,11 @@ public class PropertyHolder implements IMutablePropertyHolder {
   @Override
   public String getSSOLogoutUrl() {
     return ssoLogoutUrl;
+  }
+
+  @Override
+  public String getSSOIdpLogoutUrl() {
+    return ssoIdpLogoutUrl;
   }
 
   @Override

--- a/src/main/java/com/researchspace/webapp/filter/AbstractSsoRemoteUserPolicy.java
+++ b/src/main/java/com/researchspace/webapp/filter/AbstractSsoRemoteUserPolicy.java
@@ -1,0 +1,50 @@
+package com.researchspace.webapp.filter;
+
+import com.researchspace.model.permissions.SecurityLogger;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Translates OpenId claims form httpRequest headers into user information */
+public abstract class AbstractSsoRemoteUserPolicy implements RemoteUserRetrievalPolicy {
+
+  protected static final Logger SECURITY_LOG = LoggerFactory.getLogger(SecurityLogger.class);
+
+  @Override
+  public String getPassword() {
+    return SSO_DUMMY_PASSWORD;
+  }
+
+  @Override
+  public Map<RemoteUserAttribute, String> getOtherRemoteAttributes(HttpServletRequest httpRequest) {
+    return Collections.emptyMap();
+  }
+
+  protected StringBuilder logHeaders(HttpServletRequest httpRequest) {
+    StringBuilder sb = new StringBuilder();
+    for (String header : Collections.list(httpRequest.getHeaderNames())) {
+      sb.append(header + ":" + httpRequest.getHeader(header) + ", ");
+    }
+    return sb;
+  }
+
+  protected StringBuilder logReqAttributes(HttpServletRequest httpRequest) {
+    Enumeration<String> attrNames = httpRequest.getAttributeNames();
+    StringBuilder sb = new StringBuilder();
+    while (attrNames.hasMoreElements()) {
+      String attr = attrNames.nextElement();
+      sb.append(attr + ":" + httpRequest.getAttribute(attr).toString() + ", ");
+    }
+    return sb;
+  }
+
+  protected StringBuilder logEnv() {
+    StringBuilder sb = new StringBuilder();
+    System.getenv().entrySet().stream()
+        .forEach(e -> sb.append(e.getKey() + ":" + e.getValue() + ", "));
+    return sb;
+  }
+}

--- a/src/main/java/com/researchspace/webapp/filter/EASERemoteUserPolicy.java
+++ b/src/main/java/com/researchspace/webapp/filter/EASERemoteUserPolicy.java
@@ -1,41 +1,31 @@
 package com.researchspace.webapp.filter;
 
-import com.researchspace.model.permissions.SecurityLogger;
 import javax.servlet.http.HttpServletRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 
 /** Gets the EASE username based on HttpHeader information. */
-public class EASERemoteUserPolicy implements RemoteUserRetrievalPolicy {
+public class EASERemoteUserPolicy extends AbstractSsoRemoteUserPolicy {
 
   @Value("${deployment.REMOTE_HEADER_NAME_FROM_PROPERTY}")
   private String remoteUserProperty;
 
   protected static final String RMU_HEADER = "REMOTE_USER";
 
-  private static final Logger log = LoggerFactory.getLogger(SecurityLogger.class);
-
   @Override
   public String getRemoteUser(HttpServletRequest httpRequest) {
     if (remoteUserProperty == null) {
       remoteUserProperty = RMU_HEADER;
-      log.debug(
+      SECURITY_LOG.debug(
           "Warning: remote user key not set from the property file, using default: {}",
           remoteUserProperty);
     }
     String remoteUser = httpRequest.getHeader(remoteUserProperty);
-    log.info("[{}] header from HttpRequest: ", remoteUserProperty, remoteUser);
+    SECURITY_LOG.info("[{}] header from HttpRequest: {}", remoteUserProperty, remoteUser);
 
     if (remoteUser == null) {
       remoteUser = httpRequest.getRemoteUser();
-      log.info("HttpRequest.getRemoteUser(): {}", remoteUser);
+      SECURITY_LOG.info("HttpRequest.getRemoteUser(): {}", remoteUser);
     }
     return remoteUser;
-  }
-
-  @Override
-  public String getPassword() {
-    return SSO_DUMMY_PASSWORD;
   }
 }

--- a/src/main/java/com/researchspace/webapp/filter/MockRemoteUserPolicy.java
+++ b/src/main/java/com/researchspace/webapp/filter/MockRemoteUserPolicy.java
@@ -9,13 +9,10 @@ import org.springframework.beans.factory.annotation.Value;
  * Use this in dev/ test environments to set in a remote username/password using a default property
  * name
  */
-public class MockRemoteUserPolicy implements RemoteUserRetrievalPolicy {
+public class MockRemoteUserPolicy extends AbstractSsoRemoteUserPolicy {
 
   @Value("${mock.remote.username:}")
   private String username = "user1a";
-
-  @Value("${default.user.password}")
-  private String password;
 
   @Value("${mock.remote.email:somebody@somwhere.com}")
   private String email = "somebody@somwhere.com";
@@ -35,17 +32,12 @@ public class MockRemoteUserPolicy implements RemoteUserRetrievalPolicy {
   }
 
   @Override
-  public String getPassword() {
-    return password;
-  }
-
-  @Override
-  public Map<String, String> getOtherRemoteAttributes(HttpServletRequest httpRequest) {
-    Map<String, String> rc = new TreeMap<>();
-    rc.put("mail", email);
-    rc.put("Shib-surName", lastName);
-    rc.put("Shib-givenName", firstName);
-    rc.put("isAllowedPiRole", isAllowedPiRole);
+  public Map<RemoteUserAttribute, String> getOtherRemoteAttributes(HttpServletRequest httpRequest) {
+    Map<RemoteUserAttribute, String> rc = new TreeMap<>();
+    rc.put(RemoteUserAttribute.EMAIL, email);
+    rc.put(RemoteUserAttribute.FIRST_NAME, firstName);
+    rc.put(RemoteUserAttribute.LAST_NAME, lastName);
+    rc.put(RemoteUserAttribute.IS_ALLOWED_PI_ROLE, isAllowedPiRole);
 
     return rc;
   }
@@ -56,10 +48,6 @@ public class MockRemoteUserPolicy implements RemoteUserRetrievalPolicy {
 
   public void setUsername(String username) {
     this.username = username;
-  }
-
-  void setPassword(String pword) {
-    this.password = pword;
   }
 
   void setIsAllowedPiRole(String isAllowedPiRole) {

--- a/src/main/java/com/researchspace/webapp/filter/OpenIdRemoteUserPolicy.java
+++ b/src/main/java/com/researchspace/webapp/filter/OpenIdRemoteUserPolicy.java
@@ -1,0 +1,102 @@
+package com.researchspace.webapp.filter;
+
+import com.researchspace.core.util.CryptoUtils;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+
+/** Translates OpenId claims form httpRequest headers into user information */
+@Slf4j
+@Setter(AccessLevel.PACKAGE)
+public class OpenIdRemoteUserPolicy extends AbstractSsoRemoteUserPolicy {
+
+  private static final String ADDITIONAL_CLAIMS_SEPARATOR = ".";
+
+  @Value("${deployment.sso.openid.usernameClaim}")
+  private String usernameClaim;
+
+  @Value("${deployment.sso.openid.additionalUsernameClaim}")
+  private String additionalUsernameClaim;
+
+  @Value("${deployment.sso.openid.additionalHashedUsernameClaim}")
+  private String additionalHashedUsernameClaim;
+
+  @Value("${deployment.sso.openid.additionalUsernameClaimLength}")
+  private int additionalUsernameClaimLength = 4;
+
+  @Value("${deployment.sso.openid.emailClaim}")
+  private String emailClaim;
+
+  @Value("${deployment.sso.openid.firstNameClaim}")
+  private String firstNameClaim;
+
+  @Value("${deployment.sso.openid.lastNameClaim}")
+  private String lastNameClaim;
+
+  @Override
+  public String getRemoteUser(HttpServletRequest httpRequest) {
+    log.debug("Req headers: {}", logHeaders(httpRequest));
+    String username = getOpenIdUsernameFromRequestClaims(httpRequest);
+    log.info("Logging in remote user: {}", username);
+    return username;
+  }
+
+  private String getOpenIdUsernameFromRequestClaims(HttpServletRequest httpRequest) {
+    log.debug("using usernameClaim: {}", usernameClaim);
+    log.debug("using additionalUsernameClaim: {}", additionalUsernameClaim);
+    log.debug("using additionalHashedUsernameClaim: {}", additionalHashedUsernameClaim);
+
+    String username = httpRequest.getHeader(usernameClaim);
+
+    // additional claim
+    if (StringUtils.isNotEmpty(additionalUsernameClaim)) {
+      String additionalClaim = httpRequest.getHeader(additionalUsernameClaim);
+      if (StringUtils.length(additionalClaim) > additionalUsernameClaimLength) {
+        additionalClaim = StringUtils.substring(additionalClaim, 0, additionalUsernameClaimLength);
+      }
+      if (StringUtils.isNotEmpty(additionalClaim)) {
+        username += ADDITIONAL_CLAIMS_SEPARATOR + additionalClaim;
+      }
+    }
+
+    // additional hashed claim
+    if (StringUtils.isNotEmpty(additionalHashedUsernameClaim)) {
+      String additionalHashedClaim = httpRequest.getHeader(additionalHashedUsernameClaim);
+      if (StringUtils.isNotEmpty(additionalHashedClaim)) {
+        additionalHashedClaim = CryptoUtils.hashWithSha256inHex(additionalHashedClaim);
+        username +=
+            ADDITIONAL_CLAIMS_SEPARATOR
+                + StringUtils.substring(additionalHashedClaim, 0, additionalUsernameClaimLength);
+      }
+    }
+
+    return username;
+  }
+
+  @Override
+  public Map<RemoteUserAttribute, String> getOtherRemoteAttributes(HttpServletRequest httpRequest) {
+    Map<RemoteUserAttribute, String> rc = new TreeMap<>();
+
+    String mail = httpRequest.getHeader(emailClaim);
+    if (!StringUtils.isBlank(mail)) {
+      rc.put(RemoteUserAttribute.EMAIL, mail);
+    }
+
+    String firstName = httpRequest.getHeader(firstNameClaim);
+    if (!StringUtils.isBlank(firstName)) {
+      rc.put(RemoteUserAttribute.FIRST_NAME, firstName);
+    }
+
+    String lastName = httpRequest.getHeader(lastNameClaim);
+    if (!StringUtils.isBlank(lastName)) {
+      rc.put(RemoteUserAttribute.LAST_NAME, lastName);
+    }
+
+    return rc;
+  }
+}

--- a/src/main/java/com/researchspace/webapp/filter/OpenIdRemoteUserPolicy.java
+++ b/src/main/java/com/researchspace/webapp/filter/OpenIdRemoteUserPolicy.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 /** Translates OpenId claims form httpRequest headers into user information */
 @Slf4j
-@Setter(AccessLevel.PACKAGE)
+@Setter(AccessLevel.PROTECTED)
 public class OpenIdRemoteUserPolicy extends AbstractSsoRemoteUserPolicy {
 
   private static final String ADDITIONAL_CLAIMS_SEPARATOR = ".";

--- a/src/main/java/com/researchspace/webapp/filter/RemoteUserRetrievalPolicy.java
+++ b/src/main/java/com/researchspace/webapp/filter/RemoteUserRetrievalPolicy.java
@@ -1,6 +1,5 @@
 package com.researchspace.webapp.filter;
 
-import java.util.Collections;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
@@ -16,6 +15,13 @@ public interface RemoteUserRetrievalPolicy {
    */
   String SSO_DUMMY_PASSWORD = "user1234";
 
+  public enum RemoteUserAttribute {
+    FIRST_NAME,
+    LAST_NAME,
+    EMAIL,
+    IS_ALLOWED_PI_ROLE
+  }
+
   /**
    * Supplied with an {@link HttpServletRequest}, this method will attempt to extract the remote
    * user name.
@@ -28,7 +34,7 @@ public interface RemoteUserRetrievalPolicy {
   /**
    * Because the database requires a password for non SSO environments, in most SSO implementations
    * this will return a dummy placeholder value, since RSpace will never actually know the real SSO
-   * password (and nor should we).
+   * password (and nor should it).
    *
    * <p>For signing/verification password, see details of RSPAC-1206
    *
@@ -39,7 +45,5 @@ public interface RemoteUserRetrievalPolicy {
   /**
    * Get a map of additional remote attributes Default behaviour is to return an immutable empty map
    */
-  default Map<String, String> getOtherRemoteAttributes(HttpServletRequest httpRequest) {
-    return Collections.emptyMap();
-  }
+  Map<RemoteUserAttribute, String> getOtherRemoteAttributes(HttpServletRequest httpRequest);
 }

--- a/src/main/java/com/researchspace/webapp/filter/SAMLRemoteUserPolicy.java
+++ b/src/main/java/com/researchspace/webapp/filter/SAMLRemoteUserPolicy.java
@@ -1,24 +1,18 @@
 package com.researchspace.webapp.filter;
 
-import com.researchspace.model.permissions.SecurityLogger;
-import java.util.Enumeration;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Gets the Shibboleth remote username based on HttpHeader information. */
-public class SAMLRemoteUserPolicy implements RemoteUserRetrievalPolicy {
+public class SAMLRemoteUserPolicy extends AbstractSsoRemoteUserPolicy {
 
   protected static final String SHIBBOLETH_ID_ATTRIBUTE = "eduPersonPrincipalName";
 
-  private static final Logger log = LoggerFactory.getLogger(SecurityLogger.class);
-
-  // don't alter, edit or remove these as they may be used in production deployments
-  // only add new values if needed.
-  static final String[] shib_attributes = {
+  /* don't alter, edit or remove these as they may be used in production deployments;
+  only add new values if needed. */
+  private static final String[] shib_attributes = {
     "persistent-id",
     "eppn",
     "mail",
@@ -40,71 +34,57 @@ public class SAMLRemoteUserPolicy implements RemoteUserRetrievalPolicy {
   @Override
   public String getRemoteUser(HttpServletRequest httpRequest) {
 
-    log.debug("Req headers: {}", logHeaders(httpRequest).toString());
-    log.debug("Environment variables: {}", logEnv().toString());
-    log.debug("Attributes: {}", logReqAttributes(httpRequest).toString());
-    log.debug("SAML attributes: {}", logSamlAttributes(httpRequest).toString());
-    log.debug("Remote user:  {}", httpRequest.getRemoteUser());
+    SECURITY_LOG.debug("Req headers: {}", logHeaders(httpRequest));
+    SECURITY_LOG.debug("Environment variables: {}", logEnv());
+    SECURITY_LOG.debug("Attributes: {}", logReqAttributes(httpRequest));
+    SECURITY_LOG.debug("SAML attributes: {}", logSamlAttributes(httpRequest));
+    SECURITY_LOG.debug("Remote user:  {}", httpRequest.getRemoteUser());
     Object username = httpRequest.getAttribute(SHIBBOLETH_ID_ATTRIBUTE);
-    log.info("SAML [{}] attribute from HttpRequest: {}", SHIBBOLETH_ID_ATTRIBUTE, username);
+    SECURITY_LOG.info(
+        "SAML [{}] attribute from HttpRequest: {}", SHIBBOLETH_ID_ATTRIBUTE, username);
 
     if (username == null) {
       username = httpRequest.getAttribute("eppn");
-      log.info("SAML [eppn] attribute from HttpRequest: {}", username);
+      SECURITY_LOG.info("SAML [eppn] attribute from HttpRequest: {}", username);
     }
     return username == null ? null : username.toString();
   }
 
-  private Object logReqAttributes(HttpServletRequest httpRequest) {
-    Enumeration<String> attrNames = httpRequest.getAttributeNames();
-    StringBuilder sb = new StringBuilder();
-    while (attrNames.hasMoreElements()) {
-      String attr = attrNames.nextElement();
-      sb.append(attr + ":" + httpRequest.getAttribute(attr).toString() + ", ");
+  @Override
+  public Map<RemoteUserAttribute, String> getOtherRemoteAttributes(HttpServletRequest httpRequest) {
+    Map<RemoteUserAttribute, String> rc = new TreeMap<>();
+
+    String mail = (String) httpRequest.getAttribute("mail");
+    if (StringUtils.isBlank(mail)) {
+      mail = (String) httpRequest.getAttribute("Shib-email");
     }
-    return sb;
+    if (!StringUtils.isBlank(mail)) {
+      rc.put(RemoteUserAttribute.EMAIL, mail);
+    }
+
+    String givenName = (String) httpRequest.getAttribute("Shib-givenName");
+    if (!StringUtils.isBlank(givenName)) {
+      rc.put(RemoteUserAttribute.FIRST_NAME, givenName);
+    }
+
+    String surName = (String) httpRequest.getAttribute("Shib-surName");
+    if (!StringUtils.isBlank(surName)) {
+      rc.put(RemoteUserAttribute.LAST_NAME, surName);
+    }
+
+    String isAllowedPiRole = (String) httpRequest.getAttribute("isAllowedPiRole");
+    if (!StringUtils.isBlank(isAllowedPiRole)) {
+      rc.put(RemoteUserAttribute.IS_ALLOWED_PI_ROLE, isAllowedPiRole);
+    }
+
+    return rc;
   }
 
   private Object logSamlAttributes(HttpServletRequest httpRequest) {
     StringBuilder sb = new StringBuilder();
-    /* names of the SAML attributes to display */
-
-    for (int i = 0; i < shib_attributes.length; i++) {
-      sb.append(shib_attributes[i] + " : " + httpRequest.getAttribute(shib_attributes[i]) + ", ");
+    for (String shibAttribute : shib_attributes) {
+      sb.append(shibAttribute + " : " + httpRequest.getAttribute(shibAttribute) + ", ");
     }
     return sb;
-  }
-
-  private StringBuilder logEnv() {
-    StringBuilder sb = new StringBuilder();
-    System.getenv().entrySet().stream()
-        .forEach(e -> sb.append(e.getKey() + ":" + e.getValue() + ", "));
-    return sb;
-  }
-
-  private StringBuilder logHeaders(HttpServletRequest httpRequest) {
-    Enumeration<String> headrenames = httpRequest.getHeaderNames();
-    StringBuilder sb = new StringBuilder();
-    while (headrenames.hasMoreElements()) {
-      String header = headrenames.nextElement();
-      sb.append(header + ":" + httpRequest.getHeader(header) + ", ");
-    }
-    return sb;
-  }
-
-  @Override
-  public String getPassword() {
-    return SSO_DUMMY_PASSWORD;
-  }
-
-  public Map<String, String> getOtherRemoteAttributes(HttpServletRequest httpRequest) {
-    Map<String, String> rc = new TreeMap<>();
-    for (String attribute : shib_attributes) {
-      String value = (String) httpRequest.getAttribute(attribute);
-      if (!StringUtils.isBlank(value)) {
-        rc.put(attribute, value);
-      }
-    }
-    return rc;
   }
 }

--- a/src/main/java/com/researchspace/webapp/filter/SSOShiroFormAuthFilterExt.java
+++ b/src/main/java/com/researchspace/webapp/filter/SSOShiroFormAuthFilterExt.java
@@ -5,6 +5,7 @@ import com.researchspace.auth.SSOAuthenticationToken;
 import com.researchspace.model.SignupSource;
 import com.researchspace.model.User;
 import com.researchspace.webapp.controller.SignupController;
+import com.researchspace.webapp.filter.RemoteUserRetrievalPolicy.RemoteUserAttribute;
 import java.io.IOException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -100,10 +101,10 @@ public class SSOShiroFormAuthFilterExt extends BaseShiroFormAuthFilterExt {
         return false;
       }
 
-      boolean maintenanceLogin =
+      boolean maintenancePermitsLogin =
           maintenanceLoginAuthorizer.isLoginPermitted(httpRequest, response, user);
       boolean userEnabled = accountEnabledAuthorizer.isLoginPermitted(request, response, user);
-      if (maintenanceLogin && userEnabled) {
+      if (maintenancePermitsLogin && userEnabled) {
         AuthenticationToken token = new SSOAuthenticationToken(user.getUsername());
         Subject subject = SecurityUtils.getSubject();
         subject.login(token); // not call onLogSucess methods at all
@@ -146,7 +147,9 @@ public class SSOShiroFormAuthFilterExt extends BaseShiroFormAuthFilterExt {
     // RSPAC-2588
     if (properties.isSSOSelfDeclarePiEnabled()) {
       String isAllowedPiRoleParam =
-          remoteUserPolicy.getOtherRemoteAttributes(request).get("isAllowedPiRole");
+          remoteUserPolicy
+              .getOtherRemoteAttributes(request)
+              .get(RemoteUserAttribute.IS_ALLOWED_PI_ROLE);
       if (StringUtils.isEmpty(isAllowedPiRoleParam)) {
         log.info(
             "deployment property 'deployment.sso.selfDeclarePI.enabled' is set to true, "

--- a/src/main/resources/bundles/workspace/workspace.properties
+++ b/src/main/resources/bundles/workspace/workspace.properties
@@ -67,7 +67,7 @@ dialogs.pdfArchiving.label.dateFormat=Timestamp format for date footer
 dialogs.pdfArchiving.label.footer=Insert date footer at file end only
 dialogs.pdfArchiving.label.fileName=Name your file
 workspace.export.msgSuccess=Your export [{0}] is now available in the Exports section of <a href="{1}">the Gallery</a>.
-workspace.export.msgFailure=Your export [{0}] failed for the following reason : {1}.
+workspace.export.msgFailure=Your export [{0}] failed for the following reason: {1}.
 workspace.export.noDiskSpace=RSpace has not enough disk space to start archive export process. Please contact your System Admin.
 pdfArchiving.submission.successMsg=Your export generation request has been submitted to the server. \
  RSpace will notify you when the export is ready.

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -322,6 +322,7 @@ username.length.min=6
 # supported sso type values are SAML or openid
 deployment.sso.type=
 deployment.sso.logout.url=/public/ssologout
+deployment.sso.idp.logout.url=
 # customer-specific sso info page. See RSPAC-1218.
 deployment.sso.ssoInfoVariant=
 # backdoor login and backdoor sysadmin creation for SSO. See RSPAC-2189.

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -319,6 +319,7 @@ deployment.cloud=false
 ## RSPAC-2173. Overridable minimum username length
 username.length.min=6
 
+# supported sso type values are SAML or openid
 deployment.sso.type=
 deployment.sso.logout.url=/public/ssologout
 # customer-specific sso info page. See RSPAC-1218.
@@ -332,6 +333,16 @@ deployment.sso.selfDeclarePI.enabled=false
 deployment.sso.adminEmail=support@<your_server>.com
 # enables mechanism for correcting encoding of names within SSO-SAML response. See RSPAC-2209
 deployment.sso.recodeIncomingFirstNameLastNameToUtf8=true
+
+# openid claims used to construct unique, stable username. See RSDEV-284
+deployment.sso.openid.usernameClaim=OIDC_CLAIM_sub
+deployment.sso.openid.additionalUsernameClaim=
+deployment.sso.openid.additionalHashedUsernameClaim=OIDC_CLAIM_iss
+deployment.sso.openid.additionalUsernameClaimLength=4
+# openid claims used to populate signup page. See RSDEV-284
+deployment.sso.openid.emailClaim=OIDC_CLAIM_email
+deployment.sso.openid.firstNameClaim=OIDC_CLAIM_given_name
+deployment.sso.openid.lastNameClaim=OIDC_CLAIM_family_name
 
 ## Must be set if running with Aspose at all.
 aspose.enabled=true

--- a/src/main/resources/deployments/dev/deployment.properties
+++ b/src/main/resources/deployments/dev/deployment.properties
@@ -25,6 +25,7 @@ ui.bannerImage.loggedOutUrl=https://www.bbc.com/
 #deployment.sso.adminLogin.enabled=true
 #deployment.sso.backdoorUserCreation.enabled=true
 #deployment.sso.selfDeclarePI.enabled=true
+#deployment.sso.idp.logout.url=https://researchspace.com
 
 onedrive.client.id=
 onedrive.redirect=

--- a/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -79,16 +79,16 @@
 	<mvc:view-controller path="/import/archiveImport" view-name="import/archiveImport" />
 	<mvc:view-controller path="/import/archiveImportReport" view-name="import/archiveImportReport" />
 	<mvc:view-controller path="/styleGuide" view-name="styleGuide/styleGuide" />
-    <mvc:view-controller path="/tools" view-name="tools/tools" />
+	<mvc:view-controller path="/tools" view-name="tools/tools" />
 	<mvc:view-controller path="/admin" view-name="admin/admin" />
 	<mvc:view-controller path="/public/signupConfirmation" view-name="public/signupConfirmation" />
 	<mvc:view-controller path="/public/awaitingAuthorisation" view-name="public/awaitingAuthorisation" />
 	<mvc:view-controller path="/public/accountDisabled" view-name="public/accountDisabled" />
 	<mvc:view-controller path="/public/requestPasswordReset" view-name="public/requestPasswordReset" />
 	<mvc:view-controller path="/public/requestUsernameReminder" view-name="public/requestUsernameReminder" />
-    <mvc:view-controller path="/public/maintenanceInProgress" view-name="public/maintenanceInProgress" />
+	<mvc:view-controller path="/public/maintenanceInProgress" view-name="public/maintenanceInProgress" />
 	<mvc:view-controller path="/public/terms" view-name="public/terms" />
-    <mvc:view-controller path="/public/ssoinfo" view-name="public/ssoinfo" />
+	<mvc:view-controller path="/public/ssoinfo" view-name="public/ssoinfo" />
 	<mvc:view-controller path="/public/ssologout" view-name="public/ssologout" />
 	<mvc:view-controller path="/public/ipAddressInvalid" view-name="public/ipAddressInvalid" />
 	<mvc:view-controller path="/public/apiDocs" view-name="public/apiDocs" />
@@ -96,7 +96,7 @@
 	<mvc:view-controller path="/admin/cloud/createCloudGroupSuccess" view-name="admin/cloud/createCloudGroupSuccess" />
 	<mvc:view-controller path="/cloud/signup/cloudSignupConfirmation" view-name="cloud/signup/cloudSignupConfirmation" />
 	<mvc:view-controller path="/cloud/signup/accountActivationComplete" view-name="cloud/signup/accountActivationComplete" />
-    <mvc:view-controller path="/cloud/verifyEmailChange/emailChangeConfirmed" view-name="cloud/verifyEmailChange/emailChangeConfirmed" />
+	<mvc:view-controller path="/cloud/verifyEmailChange/emailChangeConfirmed" view-name="cloud/verifyEmailChange/emailChangeConfirmed" />
 	<mvc:view-controller path="/cloud/resendConfirmationEmail/resendFailure" view-name="cloud/resendConfirmationEmail/resendFailure" />
 	<mvc:view-controller path="/cloud/resendConfirmationEmail/resendSuccess" view-name="cloud/resendConfirmationEmail/resendSuccess" />
 

--- a/src/main/webapp/WEB-INF/pages/public/ssologout.jsp
+++ b/src/main/webapp/WEB-INF/pages/public/ssologout.jsp
@@ -4,17 +4,23 @@
     <title>Logged out</title>
 </head>
 
-	<div class="container" style="max-width:960px;padding:0 5% 0 5%;">
+<div class="container" style="max-width:960px;padding:0 5% 0 5%;">
 	<div class="row">
     	<axt:biggerLogo/>
     	<div style="text-align:center; margin-top:46px;">
-    	    <h2 class="form-signup-heading">Logged out</h2>
+    	    <h2 class="form-signup-heading">Logged out of RSpace</h2>
         </div>
     </div>
     <div style="max-width:550px;margin: 0 auto;margin-top:30px;text-align:center;">
-		You are logged out of RSpace.
+		You are <b>still logged</b> into your <b>institutional Single Sign-On</b> account.
+
 		<br />
-		<br />
-		Please don't forget to log out from your institutional Single Sign-On account.
+		<c:set var="ssoIdpLogoutUrl" value="${applicationScope['RS_DEPLOY_PROPS']['SSOIdpLogoutUrl']}"/>
+		<c:if test="${not empty ssoIdpLogoutUrl}">
+			You can <a href="${ssoIdpLogoutUrl}">click here</a> to fully log out.
+		</c:if>
+		<c:if test="${empty ssoIdpLogoutUrl}">
+			Please don't forget to fully log out.
+		</c:if>
 	</div>
 </div>

--- a/src/test/java/com/researchspace/webapp/controller/SignupControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SignupControllerTest.java
@@ -100,18 +100,18 @@ public class SignupControllerTest {
     mockIso8859Request.setAttribute("Shib-givenName", "MÃ¦ck");
     mockIso8859Request.setAttribute("Shib-surName", "SchÃ¸dt-Å»Ä\u0099bski");
     assertEquals("Mæck", signupCtrller.getFirstNameFromRemote(mockIso8859Request));
-    assertEquals("Schødt-Żębski", signupCtrller.getLastnameFromRemote(mockIso8859Request));
+    assertEquals("Schødt-Żębski", signupCtrller.getLastNameFromRemote(mockIso8859Request));
 
     // check if still works for utf8 chars
     MockHttpServletRequest mockUtf8Request = new MockHttpServletRequest();
     mockUtf8Request.setAttribute("Shib-givenName", "Mæck");
     mockUtf8Request.setAttribute("Shib-surName", "Schødt-Żębski");
     assertEquals("Mæck", signupCtrller.getFirstNameFromRemote(mockUtf8Request));
-    assertEquals("Schødt-Żębski", signupCtrller.getLastnameFromRemote(mockUtf8Request));
+    assertEquals("Schødt-Żębski", signupCtrller.getLastNameFromRemote(mockUtf8Request));
 
     // confirm no conversion if encoding is disabled in deployment property
     signupCtrller.setDeploymentSsoRecodeNamesToUft8(false);
     assertEquals("MÃ¦ck", signupCtrller.getFirstNameFromRemote(mockIso8859Request));
-    assertEquals("SchÃ¸dt-Å»Ä\u0099bski", signupCtrller.getLastnameFromRemote(mockIso8859Request));
+    assertEquals("SchÃ¸dt-Å»Ä\u0099bski", signupCtrller.getLastNameFromRemote(mockIso8859Request));
   }
 }

--- a/src/test/java/com/researchspace/webapp/filter/OpenIdRemoteUserPolicyTest.java
+++ b/src/test/java/com/researchspace/webapp/filter/OpenIdRemoteUserPolicyTest.java
@@ -1,0 +1,77 @@
+package com.researchspace.webapp.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.webapp.filter.RemoteUserRetrievalPolicy.RemoteUserAttribute;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class OpenIdRemoteUserPolicyTest {
+
+  OpenIdRemoteUserPolicy openIdPolicy;
+  MockHttpServletRequest req;
+
+  @Before
+  public void before() {
+    openIdPolicy = new OpenIdRemoteUserPolicy();
+    req = new MockHttpServletRequest();
+  }
+
+  @Test
+  public void getRemoteUsername() {
+
+    // empty request
+    assertNull(openIdPolicy.getRemoteUser(req));
+
+    // request with all headers
+    req.addHeader("OIDC_CLAIM_preferred_username", "user1234");
+    req.addHeader("OIDC_CLAIM_sub", "0a3ba4df5");
+    req.addHeader("OIDC_CLAIM_iss", "https://test.researchspace.com");
+
+    // policy setting only a username claim, based on preferred_username
+    openIdPolicy.setUsernameClaim("OIDC_CLAIM_preferred_username");
+    assertEquals("user1234", openIdPolicy.getRemoteUser(req));
+
+    // policy also setting additional claim, based on sub
+    openIdPolicy.setAdditionalUsernameClaim("OIDC_CLAIM_sub");
+    assertEquals("user1234.0a3b", openIdPolicy.getRemoteUser(req));
+
+    // policy also setting additional hashed claim, based on iss
+    openIdPolicy.setAdditionalHashedUsernameClaim("OIDC_CLAIM_iss");
+    assertEquals("user1234.0a3b.3e07", openIdPolicy.getRemoteUser(req));
+
+    // policy setting only hashed claim as additional
+    openIdPolicy.setAdditionalUsernameClaim("");
+    assertEquals("user1234.3e07", openIdPolicy.getRemoteUser(req));
+  }
+
+  @Test
+  public void getRemoteOtherAttributes() {
+    openIdPolicy.setEmailClaim("OIDC_CLAIM_email");
+    openIdPolicy.setFirstNameClaim("OIDC_CLAIM_given_name");
+    openIdPolicy.setLastNameClaim("OIDC_CLAIM_family_name");
+
+    assertNotNull(openIdPolicy.getOtherRemoteAttributes(req));
+    assertTrue(openIdPolicy.getOtherRemoteAttributes(req).isEmpty());
+
+    req.addHeader("OIDC_CLAIM_email", "someone@somewhere.com");
+    req.addHeader("OIDC_CLAIM_given_name", "Mark");
+    req.addHeader("OIDC_CLAIM_family_name", "Smith");
+    req.addHeader("OIDC_CLAIM_unknown", "unknown");
+
+    assertFalse(openIdPolicy.getOtherRemoteAttributes(req).isEmpty());
+    assertEquals(3, openIdPolicy.getOtherRemoteAttributes(req).size());
+    assertEquals(
+        "someone@somewhere.com",
+        openIdPolicy.getOtherRemoteAttributes(req).get(RemoteUserAttribute.EMAIL));
+    assertEquals(
+        "Mark", openIdPolicy.getOtherRemoteAttributes(req).get(RemoteUserAttribute.FIRST_NAME));
+    assertEquals(
+        "Smith", openIdPolicy.getOtherRemoteAttributes(req).get(RemoteUserAttribute.LAST_NAME));
+  }
+}

--- a/src/test/java/com/researchspace/webapp/filter/SAMLRemoteUserPolicyTest.java
+++ b/src/test/java/com/researchspace/webapp/filter/SAMLRemoteUserPolicyTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import com.researchspace.webapp.filter.RemoteUserRetrievalPolicy.RemoteUserAttribute;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -32,10 +33,8 @@ public class SAMLRemoteUserPolicyTest {
     assertNotNull(samlPolicy.getOtherRemoteAttributes(req));
     // this is a known saml attribute ID
     req.setAttribute("mail", "someone@somewhere.com");
-    assertEquals("someone@somewhere.com", samlPolicy.getOtherRemoteAttributes(req).get("mail"));
-
-    // get null if not set
-    req.setAttribute("unknown-attribute", "someone@somewhere.com");
-    assertNull(samlPolicy.getOtherRemoteAttributes(req).get("unknown-attribute"));
+    assertEquals(
+        "someone@somewhere.com",
+        samlPolicy.getOtherRemoteAttributes(req).get(RemoteUserAttribute.EMAIL));
   }
 }

--- a/src/test/java/com/researchspace/webapp/filter/SSOShiroFormAuthFilterTest.java
+++ b/src/test/java/com/researchspace/webapp/filter/SSOShiroFormAuthFilterTest.java
@@ -70,7 +70,6 @@ public class SSOShiroFormAuthFilterTest extends SpringTransactionalTest {
     User u = createAndSaveSsoTestUser();
     assertFalse(hasRemoteUserUsernameSet());
     remoteUserPolicy.setUsername(u.getUsername());
-    remoteUserPolicy.setPassword(RemoteUserRetrievalPolicy.SSO_DUMMY_PASSWORD);
     assertTrue(filter.isAccessAllowed(req, resp, null));
     assertTrue(hasRemoteUserUsernameSet());
 


### PR DESCRIPTION
This PR implements [RSDEV-284](https://researchspace.atlassian.net/browse/RSDEV-284) ticket, and it can be functionally tested at https://openid-connect.researchspace.com (maybe contact me/Ramon before trying, as we're testing various configurations right now).

Code-wise the new functionality is implemented through new `OpenIdRemoteUserPolicy.java` class, but I also did some refactoring around classes implementing `RemoteUserRetrievalPolicy`, as the code was quite tied to SAML (shibboleth) integration, which was the main SSO system we've been using until now.
