### PR TITLE
RSDEV-358 Remove onboarding sysadmin config option

### DIFF
--- a/src/main/webapp/scripts/pages/system/settings_mod.js
+++ b/src/main/webapp/scripts/pages/system/settings_mod.js
@@ -85,9 +85,6 @@ define(function() {
         _printCategory('API');
         _printSettings([ 'api.available' ]);
 
-        _printCategory('Onboarding');
-        _printSettings([ 'onboarding.available' ]);
-
         _printCategory('Lab Group Settings');
         _printSettings([ 'pi_can_edit_all_work_in_labgroup' ]);
         _printSettings(['group_autosharing.available']);


### PR DESCRIPTION
Currently unused so we're removing it from the UI so as not to confuse sysadmins but leaving the rest of the code in place in case we want to starting using again.