### PR TITLE
RSDEV-339 Replace image editor in Inventory

### DIFF
--- a/src/main/webapp/ui/.dependency-cruiser.js
+++ b/src/main/webapp/ui/.dependency-cruiser.js
@@ -332,6 +332,20 @@ module.exports = {
         path: "src/stores/stores",
         reachable: true
       },
+    },
+
+    {
+      name: "react-image-editor is deprecated",
+      severity: "error",
+      from: {
+        pathNot: [
+          // once the old gallery is removed, we can remove the dependency and stop using `--force` when calling `npm install`
+          "^src/Gallery"
+        ]
+      },
+      to: {
+        path: "@toast-ui/react-image-editor",
+      }
     }
 
   ],

--- a/src/main/webapp/ui/.dependency-cruiser.js
+++ b/src/main/webapp/ui/.dependency-cruiser.js
@@ -7,7 +7,7 @@ module.exports = {
       severity: "error",
       from: {},
       to: {
-        licenseNot: ["MIT", "BSD", "Apache", "Hippocratic"]
+        licenseNot: ["MIT", "BSD", "Apache", "Hippocratic", "ISC"]
       }
     },
     // {

--- a/src/main/webapp/ui/package-lock.json
+++ b/src/main/webapp/ui/package-lock.json
@@ -54,6 +54,7 @@
         "react-autosuggest": "=10.1.0",
         "react-device-detect": "=2.2.3",
         "react-dom": "=18.2.0",
+        "react-image-crop": "^11.0.7",
         "react-leaflet": "^4.2.1",
         "react-pdf": "^9.1.0",
         "react-photoswipe-gallery": "=2.2.7",
@@ -16917,6 +16918,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-image-crop": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.7.tgz",
+      "integrity": "sha512-ZciKWHDYzmm366JDL18CbrVyjnjH0ojufGDmScfS4ZUqLHg4nm6ATY+K62C75W4ZRNt4Ii+tX0bSjNk9LQ2xzQ==",
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -31847,6 +31856,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-image-crop": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.7.tgz",
+      "integrity": "sha512-ZciKWHDYzmm366JDL18CbrVyjnjH0ojufGDmScfS4ZUqLHg4nm6ATY+K62C75W4ZRNt4Ii+tX0bSjNk9LQ2xzQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "18.3.1",

--- a/src/main/webapp/ui/package-lock.json
+++ b/src/main/webapp/ui/package-lock.json
@@ -9017,9 +9017,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
     },
     "node_modules/flow-bin": {
       "version": "0.239.1",
@@ -26277,9 +26277,9 @@
       }
     },
     "flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
     },
     "flow-bin": {
       "version": "0.239.1",

--- a/src/main/webapp/ui/package.json
+++ b/src/main/webapp/ui/package.json
@@ -104,6 +104,7 @@
     "react-autosuggest": "=10.1.0",
     "react-device-detect": "=2.2.3",
     "react-dom": "=18.2.0",
+    "react-image-crop": "^11.0.7",
     "react-leaflet": "^4.2.1",
     "react-pdf": "^9.1.0",
     "react-photoswipe-gallery": "=2.2.7",

--- a/src/main/webapp/ui/package.json
+++ b/src/main/webapp/ui/package.json
@@ -140,6 +140,7 @@
       "default",
       "jest-junit",
       "<rootDir>/__tests__/reporters/slowest"
-    ]
+    ],
+    "testEnvironmentOptions": { "resources": "usable" }
   }
 }

