### PR TITLE
Fix for ldapsearch command (which RSpace calls on LDAP setup) no longer working on ubuntu22.04 and newer

### DIFF
--- a/src/main/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutor.java
+++ b/src/main/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutor.java
@@ -17,7 +17,7 @@ public class LdapSearchCmdLineExecutor {
 
   public LdapSearchCmdLineExecutor(String ldapBaseSuffix, String ldapUrl, String dnField) {
     searchBase = ldapBaseSuffix;
-    host = ldapUrl.split("//")[1];
+    host = ldapUrl;
     this.dnField = dnField;
   }
 
@@ -29,8 +29,7 @@ public class LdapSearchCmdLineExecutor {
    */
   public String findDnForUid(String ldapUsername) {
 
-    String command =
-        String.format("ldapsearch -x %s -b \"%s\" uid=%s", host, searchBase, ldapUsername);
+    String command = getLdapSearchCommandString(ldapUsername);
     log.debug("running: " + command);
 
     String foundDn = null;
@@ -49,6 +48,10 @@ public class LdapSearchCmdLineExecutor {
     }
 
     return foundDn;
+  }
+
+  protected String getLdapSearchCommandString(String ldapUsername) {
+    return String.format("ldapsearch -x -H %s -b \"%s\" uid=%s", host, searchBase, ldapUsername);
   }
 
   private String readDnFromProcessOutput(InputStream inputStream) throws IOException {

--- a/src/main/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutor.java
+++ b/src/main/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutor.java
@@ -30,7 +30,7 @@ public class LdapSearchCmdLineExecutor {
   public String findDnForUid(String ldapUsername) {
 
     String command =
-        String.format("ldapsearch -x -h %s -b \"%s\" uid=%s", host, searchBase, ldapUsername);
+        String.format("ldapsearch -x %s -b \"%s\" uid=%s", host, searchBase, ldapUsername);
     log.debug("running: " + command);
 
     String foundDn = null;

--- a/src/test/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutorTest.java
+++ b/src/test/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutorTest.java
@@ -1,0 +1,22 @@
+package com.researchspace.ldap.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class LdapSearchCmdLineExecutorTest {
+
+  @Test
+  public void testLdapsearchCommandConstruction() {
+    LdapSearchCmdLineExecutor cmdLineExecutor =
+        new LdapSearchCmdLineExecutor(
+            "dc=test,dc=howler,dc=researchspace,dc=com",
+            "ldap://howler.researchspace.com",
+            "description");
+
+    String expectedCmd =
+        "ldapsearch -x -H ldap://howler.researchspace.com -b"
+            + " \"dc=test,dc=howler,dc=researchspace,dc=com\" uid=ldapUser1";
+    assertEquals(expectedCmd, cmdLineExecutor.getLdapSearchCommandString("ldapUser1"));
+  }
+}

--- a/src/test/java/com/researchspace/webapp/filter/SSOShiroFormAuthFilterTest.java
+++ b/src/test/java/com/researchspace/webapp/filter/SSOShiroFormAuthFilterTest.java
@@ -221,5 +221,4 @@ public class SSOShiroFormAuthFilterTest extends SpringTransactionalTest {
     u = userMgr.saveNewUser(u);
     return u;
   }
-
 }


### PR DESCRIPTION
In previous versions of Ubuntu the ldapsearch command required the -h flag to specify the host. However on ubuntu 22.04 and newer the -h flag breaks the command and you can just specify the IP with the -h flag and it works.

As a result, this breaks RSpace from being able to be setup with LDAP SSO when running on Ubuntu 22.04

I've edited the Java code to remove the -h flag when it calls the ldapsearch command.

This would fix LDAP for ubuntu 22.04 servers. 

Just creating this as a draft request at the moment, because I still need to check some things over from the DevOps side. When I have I'll change to a full pull request 