### PR TITLE
Use user-event in jest tests

### DIFF
--- a/src/main/webapp/ui/flow-typed/testing-library/react.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/react.js
@@ -45,6 +45,9 @@ declare module "@testing-library/react" {
 
     getByDisplayValue(string | number): Element,
   |};
+
+  declare export var queries: Queries;
+
   declare export function render<T: { ...Queries, ... } = Queries>(
     Node,
     ?{|

--- a/src/main/webapp/ui/flow-typed/testing-library/react.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/react.js
@@ -4,9 +4,6 @@ declare module "@testing-library/react" {
   import type { Node } from "react";
 
   declare export type Element = {|
-    // avoid using
-    click(): void,
-
     checked: boolean,
     value: string,
     textContent: string,

--- a/src/main/webapp/ui/flow-typed/testing-library/react.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/react.js
@@ -1,0 +1,71 @@
+//@flow strict
+
+declare module "@testing-library/react" {
+  import { type Node } from "react";
+
+  declare export type Element = {|
+    // avoid using
+    click(): void,
+
+    checked: boolean,
+    value: string,
+    textContent: string,
+    className: string,
+  |};
+
+  type Queries = {|
+    getByRole(string, ?{| name?: RegExp | string, level?: number |}): Element;
+    getAllByRole(string, ?{| name?: RegExp | string |}): $ReadOnlyArray<Element>;
+    findByRole(string, ?{| name?: RegExp | string |}): Promise<Element>;
+    findAllByRole(string, ?{|name?: RegExp | string |}): Promise<$ReadOnlyArray<Element>>;
+    queryByRole(string, ?{|name?: RegExp | string |}): null | Element;
+    queryAllByRole(string, ?{|name?: RegExp | string |}): $ReadOnlyArray<Element>;
+
+    getByLabelText(string): Element;
+    getAllByLabelText(string): $ReadOnlyArray<Element>;
+
+    getByText(string | RegExp): Element;
+    getAllByText(string | RegExp): $ReadOnlyArray<Element>;
+    findAllByText(string | RegExp): Promise<$ReadOnlyArray<Element>>;
+    queryByText(string | RegExp): null | Element;
+    queryAllByText(string | RegExp): $ReadOnlyArray<Element>;
+
+    getByTestId(string): Element;
+
+    getByDisplayValue(string): Element;
+  |}
+  declare export function render(Node): {|
+    container: {|
+      ...Queries
+    |},
+    baseElement: Element,
+  |};
+
+  declare export const screen: {|
+    ...Queries,
+  |};
+
+  declare export function within(Element): Queries;
+
+  // use user-event instead in almost all cases
+  declare export const fireEvent: {|
+    click(Element): void,
+    mouseDown(Element): void,
+    input(Element, {|
+      target?: {| value: string |},
+      name?: string,
+      checkValidity?: () => boolean,
+    |}): void,
+    change(Element, {|
+      target?: {| value: string |},
+    |}): void,
+    keyDown(Element): void,
+    submit(Element): void,
+  |};
+
+  declare export function act<T: void | Promise<void>>(() => T): T;
+
+  declare export function waitFor<T: void | Promise<void>>(() => T, ?{| timeout: number |}): T;
+
+  declare export function cleanup(): void;
+}

--- a/src/main/webapp/ui/flow-typed/testing-library/react.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/react.js
@@ -1,7 +1,7 @@
 //@flow strict
 
 declare module "@testing-library/react" {
-  import { type Node } from "react";
+  import type { Node } from "react";
 
   declare export type Element = {|
     // avoid using
@@ -13,59 +13,96 @@ declare module "@testing-library/react" {
     className: string,
   |};
 
-  type Queries = {|
-    getByRole(string, ?{| name?: RegExp | string, level?: number |}): Element;
-    getAllByRole(string, ?{| name?: RegExp | string |}): $ReadOnlyArray<Element>;
-    findByRole(string, ?{| name?: RegExp | string |}): Promise<Element>;
-    findAllByRole(string, ?{|name?: RegExp | string |}): Promise<$ReadOnlyArray<Element>>;
-    queryByRole(string, ?{|name?: RegExp | string |}): null | Element;
-    queryAllByRole(string, ?{|name?: RegExp | string |}): $ReadOnlyArray<Element>;
+  declare export type Queries = {|
+    getByRole(string, ?{| name?: RegExp | string, level?: number |}): Element,
+    getAllByRole(
+      string,
+      ?{| name?: RegExp | string | ((string) => boolean) |}
+    ): $ReadOnlyArray<Element>,
+    findByRole(string, ?{| name?: RegExp | string |}): Promise<Element>,
+    findAllByRole(
+      string,
+      ?{| name?: RegExp | string |}
+    ): Promise<$ReadOnlyArray<Element>>,
+    queryByRole(string, ?{| name?: RegExp | string |}): null | Element,
+    queryAllByRole(
+      string,
+      ?{| name?: RegExp | string |}
+    ): $ReadOnlyArray<Element>,
 
-    getByLabelText(string): Element;
-    getAllByLabelText(string): $ReadOnlyArray<Element>;
+    getByLabelText(string): Element,
+    getAllByLabelText(string): $ReadOnlyArray<Element>,
+    findByLabelText(string): Promise<Element>,
 
-    getByText(string | RegExp): Element;
-    getAllByText(string | RegExp): $ReadOnlyArray<Element>;
-    findAllByText(string | RegExp): Promise<$ReadOnlyArray<Element>>;
-    queryByText(string | RegExp): null | Element;
-    queryAllByText(string | RegExp): $ReadOnlyArray<Element>;
+    getByText(string | RegExp | ((string) => boolean)): Element,
+    getAllByText(string | RegExp): $ReadOnlyArray<Element>,
+    findByText(string | RegExp): Promise<Element>,
+    findAllByText(string | RegExp): Promise<$ReadOnlyArray<Element>>,
+    queryByText(string | RegExp): null | Element,
+    queryAllByText(string | RegExp): $ReadOnlyArray<Element>,
 
-    getByTestId(string): Element;
+    getByTestId(string): Element,
 
-    getByDisplayValue(string): Element;
-  |}
-  declare export function render(Node): {|
+    getByDisplayValue(string): Element,
+  |};
+  declare export function render<T: { ...Queries, ... } = Queries>(
+    Node,
+    ?{|
+      queries: T,
+    |}
+  ): {
+    ...T,
     container: {|
-      ...Queries
-    |},
+      ...Queries,
+    |} & Element,
     baseElement: Element,
-  |};
+  };
 
-  declare export const screen: {|
+  declare export var screen: {|
     ...Queries,
+    debug: typeof console.debug,
   |};
 
-  declare export function within(Element): Queries;
+  declare export function within<MoreQueries: { ... } = {}>(
+    Element,
+    ?MoreQueries
+  ): { ...Queries, ...MoreQueries };
 
   // use user-event instead in almost all cases
-  declare export const fireEvent: {|
+  declare export var fireEvent: {|
     click(Element): void,
     mouseDown(Element): void,
-    input(Element, {|
-      target?: {| value: string |},
-      name?: string,
-      checkValidity?: () => boolean,
-    |}): void,
-    change(Element, {|
-      target?: {| value: string |},
-    |}): void,
-    keyDown(Element): void,
-    submit(Element): void,
+    input(
+      Element,
+      {|
+        target?: {|
+          value: string,
+          checkValidity?: () => boolean,
+        |},
+        name?: string,
+      |}
+    ): void,
+    change(
+      Element,
+      {|
+        target?: {| value: string |},
+      |}
+    ): void,
+    keyDown(Element, ?{||}): void,
+    submit(
+      Element,
+      ?{|
+        target?: {| value: string |},
+      |}
+    ): void,
   |};
 
   declare export function act<T: void | Promise<void>>(() => T): T;
 
-  declare export function waitFor<T: void | Promise<void>>(() => T, ?{| timeout: number |}): T;
+  declare export function waitFor<T: void | Promise<void>>(
+    () => T,
+    ?{| timeout: number |}
+  ): T;
 
   declare export function cleanup(): void;
 }

--- a/src/main/webapp/ui/flow-typed/testing-library/react.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/react.js
@@ -48,18 +48,13 @@ declare module "@testing-library/react" {
 
   declare export var queries: Queries;
 
-  declare export function render<T: { ...Queries, ... } = Queries>(
-    Node,
-    ?{|
-      queries: T,
-    |}
-  ): {
-    ...T,
+  declare export function render(Node): {|
+    ...Queries,
     container: {|
       ...Queries,
     |} & Element,
     baseElement: Element,
-  };
+  |};
 
   declare export var screen: {|
     ...Queries,

--- a/src/main/webapp/ui/flow-typed/testing-library/react.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/react.js
@@ -43,7 +43,7 @@ declare module "@testing-library/react" {
 
     getByTestId(string): Element,
 
-    getByDisplayValue(string): Element,
+    getByDisplayValue(string | number): Element,
   |};
   declare export function render<T: { ...Queries, ... } = Queries>(
     Node,
@@ -63,10 +63,10 @@ declare module "@testing-library/react" {
     debug: typeof console.debug,
   |};
 
-  declare export function within<MoreQueries: { ... } = {}>(
+  declare export function within<MoreQueries: { ... } = {||}>(
     Element,
     ?MoreQueries
-  ): { ...Queries, ...MoreQueries };
+  ): Queries & {| ...Queries, ...MoreQueries |};
 
   // use user-event instead in almost all cases
   declare export var fireEvent: {|
@@ -76,7 +76,7 @@ declare module "@testing-library/react" {
       Element,
       {|
         target?: {|
-          value: string,
+          value?: string | number,
           checkValidity?: () => boolean,
         |},
         name?: string,

--- a/src/main/webapp/ui/flow-typed/testing-library/user-event.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/user-event.js
@@ -1,0 +1,16 @@
+//@flow strict
+
+declare module "@testing-library/user-event" {
+  import { type Element } from "@testing-library/react";
+
+
+    declare export type User = {|
+      click(Element): void;
+    |}
+
+    //declare export function setup(): User;
+
+    declare export default const {
+      setup(): User,
+    };
+}

--- a/src/main/webapp/ui/flow-typed/testing-library/user-event.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/user-event.js
@@ -1,16 +1,15 @@
 //@flow strict
 
 declare module "@testing-library/user-event" {
-  import { type Element } from "@testing-library/react";
+  import type { Element } from "@testing-library/react";
 
+  declare export type User = {|
+    click(Element): void,
+  |};
 
-    declare export type User = {|
-      click(Element): void;
-    |}
+  //declare export function setup(): User;
 
-    //declare export function setup(): User;
-
-    declare export default const {
-      setup(): User,
-    };
+  declare export default {|
+    setup(): User,
+  |};
 }

--- a/src/main/webapp/ui/flow-typed/testing-library/user-event.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/user-event.js
@@ -5,6 +5,35 @@ declare module "@testing-library/user-event" {
 
   declare export type User = {|
     click(Element): void,
+    dblClick(Element): void,
+    hover(Element): void,
+    unhover(Element): void,
+
+    /**
+     * Moves the tab focus
+     */
+    tab(?{| shift?: boolean |}): void,
+
+    /**
+     * Clears a text field
+     */
+    clear(Element): Promise<void>,
+
+    /**
+     * Type in a textfield
+     */
+    type(Element, string): Promise<void>,
+
+    /**
+     * Upload a file using a input[type="file"]
+     */
+    upload(Element, File | $ReadOnlyArray<File>): Promise<void>,
+
+    /**
+     * Simulate keyboard presses
+     * For information on how to encode keys, see https://testing-library.com/docs/user-event/keyboard
+     */
+    keyboard(string): Promise<void>,
   |};
 
   declare export default {|

--- a/src/main/webapp/ui/flow-typed/testing-library/user-event.js
+++ b/src/main/webapp/ui/flow-typed/testing-library/user-event.js
@@ -7,8 +7,6 @@ declare module "@testing-library/user-event" {
     click(Element): void,
   |};
 
-  //declare export function setup(): User;
-
   declare export default {|
     setup(): User,
   |};

--- a/src/main/webapp/ui/package-lock.json
+++ b/src/main/webapp/ui/package-lock.json
@@ -82,7 +82,7 @@
         "@babel/runtime": "=7.24.6",
         "@testing-library/jest-dom": "=6.2.0",
         "@testing-library/react": "^13.4.0",
-        "@testing-library/user-event": "^14.4.3",
+        "@testing-library/user-event": "^14.5.2",
         "axios-mock-adapter": "^1.20.0",
         "babel-loader": "=9.1.2",
         "canvas": "^2.11.2",

--- a/src/main/webapp/ui/package.json
+++ b/src/main/webapp/ui/package.json
@@ -30,7 +30,7 @@
     "@babel/runtime": "=7.24.6",
     "@testing-library/jest-dom": "=6.2.0",
     "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/user-event": "^14.5.2",
     "axios-mock-adapter": "^1.20.0",
     "babel-loader": "=9.1.2",
     "canvas": "^2.11.2",

--- a/src/main/webapp/ui/src/Export/__tests__/ExportDialog.test.js
+++ b/src/main/webapp/ui/src/Export/__tests__/ExportDialog.test.js
@@ -24,6 +24,7 @@ import each from "jest-each";
 import { type UseState } from "../../util/types";
 import Alerts from "../../components/Alerts/Alerts";
 import { sleep } from "../../util/Util";
+import userEvent from "@testing-library/user-event";
 
 window.fetch = jest.fn(() =>
   Promise.resolve({
@@ -146,6 +147,7 @@ describe("ExportDialog", () => {
   describe("Validations should be enforced.", () => {
     describe("Exporting with filestores links", () => {
       test("but without being logged in should show a warning.", async () => {
+        const user = userEvent.setup();
         mockAxios
           .onPost("/nfsExport/ajax/createQuickExportPlan")
           .reply(200, { ...CREATE_QUICK_EXPORT_PLAN });
@@ -163,21 +165,17 @@ describe("ExportDialog", () => {
           });
         });
 
-        act(() => {
-          screen
-            .getByRole("radio", { name: /^.ZIP bundle containing .HTML files/ })
-            .click();
-        });
+        await user.click(
+          screen.getByRole("radio", {
+            name: /^.ZIP bundle containing .HTML files/,
+          })
+        );
 
-        act(() => {
-          screen
-            .getByRole("checkbox", { name: "Include filestore links" })
-            .click();
-        });
+        await user.click(
+          screen.getByRole("checkbox", { name: "Include filestore links" })
+        );
 
-        act(() => {
-          screen.getByRole("button", { name: "Next" }).click();
-        });
+        await user.click(screen.getByRole("button", { name: "Next" }));
 
         await waitFor(() => {
           expect(
@@ -187,9 +185,7 @@ describe("ExportDialog", () => {
           ).toBeVisible();
         });
 
-        act(() => {
-          screen.getByRole("button", { name: "Next" }).click();
-        });
+        await user.click(screen.getByRole("button", { name: "Next" }));
 
         await waitFor(() => {
           expect(
@@ -199,9 +195,7 @@ describe("ExportDialog", () => {
           ).toBeVisible();
         });
 
-        act(() => {
-          screen.getByRole("button", { name: "Export" }).click();
-        });
+        await user.click(screen.getByRole("button", { name: "Export" }));
 
         await waitFor(() => {
           expect(
@@ -213,6 +207,7 @@ describe("ExportDialog", () => {
       });
 
       test("but without scanning should show a warning.", async () => {
+        const user = userEvent.setup();
         /*
          * Here, we're setting loggedAs on the mocked samba file system because
          * the scanning warning is only shown if the user is logged in,
@@ -241,21 +236,17 @@ describe("ExportDialog", () => {
           });
         });
 
-        act(() => {
-          screen
-            .getByRole("radio", { name: /^.ZIP bundle containing .HTML files/ })
-            .click();
-        });
+        await user.click(
+          screen.getByRole("radio", {
+            name: /^.ZIP bundle containing .HTML files/,
+          })
+        );
 
-        act(() => {
-          screen
-            .getByRole("checkbox", { name: "Include filestore links" })
-            .click();
-        });
+        await user.click(
+          screen.getByRole("checkbox", { name: "Include filestore links" })
+        );
 
-        act(() => {
-          screen.getByRole("button", { name: "Next" }).click();
-        });
+        await user.click(screen.getByRole("button", { name: "Next" }));
 
         await waitFor(() => {
           expect(
@@ -265,9 +256,7 @@ describe("ExportDialog", () => {
           ).toBeVisible();
         });
 
-        act(() => {
-          screen.getByRole("button", { name: "Next" }).click();
-        });
+        await user.click(screen.getByRole("button", { name: "Next" }));
 
         await waitFor(() => {
           expect(
@@ -285,9 +274,7 @@ describe("ExportDialog", () => {
           ).toBeVisible();
         });
 
-        await act(() => {
-          screen.getByRole("button", { name: "Export" }).click();
-        });
+        await user.click(screen.getByRole("button", { name: "Export" }));
 
         await waitFor(() => {
           expect(
@@ -376,6 +363,7 @@ describe("ExportDialog", () => {
         "Your export generation request has been submitted to the server. RSpace will notify you when the export is ready."
       );
     test("allVersions is set by the version switch.", async () => {
+      const user = userEvent.setup();
       await fc.assert(
         fc
           .asyncProperty(fc.boolean(), async (setAllVersionsSwitch) => {
@@ -393,27 +381,21 @@ describe("ExportDialog", () => {
               });
             });
 
-            act(() => {
-              screen
-                .getByRole("radio", {
-                  name: /^.ZIP bundle containing .XML files/,
-                })
-                .click();
-            });
+            await user.click(
+              screen.getByRole("radio", {
+                name: /^.ZIP bundle containing .XML files/,
+              })
+            );
 
             if (setAllVersionsSwitch) {
-              await act(async () => {
-                (
-                  await screen.findByRole("checkbox", {
-                    name: /^Check to include all previous versions of your documents/,
-                  })
-                ).click();
-              });
+              await user.click(
+                await screen.findByRole("checkbox", {
+                  name: /^Check to include all previous versions of your documents/,
+                })
+              );
             }
 
-            act(() => {
-              screen.getByRole("button", { name: "Next" }).click();
-            });
+            await user.click(screen.getByRole("button", { name: "Next" }));
 
             await waitFor(() => {
               expect(
@@ -498,6 +480,7 @@ describe("ExportDialog", () => {
         .reply(200, { data: { pageSize: "A4" } });
       describe("When the selected export type is PDF", () => {
         test("and the selection is a set of documents.", async () => {
+          const user = userEvent.setup();
           await fc.assert(
             fc
               .asyncProperty(
@@ -510,9 +493,9 @@ describe("ExportDialog", () => {
                     setProps({ open: true, selection });
                   });
                   fireEvent.click(screen.getByRole("radio", { name: /^PDF/ }));
-                  act(() => {
-                    screen.getByRole("button", { name: "Next" }).click();
-                  });
+                  await user.click(
+                    screen.getByRole("button", { name: "Next" })
+                  );
 
                   await waitFor(() => {
                     expect(screen.getByRole("textbox")).toBeVisible();
@@ -528,6 +511,7 @@ describe("ExportDialog", () => {
           );
         });
         test("and the selection is a group.", async () => {
+          const user = userEvent.setup();
           await fc.assert(
             fc
               .asyncProperty(arbGroupSelection, async (selection) => {
@@ -535,10 +519,8 @@ describe("ExportDialog", () => {
                 act(() => {
                   setProps({ open: true, selection });
                 });
-                fireEvent.click(screen.getByRole("radio", { name: /^PDF/ }));
-                act(() => {
-                  screen.getByRole("button", { name: "Next" }).click();
-                });
+                await user.click(screen.getByRole("radio", { name: /^PDF/ }));
+                await user.click(screen.getByRole("button", { name: "Next" }));
 
                 await waitFor(() => {
                   expect(screen.getByRole("textbox")).toBeVisible();
@@ -553,6 +535,7 @@ describe("ExportDialog", () => {
           );
         });
         test("and the selection is a user.", async () => {
+          const user = userEvent.setup();
           await fc.assert(
             fc
               .asyncProperty(arbUserSelection, async (selection) => {
@@ -561,9 +544,7 @@ describe("ExportDialog", () => {
                   setProps({ open: true, selection });
                 });
                 fireEvent.click(screen.getByRole("radio", { name: /^PDF/ }));
-                act(() => {
-                  screen.getByRole("button", { name: "Next" }).click();
-                });
+                await user.click(screen.getByRole("button", { name: "Next" }));
 
                 await waitFor(() => {
                   expect(screen.getByRole("textbox")).toBeVisible();
@@ -580,6 +561,7 @@ describe("ExportDialog", () => {
       });
       describe("When the selected export type is DOC", () => {
         test("and the selection is a single document.", async () => {
+          const user = userEvent.setup();
           mockAxios
             .onGet("deploymentproperties/ajax/property")
             .reply(200, true);
@@ -599,9 +581,9 @@ describe("ExportDialog", () => {
                     await screen.findByRole("radio", { name: /^.DOC/ })
                   );
 
-                  act(() => {
-                    screen.getByRole("button", { name: "Next" }).click();
-                  });
+                  await user.click(
+                    screen.getByRole("button", { name: "Next" })
+                  );
 
                   await waitFor(() => {
                     expect(screen.getByRole("textbox")).toBeVisible();
@@ -620,6 +602,7 @@ describe("ExportDialog", () => {
     });
     describe("The page size displayed on the second page should be set by a call to /defaultPDFConfig", () => {
       each(["A4", "LETTER"]).test("PDF export: pageSize = %s", (pageSize) => {
+        const user = userEvent.setup();
         fc.assert(
           fc
             .asyncProperty(
@@ -638,9 +621,7 @@ describe("ExportDialog", () => {
                 fireEvent.click(
                   await screen.findByRole("radio", { name: /^.DOC/ })
                 );
-                act(() => {
-                  screen.getByRole("button", { name: "Next" }).click();
-                });
+                await user.click(screen.getByRole("button", { name: "Next" }));
                 await waitFor(() => {
                   expect(
                     screen.getByRole("button", { name: pageSize })
@@ -653,6 +634,7 @@ describe("ExportDialog", () => {
         );
       });
       each(["A4", "LETTER"]).test("DOC export: pageSize = %s", (pageSize) => {
+        const user = userEvent.setup();
         fc.assert(
           fc
             .asyncProperty(
@@ -671,9 +653,7 @@ describe("ExportDialog", () => {
                 fireEvent.click(
                   await screen.findByRole("radio", { name: /^.DOC/ })
                 );
-                act(() => {
-                  screen.getByRole("button", { name: "Next" }).click();
-                });
+                await user.click(screen.getByRole("button", { name: "Next" }));
                 await waitFor(() => {
                   expect(
                     screen.getByRole("button", { name: pageSize })

--- a/src/main/webapp/ui/src/Export/__tests__/ExportFileStore.test.js
+++ b/src/main/webapp/ui/src/Export/__tests__/ExportFileStore.test.js
@@ -18,6 +18,7 @@ import MockAdapter from "axios-mock-adapter";
 import * as axios from "axios";
 import CREATE_QUICK_EXPORT_PLAN from "./createQuickExportPlan";
 import { mkValidator } from "../../util/Validator";
+import userEvent from "@testing-library/user-event";
 
 const mockAxios = new MockAdapter(axios);
 
@@ -67,6 +68,7 @@ describe("ExportFileStore", () => {
     ).toBeVisible();
   });
   test("Found filestore links dialog should show linked file.", async () => {
+    const user = userEvent.setup();
     mockAxios
       .onPost("/nfsExport/ajax/createQuickExportPlan")
       .reply(200, CREATE_QUICK_EXPORT_PLAN);
@@ -107,11 +109,9 @@ describe("ExportFileStore", () => {
       ).toBeVisible();
     }));
 
-    act(() => {
-      screen
-        .getByRole("button", { name: "Show found filestore links" })
-        .click();
-    });
+    await user.click(
+      screen.getByRole("button", { name: "Show found filestore links" })
+    );
 
     expect(
       within(within(screen.getByRole("dialog")).getByRole("table")).getByRole(
@@ -120,13 +120,12 @@ describe("ExportFileStore", () => {
       )
     ).toBeVisible();
 
-    act(() => {
-      within(screen.getByRole("dialog"))
-        .getByRole("button", { name: /OK/i })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: /OK/i })
+    );
   });
   test("Filesystem login details dialog should show such info.", async () => {
+    const user = userEvent.setup();
     mockAxios.onPost("/nfsExport/ajax/createQuickExportPlan").reply(200, {
       ...CREATE_QUICK_EXPORT_PLAN,
       foundFileSystems: [
@@ -173,11 +172,9 @@ describe("ExportFileStore", () => {
       ).toBeVisible();
     }));
 
-    act(() => {
-      screen
-        .getByRole("button", { name: /Check file systems login details/i })
-        .click();
-    });
+    await user.click(
+      screen.getByRole("button", { name: /Check file systems login details/i })
+    );
 
     expect(
       within(within(screen.getByRole("dialog")).getByRole("table")).getByRole(
@@ -192,10 +189,8 @@ describe("ExportFileStore", () => {
       )
     ).toBeVisible();
 
-    act(() => {
-      within(screen.getByRole("dialog"))
-        .getByRole("button", { name: /OK/i })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: /OK/i })
+    );
   });
 });

--- a/src/main/webapp/ui/src/Export/repositories/__tests__/ZenodoRepo.test.js
+++ b/src/main/webapp/ui/src/Export/repositories/__tests__/ZenodoRepo.test.js
@@ -4,11 +4,12 @@
 //@flow
 /* eslint-env jest */
 import React from "react";
-import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { render, cleanup, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import ZenodoRepo from "../ZenodoRepo";
 import "../../../../__mocks__/matchMedia.js";
 import { type Person } from "../common";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -23,7 +24,8 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("ZenodoRepo", () => {
-  test("Upon editing, title should be set to the entered value.", () => {
+  test("Upon editing, title should be set to the entered value.", async () => {
+    const user = userEvent.setup();
     const handleChange = jest.fn<
       [
         { target: { name: "subject" | "title" | "description", value: string } }
@@ -31,29 +33,36 @@ describe("ZenodoRepo", () => {
       void
     >();
 
-    render(
-      <ZenodoRepo
-        handleChange={handleChange}
-        inputValidations={{
-          description: true,
-          title: true,
-          author: true,
-          contact: true,
-          subject: true,
-        }}
-        submitAttempt={false}
-        updatePeople={() => {}}
-        title=""
-        description=""
-        tags={[]}
-        onTagsChange={() => {}}
-        fetchingTags={false}
-      />
-    );
+    const Wrapper = ({ onChange }: {| onChange: typeof handleChange |}) => {
+      const [title, setTitle] = React.useState("");
 
-    fireEvent.change(screen.getByRole("textbox", { name: /Title/ }), {
-      target: { value: "foo" },
-    });
+      return (
+        <ZenodoRepo
+          handleChange={(e) => {
+            if (e.target.name === "title") setTitle(e.target.value);
+            onChange(e);
+          }}
+          inputValidations={{
+            description: true,
+            title: true,
+            author: true,
+            contact: true,
+            subject: true,
+          }}
+          submitAttempt={false}
+          updatePeople={() => {}}
+          title={title}
+          description=""
+          tags={[]}
+          onTagsChange={() => {}}
+          fetchingTags={false}
+        />
+      );
+    };
+
+    render(<Wrapper onChange={handleChange} />);
+
+    await user.type(screen.getByRole("textbox", { name: /Title/ }), "foo");
 
     expect(handleChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -65,7 +74,8 @@ describe("ZenodoRepo", () => {
     );
   });
 
-  test("Upon editing, description should be set to the entered value.", () => {
+  test("Upon editing, description should be set to the entered value.", async () => {
+    const user = userEvent.setup();
     const handleChange = jest.fn<
       [
         { target: { name: "subject" | "title" | "description", value: string } }
@@ -73,29 +83,39 @@ describe("ZenodoRepo", () => {
       void
     >();
 
-    render(
-      <ZenodoRepo
-        handleChange={handleChange}
-        inputValidations={{
-          description: true,
-          title: true,
-          author: true,
-          contact: true,
-          subject: true,
-        }}
-        submitAttempt={false}
-        updatePeople={() => {}}
-        title=""
-        description=""
-        tags={[]}
-        onTagsChange={() => {}}
-        fetchingTags={false}
-      />
-    );
+    const Wrapper = ({ onChange }: {| onChange: typeof handleChange |}) => {
+      const [description, setDescription] = React.useState("");
 
-    fireEvent.change(screen.getByRole("textbox", { name: /Description/ }), {
-      target: { value: "foo" },
-    });
+      return (
+        <ZenodoRepo
+          handleChange={(e) => {
+            if (e.target.name === "description") setDescription(e.target.value);
+            onChange(e);
+          }}
+          inputValidations={{
+            description: true,
+            title: true,
+            author: true,
+            contact: true,
+            subject: true,
+          }}
+          submitAttempt={false}
+          updatePeople={() => {}}
+          title=""
+          description={description}
+          tags={[]}
+          onTagsChange={() => {}}
+          fetchingTags={false}
+        />
+      );
+    };
+
+    render(<Wrapper onChange={handleChange} />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /Description/ }),
+      "foo"
+    );
 
     expect(handleChange).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/src/main/webapp/ui/src/Inventory/Container/Fields/Organization/__tests__/GridDimensions.test.js
+++ b/src/main/webapp/ui/src/Inventory/Container/Fields/Organization/__tests__/GridDimensions.test.js
@@ -25,6 +25,7 @@ import { assertNotNull } from "../../../../../util/__tests__/helpers";
 import { type StoreContainer } from "../../../../../stores/stores/RootStore";
 import ContainerModel from "../../../../../stores/models/ContainerModel";
 import * as ArrayUtils from "../../../../../util/ArrayUtils";
+import userEvent from "@testing-library/user-event";
 
 function makeRootStoreWithGridContainer(): {|
   rootStore: StoreContainer,
@@ -55,7 +56,8 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("GridDimensions", () => {
-  test("Each of the standard dimension menu options sets the rows and columns to a valid number.", () => {
+  test("Each of the standard dimension menu options sets the rows and columns to a valid number.", async () => {
+    const user = userEvent.setup();
     const { rootStore } = makeRootStoreWithGridContainer();
     render(
       <ThemeProvider theme={materialTheme}>
@@ -70,20 +72,20 @@ describe("GridDimensions", () => {
     const menuOptions = within(screen.getByRole("listbox"))
       .getAllByRole("option")
       .map((o) => o.textContent);
-    act(() => {
-      within(screen.getByRole("listbox"))
-        .getByRole("option", { name: "Custom" })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: "Custom",
+      })
+    );
 
     // for each menu option, assert it sets the rows and cols to valid values
-    menuOptions.forEach((option) => {
+    for (const option of menuOptions) {
       fireEvent.mouseDown(screen.getByRole("combobox"));
-      act(() => {
-        within(screen.getByRole("listbox"))
-          .getByRole("option", { name: option })
-          .click();
-      });
+      await user.click(
+        within(screen.getByRole("listbox")).getByRole("option", {
+          name: option,
+        })
+      );
 
       const rows = parseInteger(
         screen.getByRole("spinbutton", { name: "rows" }).value
@@ -98,10 +100,11 @@ describe("GridDimensions", () => {
       expect(columns).not.toBeNull();
       expect(columns).toBeGreaterThanOrEqual(2);
       expect(columns).toBeLessThanOrEqual(24);
-    });
+    }
   });
 
-  test("Choosing custom should not change the dimensions.", () => {
+  test("Choosing custom should not change the dimensions.", async () => {
+    const user = userEvent.setup();
     const { rootStore } = makeRootStoreWithGridContainer();
     render(
       <ThemeProvider theme={materialTheme}>
@@ -123,11 +126,11 @@ describe("GridDimensions", () => {
     );
 
     // tap that menu option, setting the rows and columns
-    act(() => {
-      within(screen.getByRole("listbox"))
-        .getByRole("option", { name: menuOption })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: menuOption,
+      })
+    );
     const rowsBefore = parseInteger(
       screen.getByRole("spinbutton", { name: "rows" }).value
     ).orElse(null);
@@ -139,11 +142,11 @@ describe("GridDimensions", () => {
 
     // choose "custom"
     fireEvent.mouseDown(screen.getByRole("combobox"));
-    act(() => {
-      within(screen.getByRole("listbox"))
-        .getByRole("option", { name: "Custom" })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: "Custom",
+      })
+    );
 
     // assert that the values have not changed
     const rowsAfter = parseInteger(
@@ -158,7 +161,8 @@ describe("GridDimensions", () => {
     expect(columnsBefore).toEqual(columnsAfter);
   });
 
-  test("Changing rows sets menu to Custom", () => {
+  test("Changing rows sets menu to Custom", async () => {
+    const user = userEvent.setup();
     const { rootStore } = makeRootStoreWithGridContainer();
     render(
       <ThemeProvider theme={materialTheme}>
@@ -179,11 +183,11 @@ describe("GridDimensions", () => {
       ).orElse(null)
     );
     expect(menuOption).not.toBeNull();
-    act(() => {
-      within(screen.getByRole("listbox"))
-        .getByRole("option", { name: menuOption })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: menuOption,
+      })
+    );
 
     // change the rows
     const rowsBefore = parseInteger(
@@ -198,7 +202,8 @@ describe("GridDimensions", () => {
     expect(screen.getByRole("combobox")).toBeVisible();
   });
 
-  test("Changing columns sets menu to Custom", () => {
+  test("Changing columns sets menu to Custom", async () => {
+    const user = userEvent.setup();
     const { rootStore } = makeRootStoreWithGridContainer();
     render(
       <ThemeProvider theme={materialTheme}>
@@ -219,11 +224,11 @@ describe("GridDimensions", () => {
       ).orElse(null)
     );
     expect(menuOption).not.toBeNull();
-    act(() => {
-      within(screen.getByRole("listbox"))
-        .getByRole("option", { name: menuOption })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: menuOption,
+      })
+    );
 
     // change the columns
     const columnsBefore = parseInteger(
@@ -239,7 +244,8 @@ describe("GridDimensions", () => {
     expect(screen.getByRole("combobox")).toBeVisible();
   });
 
-  test("The multiplication of the rows and columns should equal the size quoted in the menu item.", () => {
+  test("The multiplication of the rows and columns should equal the size quoted in the menu item.", async () => {
+    const user = userEvent.setup();
     const { rootStore } = makeRootStoreWithGridContainer();
     render(
       <ThemeProvider theme={materialTheme}>
@@ -255,20 +261,20 @@ describe("GridDimensions", () => {
       .getAllByRole("option")
       .map((o) => o.textContent)
       .filter((o) => o !== "Custom");
-    act(() => {
-      within(screen.getByRole("listbox"))
-        .getByRole("option", { name: "Custom" })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: "Custom",
+      })
+    );
 
     // for each menu option, assert that the rows and colunmns, when multiplied, are the number quoted by the option
-    menuOptions.forEach((option) => {
+    for (const option of menuOptions) {
       fireEvent.mouseDown(screen.getByRole("combobox"));
-      act(() => {
-        within(screen.getByRole("listbox"))
-          .getByRole("option", { name: option })
-          .click();
-      });
+      await user.click(
+        within(screen.getByRole("listbox")).getByRole("option", {
+          name: option,
+        })
+      );
 
       const rows = parseInteger(
         screen.getByRole("spinbutton", { name: "rows" }).value
@@ -280,7 +286,7 @@ describe("GridDimensions", () => {
       expect(option).toMatch(
         new RegExp(`${assertNotNull(rows) * assertNotNull(columns)}`)
       );
-    });
+    }
   });
 
   test("The first option, the most popular, should be 96-well plate.", () => {
@@ -302,7 +308,8 @@ describe("GridDimensions", () => {
     expect(assertNotNull(menuOption)).toMatch(/96 well plate/);
   });
 
-  test("Selecting 96-well should save cols: 12 and rows: 8.", () => {
+  test("Selecting 96-well should save cols: 12 and rows: 8.", async () => {
+    const user = userEvent.setup();
     const { rootStore, gridContainer } = makeRootStoreWithGridContainer();
     const spy = jest.spyOn(gridContainer, "setAttributesDirty");
     render(
@@ -315,20 +322,21 @@ describe("GridDimensions", () => {
 
     fireEvent.mouseDown(screen.getByRole("combobox"));
 
-    act(() => {
-      within(screen.getByRole("listbox"))
-        .getByRole("option", { name: "96 well plate" })
-        .click();
-    });
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: "96 well plate",
+      })
+    );
 
     expect(spy).toHaveBeenCalledWith({
       gridLayout: expect.objectContaining({ columnsNumber: 12, rowsNumber: 8 }),
     });
   });
 
-  test("When a menu option is chosen, the same values should be passed to setAttributesDirty as displayed in the numerical fields.", () => {
+  test("When a menu option is chosen, the same values should be passed to setAttributesDirty as displayed in the numerical fields.", async () => {
+    const user = userEvent.setup();
     fc.assert(
-      fc.property(fc.nat(), (unboundedIndex) => {
+      fc.asyncProperty(fc.nat(), async (unboundedIndex) => {
         cleanup();
         const { rootStore, gridContainer } = makeRootStoreWithGridContainer();
         render(
@@ -355,11 +363,11 @@ describe("GridDimensions", () => {
             gridLayout = newGridLayout;
           });
 
-        act(() => {
-          within(screen.getByRole("listbox"))
-            .getByRole("option", { name: option })
-            .click();
-        });
+        await user.click(
+          within(screen.getByRole("listbox")).getByRole("option", {
+            name: option,
+          })
+        );
 
         const rows = parseInteger(
           screen.getByRole("spinbutton", { name: "rows" }).value

--- a/src/main/webapp/ui/src/Inventory/Container/Fields/__tests__/LocationsImageField.test.js
+++ b/src/main/webapp/ui/src/Inventory/Container/Fields/__tests__/LocationsImageField.test.js
@@ -21,6 +21,7 @@ import materialTheme from "../../../../theme";
 import LocationsImageField from "../LocationsImageField";
 import ImageField from "../../../../components/Inputs/ImageField";
 import LocationsImageMarkersDialog from "../LocationsImageMarkersDialog";
+import userEvent from "@testing-library/user-event";
 
 let storeImageFunction;
 
@@ -70,7 +71,7 @@ const mockRootStore = (
         removeAlert: jest.fn(),
       },
       searchStore: {
-        activeResult: activeResult,
+        activeResult,
       },
     }),
     activeResult,
@@ -277,7 +278,8 @@ describe("LocationImageField", () => {
    * dialog to provide markers as to where items are located in the image.
    */
   describe("When the 'Edit Locations' button is tapped there should", () => {
-    test("be a LocationsImageMarkersDialog that opens.", () => {
+    test("be a LocationsImageMarkersDialog that opens.", async () => {
+      const user = userEvent.setup();
       const [rootStore, container] = mockRootStore();
       container.locationsImage = "someImage";
 
@@ -290,9 +292,7 @@ describe("LocationImageField", () => {
       );
 
       const editLocationsButtons = screen.getByText("Edit Locations");
-      act(() => {
-        editLocationsButtons.click();
-      });
+      await user.click(editLocationsButtons);
       expect(LocationsImageMarkersDialog).toHaveBeenLastCalledWith(
         { open: true, close: expect.any(Function) },
         expect.anything()
@@ -301,7 +301,8 @@ describe("LocationImageField", () => {
   });
 
   describe('When the "Close" button inside the LocationsImageMarkersDialog is tapped', () => {
-    test("The dialog should close.", () => {
+    test("The dialog should close.", async () => {
+      const user = userEvent.setup();
       const [rootStore, container] = mockRootStore({
         trackingStore: {
           trackEvent: () => {},
@@ -318,10 +319,8 @@ describe("LocationImageField", () => {
       );
 
       const editLocationsButtons = screen.getByText("Edit Locations");
-      act(() => {
-        editLocationsButtons.click();
-        screen.getByText("Close").click();
-      });
+      await user.click(editLocationsButtons);
+      await user.click(screen.getByText("Close"));
       expect(LocationsImageMarkersDialog).toHaveBeenLastCalledWith(
         { open: false, close: expect.any(Function) },
         expect.anything()

--- a/src/main/webapp/ui/src/Inventory/Import/__tests__/NavigationContext.test.js
+++ b/src/main/webapp/ui/src/Inventory/Import/__tests__/NavigationContext.test.js
@@ -11,6 +11,7 @@ import NavigateContext from "../../../stores/contexts/Navigate";
 import NavigationContext from "../NavigationContext";
 import { storesContext } from "../../../stores/stores-context";
 import { makeMockRootStore } from "../../../stores/stores/__tests__/RootStore/mocking";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -57,6 +58,7 @@ describe("NavigationContext", () => {
         userDiscards: boolean,
         expectToNavigate: boolean,
       |}) => {
+        const user = userEvent.setup();
         const dummyUseLocation = {
           hash: "",
           pathname: "",
@@ -93,7 +95,7 @@ describe("NavigationContext", () => {
             </NavigateContext.Provider>
           </storesContext.Provider>
         );
-        screen.getByText("Click me").click();
+        user.click(screen.getByText("Click me"));
         await waitFor(() => {
           if (expectToNavigate) {
             expect(navFn).toHaveBeenCalled();

--- a/src/main/webapp/ui/src/Inventory/Mixed/__tests__/CreateDialog.test.js
+++ b/src/main/webapp/ui/src/Inventory/Mixed/__tests__/CreateDialog.test.js
@@ -28,6 +28,7 @@ import SearchContext from "../../../stores/contexts/Search";
 import Search from "../../../stores/models/Search";
 import { mockFactory } from "../../../stores/definitions/__tests__/Factory/mocking";
 import each from "jest-each";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -158,24 +159,21 @@ describe("CreateInContextDialog", () => {
   });
 
   describe("When CreateDialog is rendered", () => {
-    const getCreateButton = () =>
-      screen.getByRole("button", {
-        name: /CREATE/i,
-      });
-    const getCancelButton = () =>
-      screen.getByRole("button", {
-        name: /CANCEL/i,
-      });
-
-    test("Cancel button exists and can be clicked", () => {
+    test("Cancel button exists and can be clicked", async () => {
+      const user = userEvent.setup();
       const onClose = jest.fn<[], void>();
       render(<Dialog selectedResult={mockContainer} onClose={onClose} />);
 
-      getCancelButton().click();
+      await user.click(
+        screen.getByRole("button", {
+          name: /CANCEL/i,
+        })
+      );
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    test("Create button calls the right action/method (createNewContainer case)", () => {
+    test("Create button calls the right action/method (createNewContainer case)", async () => {
+      const user = userEvent.setup();
       render(<Dialog selectedResult={mockContainer} onClose={() => {}} />);
 
       // with selectedResult={mockContainer}, createNewContainer will be the default option
@@ -184,11 +182,16 @@ describe("CreateInContextDialog", () => {
         "createNewContainer"
       );
 
-      getCreateButton().click();
+      await user.click(
+        screen.getByRole("button", {
+          name: /CREATE/i,
+        })
+      );
       expect(createContainerSpy).toHaveBeenCalledTimes(1);
     });
 
-    test("Create button calls the right action/method (createNewSample case)", () => {
+    test("Create button calls the right action/method (createNewSample case)", async () => {
+      const user = userEvent.setup();
       render(<Dialog selectedResult={mockContainer} onClose={() => {}} />);
 
       // with selectedResult={mockContainer}, createNewSample will be the second option
@@ -199,11 +202,16 @@ describe("CreateInContextDialog", () => {
 
       fireEvent.click(screen.getByTestId("option-radio-ic-2"));
 
-      getCreateButton().click();
+      await user.click(
+        screen.getByRole("button", {
+          name: /CREATE/i,
+        })
+      );
       expect(createSampleSpy).toHaveBeenCalledTimes(1);
     });
 
-    test("Create button calls the right action/method (setTemplateCreationContext case)", () => {
+    test("Create button calls the right action/method (setTemplateCreationContext case)", async () => {
+      const user = userEvent.setup();
       render(<Dialog selectedResult={mockSample} onClose={() => {}} />);
 
       // with selectedResult={mockSample}, setTemplateCreationContext will be the default option
@@ -212,11 +220,16 @@ describe("CreateInContextDialog", () => {
         "setTemplateCreationContext"
       );
 
-      getCreateButton().click();
+      await user.click(
+        screen.getByRole("button", {
+          name: /CREATE/i,
+        })
+      );
       expect(createTemplateSpy).toHaveBeenCalledTimes(1);
     });
 
-    test("Create button calls the right action/method (createNewSampleFromTemplate case)", () => {
+    test("Create button calls the right action/method (createNewSampleFromTemplate case)", async () => {
+      const user = userEvent.setup();
       render(<Dialog selectedResult={mockTemplate} onClose={() => {}} />);
 
       // with selectedResult={mockTemplate}, createNewSample will be the default option
@@ -225,12 +238,17 @@ describe("CreateInContextDialog", () => {
         "createNewSample"
       );
 
-      getCreateButton().click();
+      await user.click(
+        screen.getByRole("button", {
+          name: /CREATE/i,
+        })
+      );
       expect(createSampleFromTemplateSpy).toHaveBeenCalledTimes(1);
       expect(createSampleFromTemplateSpy).toHaveBeenCalledWith();
     });
 
-    test("Create button calls the right action/method (split subSample case)", () => {
+    test("Create button calls the right action/method (split subSample case)", async () => {
+      const user = userEvent.setup();
       render(<Dialog selectedResult={mockSubSample} onClose={() => {}} />);
 
       // with selectedResult={mockSubSample}, splitRecord will be the default option. that method is on search.
@@ -239,7 +257,11 @@ describe("CreateInContextDialog", () => {
         "splitRecord"
       );
 
-      getCreateButton().click();
+      await user.click(
+        screen.getByRole("button", {
+          name: /CREATE/i,
+        })
+      );
       expect(splitSubSampleSpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/Template/__tests__/Template.test.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/Template/__tests__/Template.test.js
@@ -21,6 +21,7 @@ import materialTheme from "../../../../../theme";
 import ApiService from "../../../../../common/InvApiService";
 import { sleep } from "../../../../../util/Util";
 import "__mocks__/resizeObserver";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../../../../common/InvApiService", () => ({
   query: jest.fn(() => {}),
@@ -106,6 +107,7 @@ describe("Template", () => {
   });
   describe("When a template is chosen", () => {
     test("all of the template's fields should be copied to the sample.", async () => {
+      const user = userEvent.setup();
       jest.spyOn(ApiService, "query").mockImplementation((endpoint, params) => {
         if (params.get("resultType") === "TEMPLATE") {
           return Promise.resolve({
@@ -171,8 +173,9 @@ describe("Template", () => {
         </ThemeProvider>
       );
       await waitFor(() => {
-        screen.getByText("A template").click();
+        expect(screen.getByText("A template")).toBeVisible();
       });
+      user.click(screen.getByText("A template"));
 
       await waitFor(() => {
         expect(sample.fields.length).toBe(1);

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/__tests__/StorageTemperature/WhenEnabledAndUnspecified.test.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/__tests__/StorageTemperature/WhenEnabledAndUnspecified.test.js
@@ -11,6 +11,7 @@ import { CELSIUS } from "../../../../../stores/definitions/Units";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../../../theme";
 import { type Temperature } from "../../../../../stores/definitions/Sample";
+import userEvent from "@testing-library/user-event";
 
 const mockFieldOwner = (mockedParts: {|
   fieldValues: {
@@ -45,7 +46,8 @@ afterEach(cleanup);
 
 describe("StorageTemperature", () => {
   describe("When enabled and unspecified, the component should", () => {
-    test("show a button that when tapped defaults to ambient temperature.", () => {
+    test("show a button that when tapped defaults to ambient temperature.", async () => {
+      const user = userEvent.setup();
       const fieldOwner = mockFieldOwner({
         fieldValues: {
           storageTempMin: null,
@@ -67,7 +69,7 @@ describe("StorageTemperature", () => {
           />
         </ThemeProvider>
       );
-      screen.getByText("Specify").click();
+      await user.click(screen.getByText("Specify"));
       expect(spy).toHaveBeenCalledWith({
         storageTempMin: { numericValue: 15, unitId: CELSIUS },
         storageTempMax: { numericValue: 30, unitId: CELSIUS },

--- a/src/main/webapp/ui/src/Inventory/Search/components/__tests__/SearchParameterControls.test.js
+++ b/src/main/webapp/ui/src/Inventory/Search/components/__tests__/SearchParameterControls.test.js
@@ -15,6 +15,7 @@ import SearchParameterControls from "../SearchParameterControls";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../../theme";
 import "../../../../../__mocks__/matchMedia.js";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../../../common/InvApiService", () => {});
 jest.mock("../../../../stores/stores/RootStore", () => () => ({
@@ -33,7 +34,6 @@ window.fetch = jest.fn(() =>
   })
 );
 
-
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -42,7 +42,8 @@ afterEach(cleanup);
 
 describe("SearchParameterControls", () => {
   describe("Saved searches controls", () => {
-    test("If the search disallows a particular record type, saved searches with that type filter should be disabled.", () => {
+    test("If the search disallows a particular record type, saved searches with that type filter should be disabled.", async () => {
+      const user = userEvent.setup();
       const rootStore = makeMockRootStore({
         searchStore: {
           savedSearches: [{ name: "Test search", resultType: "SAMPLE" }],
@@ -72,9 +73,7 @@ describe("SearchParameterControls", () => {
         </ThemeProvider>
       );
 
-      act(() => {
-        screen.getByRole("button", { name: "Saved Searches" }).click();
-      });
+      await user.click(screen.getByRole("button", { name: "Saved Searches" }));
       expect(
         screen.getByRole("menuitem", { name: /^Test search/ })
       ).toHaveAttribute("aria-disabled", "true");

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/CustomField.test.js
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/CustomField.test.js
@@ -11,6 +11,7 @@ import { makeMockField } from "../../../../stores/models/__tests__/FieldModel/mo
 import CustomField from "../CustomField";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../../theme";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -23,7 +24,8 @@ afterEach(cleanup);
 
 describe("CustomField", () => {
   describe("Should be able to delete the field", () => {
-    test("Keep field in existing samples", () => {
+    test("Keep field in existing samples", async () => {
+      const user = userEvent.setup();
       const field = makeMockField({
         type: "choice",
         definition: {
@@ -47,17 +49,14 @@ describe("CustomField", () => {
         </ThemeProvider>
       );
 
-      act(() => {
-        screen.getByRole("button", { name: "Delete field" }).click();
-      });
-      act(() => {
-        screen
-          .getByRole("menuitem", { name: "Keep field in existing samples" })
-          .click();
-      });
+      await user.click(screen.getByRole("button", { name: "Delete field" }));
+      await user.click(
+        screen.getByRole("menuitem", { name: "Keep field in existing samples" })
+      );
       expect(onRemove).toHaveBeenCalledWith(false);
     });
-    test("Remove field in existing samples", () => {
+    test("Remove field in existing samples", async () => {
+      const user = userEvent.setup();
       const field = makeMockField({
         type: "choice",
         definition: {
@@ -81,14 +80,12 @@ describe("CustomField", () => {
         </ThemeProvider>
       );
 
-      act(() => {
-        screen.getByRole("button", { name: "Delete field" }).click();
-      });
-      act(() => {
-        screen
-          .getByRole("menuitem", { name: "Remove field from existing samples" })
-          .click();
-      });
+      await user.click(screen.getByRole("button", { name: "Delete field" }));
+      await user.click(
+        screen.getByRole("menuitem", {
+          name: "Remove field from existing samples",
+        })
+      );
       expect(onRemove).toHaveBeenCalledWith(true);
     });
   });

--- a/src/main/webapp/ui/src/Inventory/__tests__/useNavigateHelpers.test.js
+++ b/src/main/webapp/ui/src/Inventory/__tests__/useNavigateHelpers.test.js
@@ -10,6 +10,7 @@ import { makeMockContainer } from "../../stores/models/__tests__/ContainerModel/
 import NavigateContext from "../../stores/contexts/Navigate";
 import Search from "../../stores/models/Search";
 import useNavigateHelpers from "../useNavigateHelpers";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -19,7 +20,8 @@ afterEach(cleanup);
 
 describe("useNavigateHelpers", () => {
   describe("navigateToRecord should", () => {
-    test("call setActiveResult", () => {
+    test("call setActiveResult", async () => {
+      const user = userEvent.setup();
       const mockContainer = makeMockContainer();
       const FunctionComponent = () => {
         const { navigateToRecord } = useNavigateHelpers();
@@ -46,14 +48,15 @@ describe("useNavigateHelpers", () => {
           <FunctionComponent />
         </NavigateContext.Provider>
       );
-      screen.getByText("Click me.").click();
+      await user.click(screen.getByText("Click me."));
 
       expect(setActiveResultSpy).toBeCalledWith(mockContainer);
     });
   });
 
   describe("navigateToSearch should", () => {
-    test("not call setActiveResult", () => {
+    test("not call setActiveResult", async () => {
+      const user = userEvent.setup();
       const mockSearchParams = { query: "foo" };
       const FunctionComponent = () => {
         const { navigateToSearch } = useNavigateHelpers();
@@ -85,7 +88,7 @@ describe("useNavigateHelpers", () => {
           <FunctionComponent />
         </NavigateContext.Provider>
       );
-      screen.getByText("Click me.").click();
+      await user.click(screen.getByText("Click me."));
 
       expect(setActiveResultSpy).not.toBeCalled();
     });

--- a/src/main/webapp/ui/src/Inventory/components/BarcodeScanner/__tests__/AllBarcodeScanner.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/BarcodeScanner/__tests__/AllBarcodeScanner.test.js
@@ -10,6 +10,7 @@ import "../../../../../__mocks__/barcode-detection-api";
 import AllBarcodeScanner from "../AllBarcodeScanner";
 import { sleep } from "../../../../util/Util";
 import { type BarcodeInput } from "../BarcodeScannerSkeleton";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -19,6 +20,7 @@ afterEach(cleanup);
 
 describe("AllBarcodeScanner", () => {
   test("Should scan correctly.", async () => {
+    const user = userEvent.setup();
     jest.spyOn(HTMLVideoElement.prototype, "play").mockImplementation(() => {});
 
     const onScan = jest.fn<[BarcodeInput], void>();
@@ -40,7 +42,7 @@ describe("AllBarcodeScanner", () => {
       await sleep(1100);
     });
 
-    screen.getByText("Scan").click();
+    await user.click(screen.getByText("Scan"));
 
     /*
      * This mocked value comes from src/main/webapp/ui/__mocks__/barcode-detection-api.js

--- a/src/main/webapp/ui/src/Inventory/components/BarcodeScanner/__tests__/QrCodeScanner.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/BarcodeScanner/__tests__/QrCodeScanner.test.js
@@ -9,6 +9,7 @@ import "@testing-library/jest-dom";
 import "../../../../../__mocks__/barcode-detection-api";
 import QrCodeScanner from "../QrCodeScanner";
 import { type BarcodeInput } from "../BarcodeScannerSkeleton";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("qr-scanner");
 
@@ -19,16 +20,15 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("QrCodeScanner", () => {
-  test("Should scan correctly.", () => {
+  test("Should scan correctly.", async () => {
+    const user = userEvent.setup();
     const onScan = jest.fn<[BarcodeInput], void>();
 
     render(
       <QrCodeScanner onClose={() => {}} onScan={onScan} buttonPrefix="Scan" />
     );
 
-    act(() => {
-      screen.getByText("Scan").click();
-    });
+    await user.click(screen.getByText("Scan"));
 
     expect(onScan).toHaveBeenCalledWith({
       rawValue: "foo",

--- a/src/main/webapp/ui/src/Inventory/components/BatchEditing/__tests__/BatchEditingItemsTable.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/BatchEditing/__tests__/BatchEditingItemsTable.test.js
@@ -13,6 +13,7 @@ import BatchEditingItemsTable from "../BatchEditingItemsTable";
 import "../../../../../__mocks__/matchMedia.js";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../../theme";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -23,10 +24,11 @@ afterEach(cleanup);
 describe("BatchEditingItemsTable", () => {
   test("Table body should have as many rows as records that are passed.", () => {
     fc.assert(
-      fc.property(
+      fc.asyncProperty(
         fc.tuple(arbRsSet(arbitraryRecord), fc.string()),
-        ([records, label]) => {
+        async ([records, label]) => {
           fc.pre(records.map(({ globalId }) => globalId).size === records.size);
+          const user = userEvent.setup();
           cleanup();
           render(
             <ThemeProvider theme={materialTheme}>
@@ -34,9 +36,7 @@ describe("BatchEditingItemsTable", () => {
             </ThemeProvider>
           );
 
-          act(() => {
-            screen.getByRole("button").click();
-          });
+          await user.click(screen.getByRole("button"));
           // + 1 for the table head
           expect(screen.queryAllByRole("row").length).toEqual(records.size + 1);
         }

--- a/src/main/webapp/ui/src/Inventory/components/ContextMenu/__tests__/EditAction.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/ContextMenu/__tests__/EditAction.test.js
@@ -4,7 +4,13 @@
 //@flow
 /* eslint-env jest */
 import React from "react";
-import { render, cleanup, waitFor, screen } from "@testing-library/react";
+import {
+  render,
+  cleanup,
+  waitFor,
+  screen,
+  fireEvent,
+} from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { makeMockContainer } from "../../../../stores/models/__tests__/ContainerModel/mocking";
 import EditAction from "../EditAction";
@@ -59,7 +65,11 @@ describe("EditAction", () => {
         "setVisiblePanel"
       );
 
-      screen.getByText("Edit").click();
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Edit" })).toBeEnabled();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
 
       await waitFor(() => {
         expect(setVisiblePanelSpy).toHaveBeenCalledWith("right");

--- a/src/main/webapp/ui/src/Inventory/components/ContextMenu/__tests__/MoveAction.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/ContextMenu/__tests__/MoveAction.test.js
@@ -18,6 +18,7 @@ import MoveAction from "../MoveAction";
 import MoveDialog from "../../MoveToTarget/MoveDialog";
 import "__mocks__/matchMedia";
 import { type StoreContainer } from "../../../../stores/stores/RootStore";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../../Search/SearchView", () => jest.fn(() => <></>));
 jest.mock("@mui/material/Dialog", () =>
@@ -34,7 +35,8 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("MoveAction", () => {
-  test("After the dialog is closed, the overflow context menu should have been closed.", () => {
+  test("After the dialog is closed, the overflow context menu should have been closed.", async () => {
+    const user = userEvent.setup();
     let rootStore: StoreContainer;
     rootStore = makeMockRootStore(
       observable({
@@ -77,12 +79,8 @@ describe("MoveAction", () => {
       </ThemeProvider>
     );
 
-    act(() => {
-      screen.getAllByRole("button", { name: "Move" })[0].click();
-    });
-    act(() => {
-      screen.getByRole("button", { name: "Cancel" }).click();
-    });
+    await user.click(screen.getAllByRole("button", { name: "Move" })[0]);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(closeMenu).toHaveBeenCalled();
   });

--- a/src/main/webapp/ui/src/Inventory/components/ContextMenu/__tests__/TransferAction.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/ContextMenu/__tests__/TransferAction.test.js
@@ -11,6 +11,7 @@ import Dialog from "@mui/material/Dialog";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../../theme";
 import { makeMockContainer } from "../../../../stores/models/__tests__/ContainerModel/mocking";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("@mui/material/Dialog", () =>
   jest.fn(({ children }) => {
@@ -27,6 +28,7 @@ afterEach(cleanup);
 
 describe("TransferAction", () => {
   test("Dialog should close when cancel is tapped.", async () => {
+    const user = userEvent.setup();
     render(
       <ThemeProvider theme={materialTheme}>
         <TransferAction
@@ -45,9 +47,7 @@ describe("TransferAction", () => {
       );
     });
 
-    act(() => {
-      screen.getAllByText("Transfer")[0].click();
-    });
+    await user.click(screen.getAllByText("Transfer")[0]);
 
     await waitFor(() => {
       expect(Dialog).toHaveBeenCalledWith(
@@ -56,9 +56,7 @@ describe("TransferAction", () => {
       );
     });
 
-    act(() => {
-      screen.getByText("Cancel").click();
-    });
+    await user.click(screen.getByText("Cancel"));
 
     await waitFor(() => {
       expect(Dialog).toHaveBeenLastCalledWith(

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Attachments/__tests__/PreviewAction.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Attachments/__tests__/PreviewAction.test.js
@@ -10,6 +10,7 @@ import { makeMockRootStore } from "../../../../../stores/stores/__tests__/RootSt
 import { storesContext } from "../../../../../stores/stores-context";
 import PreviewAction from "../PreviewAction";
 import { mockAttachment } from "../../../../../stores/definitions/__tests__/Attachment/mocking";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../../../../common/InvApiService", () => {});
 jest.mock("../../../../../stores/stores/RootStore", () => () => ({}));
@@ -22,6 +23,7 @@ afterEach(cleanup);
 
 describe("PreviewAction", () => {
   test("An error should be shown if the image cannot be fetched.", async () => {
+    const user = userEvent.setup();
     const rootStore = makeMockRootStore({
       uiStore: {
         addAlert: () => {},
@@ -40,9 +42,9 @@ describe("PreviewAction", () => {
         <PreviewAction attachment={attachment} />
       </storesContext.Provider>
     );
-    act(() => {
-      screen.getByRole("button", { name: "Preview file as image" }).click();
-    });
+    await user.click(
+      screen.getByRole("button", { name: "Preview file as image" })
+    );
 
     await waitFor(() => {
       expect(addAlertMock).toHaveBeenCalledWith(

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/__tests__/FieldCard.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/__tests__/FieldCard.test.js
@@ -10,6 +10,7 @@ import "@testing-library/jest-dom";
 import { mockFactory } from "../../../../../stores/definitions/__tests__/Factory/mocking";
 import FieldCard from "../FieldCard";
 import { type BarcodeRecord } from "../../../../../stores/definitions/Barcode";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../../../../common/InvApiService", () => {});
 jest.mock("../../../../../stores/stores/RootStore", () => () => ({}));
@@ -22,7 +23,8 @@ afterEach(cleanup);
 
 describe("FieldCard", () => {
   describe("Has a delete button", () => {
-    test("That behaves correctly when tapped when deletedCopy returns an object.", () => {
+    test("That behaves correctly when tapped when deletedCopy returns an object.", async () => {
+      const user = userEvent.setup();
       const setFieldsDirty = jest.fn<
         [{ barcodes: Array<BarcodeRecord> }],
         void
@@ -82,13 +84,14 @@ describe("FieldCard", () => {
         />
       );
 
-      screen.getByRole("button", { name: "Remove" }).click();
+      await user.click(screen.getByRole("button", { name: "Remove" }));
 
       expect(setFieldsDirty).toHaveBeenCalledWith({
         barcodes: [expect.objectContaining({ id: 1, deleted: true })],
       });
     });
-    test("That behaves correctly when tapped when deletedCopy returns null.", () => {
+    test("That behaves correctly when tapped when deletedCopy returns null.", async () => {
+      const user = userEvent.setup();
       const setFieldsDirty = jest.fn<
         [{ barcodes: Array<BarcodeRecord> }],
         void
@@ -128,7 +131,7 @@ describe("FieldCard", () => {
         />
       );
 
-      screen.getByRole("button", { name: "Remove" }).click();
+      await user.click(screen.getByRole("button", { name: "Remove" }));
 
       expect(setFieldsDirty).toHaveBeenCalledWith({
         barcodes: [],

--- a/src/main/webapp/ui/src/Inventory/components/MoveToTarget/__tests__/MoveDialog.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/MoveToTarget/__tests__/MoveDialog.test.js
@@ -31,6 +31,7 @@ import fc from "fast-check";
 import * as ArrayUtils from "../../../../util/ArrayUtils";
 import { type StoreContainer } from "../../../../stores/stores/RootStore";
 import SubSampleModel from "../../../../stores/models/SubSampleModel";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../../Search/SearchView", () => jest.fn(() => <></>));
 jest.mock("@mui/material/Dialog", () =>
@@ -50,6 +51,7 @@ afterEach(cleanup);
 
 describe("MoveDialog", () => {
   test("When cancel is pressed, the dialog should close.", async () => {
+    const user = userEvent.setup();
     let rootStore: StoreContainer;
     rootStore = makeMockRootStore(
       observable({
@@ -89,9 +91,7 @@ describe("MoveDialog", () => {
       expect.anything()
     );
 
-    act(() => {
-      screen.getByRole("button", { name: "Cancel" }).click();
-    });
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     await waitFor(() => {
       expect(rootStore.moveStore.isMoving).toBe(false);

--- a/src/main/webapp/ui/src/Inventory/components/Picker/__tests__/TemplatePicker.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Picker/__tests__/TemplatePicker.test.js
@@ -15,6 +15,7 @@ import { makeMockRootStore } from "../../../../stores/stores/__tests__/RootStore
 import { storesContext } from "../../../../stores/stores-context";
 import "__mocks__/resizeObserver";
 import "../../../../../__mocks__/matchMedia.js";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../../../common/InvApiService", () => ({
   get: () => ({}),
@@ -57,6 +58,7 @@ afterEach(cleanup);
 describe("TemplatePicker", () => {
   describe("Should support saved searches", () => {
     test("Tapping a saved search should change the templates listed", async () => {
+      const user = userEvent.setup();
       const rootStore = makeMockRootStore({
         searchStore: {
           savedSearches: [{ name: "Dummy saved search", query: "foo" }],
@@ -99,12 +101,10 @@ describe("TemplatePicker", () => {
       });
       expect(screen.getByRole("table")).toHaveTextContent("bar");
 
-      act(() => {
-        screen.getByRole("button", { name: "Saved Searches" }).click();
-      });
-      act(() => {
-        screen.getByRole("menuitem", { name: /^Dummy saved search/ }).click();
-      });
+      await user.click(screen.getByRole("button", { name: "Saved Searches" }));
+      await user.click(
+        screen.getByRole("menuitem", { name: /^Dummy saved search/ })
+      );
 
       await waitFor(() => {
         expect(screen.getByRole("table")).toHaveTextContent("foo");

--- a/src/main/webapp/ui/src/Inventory/components/Stepper/__tests__/StepperPanel.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Stepper/__tests__/StepperPanel.test.js
@@ -14,6 +14,7 @@ import SynchroniseFormSections from "../SynchroniseFormSections";
 import FormSectionsContext, {
   type AllowedFormTypes,
 } from "../../../../stores/contexts/FormSections";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../../../common/InvApiService", () => {});
 jest.mock("../../../../stores/stores/RootStore", () => () => ({}));
@@ -65,7 +66,8 @@ describe("StepperPanel", () => {
   });
 
   describe("Expands and collapses properly", () => {
-    test("Expand button works correctly", () => {
+    test("Expand button works correctly", async () => {
+      const user = userEvent.setup();
       const setExpanded = jest.fn<[AllowedFormTypes, string, boolean], void>();
       render(
         <ThemeProvider theme={materialTheme}>
@@ -83,12 +85,11 @@ describe("StepperPanel", () => {
         </ThemeProvider>
       );
 
-      act(() => {
-        screen.getByLabelText("Expand section").click();
-      });
+      await user.click(screen.getByLabelText("Expand section"));
       expect(setExpanded).toHaveBeenCalledWith("container", "bar", true);
     });
-    test("Collapse button works correctly", () => {
+    test("Collapse button works correctly", async () => {
+      const user = userEvent.setup();
       const setExpanded = jest.fn<[AllowedFormTypes, string, boolean], void>();
       render(
         <ThemeProvider theme={materialTheme}>
@@ -106,9 +107,7 @@ describe("StepperPanel", () => {
         </ThemeProvider>
       );
 
-      act(() => {
-        screen.getByLabelText("Collapse section").click();
-      });
+      await user.click(screen.getByLabelText("Collapse section"));
       expect(setExpanded).toHaveBeenCalledWith("container", "bar", false);
     });
   });
@@ -141,30 +140,24 @@ describe("StepperPanel", () => {
       );
     }
 
-    test("Collapse all", () => {
+    test("Collapse all", async () => {
+      const user = userEvent.setup();
       const setAllExpanded = jest.fn<[string, boolean], void>();
       render(<TestComponent setAllExpanded={setAllExpanded} openInit={true} />);
 
-      act(() => {
-        screen.getByLabelText("Collapse section").click();
-      });
-      act(() => {
-        screen.getByRole("button", { name: "Collapse All" }).click();
-      });
+      await user.click(screen.getByLabelText("Collapse section"));
+      await user.click(screen.getByRole("button", { name: "Collapse All" }));
       expect(setAllExpanded).toHaveBeenCalledWith("container", false);
     });
-    test("Expand all", () => {
+    test("Expand all", async () => {
+      const user = userEvent.setup();
       const setAllExpanded = jest.fn<[string, boolean], void>();
       render(
         <TestComponent setAllExpanded={setAllExpanded} openInit={false} />
       );
 
-      act(() => {
-        screen.getByLabelText("Expand section").click();
-      });
-      act(() => {
-        screen.getByRole("button", { name: "Expand All" }).click();
-      });
+      await user.click(screen.getByLabelText("Expand section"));
+      await user.click(screen.getByRole("button", { name: "Expand All" }));
       expect(setAllExpanded).toHaveBeenCalledWith("container", true);
     });
   });

--- a/src/main/webapp/ui/src/Inventory/components/__tests__/DeleteButton.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/__tests__/DeleteButton.test.js
@@ -9,6 +9,7 @@ import "@testing-library/jest-dom";
 import DeleteButton from "../DeleteButton";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../theme";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -44,26 +45,21 @@ describe("DeleteButton", () => {
     expect(screen.getByLabelText("bar"));
   });
 
-  test("Shows after clicked tooltip.", () => {
+  test("Shows after clicked tooltip.", async () => {
+    const user = userEvent.setup();
     const onClick = jest.fn(() => {});
     renderDeleteButton({ onClick });
-    act(() => {
-      screen.getByRole("button").click();
-    });
+    await user.click(screen.getByRole("button"));
     expect(onClick).toHaveBeenCalled();
     expect(screen.getByLabelText("foo"));
   });
 
-  test("Becomes disabled once clicked.", () => {
+  test("Becomes disabled once clicked.", async () => {
+    const user = userEvent.setup();
     const onClick = jest.fn(() => {});
     renderDeleteButton({ onClick });
 
-    act(() => {
-      screen.getByRole("button").click();
-    });
-    act(() => {
-      screen.getByRole("button").click();
-    });
-    expect(onClick).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole("button"));
+    expect(screen.getByRole("button")).toBeDisabled();
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/__tests__/RecordLink.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/__tests__/RecordLink.test.js
@@ -4,7 +4,7 @@
 //@flow
 /* eslint-env jest */
 import React from "react";
-import { render, cleanup, screen, act } from "@testing-library/react";
+import { render, cleanup, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { RecordLink } from "../RecordLink";
 import { makeMockRootStore } from "../../../stores/stores/__tests__/RootStore/mocking";
@@ -15,6 +15,7 @@ import {
 import { storesContext } from "../../../stores/stores-context";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../theme";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -23,7 +24,8 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("RecordLink", () => {
-  test("Clicking a link to a bench should show the search results.", () => {
+  test("Clicking a link to a bench should show the search results.", async () => {
+    const user = userEvent.setup();
     const rootStore = makeMockRootStore({
       uiStore: {
         setVisiblePanel: () => {},
@@ -41,12 +43,11 @@ describe("RecordLink", () => {
         </storesContext.Provider>
       </ThemeProvider>
     );
-    act(() => {
-      screen.getByRole("link", { name: /User User's Bench/ }).click();
-    });
+    await user.click(screen.getByRole("link", { name: /User User's Bench/ }));
     expect(spy).toHaveBeenCalledWith("left");
   });
-  test("Clicking a link to a container should show the container's details.", () => {
+  test("Clicking a link to a container should show the container's details.", async () => {
+    const user = userEvent.setup();
     const rootStore = makeMockRootStore({
       uiStore: {
         setVisiblePanel: () => {},
@@ -64,9 +65,7 @@ describe("RecordLink", () => {
         </storesContext.Provider>
       </ThemeProvider>
     );
-    act(() => {
-      screen.getByRole("link", { name: /A list container/ }).click();
-    });
+    await user.click(screen.getByRole("link", { name: /A list container/ }));
     expect(spy).toHaveBeenCalledWith("right");
   });
 });

--- a/src/main/webapp/ui/src/__tests__/customQueries.js
+++ b/src/main/webapp/ui/src/__tests__/customQueries.js
@@ -116,10 +116,11 @@ async function findTableCell(
 const allQueries = { ...queries, findTableCell, getIndexOfTableCell };
 const customRender: typeof render = (ui, options) =>
   render(ui, { queries: { ...queries, findTableCell }, ...options });
+
 const customWithin = (
   element: Element,
-  moreQueries: ?{ ... }
-): { ...Queries, findTableCell: ({| columnHeading: string, rowIndex: number |}) => Promise<Element>, getIndexOfTableCell: (string | RegExp) => number, ...  } => within(element, { ...allQueries, ...moreQueries });
+  //$FlowExpectedError[incompatible-return] Jest partially applied the custom queries with the element passed to `within`
+): {| ...Queries, findTableCell: ({| columnHeading: string, rowIndex: number |}) => Promise<Element>, getIndexOfTableCell: (string | RegExp) => number |} => within(element, { ...allQueries });
 
 // re-export everything
 export * from "@testing-library/react";

--- a/src/main/webapp/ui/src/__tests__/customQueries.js
+++ b/src/main/webapp/ui/src/__tests__/customQueries.js
@@ -115,6 +115,7 @@ async function findTableCell(
 
 const allQueries = { ...queries, findTableCell, getIndexOfTableCell };
 const customRender: typeof render = (ui, options) =>
+  //$FlowExpectedError[extra-arg] Only here are we allowed to pass additional queries
   render(ui, { queries: { ...queries, findTableCell }, ...options });
 
 const customWithin = (

--- a/src/main/webapp/ui/src/__tests__/customQueries.js
+++ b/src/main/webapp/ui/src/__tests__/customQueries.js
@@ -9,14 +9,13 @@
 import {
   within,
   render,
-  // $FlowExpectedError[missing-export] We may have the wrong version of the flow-typed definitions
   queries,
-  // $FlowExpectedError[missing-export] We may have the wrong version of the flow-typed definitions
-  type GetsAndQueries,
+  type Queries,
+  type Element,
 } from "@testing-library/react";
 
 export function getIndexOfTableCell(
-  tablerow: HTMLElement,
+  tablerow: Element,
   name: string | RegExp
 ): number {
   const cell = within(tablerow).getByRole("columnheader", { name });
@@ -86,9 +85,9 @@ export function getIndexOfTableCell(
  * ).toHaveTextContent("Four");
  */
 async function findTableCell(
-  table: HTMLElement,
+  table: Element,
   { columnHeading, rowIndex }: {| columnHeading: string, rowIndex: number |}
-): Promise<HTMLElement> {
+): Promise<Element> {
   const headingRow = (await within(table).findAllByRole("row"))[0];
   if (!headingRow) throw new Error("Table doesn't have a header row.");
 
@@ -118,9 +117,9 @@ const allQueries = { ...queries, findTableCell, getIndexOfTableCell };
 const customRender: typeof render = (ui, options) =>
   render(ui, { queries: { ...queries, findTableCell }, ...options });
 const customWithin = (
-  element: HTMLElement,
+  element: Element,
   moreQueries: ?{ ... }
-): GetsAndQueries => within(element, { ...allQueries, ...moreQueries });
+): { ...Queries, findTableCell: ({| columnHeading: string, rowIndex: number |}) => Promise<Element>, getIndexOfTableCell: (string | RegExp) => number, ...  } => within(element, { ...allQueries, ...moreQueries });
 
 // re-export everything
 export * from "@testing-library/react";

--- a/src/main/webapp/ui/src/components/Inputs/__tests__/AttachmentField.test.js
+++ b/src/main/webapp/ui/src/components/Inputs/__tests__/AttachmentField.test.js
@@ -5,7 +5,7 @@
 /* eslint-env jest */
 /* eslint-disable no-undefined */
 import React from "react";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, type Element } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import AttachmentField from "../AttachmentField";
 import TextField from "@mui/material/TextField";
@@ -28,7 +28,7 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-const expectLabel = (text: string) => (container: Node) =>
+const expectLabel = (text: string) => (container: Element) =>
   expect(container).toHaveTextContent(text);
 
 const expectTextField = (value: string) => () =>
@@ -84,7 +84,7 @@ describe("AttachmentField", () => {
         disabled: typeof undefined | boolean,
         value: string,
         noValueLabel: typeof undefined | string,
-        expectFn: (container: Node) => void,
+        expectFn: (container: Element) => void,
       |}) => {
         const { container } = render(
           <ThemeProvider theme={materialTheme}>

--- a/src/main/webapp/ui/src/components/Inputs/__tests__/ImageField.test.js
+++ b/src/main/webapp/ui/src/components/Inputs/__tests__/ImageField.test.js
@@ -9,10 +9,10 @@ import "@testing-library/jest-dom";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import ImageIcon from "@mui/icons-material/Image";
 import { __setIsMobile } from "react-device-detect";
-import { act } from "react-dom/test-utils";
 
 import ImageField from "../ImageField";
 import DynamicallyLoadedImageEditor from "../DynamicallyLoadedImageEditor";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("@mui/icons-material/CameraAlt", () => jest.fn(() => <div></div>));
 jest.mock("@mui/icons-material/Image", () => jest.fn(() => <div></div>));
@@ -81,15 +81,14 @@ describe("ImageField", () => {
    * Tapping 'Edit Image' should open the image editor
    */
   describe("When the 'Edit Image' button is tapped there should", () => {
-    test("be a DynamicallyLoadedImageEditor that opens.", () => {
+    test("be a DynamicallyLoadedImageEditor that opens.", async () => {
+      const user = userEvent.setup();
       render(
         <ImageField storeImage={() => {}} imageAsObjectURL={null} id="foo" />
       );
 
       const editImageButton = screen.getByText("Edit Image");
-      act(() => {
-        editImageButton.click();
-      });
+      await user.click(editImageButton);
       expect(DynamicallyLoadedImageEditor).toHaveBeenCalledWith(
         expect.objectContaining({
           editorOpen: true,

--- a/src/main/webapp/ui/src/components/Inputs/__tests__/InputWrapper.test.js
+++ b/src/main/webapp/ui/src/components/Inputs/__tests__/InputWrapper.test.js
@@ -5,7 +5,7 @@
 /* eslint-env jest */
 /* eslint-disable no-undefined */
 import React from "react";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, type Element } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import each from "jest-each";
 import InputWrapper from "../InputWrapper";
@@ -18,7 +18,7 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-const expectText = (text: string) => (container: Node) => {
+const expectText = (text: string) => (container: Element) => {
   expect(container).toHaveTextContent("Nothing here" + text);
 };
 
@@ -154,7 +154,7 @@ describe("InputWrapper", () => {
         error?: boolean,
         value?: string,
         helperText?: ?string,
-        expectFn: (container: Node) => void,
+        expectFn: (container: Element) => void,
       |}) => {
         const { container } = render(
           <ThemeProvider theme={materialTheme}>

--- a/src/main/webapp/ui/src/components/Inputs/__tests__/NumberField.test.js
+++ b/src/main/webapp/ui/src/components/Inputs/__tests__/NumberField.test.js
@@ -5,7 +5,7 @@
 /* eslint-env jest */
 /* eslint-disable no-undefined */
 import React from "react";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, type Element } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import NumberField from "../NumberField";
 import TextField from "@mui/material/TextField";
@@ -21,7 +21,7 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-const expectLabel = (text: string) => (container: Node) =>
+const expectLabel = (text: string) => (container: Element) =>
   expect(container).toHaveTextContent(text);
 
 const expectTextField = (value: ?(string | number)) => () =>
@@ -57,7 +57,7 @@ describe("NumberField", () => {
         disabled: typeof undefined | boolean,
         value: string | number,
         noValueLabel: typeof undefined | string,
-        expectFn: (container: Node) => void,
+        expectFn: (container: Element) => void,
       |}) => {
         const { container } = render(
           <ThemeProvider theme={materialTheme}>

--- a/src/main/webapp/ui/src/components/Inputs/__tests__/StringField.test.js
+++ b/src/main/webapp/ui/src/components/Inputs/__tests__/StringField.test.js
@@ -5,7 +5,7 @@
 /* eslint-env jest */
 /* eslint-disable no-undefined */
 import React from "react";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, type Element } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import StringField from "../StringField";
 import TextField from "@mui/material/TextField";
@@ -57,7 +57,7 @@ describe("StringField", () => {
         disabled: typeof undefined | boolean,
         value: string,
         noValueLabel: typeof undefined | string,
-        expectFn: (container: Node) => void,
+        expectFn: (container: Element) => void,
       |}) => {
         const { container } = render(
           <ThemeProvider theme={materialTheme}>

--- a/src/main/webapp/ui/src/components/__tests__/IconButtonWithTooltip.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/IconButtonWithTooltip.test.js
@@ -10,6 +10,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import IconButtonWithTooltip from "../IconButtonWithTooltip";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../theme";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -27,7 +28,8 @@ describe("IconButtonWithTooltip", () => {
 
     screen.getByLabelText("foo");
   });
-  test("onClick functions correctly.", () => {
+  test("onClick functions correctly.", async () => {
+    const user = userEvent.setup();
     const onClick = jest.fn<[Event], void>();
 
     render(
@@ -40,7 +42,7 @@ describe("IconButtonWithTooltip", () => {
       </ThemeProvider>
     );
 
-    screen.getByRole("button").click();
+    await user.click(screen.getByRole("button"));
 
     expect(onClick).toHaveBeenCalled();
   });

--- a/src/main/webapp/ui/src/components/__tests__/RemoveButton.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/RemoveButton.test.js
@@ -9,6 +9,7 @@ import "@testing-library/jest-dom";
 import RemoveButton from "../RemoveButton";
 import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../theme";
+import userEvent from "@testing-library/user-event";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -17,7 +18,8 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("RemoveButton", () => {
-  test("Should invoke onClick when clicked.", () => {
+  test("Should invoke onClick when clicked.", async () => {
+    const user = userEvent.setup();
     const onClick = jest.fn<[], void>();
     render(
       <ThemeProvider theme={materialTheme}>
@@ -25,7 +27,7 @@ describe("RemoveButton", () => {
       </ThemeProvider>
     );
 
-    screen.getByRole("button").click();
+    await user.click(screen.getByRole("button"));
 
     expect(onClick).toHaveBeenCalled();
   });

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/__tests__/DMPDialog.test.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/__tests__/DMPDialog.test.js
@@ -266,7 +266,7 @@ describe("DMPDialog", () => {
 
         await act(() => {
           within(screen.getByRole("listbox"))
-            .getByRole("option", { name: 5 })
+            .getByRole("option", { name: "5" })
             .click();
         });
 

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/__tests__/DMPDialog.test.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/__tests__/DMPDialog.test.js
@@ -5,13 +5,7 @@
 /* eslint-env jest */
 import "../../../../__mocks__/matchMedia.js";
 import React from "react";
-import {
-  cleanup,
-  screen,
-  waitFor,
-  act,
-  fireEvent,
-} from "@testing-library/react";
+import { cleanup, screen, waitFor, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import MockAdapter from "axios-mock-adapter";
 import DMPDialog from "../DMPDialog";
@@ -20,6 +14,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import materialTheme from "../../../theme";
 import { within, render } from "../../../__tests__/customQueries";
 import { take, incrementForever } from "../../../util/iterators";
+import userEvent from "@testing-library/user-event";
 
 const mockAxios = new MockAdapter(axios);
 
@@ -81,6 +76,7 @@ describe("DMPDialog", () => {
     "Importing a selected DMP should call the import endpoint.",
     async () => {
       jest.clearAllMocks();
+      const user = userEvent.setup();
       mockAxios.onGet(/\/apps\/argos\/plans.*/).reply(200, {
         data: {
           totalCount: 2,
@@ -117,22 +113,18 @@ describe("DMPDialog", () => {
         // i.e. the table body has been rendered
       });
 
-      await act(async () => {
-        (
-          await within(
-            await within(screen.getByRole("grid")).findTableCell({
-              columnHeading: "Select",
-              rowIndex: 0,
-            })
-          ).findByRole("radio")
-        ).click();
-      });
+      await user.click(
+        await within(
+          await within(screen.getByRole("grid")).findTableCell({
+            columnHeading: "Select",
+            rowIndex: 0,
+          })
+        ).findByRole("radio")
+      );
 
       mockAxios.resetHistory();
 
-      await act(async () => {
-        (await screen.findByRole("button", { name: "Import" })).click();
-      });
+      await user.click(await screen.findByRole("button", { name: "Import" }));
 
       expect(mockAxios.history.post.length).toBe(1);
       expect(mockAxios.history.post[0].url).toBe(
@@ -146,6 +138,7 @@ describe("DMPDialog", () => {
     test(
       "Next and previous page buttons should make the right API calls.",
       async () => {
+        const user = userEvent.setup();
         mockAxios.resetHistory();
         mockAxios.onGet(/\/apps\/argos\/plans.*/).reply(200, {
           data: {
@@ -176,21 +169,17 @@ describe("DMPDialog", () => {
           { timeout: 2000 }
         );
 
-        await act(() => {
-          screen
-            .getByRole("button", {
-              name: "Go to next page",
-            })
-            .click();
-        });
+        await user.click(
+          screen.getByRole("button", {
+            name: "Go to next page",
+          })
+        );
 
-        await act(() => {
-          screen
-            .getByRole("button", {
-              name: "Go to previous page",
-            })
-            .click();
-        });
+        await user.click(
+          screen.getByRole("button", {
+            name: "Go to previous page",
+          })
+        );
 
         expect(mockAxios.history.get.length).toBe(3);
         expect(
@@ -207,6 +196,7 @@ describe("DMPDialog", () => {
     test(
       "Changing the page size should make the right API call.",
       async () => {
+        const user = userEvent.setup();
         jest.clearAllMocks();
         mockAxios.onGet(/\/apps\/argos\/plans.*/).reply(200, {
           data: {
@@ -264,11 +254,9 @@ describe("DMPDialog", () => {
 
         fireEvent.mouseDown(screen.getByRole("combobox"));
 
-        await act(() => {
-          within(screen.getByRole("listbox"))
-            .getByRole("option", { name: "5" })
-            .click();
-        });
+        await user.click(
+          within(screen.getByRole("listbox")).getByRole("option", { name: "5" })
+        );
 
         expect(mockAxios.history.get.length).toBe(2);
         expect(
@@ -287,6 +275,7 @@ describe("DMPDialog", () => {
     test(
       "Label filter should make the right API call.",
       async () => {
+        const user = userEvent.setup();
         jest.clearAllMocks();
         mockAxios.onGet(/\/apps\/argos\/plans.*/).reply(200, {
           data: {
@@ -327,13 +316,11 @@ describe("DMPDialog", () => {
           { timeout: 2000 }
         );
 
-        await act(() => {
-          screen
-            .getByRole("button", {
-              name: "Label",
-            })
-            .click();
-        });
+        await user.click(
+          screen.getByRole("button", {
+            name: "Label",
+          })
+        );
 
         // first type in the label filter, and then press enter
         fireEvent.input(screen.getByRole("textbox"), {

--- a/src/main/webapp/ui/src/eln/apps/integrations/__tests__/GitHub.test.js
+++ b/src/main/webapp/ui/src/eln/apps/integrations/__tests__/GitHub.test.js
@@ -165,7 +165,7 @@ describe("GitHub", () => {
       const newReposTable = screen.getAllByRole("table")[1];
       expect(
         await within(newReposTable).findTableCell({
-          columnHeader: "Repository Name",
+          columnHeading: "Repository Name",
           rowIndex: 0,
         })
       ).toHaveTextContent("a repo");
@@ -306,14 +306,14 @@ describe("GitHub", () => {
       const connectedReposTable = screen.getAllByRole("table")[0];
       expect(
         await within(connectedReposTable).findTableCell({
-          columnHeader: "Repository Name",
+          columnHeading: "Repository Name",
           rowIndex: 0,
         })
       ).toHaveTextContent("a repo");
 
       expect(
         await within(allReposTable).findTableCell({
-          columnHeader: "Repository Name",
+          columnHeading: "Repository Name",
           rowIndex: 0,
         })
       ).toHaveTextContent("There are no available repositories.");

--- a/src/main/webapp/ui/src/eln/apps/integrations/__tests__/MSTeams.test.js
+++ b/src/main/webapp/ui/src/eln/apps/integrations/__tests__/MSTeams.test.js
@@ -46,7 +46,7 @@ describe("MSTeams", () => {
       const table = screen.getByRole("table");
       expect(
         await within(table).findTableCell({
-          columnHeader: "Channel Connector Name",
+          columnHeading: "Channel Connector Name",
           rowIndex: 0,
         })
       ).toHaveTextContent("foo");

--- a/src/main/webapp/ui/src/eln/sysadmin/users/__tests__/GrantUserPiRole.test.js
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/__tests__/GrantUserPiRole.test.js
@@ -8,7 +8,6 @@ import {
   render,
   cleanup,
   screen,
-  fireEvent,
   within,
   act,
   waitFor,
@@ -23,6 +22,7 @@ import * as axios from "axios";
 import USER_LISTING from "./userListing";
 import PDF_CONFIG from "./pdfConfig";
 import { sleep } from "../../../../util/Util";
+import userEvent from "@testing-library/user-event";
 
 const mockAxios = new MockAdapter(axios);
 
@@ -38,6 +38,7 @@ describe("Grant User PI Role", () => {
   test(
     "When `checkVerificationPasswordNeeded` returns true, a message should be shown.",
     async () => {
+      const user = userEvent.setup();
       const createObjectURL = jest
         .fn<[Blob], string>()
         .mockImplementation(() => "");
@@ -70,10 +71,10 @@ describe("Grant User PI Role", () => {
         await screen.findByRole("row", { name: /user8h/ })
       ).getByRole("checkbox");
 
-      fireEvent.click(checkbox);
+      await user.click(checkbox);
 
-      fireEvent.click(screen.getByRole("button", { name: /Actions/ }));
-      fireEvent.click(screen.getByRole("menuitem", { name: /Grant PI role/ }));
+      await user.click(screen.getByRole("button", { name: /Actions/ }));
+      await user.click(screen.getByRole("menuitem", { name: /Grant PI role/ }));
 
       expect(await screen.findByRole("dialog")).toBeVisible();
 
@@ -92,6 +93,7 @@ describe("Grant User PI Role", () => {
   test(
     "When `checkVerificationPasswordNeeded` returns false, a message should not be shown.",
     async () => {
+      const user = userEvent.setup();
       const createObjectURL = jest
         .fn<[Blob], string>()
         .mockImplementation(() => "");
@@ -124,10 +126,10 @@ describe("Grant User PI Role", () => {
         await screen.findByRole("row", { name: /user8h/ })
       ).getByRole("checkbox");
 
-      fireEvent.click(checkbox);
+      await user.click(checkbox);
 
-      fireEvent.click(screen.getByRole("button", { name: /Actions/ }));
-      fireEvent.click(screen.getByRole("menuitem", { name: /Grant PI role/ }));
+      await user.click(screen.getByRole("button", { name: /Actions/ }));
+      await user.click(screen.getByRole("menuitem", { name: /Grant PI role/ }));
 
       await waitFor(() => {
         expect(screen.getByRole("dialog")).toBeVisible();

--- a/src/main/webapp/ui/src/tinyMCE/jove/__tests__/Jove.test.js
+++ b/src/main/webapp/ui/src/tinyMCE/jove/__tests__/Jove.test.js
@@ -35,18 +35,12 @@ beforeEach(() => {
 describe("Renders page with jove data ", () => {
   it("displays jove table headers", async () => {
     render(<Jove />);
-    // eslint-disable-next-line testing-library/no-unnecessary-act
-    await act(() => {
-      return screen.findByText("Title");
-    });
+    await screen.findByText("Title");
   });
 
   it("displays jove search bar ", async () => {
     render(<Jove />);
-    // eslint-disable-next-line testing-library/no-unnecessary-act
-    await act(() => {
-      return screen.findByLabelText("Search");
-    });
+    await screen.findByLabelText("Search");
   });
 
   it('displays table headers for jove search results"', async () => {
@@ -58,10 +52,7 @@ describe("Renders page with jove data ", () => {
 
   it("displays jove search results", async () => {
     render(<Jove />);
-    // eslint-disable-next-line testing-library/no-unnecessary-act
-    await act(() => {
-      return screen.findByText("Title");
-    });
+    await screen.findByText("Title");
     await screen.findByText(
       "Induction and Validation of Cellular Senescence in Primary Human Cells"
     );


### PR DESCRIPTION
This change actually starts using @testing-library/user-event in the jest tests, despite it always having been in the package.json. This change includes type definition for the accompanying library as well as type definitions for the part of @testing-library/react that we use. These override the types downloaded from flow-types, allowing use to type custom queries correctly. This change also migrates a couple of tests from fireEvent to userEvent, [the reasons for doing so explained here](https://testing-library.com/docs/user-event/intro#differences-from-fireevent). Finally, this change removes usages of calling `click` on the found element, which doesn't trigger a react re-rendering without being wrapped in a call to `act` -- a foot-gun waiting to go off in many places.