### PR TITLE
Fix accessibility issues with DescriptionList component

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/DetailedListing/Card.js
+++ b/src/main/webapp/ui/src/Inventory/components/DetailedListing/Card.js
@@ -78,7 +78,6 @@ const Details = withStyles<{| record: InventoryRecord |}, { location: string }>(
   })
 )(({ record, classes }) => (
   <DescriptionList
-    rightAlignDds
     content={[
       ...(record.readAccessLevel === "full" && record instanceof ContainerModel
         ? [

--- a/src/main/webapp/ui/src/Inventory/components/RecordDetails.js
+++ b/src/main/webapp/ui/src/Inventory/components/RecordDetails.js
@@ -62,7 +62,6 @@ function RecordDetails({ record, hideName = false }: RecordDetailsArgs): Node {
       )}
       <Grid item className={classes.grow}>
         <DescriptionList
-          rightAlignDds
           /* some elements are not displayed depending on view (public or limited) */
           content={[
             ...(record.recordDetails.hideGlobalId

--- a/src/main/webapp/ui/src/components/DescriptionList.js
+++ b/src/main/webapp/ui/src/components/DescriptionList.js
@@ -14,9 +14,10 @@ import { styled } from "@mui/material/styles";
 
 const useStyles = makeStyles()((theme, { dividers, rightAlignDds }) => ({
   dl: {
-    display: "flex",
-    flexDirection: "column",
-    flexWrap: "unset",
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr",
+    fontSize: "0.8rem",
+    rowGap: "8px",
     margin: 0,
     "& > span:nth-of-type(n+2)": {
       borderTop: dividers ? theme.borders.descriptionList : "none",
@@ -45,10 +46,13 @@ const useStyles = makeStyles()((theme, { dividers, rightAlignDds }) => ({
     alignSelf: "flex-start",
   },
   ddBelow: {
-    alignSelf: "flex-end",
+    gridColumnStart: "1",
+    top: "8px",
+    position: "relative",
   },
   dd: {
     margin: 0,
+    justifySelf: "end",
   },
   spanReducedPadding: {
     paddingTop: "3px !important",
@@ -100,14 +104,7 @@ function DescriptionList({
     <Dl className={classes.dl} sx={sx}>
       {content.map(
         ({ label, value, below = false, reducedPadding = false }) => (
-          <span
-            key={label}
-            className={clsx(
-              classes.span,
-              below && classes.spanBelow,
-              reducedPadding && classes.spanReducedPadding
-            )}
-          >
+          <>
             <dt
               className={clsx(
                 classes.dt,
@@ -126,7 +123,7 @@ function DescriptionList({
             >
               {value}
             </dd>
-          </span>
+          </>
         )
       )}
     </Dl>

--- a/src/main/webapp/ui/src/components/DescriptionList.js
+++ b/src/main/webapp/ui/src/components/DescriptionList.js
@@ -13,7 +13,7 @@ import clsx from "clsx";
 import { styled } from "@mui/material/styles";
 import Divider from "@mui/material/Divider";
 
-const useStyles = makeStyles()((theme, { rightAlignDds }) => ({
+const useStyles = makeStyles()((theme) => ({
   dl: {
     display: "grid",
     gridTemplateColumns: "1fr 1fr",
@@ -54,7 +54,6 @@ type DescriptionListArgs = {|
     reducedPadding?: boolean,
   |}>,
   dividers?: boolean,
-  rightAlignDds?: boolean,
   sx?: { ... },
 |};
 
@@ -81,10 +80,9 @@ const Dl = styled("dl")``;
 function DescriptionList({
   content,
   dividers = false,
-  rightAlignDds = false,
   sx,
 }: DescriptionListArgs): Node {
-  const { classes } = useStyles({ rightAlignDds });
+  const { classes } = useStyles();
 
   return (
     <Dl className={classes.dl} sx={sx}>

--- a/src/main/webapp/ui/src/components/DescriptionList.js
+++ b/src/main/webapp/ui/src/components/DescriptionList.js
@@ -26,14 +26,23 @@ const useStyles = makeStyles()((theme, { rightAlignDds }) => ({
     color: theme.palette.text.secondary,
     fontWeight: "600",
     marginRight: theme.spacing(2),
+    alignSelf: "center",
   },
-  ddBelow: {
-    gridColumn: "1 / span 2",
-    marginTop: "-10px",
+  dtReducedPadding: {
+    marginTop: "-8px",
+    marginBottom: "-8px",
   },
   dd: {
     marginInlineStart: 0,
     justifySelf: "end",
+  },
+  ddReducedPadding: {
+    marginTop: "-8px",
+    marginBottom: "-8px",
+  },
+  ddBelow: {
+    gridColumn: "1 / span 2",
+    marginTop: "-10px",
   },
 }));
 
@@ -95,6 +104,7 @@ function DescriptionList({
             <dt
               className={clsx(
                 classes.dt,
+                reducedPadding && classes.dtReducedPadding,
                 below && classes.dtBelow,
                 below && "below"
               )}
@@ -104,6 +114,7 @@ function DescriptionList({
             <dd
               className={clsx(
                 classes.dd,
+                reducedPadding && classes.ddReducedPadding,
                 below && classes.ddBelow,
                 below && "below"
               )}

--- a/src/main/webapp/ui/src/components/DescriptionList.js
+++ b/src/main/webapp/ui/src/components/DescriptionList.js
@@ -19,20 +19,15 @@ const useStyles = makeStyles()((theme, { dividers, rightAlignDds }) => ({
     fontSize: "0.8rem",
     rowGap: "8px",
     margin: 0,
+    marginBottom: "8px",
   },
   dt: {
     color: theme.palette.text.secondary,
     fontWeight: "600",
     marginRight: theme.spacing(2),
   },
-  dtBelow: {
-    gridColumnStart: "1",
-    gridColumnEnd: "span 2",
-    marginTop: "-10px",
-  },
   ddBelow: {
-    gridColumnStart: "1",
-    gridColumnEnd: "span 2",
+    gridColumn: "1 / span 2",
     marginTop: "-10px",
   },
   dd: {

--- a/src/main/webapp/ui/src/components/DescriptionList.js
+++ b/src/main/webapp/ui/src/components/DescriptionList.js
@@ -18,9 +18,9 @@ const useStyles = makeStyles()((theme) => ({
     display: "grid",
     gridTemplateColumns: "1fr 1fr",
     fontSize: "0.8rem",
-    rowGap: "8px",
+    rowGap: theme.spacing(1),
     margin: 0,
-    marginBottom: "8px",
+    marginBottom: theme.spacing(1),
   },
   dt: {
     color: theme.palette.text.secondary,
@@ -29,16 +29,16 @@ const useStyles = makeStyles()((theme) => ({
     alignSelf: "center",
   },
   dtReducedPadding: {
-    marginTop: "-8px",
-    marginBottom: "-8px",
+    marginTop: `-${theme.spacing(1)}`,
+    marginBottom: `-${theme.spacing(1)}`,
   },
   dd: {
     marginInlineStart: 0,
     justifySelf: "end",
   },
   ddReducedPadding: {
-    marginTop: "-8px",
-    marginBottom: "-8px",
+    marginTop: `-${theme.spacing(1)}`,
+    marginBottom: `-${theme.spacing(1)}`,
   },
   ddBelow: {
     gridColumn: "1 / span 2",

--- a/src/main/webapp/ui/src/components/DescriptionList.js
+++ b/src/main/webapp/ui/src/components/DescriptionList.js
@@ -19,44 +19,25 @@ const useStyles = makeStyles()((theme, { dividers, rightAlignDds }) => ({
     fontSize: "0.8rem",
     rowGap: "8px",
     margin: 0,
-    "& > span:nth-of-type(n+2)": {
-      borderTop: dividers ? theme.borders.descriptionList : "none",
-    },
   },
   dt: {
     color: theme.palette.text.secondary,
     fontWeight: "600",
     marginRight: theme.spacing(2),
   },
-  span: {
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: rightAlignDds ? "space-between" : "unset",
-    alignItems: "center",
-    padding: dividers
-      ? theme.spacing(0.75, 1, 0.675)
-      : theme.spacing(0, 0, 1, 0),
-    fontSize: "0.8rem",
-    minHeight: "unset",
-  },
-  spanBelow: {
-    flexDirection: "column",
-  },
   dtBelow: {
-    alignSelf: "flex-start",
+    gridColumnStart: "1",
+    gridColumnEnd: "span 2",
+    marginTop: "-10px",
   },
   ddBelow: {
     gridColumnStart: "1",
-    top: "8px",
-    position: "relative",
+    gridColumnEnd: "span 2",
+    marginTop: "-10px",
   },
   dd: {
-    margin: 0,
+    marginInlineStart: 0,
     justifySelf: "end",
-  },
-  spanReducedPadding: {
-    paddingTop: "3px !important",
-    paddingBottom: "3px !important",
   },
 }));
 

--- a/src/main/webapp/ui/src/components/DescriptionList.js
+++ b/src/main/webapp/ui/src/components/DescriptionList.js
@@ -11,8 +11,9 @@ import { observer } from "mobx-react-lite";
 import { makeStyles } from "tss-react/mui";
 import clsx from "clsx";
 import { styled } from "@mui/material/styles";
+import Divider from "@mui/material/Divider";
 
-const useStyles = makeStyles()((theme, { dividers, rightAlignDds }) => ({
+const useStyles = makeStyles()((theme, { rightAlignDds }) => ({
   dl: {
     display: "grid",
     gridTemplateColumns: "1fr 1fr",
@@ -74,13 +75,23 @@ function DescriptionList({
   rightAlignDds = false,
   sx,
 }: DescriptionListArgs): Node {
-  const { classes } = useStyles({ dividers, rightAlignDds });
+  const { classes } = useStyles({ rightAlignDds });
 
   return (
     <Dl className={classes.dl} sx={sx}>
       {content.map(
-        ({ label, value, below = false, reducedPadding = false }) => (
+        ({ label, value, below = false, reducedPadding = false }, i) => (
           <>
+            {i > 0 && dividers && (
+              <Divider
+                orientation="horizontal"
+                sx={{
+                  gridColumn: "1 / span 2",
+                }}
+                aria-hidden="true"
+                component="div"
+              />
+            )}
             <dt
               className={clsx(
                 classes.dt,

--- a/src/main/webapp/ui/src/components/Tags/TagListing.js
+++ b/src/main/webapp/ui/src/components/Tags/TagListing.js
@@ -155,7 +155,6 @@ export default function TagListing({
           <Card>
             <CardContent>
               <DescriptionList
-                rightAlignDds
                 content={cardContent(metadataPopup.tag)}
                 dividers={true}
               />

--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
@@ -485,7 +485,10 @@ const InfoPanelContent = ({
         ]}
         sx={{
           "& dd.below": {
-            width: "100%",
+            gridColumnStart: "1",
+            position: "relative",
+            top: "-8px",
+            lef: "-4px",
           },
         }}
       />

--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
@@ -485,10 +485,8 @@ const InfoPanelContent = ({
         ]}
         sx={{
           "& dd.below": {
-            gridColumnStart: "1",
-            position: "relative",
-            top: "-8px",
-            lef: "-4px",
+            justifySelf: "start",
+            width: "100%",
           },
         }}
       />

--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
@@ -465,7 +465,6 @@ const InfoPanelContent = ({
   return (
     <Stack sx={{ height: "100%" }}>
       <DescriptionList
-        rightAlignDds
         content={[
           {
             label: "Global ID",
@@ -495,7 +494,6 @@ const InfoPanelContent = ({
           Details
         </Typography>
         <DescriptionList
-          rightAlignDds
           content={[
             {
               label: "Type",
@@ -541,7 +539,6 @@ const InfoPanelMultipleContent = (): Node => {
     );
   return (
     <DescriptionList
-      rightAlignDds
       content={[
         {
           label: "Total size",


### PR DESCRIPTION
Rather than using `span`s to aid with styling, which violates the semantic HTML rules, this change uses CSS Flex Grid layout instead. This also offers greater customisation it each call site by tweaking the styling rather than having to pass lots of parameters.