### PR TITLE
RSDEV-418: more robust notifications for pdf export errors

### DIFF
--- a/src/main/java/com/researchspace/api/v1/service/impl/ExportTasklet.java
+++ b/src/main/java/com/researchspace/api/v1/service/impl/ExportTasklet.java
@@ -87,7 +87,7 @@ public class ExportTasklet implements Tasklet {
       }
       try {
         ArchiveResult result =
-            exportService.exportArchiveSyncUserWork(
+            exportService.syncExportUserWorkToArchive(
                 config, toExport, serverUrl(), user, postArchiveCompleter, exportIdSupplier);
 
         updateContext(chunkContext, result);
@@ -101,7 +101,7 @@ public class ExportTasklet implements Tasklet {
       if (groupId != null) {
         try {
           ArchiveResult result =
-              exportService.exportSyncGroup(
+              exportService.syncExportGroupToArchive(
                   config, user, groupId, serverUrl(), postArchiveCompleter, exportIdSupplier);
           updateContext(chunkContext, result);
         } catch (Exception e) {
@@ -114,7 +114,7 @@ public class ExportTasklet implements Tasklet {
     } else if (config.isSelectionScope()) {
       try {
         ArchiveResult result =
-            exportService.exportSyncRecordSelection(
+            exportService.syncExportSelectionToArchive(
                 config, user, serverUrl(), postArchiveCompleter, exportIdSupplier);
         updateContext(chunkContext, result);
       } catch (Exception e) {

--- a/src/main/java/com/researchspace/service/archive/ExportImport.java
+++ b/src/main/java/com/researchspace/service/archive/ExportImport.java
@@ -74,7 +74,7 @@ public interface ExportImport {
    * @throws IOException
    */
   @Async(value = "archiveTaskExecutor")
-  Future<EcatDocumentFile> asynchExportFromSelection(
+  Future<EcatDocumentFile> asyncExportSelectionToPdf(
       Long[] exportIds,
       String[] exportNames,
       String[] exportTypes,
@@ -82,11 +82,8 @@ public interface ExportImport {
       User user)
       throws IOException;
 
-  @Async(value = "archiveTaskExecutor")
-  void handlePossibleRollbackAsync(Future<EcatDocumentFile> doc) throws IOException;
-
-  /** EXports one or more records identified by exportIds to PDF, synchronously. */
-  EcatDocumentFile synchExportFromSelection(
+  /** Exports one or more records identified by exportIds to PDF, synchronously. */
+  EcatDocumentFile syncExportSelectionToPdf(
       Long[] exportIds,
       String[] exportNames,
       String[] exportTypes,
@@ -105,7 +102,7 @@ public interface ExportImport {
    * @return an {@link Future<ArchiveResult>}
    */
   @Async(value = "archiveTaskExecutor")
-  Future<ArchiveResult> exportRecordSelection(
+  Future<ArchiveResult> asyncExportSelectionToArchive(
       ExportSelection exportSelection,
       ArchiveExportConfig config,
       User user,
@@ -131,7 +128,7 @@ public interface ExportImport {
    * @return an {@link ArchiveResult}
    * @throws Exception
    */
-  ArchiveResult exportSyncRecordSelection(
+  ArchiveResult syncExportSelectionToArchive(
       ArchiveExportConfig config,
       User user,
       URI baseURL,
@@ -186,7 +183,7 @@ public interface ExportImport {
    * @throws IOException
    */
   @Async(value = "archiveTaskExecutor")
-  Future<ArchiveResult> exportArchiveAsyncUserWork(
+  Future<ArchiveResult> asyncExportUserWorkToArchive(
       ArchiveExportConfig config,
       User toExport,
       URI baseURL,
@@ -194,7 +191,7 @@ public interface ExportImport {
       PostArchiveCompletion postArchiveCompletion)
       throws Exception;
 
-  ArchiveResult exportArchiveSyncUserWork(
+  ArchiveResult syncExportUserWorkToArchive(
       ArchiveExportConfig expCfg,
       User toExport,
       URI baseURL,
@@ -214,7 +211,7 @@ public interface ExportImport {
    * @throws Exception
    */
   @Async(value = "archiveTaskExecutor")
-  Future<ArchiveResult> exportAsyncGroup(
+  Future<ArchiveResult> asyncExportGroupToArchive(
       ArchiveExportConfig config,
       User exporter,
       Long groupId,
@@ -231,7 +228,7 @@ public interface ExportImport {
    * @return
    * @throws Exception
    */
-  ArchiveResult exportSyncGroup(
+  ArchiveResult syncExportGroupToArchive(
       ArchiveExportConfig config,
       User exporter,
       Long groupId,
@@ -259,7 +256,7 @@ public interface ExportImport {
    *     export <code>toExport's</code> data.
    */
   @Async(value = "archiveTaskExecutor")
-  public Future<EcatDocumentFile> exportPdfOfAllUserRecords(
+  public Future<EcatDocumentFile> asyncExportAllUserRecordsToPdf(
       User toExport, ExportToFileConfig config, User exporter) throws IOException;
 
   /**
@@ -273,11 +270,11 @@ public interface ExportImport {
    *     group.
    */
   @Async(value = "archiveTaskExecutor")
-  public Future<EcatDocumentFile> exportGroupPdf(
-      ExportToFileConfig expCfg, User exporter, Long groupId);
+  public Future<EcatDocumentFile> asyncExportGroupToPdf(
+      ExportToFileConfig expCfg, User exporter, Long groupId) throws IOException;
 
   @Async(value = "archiveTaskExecutor")
-  Future<File> asynchExportFromSelectionForSigning(
+  Future<File> asyncExportSelectionToPdfForSigning(
       Long[] exportIds,
       String[] exportNames,
       String[] exportTypes,

--- a/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
+++ b/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
@@ -58,6 +58,8 @@ import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 import javax.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.Setter;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.shiro.authz.AuthorizationException;
 import org.slf4j.Logger;
@@ -88,32 +90,30 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
   private String rsversion;
 
   private @Autowired IPermissionUtils permissions;
-
   private @Autowired CommunicationManager commMgr;
   private @Autowired RSMetaDataManager metaDataMgr;
   private @Autowired FolderManager folderManager;
   private @Autowired @Lazy GroupManager grpMgr;
-
   private @Autowired Collection<ArchiveExportServiceManager> archiverServiceManagers;
   private @Autowired ArchiveImporterManager archiveImporter;
   private @Autowired PdfWordExportManager pdfWordExportManager;
-
   private @Autowired UserExternalIdResolver extIdResolver;
+
+  @Setter(AccessLevel.PACKAGE)
   private @Autowired MessageSource messageSource;
+
   private @Autowired IPropertyHolder properties;
+
+  @Setter(AccessLevel.PACKAGE)
   private @Autowired ResponseUtil responseUtil;
+
   private @Autowired UserManager userManager;
   private @Autowired OperationFailedMessageGenerator authGenerator;
   private @Autowired ArchiveRemover archiveRemover;
   private @Autowired ApplicationEventPublisher publisher;
-
   private @Autowired ArchiveExportPlanner archivePlanner;
 
-  void setResponseUtil(ResponseUtil responseUtil) {
-    this.responseUtil = responseUtil;
-  }
-
-  public Future<EcatDocumentFile> exportPdfOfAllUserRecords(
+  public Future<EcatDocumentFile> asyncExportAllUserRecordsToPdf(
       User toExport, ExportToFileConfig config, User exporter) throws IOException {
     Folder rootRecord = folderManager.getRootFolderForUser(toExport);
     config.setExportScope(ExportScope.USER);
@@ -126,42 +126,64 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
     Long[] exportIds = new Long[] {rootRecord.getId()};
     String[] exportTypes = new String[] {RecordType.FOLDER.name()};
     String[] exportNames = new String[] {rootRecord.getName()};
-    EcatDocumentFile ecatdoc =
-        pdfWordExportManager.doExport(
-            toExport, exportIds, exportNames, exportTypes, config, exporter);
-    return new AsyncResult<>(ecatdoc);
+    try {
+      EcatDocumentFile pdfExport =
+          pdfWordExportManager.doExport(
+              toExport, exportIds, exportNames, exportTypes, config, exporter);
+      return new AsyncResult<>(pdfExport);
+    } catch (Exception e) {
+      logAndNotifyUserAboutExportFailure(config.getExportName(), exporter, e);
+      throw e;
+    }
+  }
+
+  private void logAndNotifyUserAboutExportFailure(String exportName, User exporter, Exception e) {
+    log.error("Unable to export.", e);
+    postArchiveExportFailure(exportName, exporter, e.getMessage());
   }
 
   @Override
-  public Future<EcatDocumentFile> asynchExportFromSelection(
+  public Future<EcatDocumentFile> asyncExportSelectionToPdf(
       Long[] exportIds,
       String[] exportNames,
       String[] exportTypes,
       ExportToFileConfig config,
       User exporter)
       throws IOException {
-    EcatDocumentFile ecatdoc =
-        pdfWordExportManager.doExport(
-            exporter, exportIds, exportNames, exportTypes, config, exporter);
-    return new AsyncResult<>(ecatdoc);
+
+    try {
+      EcatDocumentFile pdfExport =
+          pdfWordExportManager.doExport(
+              exporter, exportIds, exportNames, exportTypes, config, exporter);
+      return new AsyncResult<>(pdfExport);
+    } catch (Exception e) {
+      logAndNotifyUserAboutExportFailure(config.getExportName(), exporter, e);
+      throw e;
+    }
   }
 
   @Override
-  public Future<File> asynchExportFromSelectionForSigning(
+  public Future<File> asyncExportSelectionToPdfForSigning(
       Long[] exportIds,
       String[] exportNames,
       String[] exportTypes,
       ExportToFileConfig config,
       User exporter)
       throws IOException {
-    File pdfExport =
-        pdfWordExportManager.doExportForSigning(
-            exporter, exportIds, exportNames, exportTypes, config, exporter);
-    return new AsyncResult<>(pdfExport);
+
+    try {
+      File pdfExport =
+          pdfWordExportManager.doExportForSigning(
+              exporter, exportIds, exportNames, exportTypes, config, exporter);
+      return new AsyncResult<>(pdfExport);
+    } catch (Exception e) {
+      logAndNotifyUserAboutExportFailure(config.getExportName(), exporter, e);
+      throw e;
+    }
   }
 
   @Override
-  public EcatDocumentFile synchExportFromSelection(
+  public EcatDocumentFile syncExportSelectionToPdf(
       Long[] exportIds,
       String[] exportNames,
       String[] exportTypes,
@@ -183,7 +205,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
 
   /** Runs asynchronously */
   @Override
-  public Future<ArchiveResult> exportRecordSelection(
+  public Future<ArchiveResult> asyncExportSelectionToArchive(
       ExportSelection exportSelection,
       ArchiveExportConfig expCfg,
       User exporter,
@@ -197,8 +219,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
           doArchiveSelection(expCfg, exporter, baseURL, postArchiveCompleter, exportListSupplier);
       return new AsyncResult<>(result);
     } catch (Exception e) {
-      log.error("Unable to export.", e);
-      postArchiveExportFailure(expCfg.getArchiveType(), exporter, e.getMessage());
+      logAndNotifyUserAboutExportFailure(expCfg.getDescription(), exporter, e);
       throw e;
     }
   }
@@ -225,7 +246,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
   }
 
   @Override
-  public ArchiveResult exportSyncRecordSelection(
+  public ArchiveResult syncExportSelectionToArchive(
       ArchiveExportConfig expCfg,
       User user,
       URI baseURL,
@@ -255,8 +276,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
       postArchiveCompletionOperations(postArchiveCompleter, expCfg, user, result);
       return result;
     } catch (Exception e) {
-      log.error("Export attempt failed", e);
-      postArchiveExportFailure(expCfg.getDescription(), expCfg.getExporter(), e.getMessage());
+      logAndNotifyUserAboutExportFailure(expCfg.getDescription(), expCfg.getExporter(), e);
       throw e;
     }
   }
@@ -334,7 +354,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
   }
 
   @Override
-  public Future<ArchiveResult> exportArchiveAsyncUserWork(
+  public Future<ArchiveResult> asyncExportUserWorkToArchive(
       ArchiveExportConfig expCfg,
       User toExport,
       URI baseURL,
@@ -353,15 +373,14 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
           doSynchUserArchive(expCfg, baseURL, postArchiveCompleter, userSelection, rcdList);
       return new AsyncResult<>(result);
     } catch (Exception e) {
-      log.error("Unable to export.", e);
       String exportName = "user-" + toExport.getUsername();
-      postArchiveExportFailure(exportName, expCfg.getExporter(), e.getMessage());
+      logAndNotifyUserAboutExportFailure(exportName, exporter, e);
       throw e;
     }
   }
 
   @Override
-  public ArchiveResult exportArchiveSyncUserWork(
+  public ArchiveResult syncExportUserWorkToArchive(
       ArchiveExportConfig expCfg,
       User toExport,
       URI baseURL,
@@ -391,8 +410,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
       postArchiveCompletionOperations(postArchiveCompleter, expCfg, expCfg.getExporter(), result);
       return result;
     } catch (Exception e) {
-      log.error("Export attempt failed", e);
-      postArchiveExportFailure(expCfg.getDescription(), expCfg.getExporter(), e.getMessage());
+      logAndNotifyUserAboutExportFailure(expCfg.getDescription(), expCfg.getExporter(), e);
       throw e;
     }
   }
@@ -448,8 +466,8 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
   }
 
   @Override
-  public Future<EcatDocumentFile> exportGroupPdf(
-      ExportToFileConfig expCfg, User exporter, Long groupId) {
+  public Future<EcatDocumentFile> asyncExportGroupToPdf(
+      ExportToFileConfig expCfg, User exporter, Long groupId) throws IOException {
 
     expCfg.setExportScope(ExportScope.GROUP);
     Group grp = grpMgr.getGroup(groupId);
@@ -470,14 +488,14 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
               expCfg,
               exporter);
       return new AsyncResult<>(ecatdoc);
-    } catch (IOException e) {
-      log.error("Error performing export.", e);
+    } catch (Exception e) {
+      logAndNotifyUserAboutExportFailure(expCfg.getExportName(), exporter, e);
+      throw e;
     }
-    return null;
   }
 
   @Override
-  public Future<ArchiveResult> exportAsyncGroup(
+  public Future<ArchiveResult> asyncExportGroupToArchive(
       ArchiveExportConfig expCfg,
       User exporter,
       Long groupId,
@@ -487,8 +505,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
     try {
       createTopLevelExportFolder(expCfg);
     } catch (Exception e) {
-      log.error("Unable to export.", e);
-      postArchiveExportFailure(expCfg.getArchiveType(), exporter, e.getMessage());
+      logAndNotifyUserAboutExportFailure(expCfg.getDescription(), exporter, e);
       throw e;
     }
     ExportSelection exportSelection = configureGroupExportCfg(expCfg, exporter, groupId);
@@ -498,13 +515,12 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
             exporter,
             baseURL,
             postArchiveCompleter,
-            exportSelection,
             () -> archivePlanner.createExportRecordList(expCfg, exportSelection));
     return new AsyncResult<>(result);
   }
 
   @Override
-  public ArchiveResult exportSyncGroup(
+  public ArchiveResult syncExportGroupToArchive(
       ArchiveExportConfig expCfg,
       User exporter,
       Long groupId,
@@ -513,9 +529,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
       Supplier<ExportRecordList> exportIdSupplier)
       throws Exception {
     createTopLevelExportFolder(expCfg);
-    ExportSelection exportSelection = configureGroupExportCfg(expCfg, exporter, groupId);
-    return doGroupArchive(
-        expCfg, exporter, baseURL, postArchiveCompleter, exportSelection, exportIdSupplier);
+    return doGroupArchive(expCfg, exporter, baseURL, postArchiveCompleter, exportIdSupplier);
   }
 
   private ArchiveResult doGroupArchive(
@@ -523,23 +537,17 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
       User exporter,
       URI baseURL,
       PostArchiveCompletion postArchiveCompleter,
-      ExportSelection exportSelection,
       Supplier<ExportRecordList> exportIdSupplier) {
+
     try {
       ArchiveResult result = doArchive(expCfg, baseURL, exportIdSupplier);
       postArchiveCompletionOperations(postArchiveCompleter, expCfg, exporter, result);
       return result;
 
-    } catch (ExportFailureException exception) {
-      handleGrpExportFailure(expCfg, exception);
-      throw exception;
+    } catch (ExportFailureException e) {
+      logAndNotifyUserAboutExportFailure(expCfg.getDescription(), expCfg.getExporter(), e);
+      throw e;
     }
-  }
-
-  private void handleGrpExportFailure(
-      ArchiveExportConfig expCfg, ExportFailureException exception) {
-    log.error("Export attempt failed", exception);
-    postArchiveExportFailure(expCfg.getDescription(), expCfg.getExporter(), exception.getMessage());
   }
 
   private ExportSelection configureGroupExportCfg(
@@ -629,22 +637,6 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
           authGenerator.getFailedMessage(
               exporter.getUsername(), " export records of [" + userToExport.getUsername() + "]");
       throw new AuthorizationException(msg);
-    }
-  }
-
-  void setMessageSource(MessageSource messageSource) {
-    this.messageSource = messageSource;
-  }
-
-  @Override
-  public void handlePossibleRollbackAsync(Future<EcatDocumentFile> doc) throws IOException {
-    try {
-      doc.get();
-    } catch (Exception e) {
-      log.error(
-          "Export failed: {} - root cause is {}",
-          e.getMessage(),
-          e.getCause() != null ? e.getCause().getMessage() : "unknown");
     }
   }
 }

--- a/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
+++ b/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
@@ -528,7 +528,9 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
       PostArchiveCompletion postArchiveCompleter,
       Supplier<ExportRecordList> exportIdSupplier)
       throws Exception {
+
     createTopLevelExportFolder(expCfg);
+    configureGroupExportCfg(expCfg, exporter, groupId);
     return doGroupArchive(expCfg, exporter, baseURL, postArchiveCompleter, exportIdSupplier);
   }
 

--- a/src/main/java/com/researchspace/service/impl/PostRecordSigningExportHash.java
+++ b/src/main/java/com/researchspace/service/impl/PostRecordSigningExportHash.java
@@ -91,7 +91,7 @@ public class PostRecordSigningExportHash implements PostSigningManager {
               new Long[] {exported.getId()}, new String[] {RecordType.NORMAL.toString()});
       ArchiveResult result =
           exportImport
-              .exportRecordSelection(
+              .asyncExportSelectionToArchive(
                   exportSelection,
                   config,
                   exported.getOwner(),
@@ -115,7 +115,7 @@ public class PostRecordSigningExportHash implements PostSigningManager {
       try {
         File result =
             exportImport
-                .asynchExportFromSelectionForSigning(
+                .asyncExportSelectionToPdfForSigning(
                     new Long[] {exported.getId()},
                     new String[] {exported.getName()},
                     new String[] {RecordType.NORMAL.toString()},

--- a/src/main/java/com/researchspace/webapp/controller/ExportController.java
+++ b/src/main/java/com/researchspace/webapp/controller/ExportController.java
@@ -492,13 +492,12 @@ public class ExportController extends BaseController {
       switch (exportSelection.getType()) {
         case SELECTION:
           futureExportDocument =
-              exportManager.asynchExportFromSelection(
+              exportManager.asyncExportSelectionToPdf(
                   exportSelection.getExportIds(),
                   exportSelection.getExportNames(),
                   exportSelection.getExportTypes(),
                   exportToFileConfig,
                   exporter);
-          exportManager.handlePossibleRollbackAsync(futureExportDocument);
           break;
         case USER:
           if (isWordExport(exportToFileConfig)) {
@@ -514,7 +513,8 @@ public class ExportController extends BaseController {
           }
 
           futureExportDocument =
-              exportManager.exportPdfOfAllUserRecords(userToExport, exportToFileConfig, exporter);
+              exportManager.asyncExportAllUserRecordsToPdf(
+                  userToExport, exportToFileConfig, exporter);
           break;
         case GROUP:
           if (isWordExport(exportToFileConfig)) {
@@ -526,7 +526,7 @@ public class ExportController extends BaseController {
           if (groupPermUtils.userCanExportGroup(
               exporter, groupManager.getGroup(exportSelection.getGroupId()))) {
             futureExportDocument =
-                exportManager.exportGroupPdf(
+                exportManager.asyncExportGroupToPdf(
                     exportToFileConfig, exporter, exportSelection.getGroupId());
           } else {
             return getText(
@@ -692,7 +692,7 @@ public class ExportController extends BaseController {
       switch (exportSelection.getType()) {
         case SELECTION:
           futureArchive =
-              exportManager.exportRecordSelection(
+              exportManager.asyncExportSelectionToArchive(
                   exportSelection, exportCfg, exporter, baseUri, standardPostExport);
           break;
         case USER:
@@ -703,7 +703,7 @@ public class ExportController extends BaseController {
           Long groupId = exportSelection.getGroupId();
           if (groupPermUtils.userCanExportGroup(exporter, groupManager.getGroup(groupId))) {
             futureArchive =
-                exportManager.exportAsyncGroup(
+                exportManager.asyncExportGroupToArchive(
                     exportCfg, exporter, groupId, baseUri, standardPostExport);
           } else {
             return getText(

--- a/src/main/java/com/researchspace/webapp/controller/UserExportHandler.java
+++ b/src/main/java/com/researchspace/webapp/controller/UserExportHandler.java
@@ -42,7 +42,7 @@ public class UserExportHandler {
       exportManager.assertExporterCanExportUsersWork(userToExport, exporter);
     }
     archive =
-        exportManager.exportArchiveAsyncUserWork(
+        exportManager.asyncExportUserWorkToArchive(
             exportCfg, userToExport, baseUri, exporter, standardPostExport);
     return archive;
   }

--- a/src/main/resources/bundles/workspace/workspace.properties
+++ b/src/main/resources/bundles/workspace/workspace.properties
@@ -67,7 +67,7 @@ dialogs.pdfArchiving.label.dateFormat=Timestamp format for date footer
 dialogs.pdfArchiving.label.footer=Insert date footer at file end only
 dialogs.pdfArchiving.label.fileName=Name your file
 workspace.export.msgSuccess=Your export [{0}] is now available in the Exports section of <a href="{1}">the Gallery</a>.
-workspace.export.msgFailure=Your export [{0}] failed for the following reason: {1}.
+workspace.export.msgFailure=Your export [{0}] failed for the following reason: {1}
 workspace.export.noDiskSpace=RSpace has not enough disk space to start archive export process. Please contact your System Admin.
 pdfArchiving.submission.successMsg=Your export generation request has been submitted to the server. \
  RSpace will notify you when the export is ready.

--- a/src/test/java/com/researchspace/service/AutoshareManagerIT.java
+++ b/src/test/java/com/researchspace/service/AutoshareManagerIT.java
@@ -287,7 +287,7 @@ public class AutoshareManagerIT extends RealTransactionSpringTestBase {
         ExportSelection.createRecordsExportSelection(
             new Long[] {subFolder.getId()}, new String[] {"FOLDER"});
     Future<ArchiveResult> result =
-        exportMgr.exportRecordSelection(
+        exportMgr.asyncExportSelectionToArchive(
             exportSelection, cfg, u1, new URI("http://www.google.com"), standardPostExport);
     File zipFile = result.get().getExportFile();
     // update user

--- a/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
@@ -220,7 +220,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
 
     ArchiveResult result =
         exportImportMgr
-            .exportAsyncGroup(cfg, sysadmin, grp.getId(), anyURI(), standardPostExport)
+            .asyncExportGroupToArchive(cfg, sysadmin, grp.getId(), anyURI(), standardPostExport)
             .get();
     File zipFile = result.getExportFile();
     logoutAndLoginAs(importer);
@@ -263,7 +263,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfg.setUserOrGroupId(group.getOid());
 
     exportImportMgr
-        .exportAsyncGroup(cfg, labAdmin, group.getId(), anyURI(), standardPostExport)
+        .asyncExportGroupToArchive(cfg, labAdmin, group.getId(), anyURI(), standardPostExport)
         .get();
   }
 
@@ -303,7 +303,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
 
     ArchiveResult archive =
         exportImportMgr
-            .exportAsyncGroup(cfg, labAdmin, group.getId(), anyURI(), standardPostExport)
+            .asyncExportGroupToArchive(cfg, labAdmin, group.getId(), anyURI(), standardPostExport)
             .get();
     assertThat(archive.getArchivedRecords(), hasItem(publicUserDocument));
     assertThat(archive.getArchivedRecords(), hasItem(publicLabAdminDocument));
@@ -353,7 +353,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     ArchiveExportConfig cfg = createDefaultArchiveConfig(user, tempExportFolder.getRoot());
     cfg.setArchiveType(ArchiveExportConfig.HTML);
     Future<ArchiveResult> result =
-        exportImportMgr.exportRecordSelection(
+        exportImportMgr.asyncExportSelectionToArchive(
             getSingleRecordExportSelection(doc.getId(), "NORMAL"),
             cfg,
             user,
@@ -383,7 +383,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
             new Long[] {doc.getId(), gallrySubFolder.getId()},
             new String[] {"MEDIA_FILE", "FOLDER"});
     Future<ArchiveResult> result =
-        exportImportMgr.exportRecordSelection(
+        exportImportMgr.asyncExportSelectionToArchive(
             exportSelection, cfg, user, new URI("http://www.google.com"), standardPostExport);
 
     File zipFile = result.get().getExportFile();
@@ -438,7 +438,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
             new Long[] {f1.getId(), complexDoc.getId(), notebook.getId()},
             new String[] {"FOLDER", "NORMAL", "NOTEBOOK"});
     Future<ArchiveResult> result =
-        exportImportMgr.exportRecordSelection(
+        exportImportMgr.asyncExportSelectionToArchive(
             exportSelection, cfg, user, new URI("http://www.google.com"), standardPostExport);
     File zipFile = result.get().getExportFile();
 
@@ -542,7 +542,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     int notficationCount = getNewNotificationCount(userToExport);
     ArchiveResult result =
         exportImportMgr
-            .exportArchiveAsyncUserWork(
+            .asyncExportUserWorkToArchive(
                 cfg, userToExport, anyURI(), userToExport, standardPostExport)
             .get();
     File zipFolder = extractZipArchive(result);
@@ -584,7 +584,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     sendSimpleMessage(userToExport, "a message", msgRecipient);
     ArchiveResult result =
         exportImportMgr
-            .exportArchiveAsyncUserWork(
+            .asyncExportUserWorkToArchive(
                 cfg, userToExport, anyURI(), userToExport, standardPostExport)
             .get();
     File zipFile = result.getExportFile();
@@ -623,7 +623,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     int b4ImportCount = getFieldAttachmentCount() - b4ITest;
     ArchiveResult result =
         exportImportMgr
-            .exportArchiveAsyncUserWork(
+            .asyncExportUserWorkToArchive(
                 cfg, userToExport, anyURI(), userToExport, standardPostExport)
             .get();
     File zipFile = result.getExportFile();
@@ -743,7 +743,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
 
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(template.getId(), "NORMAL:TEMPLATE"),
                 cfg,
                 anyUser,
@@ -884,7 +884,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     ArchiveExportConfig cfg = createDefaultArchiveConfig(u1, tempExportFolder.getRoot());
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(selection, cfg, u1, anyURI(), standardPostExport)
+            .asyncExportSelectionToArchive(selection, cfg, u1, anyURI(), standardPostExport)
             .get();
     File zipFolder = extractZipArchive(result);
 
@@ -925,7 +925,9 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     // make sure to follow all links in test.
     cfg.setMaxLinkLevel(5);
     ArchiveResult result =
-        exportImportMgr.exportArchiveAsyncUserWork(cfg, u2, anyURI(), u2, standardPostExport).get();
+        exportImportMgr
+            .asyncExportUserWorkToArchive(cfg, u2, anyURI(), u2, standardPostExport)
+            .get();
     File zipFolder = extractZipArchive(result);
 
     // u2Doc and attachments should be added, but linked doc in u2Doc shouldn't be.
@@ -959,7 +961,9 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     sysadmin = logoutAndLoginAsSysAdmin();
 
     ArchiveResult result =
-        exportImportMgr.exportAsyncGroup(cfg, pi, grp.getId(), anyURI(), standardPostExport).get();
+        exportImportMgr
+            .asyncExportGroupToArchive(cfg, pi, grp.getId(), anyURI(), standardPostExport)
+            .get();
     File zipFolder = extractZipArchive(result);
     Collection<File> archiveContents = ArchiveTestUtils.getAllFilesInArchive(zipFolder);
 
@@ -1016,7 +1020,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfg.setArchiveType(ArchiveExportConfig.HTML);
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(u1DocToExport.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 u1,
@@ -1051,7 +1055,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
 
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdoc.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 u1,
@@ -1102,7 +1106,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     final ArchiveExportConfig cfg = createDefaultArchiveConfig(u1, tempExportFolder.getRoot());
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdoc.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 u1,
@@ -1166,7 +1170,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfg.setUserOrGroupId(user.getOid());
     ArchiveResult result =
         exportImportMgr
-            .exportArchiveAsyncUserWork(cfg, user, anyURI(), user, standardPostExport)
+            .asyncExportUserWorkToArchive(cfg, user, anyURI(), user, standardPostExport)
             .get();
     // check archive content - should contain updated attachments, not the original ones
     long mediaFileCountb4Import = getCountOfEntityTable("EcatMediaFile");
@@ -1210,7 +1214,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfg.setUserOrGroupId(userB.getOid());
     ArchiveResult result =
         exportImportMgr
-            .exportArchiveAsyncUserWork(cfg, userB, anyURI(), userB, standardPostExport)
+            .asyncExportUserWorkToArchive(cfg, userB, anyURI(), userB, standardPostExport)
             .get();
     File zipFile = result.getExportFile();
     ZipUtils.extractZip(zipFile, spareFolder.getRoot());
@@ -1254,7 +1258,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     final ArchiveExportConfig cfg = createDefaultArchiveConfig(user, tempExportFolder.getRoot());
     ArchiveResult firstDocExport =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(doc.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 user,
@@ -1324,7 +1328,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     final ArchiveExportConfig cfg2 = createDefaultArchiveConfig(user, tempExportFolder2.getRoot());
     ArchiveResult signedDocExport =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(signedDoc.getId(), RecordType.NORMAL.toString()),
                 cfg2,
                 user,
@@ -1399,7 +1403,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     final ArchiveExportConfig cfg = createDefaultArchiveConfig(u1, tempExportFolder.getRoot());
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(
                     createdNotebook.getId(), RecordType.NOTEBOOK.toString()),
                 cfg,
@@ -1492,7 +1496,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
             new String[] {NORMAL.toString(), NORMAL.toString()});
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(exportSelection, cfg, u1, anyURI(), standardPostExport)
+            .asyncExportSelectionToArchive(exportSelection, cfg, u1, anyURI(), standardPostExport)
             .get();
 
     ArchivalImportConfig importCfg =
@@ -1566,7 +1570,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     final ArchiveExportConfig cfg = createDefaultArchiveConfig(u1, tempExportFolder.getRoot());
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdoc.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 u1,
@@ -1609,7 +1613,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfg.setArchiveType(ArchiveExportConfig.HTML);
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdocA.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 u1,
@@ -1636,7 +1640,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
             new String[] {RecordType.NORMAL.toString(), RecordType.NORMAL.toString()});
     ArchiveResult result2 =
         exportImportMgr
-            .exportRecordSelection(exportSelection, cfg, u1, anyURI(), standardPostExport)
+            .asyncExportSelectionToArchive(exportSelection, cfg, u1, anyURI(), standardPostExport)
             .get();
 
     File zipFolder2 = extractZipArchive(result2, tempImportFolder2);
@@ -1673,7 +1677,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
             new String[] {MEDIA_FILE.toString(), MEDIA_FILE.toString()});
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(exportSelection, cfg, u1, anyURI(), standardPostExport)
+            .asyncExportSelectionToArchive(exportSelection, cfg, u1, anyURI(), standardPostExport)
             .get();
     File zipFolder = extractZipArchive(result);
     Collection<File> xmlFiles = ArchiveTestUtils.getAllXMLFilesInArchive(zipFolder);
@@ -1752,7 +1756,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfg.setMaxLinkLevel(0);
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(firstDoc.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 user,
@@ -1834,7 +1838,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
             });
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(exportSelection, cfg, user, anyURI(), standardPostExport)
+            .asyncExportSelectionToArchive(exportSelection, cfg, user, anyURI(), standardPostExport)
             .get();
     assertEquals(1, result.getArchivedRecords().size()); // one record
     assertEquals(2, result.getArchivedFolders().size()); // folder and notebook
@@ -1915,7 +1919,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
 
     try {
       exportImportMgr
-          .exportRecordSelection(exportSelection, cfg, user, anyURI(), standardPostExport)
+          .asyncExportSelectionToArchive(exportSelection, cfg, user, anyURI(), standardPostExport)
           .get();
       fail("expected to fail as archive size above the limit");
     } catch (Exception e) {
@@ -1951,7 +1955,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfg.setArchiveType(ArchiveExportConfig.HTML);
     ArchiveResult result =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdocA.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 u1,
@@ -1995,7 +1999,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfgXml.setHasAllVersion(true);
     ArchiveResult resultXml =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdocA.getId(), RecordType.NORMAL.toString()),
                 cfgXml,
                 u1,
@@ -2072,7 +2076,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfgHtml.setAvailableNfsClients(nfsClientMap);
     ArchiveResult resultHtml =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdocA.getId(), RecordType.NORMAL.toString()),
                 cfgHtml,
                 user,
@@ -2130,7 +2134,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
 
     ArchiveResult resultXml =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdocA.getId(), RecordType.NORMAL.toString()),
                 cfgXml,
                 user,
@@ -2187,7 +2191,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfgHtml.setArchiveType(ArchiveExportConfig.HTML);
     ArchiveResult resultHtml =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdocA.getId(), RecordType.NORMAL.toString()),
                 cfgHtml,
                 user,
@@ -2220,7 +2224,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfgHtml.setArchiveType(ArchiveExportConfig.HTML);
     ArchiveResult resultHtml =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdocA.getId(), RecordType.NORMAL.toString()),
                 cfgHtml,
                 user,
@@ -2305,7 +2309,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfgHtml.setAvailableNfsClients(nfsClientMap);
     ArchiveResult resultHtml =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(sdocA.getId(), RecordType.NORMAL.toString()),
                 cfgHtml,
                 user,
@@ -2367,7 +2371,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     cfg.setMaxLinkLevel(0);
     ArchiveResult resultXml =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(doc.getId(), RecordType.NORMAL.toString()),
                 cfg,
                 user,
@@ -2406,7 +2410,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
 
     File file =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(doc.getId(), "NORMAL"),
                 cfg,
                 user,
@@ -2476,7 +2480,7 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     ArchiveExportConfig cfg = createDefaultArchiveConfig(user, tempExportFolder.getRoot());
     ArchiveResult archiveResult =
         exportImportMgr
-            .exportRecordSelection(
+            .asyncExportSelectionToArchive(
                 getSingleRecordExportSelection(newFolder.getId(), "FOLDER"),
                 cfg,
                 user,

--- a/src/test/java/com/researchspace/service/PdfExportManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/PdfExportManagerTestIT.java
@@ -61,7 +61,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
     config.setExportName(exportName);
     EcatDocumentFile edf =
         exportImportMgr
-            .asynchExportFromSelection(
+            .asyncExportSelectionToPdf(
                 new Long[] {sd.getId()},
                 new String[] {sd.getName()},
                 new String[] {RecordType.NORMAL.toString()},
@@ -77,7 +77,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
     User sysadmin = logoutAndLoginAsSysAdmin();
     initUser(sysadmin);
     EcatDocumentFile edf2 =
-        exportImportMgr.synchExportFromSelection(
+        exportImportMgr.syncExportSelectionToPdf(
             new Long[] {sd.getId()},
             new String[] {sd.getName()},
             new String[] {RecordType.NORMAL.toString()},
@@ -111,7 +111,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
 
     // Exporting file of another user
     EcatDocumentFile ecatDocumentFile =
-        exportImportMgr.synchExportFromSelection(
+        exportImportMgr.syncExportSelectionToPdf(
             new Long[] {sd.getId()},
             new String[] {sd.getName()},
             new String[] {RecordType.NORMAL.toString()},
@@ -124,7 +124,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
     // Exporting folder of another user
     BaseRecord folder = searchByName(user.getUsername(), exporterPi).getFirstResult();
     ecatDocumentFile =
-        exportImportMgr.synchExportFromSelection(
+        exportImportMgr.syncExportSelectionToPdf(
             new Long[] {folder.getId()},
             new String[] {"user folder export"},
             new String[] {RecordType.INDIVIDUAL_SHARED_FOLDER_ROOT.toString()},
@@ -168,7 +168,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
 
     // Exporting file of another user
     EcatDocumentFile ecatDocumentFile =
-        exportImportMgr.synchExportFromSelection(
+        exportImportMgr.syncExportSelectionToPdf(
             new Long[] {sd.getId()},
             new String[] {sd.getName()},
             new String[] {RecordType.NORMAL.toString()},
@@ -181,7 +181,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
     // Exporting folder of another user
     BaseRecord folder = searchByName(user.getUsername(), labAdmin).getFirstResult();
     ecatDocumentFile =
-        exportImportMgr.synchExportFromSelection(
+        exportImportMgr.syncExportSelectionToPdf(
             new Long[] {folder.getId()},
             new String[] {"user folder export"},
             new String[] {RecordType.INDIVIDUAL_SHARED_FOLDER_ROOT.toString()},
@@ -209,7 +209,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
     ExportToFileConfig config = new ExportToFileConfig();
     config.setExportName("xxxx");
     logoutAndLoginAs(pi);
-    EcatDocumentFile export = exportImportMgr.exportGroupPdf(config, pi, grp.getId()).get();
+    EcatDocumentFile export = exportImportMgr.asyncExportGroupToPdf(config, pi, grp.getId()).get();
     assertNotNull(export);
 
     PdfReader reader = new PdfReader(export.getFileUri());
@@ -221,7 +221,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
             .getFirstResult();
     delMgr.deleteRecord(folderMgr.getRootFolderForUser(pi).getId(), toDelete.getId(), pi);
 
-    export = exportImportMgr.exportGroupPdf(config, pi, grp.getId()).get();
+    export = exportImportMgr.asyncExportGroupToPdf(config, pi, grp.getId()).get();
     reader = new PdfReader(export.getFileUri());
     int afterDeletedPageCount = reader.getNumberOfPages();
 

--- a/src/test/java/com/researchspace/service/impl/PostRecordSigningExportHashTest.java
+++ b/src/test/java/com/researchspace/service/impl/PostRecordSigningExportHashTest.java
@@ -85,7 +85,7 @@ public class PostRecordSigningExportHashTest {
   }
 
   private Future<ArchiveResult> performMockArchive() {
-    return exportImport.exportRecordSelection(
+    return exportImport.asyncExportSelectionToArchive(
         Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
   }
 
@@ -102,7 +102,7 @@ public class PostRecordSigningExportHashTest {
   }
 
   private void setUpPerformPdfExportOk() throws IOException {
-    when(exportImport.asynchExportFromSelectionForSigning(
+    when(exportImport.asyncExportSelectionToPdfForSigning(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
         .thenReturn(new AsyncResult<File>(mockPdfExportFile));
   }

--- a/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
@@ -437,7 +437,7 @@ public class ExportControllerTest {
     String rst = exportController.export(exportConfig, bindingResult, principal);
 
     Mockito.verify(exImportMgr, Mockito.times(1))
-        .exportPdfOfAllUserRecords(user, exportConfig.getExportConfig(), user);
+        .asyncExportAllUserRecordsToPdf(user, exportConfig.getExportConfig(), user);
     Mockito.verify(bindingResult, Mockito.times(1)).hasErrors();
 
     assertTrue(rst != null);
@@ -466,7 +466,7 @@ public class ExportControllerTest {
     // check that regular user can't export another's records
     String rst = exportController.export(exportConfig, bindingResult, principal);
     Mockito.verify(exImportMgr, never())
-        .exportPdfOfAllUserRecords(other, exportConfig.getExportConfig(), user);
+        .asyncExportAllUserRecordsToPdf(other, exportConfig.getExportConfig(), user);
     assertEquals("failure: auth_error", rst);
   }
 
@@ -485,7 +485,7 @@ public class ExportControllerTest {
     when(grpPermUtils.userCanExportGroup(user, group)).thenReturn(true);
 
     exportController.export(exportConfig, bindingResult, principal);
-    verify(exImportMgr, times(1)).exportGroupPdf(exportConfig.getExportConfig(), user, 1L);
+    verify(exImportMgr, times(1)).asyncExportGroupToPdf(exportConfig.getExportConfig(), user, 1L);
 
     exportConfig.getExportConfig().setExportFormat(WORD);
     String rst = exportController.export(exportConfig, bindingResult, principal);
@@ -569,7 +569,7 @@ public class ExportControllerTest {
 
   private void setupArchiveNotMadeExpectation() {
     verify(exImportMgr, never())
-        .exportRecordSelection(
+        .asyncExportSelectionToArchive(
             Mockito.any(ExportSelection.class),
             Mockito.any(ArchiveExportConfig.class),
             Mockito.any(User.class),


### PR DESCRIPTION
In current codebase the PDF export fails for documents that have html entity hash code in their name (e.g. a doc named `test &#x3 doc`), but such error doesn't produce any notification, just bumps the notification count.

The main change of this PR is that async PDF exports now calls `postArchiveExportFailure()` in `catch` blocks on `ExportImportImpl` class level, which is the same pattern as used in async archive exports, and that pattern does result in error notification delivered to the user. The call to produce error notification in `PdfWordExportManagerImpl.processDocsForDocExport()`, which was resulting only in bumped notification count, is removed.

As a bit of refactoring, I also renamed most of the methods in `ExportImport` interface so they follow the same naming pattern. 

### Test scenario

Compare behaviour of three problematic export PDF scenarios executed on [AWS build](https://rsdev-418-pdf-export-error-handling-5.researchspace.com/) vs 1.104.x server (or pangolins).

1. login to the account of user in a group (e.g. `user3c` on AWS build).
2. create a new ELN document named `test &#x3 doc`.
3. try exporting the document to PDF
- on AWS build you should get an error notification
- on 1.104.x builds (or pangolins) you should see just a bumped notification count, but no notification
4. try exporting whole user's account to PDF (`My RSpace -> Export/Import -> Export all my work`), and whole group content to PDF (`My RSpace -> My LabGroups -> Export LabGroup's Work`)
- again, on AWS build you should get error notification
- on 1.104.x builds (or pangolins) there should be no notification