### PR TITLE
RSDEV-346: fix repoCfg object passed on DCD export

### DIFF
--- a/src/main/webapp/ui/src/Export/FormatChoice.js
+++ b/src/main/webapp/ui/src/Export/FormatChoice.js
@@ -94,7 +94,7 @@ function FormatChoice({
               return { repoCfg: -1, ...repo };
             if (repo.displayName === "Dryad") return { repoCfg: -1, ...repo };
             if (repo.displayName === "Zenodo") return { repoCfg: -1, ...repo };
-            if (repo.displayName === "Digital Commons Data")
+            if (repo.displayName === "Digital Commons Data / Mendeley Data")
               return { repoCfg: -1, ...repo };
 
             const keys = Object.keys(repo.options);


### PR DESCRIPTION
Quick fix for an export to DCD issue found by selenium test, `repoCfg` was no longer initialized correctly as the label has changed, and the code was conditional on the label text.