### PR TITLE
RSDEV-294 Ensure API token is refreshed

### DIFF
--- a/src/main/webapp/ui/src/common/useOauthToken.js
+++ b/src/main/webapp/ui/src/common/useOauthToken.js
@@ -2,27 +2,52 @@
 
 import axios from "axios";
 import JwtService from "./JwtService";
+import React from "react";
 
 export default function useOauthToken(): {| getToken: () => Promise<string> |} {
+  const [token, setToken] = React.useState<null | string>(null);
+
   async function fetchToken(): Promise<string> {
     const response = await axios.get<{| data: string |}>(
       "/userform/ajax/inventoryOauthToken"
     );
     const newToken = response.data.data;
     JwtService.saveToken(newToken);
-    setTimeout(() => {
-      void fetchToken();
-    }, JwtService.secondsToExpiry(newToken) * 1000);
     return newToken;
   }
 
+  async function refreshToken(): Promise<void> {
+    // we get a new token, memoise it for the duration of the window in which
+    // the token is valid, and then trigger a recursive call to get another
+    const newToken = await fetchToken();
+    setToken(newToken);
+    setTimeout(() => {
+      void refreshToken();
+    }, JwtService.secondsToExpiry(newToken) * 1000);
+  }
+
   return {
-    getToken: (): Promise<string> => {
-      const savedToken = JwtService.getToken();
-      if (savedToken) {
-        return Promise.resolve(savedToken);
-      }
-      return fetchToken();
+    getToken: async () => {
+      // use the memoised token, if we've previously called this hook
+      if (token) return token;
+
+      // otherwise, get a token: either from session storage or from the API
+      const savedToken = JwtService.getToken() ?? (await fetchToken());
+      setToken(savedToken);
+
+      // before the token expires, refresh it
+      // it is important that this setTimeout is set up regardless of whether
+      // the token was got from the API or from session storage. As the user
+      // navigates around and refreshes the page throughout the window in which
+      // the token is valid, we want to keep setting up the refresh logic so
+      // that when the token expires we get a new one, put it in session
+      // storage, and the current page and all subsequent ones in the next
+      // window will continue to work
+      setTimeout(() => {
+        void refreshToken();
+      }, JwtService.secondsToExpiry(savedToken) * 1000);
+
+      return savedToken;
     },
   };
 }

--- a/src/main/webapp/ui/src/common/useOauthToken.js
+++ b/src/main/webapp/ui/src/common/useOauthToken.js
@@ -33,10 +33,10 @@ import React from "react";
  *
  * This hook also automatically refreshes the token when it expires, so be sure
  * to not cache the value returned by `getToken` in the components or hooks
- * that use this hook as otherwise they will fail to work if the token elapses.
- * If the page is loaded and there is a valid token in the session storage then
- * it is used and a timer is set up to refresh the token when it expires just
- * as if the token and been fetched directly.
+ * that use this hook as otherwise they will fail to work when the token
+ * elapses.  If the page is loaded and there is a valid token in the session
+ * storage then it is used and a timer is set up to refresh the token when it
+ * expires just as if the token and been fetched directly.
  */
 export default function useOauthToken(): {| getToken: () => Promise<string> |} {
   /*
@@ -50,9 +50,9 @@ export default function useOauthToken(): {| getToken: () => Promise<string> |} {
   const [token, setToken] = React.useState<null | string>(null);
 
   /*
-   * As part of fetching a new token we save it into session storage so that
+   * As part of fetching a new token, we save it into session storage so that
    * after the page is reloaded we can just get it from there. This is mostly
-   * for performance: the reasoning being that the content of the page can
+   * for performance: the reasoning being that the content of the page cannot
    * be loaded until we have a token so rather than having all of the content
    * wait on a single blocking network call we can just persist the value
    * across page loads and only incur that penalty on the first page load.

--- a/src/main/webapp/ui/src/common/useOauthToken.js
+++ b/src/main/webapp/ui/src/common/useOauthToken.js
@@ -4,9 +4,59 @@ import axios from "axios";
 import JwtService from "./JwtService";
 import React from "react";
 
+/**
+ * This custom hook allows us to get a token for making calls to the API
+ * endpoints that expect an API key. This started out being for Inventory
+ * (hence the name of the /userform/ajax/inventoryOauthToken endpoint) but is
+ * increasingly used for more and more of the product as we aim to expose more
+ * of the functionality to third-parties via an open API.
+ *
+ * This code makes a request to the aforementioned endpoint using the user's
+ * already established authenticated session based on cookies and in return
+ * gets a token that can thereafter be used to make requests to the API
+ * endpoints that expect an API key. To do so, do something akin to the
+ * following:
+ *
+ *   const api = axios.create({
+ *     baseURL: `/api/v1/${PART_OF_API}`,
+ *     headers: {
+ *       Authorization: "Bearer " + (await getToken()),
+ *     },
+ *   });
+ *   await api.get(ENDPOINT);
+ *
+ * Don't worry about making execessive calls to `getToken` as the value is both
+ * cached by this custom hook and by the session storage so that even on page
+ * refresh calls will not be made to the endpoint. If several calls are made
+ * whilst an initial network request is in flight then multiple API calls will
+ * be made but this isn't generally an issue.
+ *
+ * This hook also automatically refreshes the token when it expires, so be sure
+ * to not cache the value returned by `getToken` in the components or hooks
+ * that use this hook as otherwise they will fail to work if the token elapses.
+ * If the page is loaded and there is a valid token in the session storage then
+ * it is used and a timer is set up to refresh the token when it expires just
+ * as if the token and been fetched directly.
+ */
 export default function useOauthToken(): {| getToken: () => Promise<string> |} {
+  /*
+   * We memoise the token, even if all we've done is pull it from the session
+   * storage, so that every call to `getToken` does not set up a new
+   * `setTimeout`.  The first call to this hook will get the token either from
+   * the API endpoint or from the session storage and set up the logic to
+   * ensure that a new token is fetched when that one expires, and all
+   * subsequent calls will simply get it from this variable.
+   */
   const [token, setToken] = React.useState<null | string>(null);
 
+  /*
+   * As part of fetching a new token we save it into session storage so that
+   * after the page is reloaded we can just get it from there. This is mostly
+   * for performance: the reasoning being that the content of the page can
+   * be loaded until we have a token so rather than having all of the content
+   * wait on a single blocking network call we can just persist the value
+   * across page loads and only incur that penalty on the first page load.
+   */
   async function fetchToken(): Promise<string> {
     const response = await axios.get<{| data: string |}>(
       "/userform/ajax/inventoryOauthToken"
@@ -16,9 +66,12 @@ export default function useOauthToken(): {| getToken: () => Promise<string> |} {
     return newToken;
   }
 
+  /*
+   * When the token is about to expire, this function is called which
+   * recursively ensures that a new token is fetched. We also memoise that new
+   * token so that subsequent calls to `getToken` will use the new one.
+   */
   async function refreshToken(): Promise<void> {
-    // we get a new token, memoise it for the duration of the window in which
-    // the token is valid, and then trigger a recursive call to get another
     const newToken = await fetchToken();
     setToken(newToken);
     setTimeout(() => {
@@ -28,21 +81,30 @@ export default function useOauthToken(): {| getToken: () => Promise<string> |} {
 
   return {
     getToken: async () => {
-      // use the memoised token, if we've previously called this hook
+      /*
+       * If this hook has been called previously and we've either already
+       * fetched a token or pulled it from the session storage, then we can
+       * just return it; thereby ensuring that we don't setup a new
+       * `setTimeout` with each call to `getToken`.
+       */
       if (token) return token;
 
-      // otherwise, get a token: either from session storage or from the API
+      /*
+       * If this hook has not been previously called then we preferably get the
+       * token from session storage or else get it from the API endpoint.
+       */
       const savedToken = JwtService.getToken() ?? (await fetchToken());
       setToken(savedToken);
 
-      // before the token expires, refresh it
-      // it is important that this setTimeout is set up regardless of whether
-      // the token was got from the API or from session storage. As the user
-      // navigates around and refreshes the page throughout the window in which
-      // the token is valid, we want to keep setting up the refresh logic so
-      // that when the token expires we get a new one, put it in session
-      // storage, and the current page and all subsequent ones in the next
-      // window will continue to work
+      /*
+       * Whether the token is fetched from the API or got from the session
+       * storage, we set up a timer to trigger the continuous refreshing of the
+       * token. As the user navigates around and refreshes the page throughout
+       * the window in which the token is valid, we want to keep setting up the
+       * refresh logic so that when the token expires we get a new one, put it
+       * in session storage, and the current page and all subsequent ones in
+       * the next temporal window will continue to work.
+       */
       setTimeout(() => {
         void refreshToken();
       }, JwtService.secondsToExpiry(savedToken) * 1000);

--- a/src/main/webapp/ui/src/eln/gallery/components/useIrods.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/useIrods.js
@@ -1,6 +1,6 @@
 //@flow
 
-import axios, { type Axios } from "axios";
+import axios from "axios";
 import React from "react";
 import Result from "../../../util/result";
 import * as Parsers from "../../../util/parsers";
@@ -188,16 +188,6 @@ export default function useIrods(
   configuredLocations: $ReadOnlyArray<IrodsLocation>,
 |}> {
   const { getToken } = useOauthToken();
-  const api = React.useRef<Promise<Axios>>(
-    (async () => {
-      return axios.create({
-        baseURL: "/api/v1/gallery/irods",
-        headers: {
-          Authorization: "Bearer " + (await getToken()),
-        },
-      });
-    })()
-  );
   const { addAlert } = React.useContext(AlertContext);
 
   /**
@@ -222,9 +212,13 @@ export default function useIrods(
       path,
       copy: copyLink.map((cl) => async ({ username, password }) => {
         try {
-          const response = await (
-            await api.current
-          ).post<
+          const api = axios.create({
+            baseURL: "/api/v1/gallery/irods",
+            headers: {
+              Authorization: "Bearer " + (await getToken()),
+            },
+          });
+          const response = await api.post<
             {|
               username: string,
               password: string,
@@ -252,9 +246,13 @@ export default function useIrods(
       }),
       move: moveLink.map((ml) => async ({ username, password }) => {
         try {
-          const response = await (
-            await api.current
-          ).post<
+          const api = axios.create({
+            baseURL: "/api/v1/gallery/irods",
+            headers: {
+              Authorization: "Bearer " + (await getToken()),
+            },
+          });
+          const response = await api.post<
             {|
               username: string,
               password: string,
@@ -296,9 +294,13 @@ export default function useIrods(
     setLoading(true);
     setErrorMessage("");
     try {
-      const { data } = await (
-        await api.current
-      ).get<mixed>("/", {
+      const api = axios.create({
+        baseURL: "/api/v1/gallery/irods",
+        headers: {
+          Authorization: "Bearer " + (await getToken()),
+        },
+      });
+      const { data } = await api.get<mixed>("/", {
         params: new URLSearchParams({
           recordIds: selectedIds.join(","),
         }),


### PR DESCRIPTION
This change
* Refresh the API token even if it is retrieved from session storage (previously this was only happening when the token was got from the API).
* Document clearly how the custom hook works, why we persist the token in session storage and in the hook, and the importance of refreshing the token in both cases.
* Fix iRods custom hook that was storing the token, and thus stopped working when the token expired.