### PR TITLE
Correct missing labels on dialogs

### DIFF
--- a/DevDocs/DeveloperNotes/GettingStarted/Accessibility.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/Accessibility.md
@@ -600,6 +600,15 @@ by accessibility technologies, use [DialogBoundary][] to prevent MUI from making
 these floating elements inert.
 
 
+### Make sure every Dialog has a DialogTitle
+
+
+If I Dialog has a DialogTitle then Material UI will automatically wire up the
+latter to the former with an `aria-labelledby` attribute. Every DOM node with
+role "dialog" must have a label and this is the simplest way to achieve that
+given that sighted user will need a title too.
+
+
 ### Automatically adjusted heading levels
 
 It is important that heading levels are rendered in order without skipping to

--- a/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.js
@@ -10,6 +10,7 @@ import AppBar from "@mui/material/AppBar";
 import AccessibilityTips from "../../components/AccessibilityTips";
 import HelpLinkIcon from "../../components/HelpLinkIcon";
 import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
@@ -186,7 +187,6 @@ export default function FieldmarkImportDialog({
     React.useState<?HTMLElement>(null);
   const [fetchingNotebooks, setFetchingNotebooks] = React.useState(false);
   const [importing, setImporting] = React.useState(false);
-  const titleId = React.useId();
 
   React.useEffect(
     doNotAwait(async () => {
@@ -273,7 +273,6 @@ export default function FieldmarkImportDialog({
         maxWidth="lg"
         fullWidth
         fullScreen={isViewportSmall}
-        aria-labelledby={titleId}
       >
         <AppBar position="relative" open={true}>
           <Toolbar variant="dense">
@@ -300,9 +299,7 @@ export default function FieldmarkImportDialog({
             sx={{ height: "100%", flexWrap: "nowrap" }}
           >
             <Grid item>
-              <Typography variant="h3" id={titleId}>
-                Import from Fieldmark
-              </Typography>
+              <DialogTitle variant="h3">Import from Fieldmark</DialogTitle>
             </Grid>
             <Grid item>
               <Typography

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -287,7 +287,6 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
               fontWeight: 700,
               lineHeight: 1.167,
               padding: "0",
-              margin: baseTheme.spacing(2),
             },
           },
         },

--- a/src/main/webapp/ui/src/components/DialogBoundary.js
+++ b/src/main/webapp/ui/src/components/DialogBoundary.js
@@ -107,7 +107,14 @@ type DialogArgs<T> = {|
   TransitionComponent?: ComponentType<T> | Node,
   className?: string,
   onClick?: () => void,
-  "aria-labelledby"?: string,
+
+  /*
+   * If one of the descendents of the Dialog is not a Material UI DialogTitle
+   * then jest-axe will rightly complain that the dialog does not have a label.
+   * Instead of passing `aria-label` or `aria-labelledby` here, be sure to use
+   * a DialogTitle as the Material UI Dialog and DialogTitle already contain
+   * the logic for wiring up the `aria-labelledby` attribute correctly.
+   */
 |};
 
 export function Dialog<T>(props: DialogArgs<T>): Node {

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.js
@@ -49,6 +49,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import { DataGrid } from "@mui/x-data-grid";
 import Radio from "@mui/material/Radio";
 import Stack from "@mui/material/Stack";
+import DialogTitle from "@mui/material/DialogTitle";
 
 const COLOR = {
   main: {
@@ -528,7 +529,9 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
           height="calc(100% + 16px)"
         >
           <Grid item>
-            <Typography variant="h3">Import a DMP into the Gallery</Typography>
+            <DialogTitle variant="h3">
+              Import a DMP into the Gallery
+            </DialogTitle>
           </Grid>
           <Grid item>
             <Typography variant="body2">

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/__tests__/DMPDialog.test.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/__tests__/DMPDialog.test.js
@@ -15,6 +15,9 @@ import materialTheme from "../../../theme";
 import { within, render } from "../../../__tests__/customQueries";
 import { take, incrementForever } from "../../../util/iterators";
 import userEvent from "@testing-library/user-event";
+import { axe, toHaveNoViolations } from "jest-axe";
+
+expect.extend(toHaveNoViolations);
 
 const mockAxios = new MockAdapter(axios);
 
@@ -345,5 +348,47 @@ describe("DMPDialog", () => {
       },
       10 * 1000
     );
+  });
+  test("Should have no axe violations.", async () => {
+    mockAxios.onGet(/\/apps\/argos\/plans.*/).reply(200, {
+      data: {
+        totalCount: 2,
+        data: [
+          {
+            id: "e27789f1-de35-4b4a-9587-a46d131c366e",
+            label: "Foo",
+            grant: "Foo's grant",
+            createdAt: 0,
+            modifiedAt: 0,
+          },
+          {
+            id: "e9a73d77-adfa-4546-974f-4a4a623b53a8",
+            label: "Bar",
+            grant: "Bar's grant",
+            createdAt: 0,
+            modifiedAt: 0,
+          },
+        ],
+      },
+      error: null,
+      errorMsg: null,
+      success: true,
+    });
+    const { baseElement } = render(
+      <ThemeProvider theme={materialTheme}>
+        <DMPDialog open={true} setOpen={() => {}} />
+      </ThemeProvider>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getAllByRole("row").length).toBeGreaterThan(1);
+        // i.e. the table body has been rendered
+      },
+      { timeout: 2000 }
+    );
+
+    // $FlowExpectedError[incompatible-call] See expect.extend above
+    expect(await axe(baseElement)).toHaveNoViolations();
   });
 });

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPOnline/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPOnline/DMPDialog.js
@@ -7,6 +7,7 @@ import useViewportDimensions from "../../util/useViewportDimensions";
 import { withStyles } from "Styles";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
+import DialogTitle from "@mui/material/DialogTitle";
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
@@ -195,9 +196,9 @@ const DMPDialogContent = ({ setOpen }: { setOpen: (boolean) => void }) => {
             <DialogContent>
               <Grid container direction="column" spacing={2}>
                 <Grid item>
-                  <Typography variant="h3">
+                  <DialogTitle variant="h3">
                     Import a DMP into the Gallery
-                  </Typography>
+                  </DialogTitle>
                 </Grid>
                 <Grid item>
                   <Typography variant="body2">

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.js
@@ -13,6 +13,7 @@ import Button from "@mui/material/Button";
 import { Dialog, DialogBoundary } from "../../components/DialogBoundary";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import { withStyles } from "Styles";
 import { observer } from "mobx-react-lite";
@@ -224,7 +225,9 @@ function DMPDialogContent({ setOpen }: { setOpen: (boolean) => void }): Node {
           height="calc(100% + 16px)"
         >
           <Grid item>
-            <Typography variant="h3">Import a DMP into the Gallery</Typography>
+            <DialogTitle variant="h3">
+              Import a DMP into the Gallery
+            </DialogTitle>
           </Grid>
           <Grid item>
             <Typography variant="body2">

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.js
@@ -10,6 +10,7 @@ import AppBar from "@mui/material/AppBar";
 import DialogContent from "@mui/material/DialogContent";
 import Grid from "@mui/material/Grid";
 import DialogActions from "@mui/material/DialogActions";
+import DialogTitle from "@mui/material/DialogTitle";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
 import Box from "@mui/material/Box";
@@ -260,7 +261,7 @@ function MoveCopyDialog({
                 sx={{ height: "100%", flexWrap: "nowrap" }}
               >
                 <Grid item>
-                  <Typography variant="h3">Move to iRODS</Typography>
+                  <DialogTitle variant="h3">Move to iRODS</DialogTitle>
                 </Grid>
                 {FetchingData.match(irods, {
                   loading: () => <></>,

--- a/src/main/webapp/ui/src/eln/gallery/picker/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/picker/index.js
@@ -136,6 +136,7 @@ const Picker = observer(
                   md: "unset",
                 },
               }}
+              aria-label="Gallery Picker"
             >
               <AppBar
                 appliedSearchTerm={appliedSearchTerm}


### PR DESCRIPTION
This change adds a DialogTitle to various Dialogs that don't have one to meet the accessibility requirement that all dialogs have a label. Why this works is also documented to prevent such violations in the future.