### PR TITLE
Refactor setup of repoCfg

### DIFF
--- a/src/main/webapp/ui/src/Export/FormatChoice.js
+++ b/src/main/webapp/ui/src/Export/FormatChoice.js
@@ -90,23 +90,31 @@ function FormatChoice({
         exportConfigUpdate(
           "repoData",
           repos.flatMap((repo) => {
-            if (repo.displayName === "Figshare")
-              return { repoCfg: -1, ...repo };
-            if (repo.displayName === "Dryad") return { repoCfg: -1, ...repo };
-            if (repo.displayName === "Zenodo") return { repoCfg: -1, ...repo };
-            if (repo.displayName === "Digital Commons Data / Mendeley Data")
-              return { repoCfg: -1, ...repo };
-
-            const keys = Object.keys(repo.options);
-            if (keys.length) {
-              return keys.map((k) => ({
-                repoCfg: k,
-                // $FlowExpectedError[incompatible-use] It is not clear why this is here
-                label: repo.options[k]._label,
-                ...repo,
-              }));
+            if (repo.repoName === "app.dataverse") {
+              /*
+               * On the apps page, users can configure multiple dataverses, so
+               * here we process that so each dataverse config is treated as a
+               * separate repository. The `keys` for each option is the string
+               * of a integer, and so too is `repoCfg`, but that is not really
+               * an important detail.
+               */
+              const keys = Object.keys(repo.options);
+              if (keys.length) {
+                return keys.map((k) => ({
+                  repoCfg: k,
+                  // $FlowExpectedError[incompatible-use]
+                  label: repo.options[k]._label,
+                  ...repo,
+                }));
+              }
+              return [];
             }
-            return [];
+            /*
+             * On the apps page, users can only configure a just one
+             * destination for each of the other repository services so we
+             * just copy the object from the API
+             */
+            return { repoCfg: -1, ...repo };
           })
         );
       })


### PR DESCRIPTION
Most importantly this replaces the use of `displayName` with `repoName`, which is what the logic of the code should exclusively rely on. Nobody would expect that changing the `displayName` would have a functional change to the logic.

Secondly, this change makes is explicit that it is dataverse that is doing the exceptional thing by supporting multiple destinations and not all of the other repository services by inverting the conditional logic and adding explanatory comments.