--- a/src/main/webapp/ui/src/Inventory/Container/BatchForm.js
+++ b/src/main/webapp/ui/src/Inventory/Container/BatchForm.js
@@ -48,7 +48,10 @@ function OverviewSection({
       sectionName="overview"
       recordType="container"
     >
-      <Image fieldOwner={collection} />
+      <Image
+        fieldOwner={collection}
+        alt={`What all ${collection.size} containers look like`}
+      />
       {collection.isFieldEditable("image") && (
         <Box mt={1}>
           <Alert severity="info">

--- a/src/main/webapp/ui/src/Inventory/Container/Fields/LocationsImageField.js
+++ b/src/main/webapp/ui/src/Inventory/Container/Fields/LocationsImageField.js
@@ -113,6 +113,7 @@ function LocationsImageField(): Node {
                   ? "Click on ‘Edit Locations’ to add locations and start using the visual container."
                   : ""
               }
+              alt={"The marked locations of ${activeResult.name}"}
             />
             <canvas id={CANVAS_ID} style={{ display: "none" }}></canvas>
           </>

--- a/src/main/webapp/ui/src/Inventory/Container/Form.js
+++ b/src/main/webapp/ui/src/Inventory/Container/Form.js
@@ -53,7 +53,10 @@ const OverviewSection = observer(
           <>
             <LocationField fieldOwner={activeResult} />
             <OrganizationField container={activeResult} />
-            <ContainerImage fieldOwner={activeResult} />
+            <ContainerImage
+              fieldOwner={activeResult}
+              alt={`What ${activeResult.name} looks like`}
+            />
           </>
         )}
       </StepperPanel>

--- a/src/main/webapp/ui/src/Inventory/Container/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Container/NewRecordForm.js
@@ -47,7 +47,10 @@ const OverviewSection = observer(
           }
         />
         <Organization container={activeResult} />
-        <ContainerImage fieldOwner={activeResult} />
+        <ContainerImage
+          fieldOwner={activeResult}
+          alt="What the new container looks like"
+        />
       </StepperPanel>
     );
   }

--- a/src/main/webapp/ui/src/Inventory/Mixed/BatchForm.js
+++ b/src/main/webapp/ui/src/Inventory/Mixed/BatchForm.js
@@ -48,7 +48,7 @@ function OverviewSection({
       sectionName="overview"
       recordType="mixed"
     >
-      <Image fieldOwner={collection} />
+      <Image fieldOwner={collection} alt="What all of the items look like" />
       {collection.isFieldEditable("image") && (
         <Box mt={1}>
           <Alert severity="info">

--- a/src/main/webapp/ui/src/Inventory/Sample/BatchForm.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/BatchForm.js
@@ -50,7 +50,10 @@ function OverviewSection({
       sectionName="overview"
       recordType="sample"
     >
-      <Image fieldOwner={collection} />
+      <Image
+        fieldOwner={collection}
+        alt={`What the ${collection.size} samples look like`}
+      />
       {collection.isFieldEditable("image") && (
         <Box mt={1}>
           <Alert severity="info">

--- a/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Content/SubsampleDetails.js
@@ -156,7 +156,10 @@ function SubsampleDetails({ search }: SubsampleDetailsArgs) {
           <CardContent>
             <Stack spacing={2}>
               <LocationField fieldOwner={subsample} />
-              <ImageField fieldOwner={subsample} />
+              <ImageField
+                fieldOwner={subsample}
+                alt={`What the subsample, ${subsample.name}, looks like`}
+              />
               <QuantityField
                 fieldOwner={subsample}
                 quantityCategory={subsample.quantityCategory}

--- a/src/main/webapp/ui/src/Inventory/Sample/Form.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Form.js
@@ -59,7 +59,10 @@ const OverviewSection = observer(
         {activeResult.readAccessLevel !== "public" && (
           <>
             <TemplateField />
-            <ImageField fieldOwner={activeResult} />
+            <ImageField
+              fieldOwner={activeResult}
+              alt="What the sample looks like"
+            />
           </>
         )}
       </StepperPanel>

--- a/src/main/webapp/ui/src/Inventory/Sample/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/NewRecordForm.js
@@ -55,7 +55,10 @@ const OverviewSection = observer(
           }
         />
         <TemplateField />
-        <ImageField fieldOwner={activeResult} />
+        <ImageField
+          fieldOwner={activeResult}
+          alt="What the new sample looks like"
+        />
       </StepperPanel>
     );
   }

--- a/src/main/webapp/ui/src/Inventory/Subsample/BatchForm.js
+++ b/src/main/webapp/ui/src/Inventory/Subsample/BatchForm.js
@@ -49,7 +49,10 @@ function OverviewSection({
       sectionName="overview"
       recordType="subSample"
     >
-      <Image fieldOwner={setOfSubSamples} />
+      <Image
+        fieldOwner={setOfSubSamples}
+        alt={`What the ${setOfSubSamples.size} subsamples look like`}
+      />
       {setOfSubSamples.isFieldEditable("image") && (
         <Box mt={1}>
           <Alert severity="info">

--- a/src/main/webapp/ui/src/Inventory/Subsample/Form.js
+++ b/src/main/webapp/ui/src/Inventory/Subsample/Form.js
@@ -63,7 +63,10 @@ const OverviewSection = observer(
           <>
             <SampleField fieldOwner={activeResult} />
             <LocationField fieldOwner={activeResult} />
-            <ImageField fieldOwner={activeResult} />
+            <ImageField
+              fieldOwner={activeResult}
+              alt="What the subsample looks like"
+            />
           </>
         )}
       </StepperPanel>

--- a/src/main/webapp/ui/src/Inventory/Template/Form.js
+++ b/src/main/webapp/ui/src/Inventory/Template/Form.js
@@ -50,7 +50,10 @@ const OverviewSection = observer(
         />
         <OwnerField fieldOwner={activeResult} />
         {activeResult.readAccessLevel !== "public" && (
-          <ImageField fieldOwner={activeResult} />
+          <ImageField
+            fieldOwner={activeResult}
+            alt="A visual representation of the samples that are to be created from this template"
+          />
         )}
       </StepperPanel>
     );

--- a/src/main/webapp/ui/src/Inventory/Template/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Template/NewRecordForm.js
@@ -47,7 +47,10 @@ const OverviewSection = observer(
             setFormSectionError(formSectionError, "name", e)
           }
         />
-        <ImageField fieldOwner={activeResult} />
+        <ImageField
+          fieldOwner={activeResult}
+          alt="A visual representation of the samples that will be created from this new template"
+        />
       </StepperPanel>
     );
   }

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Image.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Image.js
@@ -21,7 +21,7 @@ function Image<
     ...
   },
   FieldOwner: HasEditableFields<Fields>
->({ fieldOwner }: {| fieldOwner: FieldOwner |}): Node {
+>({ fieldOwner, alt }: {| fieldOwner: FieldOwner, alt: string |}): Node {
   const { search } = useContext(SearchContext);
   const isFieldEditable = fieldOwner.isFieldEditable("image");
   let tooManytoBatchThis: boolean = false;
@@ -64,6 +64,7 @@ function Image<
             width={150}
             id="preview-image-form-element"
             noValueLabel={fieldOwner.noValueLabel.image}
+            alt={alt}
           />
           <canvas id={CANVAS_ID} style={{ display: "none" }} />
           {tooManytoBatchThis && (

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -246,7 +246,7 @@ function ImageEditingDialog({
             onClick={() => {
               onRotate("counter clockwise");
             }}
-            aria-label="rotate left"
+            aria-label="rotate counter clockwise"
             size="small"
           >
             <RotateLeftIcon />
@@ -263,7 +263,7 @@ function ImageEditingDialog({
             onClick={() => {
               onRotate("clockwise");
             }}
-            aria-label="rotate right"
+            aria-label="rotate clockwise"
             size="small"
           >
             <RotateRightIcon />

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -68,7 +68,7 @@ type ImageEditingDialogArgs = {|
   imageFile: ?Blob,
   open: boolean,
   close: () => void,
-  submitHandler: (string) => void,
+  submitHandler: (Blob) => void,
   alt: string,
 |};
 
@@ -151,7 +151,7 @@ function ImageEditingDialog({
     setEditorData(getRotatedImageURL());
   };
 
-  const cropImage = (format: string): string => {
+  const cropImage = (format: string): Promise<Blob> => {
     const image = imageElement.current;
     if (!image) throw new Error("Image file not present");
     const canvas = document.createElement("canvas");
@@ -174,7 +174,7 @@ function ImageEditingDialog({
         crop.height * imageRatio
       );
 
-    return canvas.toDataURL(format, "1.0");
+    return new Promise((resolve) => canvas.toBlob(resolve, format, "1.0"));
   };
 
   const mainDialogSubmit = () => {
@@ -190,9 +190,10 @@ function ImageEditingDialog({
      * image as the move the cropped region would prevent them from undoing
      * their changes.
      */
-    const newImage = cropImage(imageType);
-    submitHandler(newImage);
-    close();
+    void cropImage(imageType).then((newImage) => {
+      submitHandler(newImage);
+      close();
+    });
   };
 
   return (

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -24,7 +24,8 @@ const useStyles = makeStyles()((_theme, { height }) => ({
    * resulting in the need to scroll: ideally the whole image should be visible
    * when cropping. Setting `maxHeight: 100%` and `objectFit: scale-down` is
    * not sufficient; all of the DOM nodes between the HTMLImageElement and the
-   * DialogContent need to have `height: 100%`. We then have to shrink back the crop-mask to only cover the image itself and not the whitespace below.
+   * DialogContent need to have `height: 100%`. We then have to shrink back the
+   * crop-mask to only cover the image itself and not the whitespace below.
    */
   crop: {
     height: "100%",

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -17,11 +17,14 @@ import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import { makeStyles } from "tss-react/mui";
 
-const useStyles = makeStyles()(() => ({
+const useStyles = makeStyles()((_theme, { height }) => ({
   crop: {
     height: "100%",
     "& .ReactCrop__child-wrapper": {
       height: "100%",
+    },
+    "& .ReactCrop__crop-mask": {
+      height: `${height}px`,
     },
   },
 }));
@@ -60,7 +63,8 @@ function ImageEditingDialog({
   close,
   submitHandler,
 }: ImageEditingDialogArgs): Node {
-  const { classes } = useStyles();
+  const [imageHeight, setImageHeight] = React.useState(0);
+  const { classes } = useStyles({ height: imageHeight });
   const [editorData, setEditorData] = React.useState<?string>(null);
   const [crop, setCrop] = React.useState({
     unit: "px",
@@ -91,9 +95,11 @@ function ImageEditingDialog({
 
   const onImageLoad = (e: Event): void => {
     if (e.target instanceof HTMLImageElement) {
-      const { naturalHeight, naturalWidth, height, width } = e.target;
+      const target: HTMLImageElement = e.target;
+      const { naturalHeight, naturalWidth, height, width } = target;
+      setImageHeight(height);
       if (!imageElement) return;
-      imageElement.current = e.target;
+      imageElement.current = target;
       setScale({
         x: naturalWidth / width,
         y: naturalHeight / height,
@@ -162,7 +168,12 @@ function ImageEditingDialog({
     <StyledDialog maxWidth="md" open={open} onClose={close}>
       <DialogContent>
         {editorData && (
-          <ReactCrop crop={crop} onChange={setCrop} className={classes.crop}>
+          <ReactCrop
+            crop={crop}
+            onChange={setCrop}
+            className={classes.crop}
+            maxHeight={imageHeight}
+          >
             <img
               src={editorData}
               onLoad={onImageLoad}

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -8,6 +8,12 @@ import DialogContent from "@mui/material/DialogContent";
 import { observer } from "mobx-react-lite";
 import ReactCrop from "react-image-crop";
 import "react-image-crop/dist/ReactCrop.css";
+import RotateLeftIcon from "@mui/icons-material/RotateLeft";
+import RotateRightIcon from "@mui/icons-material/RotateRight";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import Divider from "@mui/material/Divider";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
 
 const imageTypeFromFile = (file: Blob): string => file.type.split("/")[1];
 
@@ -84,6 +90,24 @@ function ImageEditingDialog({
     }
   };
 
+  const onRotate = (direction: "clockwise" | "counter clockwise"): void => {
+    const getRotatedImageURL = (): string => {
+      const image = imageElement.current;
+      if (!image) throw new Error("Image file not present");
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      canvas.width = image.naturalHeight;
+      canvas.height = image.naturalWidth;
+      if (ctx) {
+        ctx.translate(canvas.width / 2, canvas.height / 2);
+        ctx.rotate(((direction === "clockwise" ? 90 : -90) * Math.PI) / 180);
+        ctx.drawImage(image, -image.naturalWidth / 2, -image.naturalHeight / 2);
+      }
+      return canvas.toDataURL("image/jpeg", "1.0");
+    };
+    setEditorData(getRotatedImageURL());
+  };
+
   const cropImage = (): string => {
     const image = imageElement.current;
     if (!image) throw new Error("Image file not present");
@@ -126,6 +150,41 @@ function ImageEditingDialog({
         )}
       </DialogContent>
       <DialogActions>
+        <ButtonGroup
+          variant="outlined"
+          sx={{
+            border: "2px solid #cfc9d2",
+            borderRadius: "8px",
+          }}
+        >
+          <IconButton
+            onClick={() => {
+              onRotate("counter clockwise");
+            }}
+            aria-label="rotate left"
+            size="small"
+          >
+            <RotateLeftIcon />
+          </IconButton>
+          <Divider
+            orientation="vertical"
+            sx={{
+              height: "26px",
+              marginTop: "4px",
+              borderRightWidth: "1px",
+            }}
+          />
+          <IconButton
+            onClick={() => {
+              onRotate("clockwise");
+            }}
+            aria-label="rotate right"
+            size="small"
+          >
+            <RotateRightIcon />
+          </IconButton>
+        </ButtonGroup>
+        <Box flexGrow={1}></Box>
         <Button onClick={mainDialogSubmit} color="primary">
           Done
         </Button>

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -68,6 +68,7 @@ type ImageEditingDialogArgs = {|
   open: boolean,
   close: () => void,
   submitHandler: (string) => void,
+  alt: string,
 |};
 
 function ImageEditingDialog({
@@ -75,6 +76,7 @@ function ImageEditingDialog({
   open,
   close,
   submitHandler,
+  alt,
 }: ImageEditingDialogArgs): Node {
   const [imageHeight, setImageHeight] = React.useState(0);
   const { classes } = useStyles({ height: imageHeight });
@@ -225,6 +227,7 @@ function ImageEditingDialog({
             }}
           >
             <img
+              alt={alt}
               src={editorData}
               onLoad={onImageLoad}
               style={{

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -197,13 +197,7 @@ function ImageEditingDialog({
         )}
       </DialogContent>
       <DialogActions>
-        <ButtonGroup
-          variant="outlined"
-          sx={{
-            border: "2px solid #cfc9d2",
-            borderRadius: "8px",
-          }}
-        >
+        <ButtonGroup variant="outlined">
           <IconButton
             onClick={() => {
               onRotate("counter clockwise");
@@ -218,7 +212,7 @@ function ImageEditingDialog({
             sx={{
               height: "26px",
               marginTop: "4px",
-              borderRightWidth: "1px",
+              borderRightWidth: "2px",
             }}
           />
           <IconButton

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -31,6 +31,11 @@ const useStyles = makeStyles()((_theme, { height }) => ({
 
 const StyledDialog = styled(Dialog)(() => ({
   "& > .MuiDialog-container > .MuiPaper-root": {
+    /*
+     * Even though this makes the dialog taller than it needs to be for
+     * horizontal images, this is necessary to ensure that vertical images are
+     * scaled down rather than overflowing the dialog with a scrollbar.
+     */
     height: "100%",
   },
 }));

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -166,7 +166,13 @@ function ImageEditingDialog({
 
   return (
     <StyledDialog maxWidth="md" open={open} onClose={close}>
-      <DialogContent>
+      <DialogContent
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "center",
+        }}
+      >
         {editorData && (
           <ReactCrop
             crop={crop}

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -18,6 +18,16 @@ import useViewportDimensions from "../util/useViewportDimensions";
 import CardMedia from "@mui/material/CardMedia";
 import Card from "@mui/material/Card";
 import { styled } from "@mui/material/styles";
+import { makeStyles } from "tss-react/mui";
+
+const useStyles = makeStyles()(() => ({
+  crop: {
+    height: "100%",
+    "& .ReactCrop__child-wrapper": {
+      height: "100%",
+    },
+  },
+}));
 
 const StyledDialog = styled(Dialog)(() => ({
   "& > .MuiDialog-container > .MuiPaper-root": {
@@ -53,6 +63,7 @@ function ImageEditingDialog({
   close,
   submitHandler,
 }: ImageEditingDialogArgs): Node {
+  const { classes } = useStyles();
   const [editorData, setEditorData] = React.useState<?string>(null);
   const [crop, setCrop] = React.useState({
     unit: "px",
@@ -154,18 +165,17 @@ function ImageEditingDialog({
     <StyledDialog maxWidth="md" open={open} onClose={close}>
       <DialogContent>
         {editorData && (
-          <Card sx={{ height: "100%" }}>
-            <CardMedia
-              component="img"
-              image={editorData}
+          <ReactCrop crop={crop} onChange={setCrop} className={classes.crop}>
+            <img
+              src={editorData}
               onLoad={onImageLoad}
-              sx={{
+              style={{
                 maxHeight: "100%",
                 maxWidth: "100%",
                 objectFit: "scale-down",
               }}
             />
-          </Card>
+          </ReactCrop>
         )}
       </DialogContent>
       <DialogActions>

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -209,7 +209,7 @@ function ImageEditingDialog({
             onChange={setCrop}
             className={classes.crop}
             maxHeight={imageHeight}
-            onComplete={(...args) => {
+            onComplete={(newCrop) => {
               setDirtyFlag(true);
               /*
                * Prevent the user from extending the cropping region to areas
@@ -219,10 +219,10 @@ function ImageEditingDialog({
                * constitutent DOM nodes this is no longer enforced. As such, we
                * enforce it ourselves.
                */
-              if (args[0].height + args[0].y > imageHeight)
+              if (newCrop.height + newCrop.y > imageHeight)
                 setCrop({
-                  ...args[0],
-                  height: Math.min(imageHeight - args[0].y, args[0].height),
+                  ...newCrop,
+                  height: Math.min(imageHeight - newCrop.y, newCrop.height),
                 });
             }}
           >

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -14,6 +14,16 @@ import ButtonGroup from "@mui/material/ButtonGroup";
 import Divider from "@mui/material/Divider";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
+import useViewportDimensions from "../util/useViewportDimensions";
+import CardMedia from "@mui/material/CardMedia";
+import Card from "@mui/material/Card";
+import { styled } from "@mui/material/styles";
+
+const StyledDialog = styled(Dialog)(() => ({
+  "& > .MuiDialog-container > .MuiPaper-root": {
+    height: "100%",
+  },
+}));
 
 const imageTypeFromFile = (file: Blob): string => file.type.split("/")[1];
 
@@ -141,12 +151,21 @@ function ImageEditingDialog({
   };
 
   return (
-    <Dialog fullScreen open={open} onClose={close}>
-      <DialogContent style={{ overscrollBehavior: "contain", padding: "0px" }}>
+    <StyledDialog maxWidth="md" open={open} onClose={close}>
+      <DialogContent>
         {editorData && (
-          <ReactCrop crop={crop} onChange={setCrop}>
-            <img src={editorData} onLoad={onImageLoad} />
-          </ReactCrop>
+          <Card sx={{ height: "100%" }}>
+            <CardMedia
+              component="img"
+              image={editorData}
+              onLoad={onImageLoad}
+              sx={{
+                maxHeight: "100%",
+                maxWidth: "100%",
+                objectFit: "scale-down",
+              }}
+            />
+          </Card>
         )}
       </DialogContent>
       <DialogActions>
@@ -189,7 +208,7 @@ function ImageEditingDialog({
           Done
         </Button>
       </DialogActions>
-    </Dialog>
+    </StyledDialog>
   );
 }
 

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -184,6 +184,10 @@ function ImageEditingDialog({
               src={editorData}
               onLoad={onImageLoad}
               style={{
+                /*
+                 * Can't add a border or outline as it throws off the logic of
+                 * the crop region and draggable anchors.
+                 */
                 maxHeight: "100%",
                 maxWidth: "100%",
                 objectFit: "scale-down",

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -14,8 +14,6 @@ import ButtonGroup from "@mui/material/ButtonGroup";
 import Divider from "@mui/material/Divider";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
-import CardMedia from "@mui/material/CardMedia";
-import Card from "@mui/material/Card";
 import { styled } from "@mui/material/styles";
 import { makeStyles } from "tss-react/mui";
 

--- a/src/main/webapp/ui/src/components/ImageEditingDialog.js
+++ b/src/main/webapp/ui/src/components/ImageEditingDialog.js
@@ -14,7 +14,6 @@ import ButtonGroup from "@mui/material/ButtonGroup";
 import Divider from "@mui/material/Divider";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
-import useViewportDimensions from "../util/useViewportDimensions";
 import CardMedia from "@mui/material/CardMedia";
 import Card from "@mui/material/Card";
 import { styled } from "@mui/material/styles";

--- a/src/main/webapp/ui/src/components/Inputs/DynamicallyLoadedImageEditor.js
+++ b/src/main/webapp/ui/src/components/Inputs/DynamicallyLoadedImageEditor.js
@@ -36,7 +36,7 @@ type DynamicallyLoadedImageEditorArgs = {|
   editorFile: ?Blob,
   editorOpen: boolean,
   close: () => void,
-  submitHandler: (string) => void,
+  submitHandler: (Blob) => void,
   alt: string,
 |};
 

--- a/src/main/webapp/ui/src/components/Inputs/DynamicallyLoadedImageEditor.js
+++ b/src/main/webapp/ui/src/components/Inputs/DynamicallyLoadedImageEditor.js
@@ -37,6 +37,7 @@ type DynamicallyLoadedImageEditorArgs = {|
   editorOpen: boolean,
   close: () => void,
   submitHandler: (string) => void,
+  alt: string,
 |};
 
 function DynamicallyLoadedImageEditor({
@@ -44,6 +45,7 @@ function DynamicallyLoadedImageEditor({
   editorOpen,
   close,
   submitHandler,
+  alt,
 }: DynamicallyLoadedImageEditorArgs): Node {
   return (
     <ErrorBoundary>
@@ -53,6 +55,7 @@ function DynamicallyLoadedImageEditor({
           open={editorOpen}
           close={close}
           submitHandler={submitHandler}
+          alt={alt}
         />
       </Suspense>
     </ErrorBoundary>

--- a/src/main/webapp/ui/src/components/Inputs/ImageField.js
+++ b/src/main/webapp/ui/src/components/Inputs/ImageField.js
@@ -112,11 +112,23 @@ function ImageField({
     });
   };
 
-  const submit = async (editedImageDataURL: string) => {
-    const newFile = await fetch(editedImageDataURL).then((r) => r.blob());
+  const readAsDataUrl = (file: Blob): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        // $FlowExpectedError[incompatible-cast] reader.result will be string because we called readAsDataUrl
+        resolve((reader.result: string));
+      };
+      reader.onerror = () => {
+        reject(reader.error);
+      };
+      reader.readAsDataURL(file);
+    });
+
+  const submit = async (editedImage: Blob) => {
     storeNewImage({
-      dataURL: editedImageDataURL,
-      file: newFile,
+      dataURL: await readAsDataUrl(editedImage),
+      file: editedImage,
     });
   };
 

--- a/src/main/webapp/ui/src/components/Inputs/ImageField.js
+++ b/src/main/webapp/ui/src/components/Inputs/ImageField.js
@@ -4,7 +4,6 @@ import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import CropIcon from "@mui/icons-material/Crop";
-import Divider from "@mui/material/Divider";
 import Grid from "@mui/material/Grid";
 import ImageIcon from "@mui/icons-material/Image";
 import React, {
@@ -48,6 +47,7 @@ type ImageFieldArgs = {|
   // required
   storeImage: (ImageData) => void,
   imageAsObjectURL: ?string,
+  alt: string,
 
   // optional
   id?: string,
@@ -71,6 +71,7 @@ function ImageField({
   showPreview = true,
   warningAlert = "",
   noValueLabel,
+  alt,
 }: ImageFieldArgs): Node {
   const { classes } = useStyles({ width, height });
   const [editorFile, setEditorFile] = useState<?Blob>(null);
@@ -149,6 +150,7 @@ function ImageField({
       imgProps={{
         width: typeof width === "number" ? width : null,
         height: typeof height === "number" ? height : null,
+        alt,
       }}
       {...props}
     />
@@ -222,6 +224,7 @@ function ImageField({
                 setEditorOpen(false);
               }}
               submitHandler={doNotAwait(submit)}
+              alt={alt}
             />
           )}
         </>

--- a/src/main/webapp/ui/src/components/Inputs/ImageField.js
+++ b/src/main/webapp/ui/src/components/Inputs/ImageField.js
@@ -1,6 +1,5 @@
 // @flow
 
-import "tui-image-editor/dist/tui-image-editor.css";
 import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";

--- a/src/main/webapp/ui/src/components/Inputs/__tests__/ImageField.test.js
+++ b/src/main/webapp/ui/src/components/Inputs/__tests__/ImageField.test.js
@@ -57,7 +57,12 @@ describe("ImageField", () => {
 
       test("be a camera icon shown.", () => {
         render(
-          <ImageField storeImage={() => {}} imageAsObjectURL={null} id="foo" />
+          <ImageField
+            storeImage={() => {}}
+            imageAsObjectURL={null}
+            id="foo"
+            alt="dummy alt text"
+          />
         );
         expect(CameraAltIcon).toHaveBeenCalled();
       });
@@ -70,7 +75,12 @@ describe("ImageField", () => {
 
       test("be an image icon shown.", () => {
         render(
-          <ImageField storeImage={() => {}} imageAsObjectURL={null} id="foo" />
+          <ImageField
+            storeImage={() => {}}
+            imageAsObjectURL={null}
+            id="foo"
+            alt="dummy alt text"
+          />
         );
         expect(ImageIcon).toHaveBeenCalled();
       });
@@ -84,7 +94,12 @@ describe("ImageField", () => {
     test("be a DynamicallyLoadedImageEditor that opens.", async () => {
       const user = userEvent.setup();
       render(
-        <ImageField storeImage={() => {}} imageAsObjectURL={null} id="foo" />
+        <ImageField
+          storeImage={() => {}}
+          imageAsObjectURL={null}
+          id="foo"
+          alt="dummy alt text"
+        />
       );
 
       const editImageButton = screen.getByText("Edit Image");

--- a/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
@@ -151,6 +151,53 @@ describe("ImageEditingDialog", () => {
     );
   });
 
+  test("Rotating by 90º counter clockwise should result in the correct image", async () => {
+    const user = userEvent.setup();
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    // 600px to negate any scaling effects
+    ctx.canvas.width = 600;
+    ctx.canvas.height = 600;
+    ctx.fillStyle = "green";
+    ctx.fillRect(0, 0, 300, 300);
+
+    const blob: Blob = await new Promise((resolve) => {
+      canvas.toBlob(resolve);
+    });
+
+    const submitHandler = jest.fn<[string], void>();
+    render(
+      <ImageEditingDialog
+        imageFile={blob}
+        open={true}
+        close={() => {}}
+        submitHandler={submitHandler}
+        alt="dummy alt text"
+      />
+    );
+
+    await screen.findByRole("img");
+
+    const rotateButton = screen.getByRole("button", {
+      name: "rotate counter clockwise",
+    });
+    await user.click(rotateButton);
+
+    await user.click(screen.getByRole("button", { name: /done/i }));
+
+    const canvas2 = document.createElement("canvas");
+    const ctx2 = canvas2.getContext("2d");
+    // 600px to negate any scaling effects
+    ctx2.canvas.width = 600;
+    ctx2.canvas.height = 600;
+    ctx2.fillStyle = "green";
+    ctx2.fillRect(0, 300, 300, 600);
+
+    expect(submitHandler).toHaveBeenCalledWith(
+      canvas2.toDataURL("image/png", "1.0")
+    );
+  });
+
   /*
    * Testing the cropping functionality was attempted but it seems to be
    * impossible to get the keyDown events for moving the anchors around to

--- a/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
@@ -47,6 +47,7 @@ describe("ImageEditingDialog", () => {
               open={true}
               close={() => {}}
               submitHandler={submitHandler}
+              alt="dummy alt text"
             />
           );
 

--- a/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
@@ -103,6 +103,54 @@ describe("ImageEditingDialog", () => {
       { numRuns: 4 }
     );
   });
+
+  test("Rotating by 90º clockwise should result in the correct image", async () => {
+    const user = userEvent.setup();
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    // 600px to negate any scaling effects
+    ctx.canvas.width = 600;
+    ctx.canvas.height = 600;
+    ctx.fillStyle = "green";
+    ctx.fillRect(0, 0, 300, 300);
+
+    const blob: Blob = await new Promise((resolve) => {
+      canvas.toBlob(resolve);
+    });
+
+    const submitHandler = jest.fn<[string], void>();
+    render(
+      <ImageEditingDialog
+        imageFile={blob}
+        open={true}
+        close={() => {}}
+        submitHandler={submitHandler}
+        alt="dummy alt text"
+      />
+    );
+
+    await screen.findByRole("img");
+
+    const rotateButton = screen.getByRole("button", {
+      name: "rotate clockwise",
+    });
+    await user.click(rotateButton);
+
+    await user.click(screen.getByRole("button", { name: /done/i }));
+
+    const canvas2 = document.createElement("canvas");
+    const ctx2 = canvas2.getContext("2d");
+    // 600px to negate any scaling effects
+    ctx2.canvas.width = 600;
+    ctx2.canvas.height = 600;
+    ctx2.fillStyle = "green";
+    ctx2.fillRect(300, 0, 600, 300);
+
+    expect(submitHandler).toHaveBeenCalledWith(
+      canvas2.toDataURL("image/png", "1.0")
+    );
+  });
+
   /*
    * Testing the cropping functionality was attempted but it seems to be
    * impossible to get the keyDown events for moving the anchors around to

--- a/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
@@ -9,6 +9,9 @@ import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import ImageEditingDialog from "../ImageEditingDialog";
 import fc from "fast-check";
+import { axe, toHaveNoViolations } from "jest-axe";
+
+expect.extend(toHaveNoViolations);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -17,6 +20,32 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("ImageEditingDialog", () => {
+  test("Should have no axe violations.", async () => {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    // 600px to negate any scaling effects
+    ctx.canvas.width = 600;
+    ctx.canvas.height = 400;
+    ctx.fillStyle = "green";
+    ctx.fillRect(10, 10, 150, 100);
+
+    const blob: Blob = await new Promise((resolve) => {
+      canvas.toBlob(resolve);
+    });
+
+    const { container } = render(
+      <ImageEditingDialog
+        imageFile={blob}
+        open={true}
+        close={() => {}}
+        submitHandler={() => {}}
+        alt="dummy alt text"
+      />
+    );
+
+    // $FlowExpectedError[incompatible-call] See expect.extend above
+    expect(await axe(container)).toHaveNoViolations();
+  });
   test("Rotating four times in either direction is a no-op.", async () => {
     const user = userEvent.setup();
     await fc.assert(

--- a/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
@@ -103,4 +103,11 @@ describe("ImageEditingDialog", () => {
       { numRuns: 4 }
     );
   });
+  /*
+   * Testing the cropping functionality was attempted but it seems to be
+   * impossible to get the keyDown events for moving the anchors around to
+   * trigger react-image-crop's onChange event handler. There is a console
+   * error reported that `scrollTo` could not be invoked on the root div of
+   * ReactCrop, so perhaps that is the issue.
+   */
 });

--- a/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
@@ -1,0 +1,76 @@
+/*
+ * @jest-environment jsdom
+ */
+//@flow
+/* eslint-env jest */
+import React from "react";
+import { render, cleanup, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import ImageEditingDialog from "../ImageEditingDialog";
+import fc from "fast-check";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("ImageEditingDialog", () => {
+  test("Rotating four times in either direction is a no-op.", async () => {
+    const user = userEvent.setup();
+    await fc.assert(
+      fc.asyncProperty(
+        fc.tuple(fc.constantFrom("clockwise", "counter clockwise"), fc.nat(20)),
+        async ([direction, number]) => {
+          cleanup();
+
+          // submitHandler is not invoked if no edits have been made
+          fc.pre(number > 0);
+
+          const canvas = document.createElement("canvas");
+          const ctx = canvas.getContext("2d");
+          // 600px to negate any scaling effects
+          ctx.canvas.width = 600;
+          ctx.canvas.height = 400;
+          ctx.fillStyle = "green";
+          ctx.fillRect(10, 10, 150, 100);
+
+          const blob: Blob = await new Promise((resolve) => {
+            canvas.toBlob(resolve);
+          });
+
+          const submitHandler = jest.fn<[string], void>();
+          render(
+            <ImageEditingDialog
+              imageFile={blob}
+              open={true}
+              close={() => {}}
+              submitHandler={submitHandler}
+            />
+          );
+
+          await screen.findByRole("img");
+
+          const rotateButton = screen.getByRole("button", {
+            name: "rotate " + direction,
+          });
+          for (let i = 0; i < number; i++) await user.click(rotateButton);
+
+          await user.click(screen.getByRole("button", { name: /done/i }));
+
+          if (number % 4 === 0) {
+            expect(submitHandler).toHaveBeenCalledWith(
+              canvas.toDataURL("image/png", "1.0")
+            );
+          } else {
+            expect(submitHandler).not.toHaveBeenCalledWith(
+              canvas.toDataURL("image/png", "1.0")
+            );
+          }
+        }
+      ),
+      { numRuns: 4 }
+    );
+  });
+});

--- a/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
@@ -198,6 +198,38 @@ describe("ImageEditingDialog", () => {
     );
   });
 
+  test("If no change has been made, then submitHandler is not called", async () => {
+    const user = userEvent.setup();
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    // 600px to negate any scaling effects
+    ctx.canvas.width = 600;
+    ctx.canvas.height = 600;
+    ctx.fillStyle = "green";
+    ctx.fillRect(0, 0, 300, 300);
+
+    const blob: Blob = await new Promise((resolve) => {
+      canvas.toBlob(resolve);
+    });
+
+    const submitHandler = jest.fn<[string], void>();
+    const close = jest.fn<[], void>();
+    render(
+      <ImageEditingDialog
+        imageFile={blob}
+        open={true}
+        close={close}
+        submitHandler={submitHandler}
+        alt="dummy alt text"
+      />
+    );
+
+    await screen.findByRole("img");
+    await user.click(screen.getByRole("button", { name: /done/i }));
+    expect(close).toHaveBeenCalled();
+    expect(submitHandler).not.toHaveBeenCalled();
+  });
+
   /*
    * Testing the cropping functionality was attempted but it seems to be
    * impossible to get the keyDown events for moving the anchors around to

--- a/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
+++ b/src/main/webapp/ui/src/components/__tests__/ImageEditingDialog.test.js
@@ -69,7 +69,7 @@ describe("ImageEditingDialog", () => {
             canvas.toBlob(resolve);
           });
 
-          const submitHandler = jest.fn<[string], void>();
+          const submitHandler = jest.fn<[Blob], void>();
           render(
             <ImageEditingDialog
               imageFile={blob}
@@ -89,14 +89,14 @@ describe("ImageEditingDialog", () => {
 
           await user.click(screen.getByRole("button", { name: /done/i }));
 
+          const expected = await new Promise((resolve) =>
+            canvas.toBlob(resolve, "image/png", "1.0")
+          );
+
           if (number % 4 === 0) {
-            expect(submitHandler).toHaveBeenCalledWith(
-              canvas.toDataURL("image/png", "1.0")
-            );
+            expect(submitHandler).toHaveBeenCalledWith(expected);
           } else {
-            expect(submitHandler).not.toHaveBeenCalledWith(
-              canvas.toDataURL("image/png", "1.0")
-            );
+            expect(submitHandler).not.toHaveBeenCalledWith(expected);
           }
         }
       ),
@@ -118,7 +118,7 @@ describe("ImageEditingDialog", () => {
       canvas.toBlob(resolve);
     });
 
-    const submitHandler = jest.fn<[string], void>();
+    const submitHandler = jest.fn<[Blob], void>();
     render(
       <ImageEditingDialog
         imageFile={blob}
@@ -145,10 +145,11 @@ describe("ImageEditingDialog", () => {
     ctx2.canvas.height = 600;
     ctx2.fillStyle = "green";
     ctx2.fillRect(300, 0, 600, 300);
-
-    expect(submitHandler).toHaveBeenCalledWith(
-      canvas2.toDataURL("image/png", "1.0")
+    const expected = await new Promise((resolve) =>
+      canvas2.toBlob(resolve, "image/png", "1.0")
     );
+
+    expect(submitHandler).toHaveBeenCalledWith(expected);
   });
 
   test("Rotating by 90º counter clockwise should result in the correct image", async () => {
@@ -165,7 +166,7 @@ describe("ImageEditingDialog", () => {
       canvas.toBlob(resolve);
     });
 
-    const submitHandler = jest.fn<[string], void>();
+    const submitHandler = jest.fn<[Blob], void>();
     render(
       <ImageEditingDialog
         imageFile={blob}
@@ -192,10 +193,11 @@ describe("ImageEditingDialog", () => {
     ctx2.canvas.height = 600;
     ctx2.fillStyle = "green";
     ctx2.fillRect(0, 300, 300, 600);
-
-    expect(submitHandler).toHaveBeenCalledWith(
-      canvas2.toDataURL("image/png", "1.0")
+    const expected = await new Promise((resolve) =>
+      canvas2.toBlob(resolve, "image/png", "1.0")
     );
+
+    expect(submitHandler).toHaveBeenCalledWith(expected);
   });
 
   test("If no change has been made, then submitHandler is not called", async () => {
@@ -212,7 +214,7 @@ describe("ImageEditingDialog", () => {
       canvas.toBlob(resolve);
     });
 
-    const submitHandler = jest.fn<[string], void>();
+    const submitHandler = jest.fn<[Blob], void>();
     const close = jest.fn<[], void>();
     render(
       <ImageEditingDialog


### PR DESCRIPTION
This change replaces the image editor implemented with `@toast-ui/react-image-editor` -- which is no longer supported -- with one implemented mostly by us with use of the much smaller `react-image-crop` library. `react-image-editor` is not removed from the codebase yet, as it is also used by the Gallery, but once the Gallery has been migrated to the new UI code we will be able to remove this deprecated dependency, which will mean we will no longer have to pass `--force` to `npm install`.