### PR TITLE
RSDEV-411: a few fixes for pdf export, most importantly allow docs to have & (ampersand) in the name

### DIFF
--- a/src/main/java/com/researchspace/export/pdf/ExportToFileConfig.java
+++ b/src/main/java/com/researchspace/export/pdf/ExportToFileConfig.java
@@ -112,7 +112,7 @@ public class ExportToFileConfig implements StructuredDocumentHTMLViewConfig, IEx
         + pageSize
         + ", dateType="
         + dateType
-        + ", includeFooter="
+        + ", includeFooterAtEndOnly="
         + includeFooterAtEndOnly
         + ", exportName="
         + exportName

--- a/src/main/java/com/researchspace/export/pdf/PdfHtmlGenerator.java
+++ b/src/main/java/com/researchspace/export/pdf/PdfHtmlGenerator.java
@@ -36,30 +36,33 @@ public class PdfHtmlGenerator {
 
   private final VelocityEngine velocityEngine;
 
+  private HTMLUnicodeFontProcesser htmlUnicodeFontProcesser;
+
   public static final int MAX_TITLE_WIDTH = 50;
 
   public final SimpleDateFormat simpleDateFmt = new SimpleDateFormat("yyyy-MM-dd");
 
   @Autowired
-  public PdfHtmlGenerator(VelocityEngine velocityEngine) {
+  public PdfHtmlGenerator(VelocityEngine velocityEngine, HTMLUnicodeFontProcesser fontProcessor) {
     this.velocityEngine = velocityEngine;
+    this.htmlUnicodeFontProcesser = fontProcessor;
   }
 
   public String prepareHtml(
       ExportProcesserInput documentData, IRSpaceDoc doc, ExportToFileConfig config) {
-    String pageSize = config.getPageSize().equals("A4") ? "A4" : "LETTER";
-    String docOwner = String.format("Owner: %s", doc.getOwner().getFullName());
     String docTitle = StringUtils.abbreviate(doc.getName(), MAX_TITLE_WIDTH);
+    String pageSize = config.getPageSize().equals("A4") ? "A4" : "LETTER";
     String footerFormattedDate = formatFooterDate(doc, config);
-    String styles =
-        makeStyleElement(
-            docOwner,
-            docTitle,
-            pageSize,
-            !config.isIncludeFooterAtEndOnly(),
-            config.getExporter().getFullName(),
-            footerFormattedDate);
-    String html = addStyleElement(documentData.getDocumentAsHtml(), styles);
+
+    String html = documentData.getDocumentAsHtml();
+    html =
+        addStyleElement(
+            html,
+            makeHtmlStyleElement(
+                pageSize, !config.isIncludeFooterAtEndOnly(), footerFormattedDate));
+    html =
+        addEachPageElems(
+            html, doc.getOwner().getFullName(), docTitle, config.getExporter().getFullName());
     html = prepareTables(html);
     html = addDocExtras(documentData, config, html);
     if (config.isIncludeFooterAtEndOnly()) {
@@ -82,22 +85,27 @@ public class PdfHtmlGenerator {
     return footerFormattedDate;
   }
 
-  private String makeStyleElement(
-      String docOwner,
-      String docTitle,
-      String pageSize,
-      boolean footerEachPage,
-      String exporterFullName,
-      String footerDate) {
+  private String makeHtmlStyleElement(String pageSize, boolean footerEachPage, String footerDate) {
     Map<String, Object> context = new HashMap<>();
     context.put("pageSize", pageSize);
-    context.put("docOwner", docOwner);
-    context.put("docTitle", docTitle);
     context.put("footerEachPage", footerEachPage);
-    context.put("exporterFullName", exporterFullName);
     context.put("footerDate", footerDate);
     return VelocityEngineUtils.mergeTemplateIntoString(
         velocityEngine, "pdf/styles.vm", "UTF-8", context);
+  }
+
+  private String addEachPageElems(
+      String html, String docOwner, String docTitle, String exporterFullName) {
+
+    Map<String, Object> context = new HashMap<>();
+    context.put("docOwner", docOwner);
+    context.put("docTitle", docTitle);
+    context.put("exporterFullName", exporterFullName);
+    String runningPageHtml =
+        VelocityEngineUtils.mergeTemplateIntoString(
+            velocityEngine, "pdf/runningPageElems.vm", "UTF-8", context);
+    runningPageHtml = htmlUnicodeFontProcesser.apply(runningPageHtml);
+    return appendToStartOfBody(html, runningPageHtml);
   }
 
   private Document stringToJsoupDoc(String html) {
@@ -245,6 +253,13 @@ public class PdfHtmlGenerator {
     Document document = stringToJsoupDoc(html);
     Element head = document.head();
     head.append(styles);
+    return document.toString();
+  }
+
+  private String appendToStartOfBody(String html, String toAppend) {
+    Document document = stringToJsoupDoc(html);
+    List<Node> bodyChildren = document.selectFirst("body").childNodes();
+    bodyChildren.get(0).before(toAppend);
     return document.toString();
   }
 

--- a/src/main/java/com/researchspace/webapp/controller/GalleryController.java
+++ b/src/main/java/com/researchspace/webapp/controller/GalleryController.java
@@ -253,22 +253,22 @@ public class GalleryController extends BaseController {
     int numberOfRecords = getNumberOfRecordsOnGalleryPage(isOnRoot);
     pgCrit.setResultsPerPage(numberOfRecords);
 
-    RecordTypeFilter galleryMove = new RecordTypeFilter(EnumSet.of(
-        RecordType.FOLDER,
-            RecordType.ROOT_MEDIA,
-            RecordType.SHARED_GROUP_FOLDER_ROOT,
-            RecordType.INDIVIDUAL_SHARED_FOLDER_ROOT,
-            RecordType.API_INBOX),
-        // excluded
-        EnumSet.of(
-            RecordType.NORMAL_EXAMPLE
-            // removed for APiInbox
-            //RecordType.SYSTEM
-        ));
+    RecordTypeFilter galleryMove =
+        new RecordTypeFilter(
+            EnumSet.of(
+                RecordType.FOLDER,
+                RecordType.ROOT_MEDIA,
+                RecordType.SHARED_GROUP_FOLDER_ROOT,
+                RecordType.INDIVIDUAL_SHARED_FOLDER_ROOT,
+                RecordType.API_INBOX),
+            // excluded
+            EnumSet.of(
+                RecordType.NORMAL_EXAMPLE
+                // removed for APiInbox
+                // RecordType.SYSTEM
+                ));
 
-
-    RecordTypeFilter recordTypeFilter =
-        foldersOnly ? galleryMove : RecordTypeFilter.GALLERY_FILTER;
+    RecordTypeFilter recordTypeFilter = foldersOnly ? galleryMove : RecordTypeFilter.GALLERY_FILTER;
     ISearchResults<BaseRecord> records =
         recordManager.getGalleryItems(
             galleryItemParent.getId(), pgCrit, filterCriteria, recordTypeFilter, user);

--- a/src/main/resources/velocityTemplates/pdf/runningPageElems.vm
+++ b/src/main/resources/velocityTemplates/pdf/runningPageElems.vm
@@ -1,0 +1,9 @@
+<div class="runningHeaderLeft">
+  Owner: $docOwner
+</div>
+<div class="runningHeaderCenter">
+  $docTitle
+</div>
+<div class="runningFooterRight">
+  Exported by: $exporterFullName
+</div>

--- a/src/main/resources/velocityTemplates/pdf/styles.vm
+++ b/src/main/resources/velocityTemplates/pdf/styles.vm
@@ -3,13 +3,13 @@
     size: $pageSize;
 
     @top-left {
-      content: '$docOwner';
+      content: element(headerLeft);
       border-bottom: solid black;
       font-family: 'Arial', 'Helvetica', 'sans-serif';
     }
 
     @top-center {
-      content: '$docTitle';
+      content: element(headerCenter);
       border-bottom: solid black;
       font-family: 'Arial', 'noto sans', 'Helvetica', 'sans-serif';
     }
@@ -22,19 +22,29 @@
 
     #if ($footerEachPage == true)
       @bottom-left {
-        content: $footerDate;
+        content: '$footerDate';
+        border-top: solid black;
+        font-family: 'Arial', 'Helvetica', 'sans-serif';
+      }
+
+      @bottom-center {
+        content: '';
         border-top: solid black;
         font-family: 'Arial', 'Helvetica', 'sans-serif';
       }
 
       @bottom-right {
-        content: 'Exported by: $exporterFullName';
-        border-bottom: solid black;
+        content: element(footerRight);
+        border-top: solid black;
         font-family: 'Arial', 'Helvetica', 'sans-serif';
       }
     #end
 
   }
+
+  .runningHeaderLeft {position: running(headerLeft);}
+  .runningHeaderCenter {position: running(headerCenter);}
+  .runningFooterRight {position: running(footerRight);}
 
   #footer {
     text-align: center;

--- a/src/main/webapp/scripts/tags/exportOtherDialogs.js
+++ b/src/main/webapp/scripts/tags/exportOtherDialogs.js
@@ -63,7 +63,7 @@ function _setUpPdfDialog() {
                     restartPageNumberPerDoc : restartPageNumberPerDoc,
                     pageSize : pageSize,
                     dateType: dateType,
-                    includeFooter : includeFooter,
+                    includeFooterAtEndOnly : includeFooter,
                     setPageSizeAsDefault: setPageSizeAsDefault,
                     includeFieldLastModifiedDate: includeFieldLastModifiedDate
                 };

--- a/src/main/webapp/ui/src/Export/ExportDialog.js
+++ b/src/main/webapp/ui/src/Export/ExportDialog.js
@@ -541,7 +541,7 @@ const pdfConfig = {
   pageSize: "A4",
   defaultPageSize: "A4",
   dateType: "EXP",
-  includeFooter: true,
+  includeFooterAtEndOnly: true,
   setPageSizeAsDefault: false,
   includeFieldLastModifiedDate: true,
 };

--- a/src/main/webapp/ui/src/Export/PdfExport.js
+++ b/src/main/webapp/ui/src/Export/PdfExport.js
@@ -21,7 +21,7 @@ export type PdfExportDetails = {|
   pageSize: PageSize,
   defaultPageSize: PageSize,
   dateType: "EXP" | "NEW" | "UPD",
-  includeFooter: boolean,
+  includeFooterAtEndOnly: boolean,
   setPageSizeAsDefault: boolean,
   includeFieldLastModifiedDate: boolean,
 |};
@@ -50,7 +50,7 @@ const checkboxes = {
   annotations: "Include image annotations",
   includeFieldLastModifiedDate: "Include last modified dates for fields",
   restartPageNumberPerDoc: "Restart page numbering for each document",
-  includeFooter: "Insert date footer at file end only",
+  includeFooterAtEndOnly: "Insert date footer at file end only",
 };
 
 export default function PdfExport({

--- a/src/main/webapp/ui/src/Export/__tests__/PdfExport.test.js
+++ b/src/main/webapp/ui/src/Export/__tests__/PdfExport.test.js
@@ -30,7 +30,7 @@ describe("PdfExport", () => {
           pageSize: "A4",
           defaultPageSize: "A4",
           dateType: "EXP",
-          includeFooter: false,
+          includeFooterAtEndOnly: false,
           setPageSizeAsDefault: false,
           includeFieldLastModifiedDate: false,
         }}

--- a/src/main/webapp/ui/src/eln/sysadmin/users/__tests__/pdfConfig.json
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/__tests__/pdfConfig.json
@@ -12,7 +12,7 @@
     "includeFieldLastModifiedDate" : true,
     "pageSize" : "A4",
     "dateType" : "EXP",
-    "includeFooter" : true,
+    "includeFooterAtEndOnly" : true,
     "setPageSizeAsDefault" : false,
     "selectionScope" : true,
     "userScope" : false,

--- a/src/test/java/com/researchspace/export/pdf/HTMLStringGeneratorTest.java
+++ b/src/test/java/com/researchspace/export/pdf/HTMLStringGeneratorTest.java
@@ -281,7 +281,7 @@ public class HTMLStringGeneratorTest {
     form.addFieldForm(fieldForm);
     StructuredDocument doc = createAnySD(form);
     doc.setId(1L);
-    doc.setName("<img src='' onerror='alert(2);'>");
+    doc.setName("<img src='' onerror='alert(2);'>name with special html chars &∅∈∌");
     ExportToFileConfig cfg = makeConfig();
     ExportProcesserInput documentData = htmlGenerator.extractHtmlStr(doc, cfg);
     String data = documentData.getDocumentAsHtml();
@@ -290,6 +290,11 @@ public class HTMLStringGeneratorTest {
     assertTrue(data.contains("&lt;img"));
     assertTrue(data.contains("alert(1)"));
     assertTrue(data.contains("alert(2)"));
+    // html chars in name escaped
+    assertFalse(data.contains("special html chars &∅∈∌"));
+    assertTrue(
+        "unexpected:" + data,
+        data.contains("special html chars &amp;amp;&amp;empty;&amp;isin;&amp;#8716;"));
   }
 
   @Test

--- a/src/test/java/com/researchspace/export/pdf/PdfHtmlGeneratorTest.java
+++ b/src/test/java/com/researchspace/export/pdf/PdfHtmlGeneratorTest.java
@@ -1,11 +1,14 @@
 package com.researchspace.export.pdf;
 
 import static com.researchspace.export.pdf.PdfHtmlGenerator.MAX_TITLE_WIDTH;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.researchspace.archive.ArchivalNfsFile;
 import com.researchspace.model.User;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.model.record.TestFactory;
 import com.researchspace.testutils.RSpaceTestUtils;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -36,7 +39,7 @@ public class PdfHtmlGeneratorTest {
   public void setUp() throws Exception {
     VelocityEngine velocityEngine =
         RSpaceTestUtils.setupVelocity("src/main/resources/velocityTemplates");
-    pdfHtmlGenerator = new PdfHtmlGenerator(velocityEngine);
+    pdfHtmlGenerator = new PdfHtmlGenerator(velocityEngine, new HTMLUnicodeFontProcesser());
     basicHtmlDoc = RSpaceTestUtils.loadTextResourceFromPdfDir("basic.html");
     User user = new User();
     user.setFirstName("Some");
@@ -85,25 +88,9 @@ public class PdfHtmlGeneratorTest {
     String processedHtml = pdfHtmlGenerator.prepareHtml(input, doc, config);
 
     // output contains the shortened title with ellipsis but not the original one
-    Assertions.assertTrue(htmlElementContains(processedHtml, "style", shortenedTitle));
-    Assertions.assertFalse(htmlElementContains(processedHtml, "style", sixtyCharacterTitle));
-  }
-
-  @Test
-  public void headerCreated() {
-    String title = "A Document Title";
-    doc.setName(title);
-    input =
-        new ExportProcesserInput(
-            basicHtmlDoc, Collections.emptyList(), new RevisionInfo(), Collections.emptyList());
-
-    String processedHtml = pdfHtmlGenerator.prepareHtml(input, doc, config);
-
-    // doc owner name and title are set in style element using CSS page-margin boxes i.e. @page
-    // {@top-left ...
     Assertions.assertTrue(
-        htmlElementContains(processedHtml, "style", doc.getOwner().getFullName()));
-    Assertions.assertTrue(htmlElementContains(processedHtml, "style", doc.getName()));
+        htmlElementContains(processedHtml, "div.runningHeaderCenter", shortenedTitle));
+    Assertions.assertFalse(processedHtml.contains(sixtyCharacterTitle));
   }
 
   @Test
@@ -272,18 +259,12 @@ public class PdfHtmlGeneratorTest {
 
     String processedHtml = pdfHtmlGenerator.prepareHtml(input, doc, config);
 
-    // the footer should be defined in CSS as a page-margin box to be applied at the bottom of each
-    // page
+    // the footer should be defined as a running-footer, to be applied at the bottom of each page
     Assertions.assertTrue(
         htmlElementContains(
             processedHtml, "style", String.format("Export date: %s", LocalDate.now())));
-    Assertions.assertTrue(htmlElementContains(processedHtml, "style", "Exported by: Some User"));
-
-    // the footer info shouldn't be present in the body
-    Assertions.assertFalse(
-        htmlElementContains(
-            processedHtml, "body", String.format("Export date: %s", LocalDate.now())));
-    Assertions.assertFalse(htmlElementContains(processedHtml, "body", "Exported by: Some User"));
+    Assertions.assertTrue(
+        htmlElementContains(processedHtml, "div.runningFooterRight", "Exported by: Some User"));
   }
 
   @Test
@@ -340,6 +321,33 @@ public class PdfHtmlGeneratorTest {
     Assertions.assertTrue(
         htmlElementContains(
             processedHtml, "#footer", String.format("Last updated: %s", modificationDate)));
+  }
+
+  @Test
+  public void htmlCharsEncodingOfDocNameAndOwner() {
+    input =
+        new ExportProcesserInput(
+            basicHtmlDoc, Collections.emptyList(), new RevisionInfo(), Collections.emptyList());
+
+    doc = new StructuredDocument(TestFactory.createAnyForm());
+    doc.setName("name with special html chars &∅∈∌");
+
+    User owner = new User();
+    owner.setFirstName("Dev&Ops");
+    owner.setLastName("Team");
+    doc.setOwner(owner);
+
+    String processedHtml = pdfHtmlGenerator.prepareHtml(input, doc, config);
+    // verfiy doc name chars converted
+    assertFalse("unexpected: " + processedHtml, processedHtml.contains("&∅∈∌"));
+    assertTrue(
+        "unexpected: " + processedHtml, processedHtml.contains("special html chars &amp;</span>"));
+    assertTrue(
+        "unexpected: " + processedHtml,
+        processedHtml.contains("<span style=\"font-family: noto sans math;\">∅∈∌ </span>"));
+    // verify owner name chars converted
+    assertFalse("unexpected: " + processedHtml, processedHtml.contains("Dev&Ops"));
+    assertTrue("unexpected: " + processedHtml, processedHtml.contains("Dev&amp;Ops"));
   }
 
   private List<ArchivalNfsFile> makeArchiveFileList() {

--- a/src/test/java/com/researchspace/export/pdf/PdfProcessorTest.java
+++ b/src/test/java/com/researchspace/export/pdf/PdfProcessorTest.java
@@ -35,6 +35,8 @@ public class PdfProcessorTest {
 
   @Mock private PdfHtmlGenerator pdfHtmlGenerator;
 
+  @Mock private HTMLUnicodeFontProcesser fontProcesser;
+
   @InjectMocks private PdfProcessor pdfProcessor;
 
   File outputFile;

--- a/src/test/java/com/researchspace/service/PdfExportManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/PdfExportManagerTestIT.java
@@ -34,6 +34,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
   private @Autowired ExportImport exportImportMgr;
   private @Autowired InternalFileStore fStore;
   private @Autowired RecordDeletionManager delMgr;
+  private @Autowired RecordManager recordMgr;
 
   @Before
   public void setUp() throws Exception {
@@ -50,7 +51,11 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
     User exporter = createAndSaveUser(getRandomAlphabeticString("pdf"));
     initUser(exporter);
     logoutAndLoginAs(exporter);
+
     StructuredDocument sd = createBasicDocumentInRootFolderWithText(exporter, "text");
+    sd.setName(sd.getName() + " + special chars &∅∈∌");
+    recordMgr.save(sd, exporter);
+
     ExportToFileConfig config = new ExportToFileConfig();
     final String exportName = "xxxx";
     config.setExportName(exportName);


### PR DESCRIPTION
Turns out that introducing a new pdf-printing library (`flying-saucer-pdf`) caused a problem with exporting some ELN documents to PDF. The problem was caused by & (ampersand) character that RSpace may try to put into PDF page header (or footer) as a part of document name, or (less likely) as a part of full name of the exporting user. Attempt to export a document that has `&` in the name was resulting in an error like:
```
Can't load the XML resource (using TrAX transformer). org.xml.sax.SAXParseException; lineNumber: 19; 
columnNumber: 67; The reference to entity "in..." must end with the ';' delimiter..
```

After investigating, it seems that `flying-saucer-pdf` has a problem with interpreting html entities/chars passed through CSS 'content' attribute, which was how the header/footer generation was done. The fix applied in this PR is to use [running CSS headers/footers](https://printcss.net/articles/running-headers-and-footers), which allows to define content of header/footer through html fragment in '<body>' section, rather than CSS attribute in '<style>' section. When html entities/chars are set in body, the lib can print them to pdf fine. 

This PR also fixes a couple of other PDF export issues found during the investigation:
- when document name contained non-ascii symbols, these symbols were generally not printed to PDF in a document name that is put into page header (they were printed fine if inside part of document content); this was because non-ascii symbols require defining a different font family, which was not done for header part
- the PDF export dialog toggle 'Insert date footer at file end only' was not working properly, i.e. the PDF output always had the footer at file end only; this was due to front-end passing the parameter under a different name than expected by back-end (`includeFooter` rather than `includeFooterAtEndOnly`)

--- 

### Test scenario 

Test AWS build running at [https://rsdev-411-pdf-special-chars-5.researchspace.com](https://rsdev-411-pdf-special-chars-5.researchspace.com), compare to any 1.104 build (e.g. pangolin).

1. Go to My RSpace -> My Profile, update user's first/last name to one with non-ascii chars, e.g. `Mæck Schødt-Żębski`
2. Create a new basic document named with ampersand and non-ascii chars, e.g. `my special chars &™∞§`; put non-ascii content into text field e.g. `my special content &™∞§`. Save the doc;
3. Try exporting doc to PDF, with `Insert date footer at file end only` toggle disabled in pdf dialog
- on 1.104 server the export will fail - notification count will be up by 1, but there will be no notification
- on AWS build with the fix, the PDF will generate fine
4. On 1.104 server, rename the doc to not have `&` in the name, then try exporting again, with  `Insert date footer at file end only` toggle disabled
- the PDF will generate fine, but compare to PDF generated from AWS instance build with the fix, and note: 1) not all non-ascii chars printed in header 2) no footer on every page

