### PR TITLE
PRT-815 Fix the autosuggesting of tags when exporting documents

### DIFF
--- a/src/main/webapp/ui/src/Export/ExportDialog.js
+++ b/src/main/webapp/ui/src/Export/ExportDialog.js
@@ -299,6 +299,9 @@ function ExportDialog({
         Parsers.isObject(response)
           .flatMap(Parsers.isNotNull)
           .flatMap(Parsers.getValueWithKey("data"))
+          .flatMap(Parsers.isObject)
+          .flatMap(Parsers.isNotNull)
+          .flatMap(Parsers.getValueWithKey("data"))
           .flatMap(Parsers.isArray)
           .flatMap((data) => Result.all(...data.map(Parsers.isString)))
           .map((data) =>
@@ -319,9 +322,14 @@ function ExportDialog({
               parseEncodedTags(data.flatMap((str) => str.split(",")))
             )
           )
+          .mapError(([e]) => {
+            console.error(e);
+            return e;
+          })
           .orElse<Array<Tag>>([])
       )
-      .catch(() => {
+      .catch((e) => {
+        console.error(e);
         return ([]: Array<Tag>);
       })
       .finally(() => {


### PR DESCRIPTION
Commit c65e40c6c9 broke the logic that deserialises the API response for getting the list of tags set on a list of documents, which is used to suggest the tags that should be included in an export to the repositories. As such, the tags were silently not being included.