### PR TITLE
Jenkins: Prevent ansi-escape codes from being logged by jest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,7 @@ pipeline {
             steps {
                 echo 'Running Jest tests'
                 dir('src/main/webapp/ui') {
-                    sh 'npm run test -- --maxWorkers=2'
+                    sh 'env COLORS=false FORCE_COLOR=false npm run test -- --maxWorkers=2'
                 }
             }
             post {


### PR DESCRIPTION
`FORCE_COLOR=false` [is necessary for jest itself](https://jestjs.io/docs/cli#--colors).

> Alternatively you can set the environment variable FORCE_COLOR=true to forcefully enable or FORCE_COLOR=false to disable colorized output. The use of FORCE_COLOR overrides all other color support checks.

`COLORS=false` [is necessary for the DOM printing by testing-library to not include colours](https://testing-library.com/docs/dom-testing-library/api-debugging/#prettydom:~:text=Note%3A%20The%20output,on.%20For%20example%3A).

> Note: The output of the DOM is colorized by default if your tests are running in a node environment. However, you may sometimes want to turn off colors, such as in cases where the output is written to a log file for debugging purposes. You can use the environment variable COLORS to explicitly force the colorization off or on. For example:
>
> ```
> COLORS=false npm test
> ```