### PR TITLE
RSDEV-411: fix pdf exporting for documents with html hash-entity char sequence (&#) in name

### DIFF
--- a/src/main/java/com/researchspace/export/pdf/PdfHtmlGenerator.java
+++ b/src/main/java/com/researchspace/export/pdf/PdfHtmlGenerator.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.velocity.app.VelocityEngine;
 import org.jsoup.Jsoup;
@@ -98,9 +99,9 @@ public class PdfHtmlGenerator {
       String html, String docOwner, String docTitle, String exporterFullName) {
 
     Map<String, Object> context = new HashMap<>();
-    context.put("docOwner", docOwner);
-    context.put("docTitle", docTitle);
-    context.put("exporterFullName", exporterFullName);
+    context.put("docOwner", StringEscapeUtils.escapeHtml(docOwner));
+    context.put("docTitle", StringEscapeUtils.escapeHtml(docTitle));
+    context.put("exporterFullName", StringEscapeUtils.escapeHtml(exporterFullName));
     String runningPageHtml =
         VelocityEngineUtils.mergeTemplateIntoString(
             velocityEngine, "pdf/runningPageElems.vm", "UTF-8", context);

--- a/src/test/java/com/researchspace/export/pdf/PdfHtmlGeneratorTest.java
+++ b/src/test/java/com/researchspace/export/pdf/PdfHtmlGeneratorTest.java
@@ -330,7 +330,7 @@ public class PdfHtmlGeneratorTest {
             basicHtmlDoc, Collections.emptyList(), new RevisionInfo(), Collections.emptyList());
 
     doc = new StructuredDocument(TestFactory.createAnyForm());
-    doc.setName("name with special html chars &∅∈∌");
+    doc.setName("name with non-ascii &∅∈∌ and html entities &#x3");
 
     User owner = new User();
     owner.setFirstName("Dev&Ops");
@@ -338,13 +338,16 @@ public class PdfHtmlGeneratorTest {
     doc.setOwner(owner);
 
     String processedHtml = pdfHtmlGenerator.prepareHtml(input, doc, config);
-    // verfiy doc name chars converted
-    assertFalse("unexpected: " + processedHtml, processedHtml.contains("&∅∈∌"));
+    // verify doc name chars converted
+    assertFalse(
+        "unexpected: " + processedHtml,
+        processedHtml.contains("&∅∈∌") || processedHtml.contains("&#x3"));
     assertTrue(
-        "unexpected: " + processedHtml, processedHtml.contains("special html chars &amp;</span>"));
+        "unexpected: " + processedHtml, processedHtml.contains("name with non-ascii &amp;</span>"));
     assertTrue(
         "unexpected: " + processedHtml,
         processedHtml.contains("<span style=\"font-family: noto sans math;\">∅∈∌ </span>"));
+    assertTrue("unexpected: " + processedHtml, processedHtml.contains("&amp;#x3"));
     // verify owner name chars converted
     assertFalse("unexpected: " + processedHtml, processedHtml.contains("Dev&Ops"));
     assertTrue("unexpected: " + processedHtml, processedHtml.contains("Dev&amp;Ops"));

--- a/src/test/java/com/researchspace/service/PdfExportManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/PdfExportManagerTestIT.java
@@ -53,7 +53,7 @@ public class PdfExportManagerTestIT extends RealTransactionSpringTestBase {
     logoutAndLoginAs(exporter);
 
     StructuredDocument sd = createBasicDocumentInRootFolderWithText(exporter, "text");
-    sd.setName(sd.getName() + " + special chars &∅∈∌");
+    sd.setName("special chars in doc name &∅∈∌ and &#x3");
     recordMgr.save(sd, exporter);
 
     ExportToFileConfig config = new ExportToFileConfig();


### PR DESCRIPTION
When exporting documents to PDF we convert them to xhtml representation, which is one expected by itext/flying-saucer. The content taken from document's rich text fields can be directly mapped, as it is already in html, but other data that is put into pdf, i.e. document's name/owner/exporting user's names, is not expected to be html-encoded. 

This PR escapes that other content for html output, so the random html-like char sequence occurring e.g. in document name, will not be treated by PDF lib as a request to print an html entity.

