### PR TITLE
RSDEV-390 Show file name and description in image preview

### DIFF
--- a/src/main/webapp/ui/src/components/ImagePreview.js
+++ b/src/main/webapp/ui/src/components/ImagePreview.js
@@ -6,6 +6,15 @@ import { Gallery, Item } from "react-photoswipe-gallery";
 import { type URL } from "../util/types";
 import { makeStyles } from "tss-react/mui";
 
+function escapeHtml(unsafe: string) {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 const useStyles = makeStyles()(() => ({
   image: {
     height: 0,
@@ -24,6 +33,12 @@ type ImagePreviewArgs = {|
   size: ?PreviewSize,
   setSize: (PreviewSize) => void,
   modal?: boolean,
+
+  /*
+   * A list of strings, shown from top to bottom, separated by two `<br />`s,
+   * placed at the bottom of the viewport
+   */
+  caption?: null | $ReadOnlyArray<string>,
 |};
 
 export default function ImagePreview({
@@ -32,6 +47,7 @@ export default function ImagePreview({
   size,
   setSize,
   modal = true,
+  caption,
 }: ImagePreviewArgs): Node {
   const { classes } = useStyles();
   return (
@@ -48,6 +64,7 @@ export default function ImagePreview({
           closePreview();
         });
       }}
+      withCaption={(caption ?? []).length > 0}
     >
       <Item
         original={link}
@@ -55,6 +72,7 @@ export default function ImagePreview({
         thumbnail={link}
         width={size?.width ?? 100}
         height={size?.height ?? 100}
+        caption={(caption ?? []).map(escapeHtml).join("<br /><br />")}
       >
         {({ ref, open: openFn }) => (
           <img

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.js
@@ -340,7 +340,18 @@ function ActionsMenu({
       .only.toResult(() => new Error("Too many items selected."))
       .flatMap((file) =>
         canPreviewAsImage(file)
-          .map((downloadHref) => ({ key: "image", downloadHref }))
+          .map((downloadHref) => ({
+            key: "image",
+            downloadHref,
+            caption: [
+              file.description.match({
+                missing: () => "",
+                empty: () => "",
+                present: (desc) => desc,
+              }),
+              file.name,
+            ],
+          }))
           .orElseTry(() =>
             canPreviewAsPdf(file).map((downloadHref) => ({
               key: "pdf",
@@ -463,7 +474,9 @@ function ActionsMenu({
             onClick={() => {
               viewAllowed.get().do((viewAction) => {
                 if (viewAction.key === "image")
-                  openImagePreview(viewAction.downloadHref);
+                  openImagePreview(viewAction.downloadHref, {
+                    caption: viewAction.caption,
+                  });
                 if (viewAction.key === "pdf")
                   openPdfPreview(viewAction.downloadHref);
                 if (viewAction.key === "aspose")

--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
@@ -693,7 +693,9 @@ export const InfoPanelForLargeViewports: ComponentType<{||}> = () => {
                     <Grid item sx={{ mt: 0.5, mb: 0.25 }} key={null}>
                       <ActionButton
                         onClick={() => {
-                          openImagePreview(action.downloadHref);
+                          openImagePreview(action.downloadHref, {
+                            caption: action.caption,
+                          });
                         }}
                         label="View"
                         sx={{

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -645,7 +645,9 @@ const GridView = observer(
                         return;
                       }
                       if (action.tag === "image") {
-                        openImagePreview(action.downloadHref);
+                        openImagePreview(action.downloadHref, {
+                          caption: action.caption,
+                        });
                         return;
                       }
                       if (action.tag === "collabora") {

--- a/src/main/webapp/ui/src/eln/gallery/primaryActionHooks.js
+++ b/src/main/webapp/ui/src/eln/gallery/primaryActionHooks.js
@@ -106,7 +106,7 @@ export default function usePrimaryAction(): (
   file: GalleryFile
 ) => Result<
   | {| tag: "open", open: () => void |}
-  | {| tag: "image", downloadHref: string |}
+  | {| tag: "image", downloadHref: string, caption: $ReadOnlyArray<string> |}
   | {| tag: "collabora", url: string |}
   | {| tag: "officeonline", url: string |}
   | {| tag: "pdf", downloadHref: string |}
@@ -126,6 +126,14 @@ export default function usePrimaryAction(): (
         canPreviewAsImage(file).map((downloadHref) => ({
           tag: "image",
           downloadHref,
+          caption: [
+            file.description.match({
+              missing: () => "",
+              empty: () => "",
+              present: (desc) => desc,
+            }),
+            file.name,
+          ],
         }))
       )
       .orElseTry(() =>


### PR DESCRIPTION
When the user previews an image in the new gallery, the lightbox preview modal now shows the filename and description just like the old gallery