### PR TITLE
RSDEV-434 Alter layout of new Gallery page

### DIFF
--- a/src/main/webapp/ui/flow-typed/mui.js
+++ b/src/main/webapp/ui/flow-typed/mui.js
@@ -143,6 +143,7 @@ declare module "@mui/x-data-grid" {
       noRowsLabel?: string,
     |},
     onCellKeyDown?: (Row, KeyboardEvent) => void,
+    sx?: { ... }
   |}): Node;
 
   declare export function GridToolbarContainer({|

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -649,6 +649,12 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
               textTransform: "uppercase",
               borderBottom: accentedBorder,
             },
+            h4: {
+              fontWeight: 700,
+              textTransform: "uppercase",
+              fontSize: "0.9rem",
+              letterSpacing: "0.01em",
+            },
           },
         },
         MuiLink: {

--- a/src/main/webapp/ui/src/eln/gallery/chemistryIcon.js
+++ b/src/main/webapp/ui/src/eln/gallery/chemistryIcon.js
@@ -1,4 +1,4 @@
-//@flow
+//@flow strict
 
 import React, { type Node } from "react";
 import SvgIcon from "@mui/material/SvgIcon";

--- a/src/main/webapp/ui/src/eln/gallery/common.js
+++ b/src/main/webapp/ui/src/eln/gallery/common.js
@@ -1,8 +1,32 @@
 //@flow strict
 
+import React, { type Node } from "react";
 import { COLORS as baseThemeColors } from "../../theme";
 import Result from "../../util/result";
 import * as Parsers from "../../util/parsers";
+import ChemistryIcon from "./chemistryIcon";
+import { FontAwesomeIcon as FaIcon } from "@fortawesome/react-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import {
+  faImage,
+  faFilm,
+  faFile,
+  faFileInvoice,
+  faDatabase,
+  faShapes,
+  faCircleDown,
+  faVolumeLow,
+} from "@fortawesome/free-solid-svg-icons";
+import { faNoteSticky } from "@fortawesome/free-regular-svg-icons";
+library.add(faImage);
+library.add(faFilm);
+library.add(faFile);
+library.add(faFileInvoice);
+library.add(faDatabase);
+library.add(faShapes);
+library.add(faNoteSticky);
+library.add(faCircleDown);
+library.add(faVolumeLow);
 
 export type GallerySection =
   | "Images"
@@ -61,6 +85,19 @@ export const gallerySectionLabel = {
   Snippets: "Snippets",
   Miscellaneous: "Miscellaneous",
   PdfDocuments: "Exports",
+};
+
+export const gallerySectionIcon: { [string]: Node } = {
+  Images: <FaIcon icon="image" />,
+  Audios: <FaIcon icon="volume-low" />,
+  Videos: <FaIcon icon="film" />,
+  Documents: <FaIcon icon="file" />,
+  Chemistry: <ChemistryIcon />,
+  DMPs: <FaIcon icon="file-invoice" />,
+  NetworkFiles: null,
+  Snippets: <FaIcon icon="fa-regular fa-note-sticky" />,
+  Miscellaneous: <FaIcon icon="shapes" />,
+  PdfDocuments: <FaIcon icon="fa-circle-down" />,
 };
 
 export const gallerySectionCollectiveNoun = {

--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
@@ -272,7 +272,7 @@ const NameFieldForLargeViewports = styled(
   [`& .${outlinedInputClasses.root}`]: {
     border: "none",
     borderRadius: "4px",
-    fontSize: "1.23rem", // to be the same height as the adjacent button
+    fontSize: "1.4rem", // to be the same height as the adjacent button
     marginTop: theme.spacing(0.5),
     marginBottom: theme.spacing(0.5),
     transition: "all .3s ease-in-out",
@@ -477,6 +477,7 @@ const InfoPanelContent = ({
           },
         ]}
         sx={{
+          pl: 2,
           "& dd.below": {
             justifySelf: "start",
             width: "100%",
@@ -484,7 +485,7 @@ const InfoPanelContent = ({
         }}
       />
       <Box component="section" sx={{ mt: 0.5 }}>
-        <Typography variant="h6" component="h4">
+        <Typography variant="h4" component="h4">
           Details
         </Typography>
         <DescriptionList
@@ -510,6 +511,9 @@ const InfoPanelContent = ({
               value: file.version,
             },
           ]}
+          sx={{
+            pl: 2,
+          }}
         />
       </Box>
       <LinkedDocumentsPanel file={file} />

--- a/src/main/webapp/ui/src/eln/gallery/components/LinkedDocumentsPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/LinkedDocumentsPanel.js
@@ -41,7 +41,7 @@ export const LinkedDocumentsPanel: ComponentType<{| file: GalleryFile |}> = ({
       sx={{ mt: 0.5, "--DataGrid-overlayHeight": "40px" }}
       flexGrow={1}
     >
-      <Typography variant="h6" component="h4">
+      <Typography variant="h4" component="h4">
         Linked Documents
       </Typography>
       <DataGrid
@@ -77,6 +77,9 @@ export const LinkedDocumentsPanel: ComponentType<{| file: GalleryFile |}> = ({
         }}
         loading={linkedDocuments.loading}
         getRowId={(row) => row.id}
+        sx={{
+          ml: 2,
+        }}
       />
     </Box>
   );

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -124,6 +124,18 @@ const DragCancelFab = () => {
 };
 
 const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
+  "& .MuiBreadcrumbs-ol": {
+    /*
+     * Scroll horizontally when there is no longer enough space. We don't want
+     * to wrap because deep hierarchies would end up taking up lots of space on
+     * mobile. We don't want to use the `maxItems` property as that prevents
+     * the possibility of using drag-and-drop to move files in to ancestor
+     * folders, and would only lead to wrapping once the button is tapped
+     * anyway.
+     */
+    flexWrap: "nowrap",
+    overflowX: "auto",
+  },
   "& .MuiBreadcrumbs-separator": {
     marginLeft: theme.spacing(0.5),
     marginRight: theme.spacing(0.5),
@@ -260,38 +272,27 @@ const Path = ({
       role="region"
       aria-label="breadcrumbs"
     >
-      {/*
-       * These two divs create a horizonally scrolling box without a scrollbar,
-       * mimicing the standard behaviour of a text field.
-       */}
-      <div
-        style={{
-          width: "calc(100% - 16px)",
-          overflow: "hidden",
-        }}
-      >
-        <StyledBreadcrumbs>
+      <StyledBreadcrumbs>
+        <BreadcrumbLink
+          section={section}
+          clearPath={clearPath}
+          sx={{
+            pl: 1,
+          }}
+          ref={getRef(0)}
+          tabIndex={getTabIndex(0)}
+        />
+        {path.map((f, i) => (
           <BreadcrumbLink
+            key={idToString(f.id)}
+            folder={f}
             section={section}
             clearPath={clearPath}
-            sx={{
-              pl: 1,
-            }}
-            ref={getRef(0)}
-            tabIndex={getTabIndex(0)}
+            ref={getRef(i + 1)}
+            tabIndex={getTabIndex(i + 1)}
           />
-          {path.map((f, i) => (
-            <BreadcrumbLink
-              key={idToString(f.id)}
-              folder={f}
-              section={section}
-              clearPath={clearPath}
-              ref={getRef(i + 1)}
-              tabIndex={getTabIndex(i + 1)}
-            />
-          ))}
-        </StyledBreadcrumbs>
-      </div>
+        ))}
+      </StyledBreadcrumbs>
     </div>
   );
 };

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -273,7 +273,6 @@ const Path = ({
             sx={{
               p: 0.5,
               pl: 1,
-              height: 26,
               fontWeight: 700,
               textTransform: "uppercase",
             }}

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -133,14 +133,20 @@ const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
 const StyledBreadcrumb = styled(
   React.forwardRef((props, ref) => <Chip ref={ref} {...props} clickable />)
 )(({ theme }) => ({
-  height: theme.spacing(3),
-  color: theme.palette.text.primary,
-  fontWeight: theme.typography.fontWeightRegular,
+  height: theme.spacing(3.5),
+  color: alpha(theme.palette.primary.contrastText, 0.85),
+  paddingLeft: theme.spacing(0.5),
+  paddingRight: theme.spacing(0.5),
+  paddingTop: theme.spacing(0.25),
+  paddingBottom: theme.spacing(0.25),
+  border: `2px solid ${theme.palette.primary.main}`,
+  fontWeight: 500,
+  fontSize: "1rem",
   cursor: "pointer",
   "& .MuiChip-icon": {
     fontSize: "1.05rem",
     marginRight: theme.spacing(-0.5),
-    color: theme.palette.primary.contrastText,
+    color: alpha(theme.palette.primary.contrastText, 0.85),
   },
 }));
 
@@ -191,9 +197,7 @@ const BreadcrumbLink = React.forwardRef<
           borderWidth: "2px",
           animation: "drop 2s linear infinite",
         }
-      : {
-          border: "2px solid transparent",
-        };
+      : {};
 
     return (
       <StyledBreadcrumb
@@ -271,10 +275,7 @@ const Path = ({
             section={section}
             clearPath={clearPath}
             sx={{
-              p: 0.5,
               pl: 1,
-              fontWeight: 700,
-              textTransform: "uppercase",
             }}
             ref={getRef(0)}
             tabIndex={getTabIndex(0)}

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1147,6 +1147,7 @@ function GalleryMainPanel({
           container
           direction="column"
           sx={{ height: "100%", flexWrap: "nowrap" }}
+          spacing={1}
         >
           <Grid item>
             <Typography variant="h3" key={selectedSection}>
@@ -1162,15 +1163,211 @@ function GalleryMainPanel({
               </Fade>
             </Typography>
           </Grid>
-          <Grid item sx={{ marginTop: 1.25 }}>
+          <Grid item>
             <Path section={selectedSection} path={path} clearPath={clearPath} />
+          </Grid>
+          <Grid item sx={{ maxWidth: "100% !important" }}>
+            <Stack
+              direction="row"
+              spacing={0.5}
+              alignItems="center"
+              role="region"
+              aria-label="files listing controls"
+            >
+              <ActionsMenu
+                refreshListing={refreshListing}
+                section={selectedSection}
+                folderId={folderId}
+              />
+              <Box sx={{ flexGrow: 1 }}></Box>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<TreeIcon />}
+                onClick={(e) => {
+                  setViewMenuAnchorEl(e.target);
+                }}
+                aria-haspopup="menu"
+                aria-expanded={viewMenuAnchorEl ? "true" : "false"}
+              >
+                Views
+              </Button>
+              <StyledMenu
+                open={Boolean(viewMenuAnchorEl)}
+                anchorEl={viewMenuAnchorEl}
+                onClose={() => setViewMenuAnchorEl(null)}
+                MenuListProps={{
+                  disablePadding: true,
+                  "aria-label": "view options",
+                }}
+              >
+                <NewMenuItem
+                  title="Grid"
+                  subheader="Browse by thumbnail previews."
+                  backgroundColor={COLOR.background}
+                  foregroundColor={COLOR.contrastText}
+                  avatar={<GridIcon />}
+                  onClick={() => {
+                    setViewMode("grid");
+                    setViewMenuAnchorEl(null);
+                    selection.clear();
+                  }}
+                />
+                <NewMenuItem
+                  title="Tree"
+                  subheader="View and manage folder hierarchy."
+                  backgroundColor={COLOR.background}
+                  foregroundColor={COLOR.contrastText}
+                  avatar={<TreeIcon />}
+                  onClick={() => {
+                    setViewMode("tree");
+                    setViewMenuAnchorEl(null);
+                    selection.clear();
+                  }}
+                />
+                <NewMenuItem
+                  title="Carousel"
+                  subheader="Flick through all files to find one."
+                  backgroundColor={COLOR.background}
+                  foregroundColor={COLOR.contrastText}
+                  avatar={<ViewCarouselIcon />}
+                  onClick={() => {
+                    setViewMode("carousel");
+                    setViewMenuAnchorEl(null);
+                    /*
+                     * We don't clear the selection because we want
+                     * carousel view to default to the selected file,
+                     * if there is one
+                     */
+                  }}
+                />
+              </StyledMenu>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<SwapVertIcon />}
+                onClick={(e) => {
+                  setSortMenuAnchorEl(e.target);
+                }}
+                aria-haspopup="menu"
+                aria-expanded={sortMenuAnchorEl ? "true" : "false"}
+              >
+                Sort
+              </Button>
+              <StyledMenu
+                open={Boolean(sortMenuAnchorEl)}
+                anchorEl={sortMenuAnchorEl}
+                onClose={() => setSortMenuAnchorEl(null)}
+                MenuListProps={{
+                  disablePadding: true,
+                  "aria-label": "sort listing",
+                }}
+              >
+                <NewMenuItem
+                  title={`Name${match<void, string>([
+                    [() => orderBy !== "name", ""],
+                    [() => sortOrder === "ASC", " (Sorted from A to Z)"],
+                    [() => sortOrder === "DESC", " (Sorted from Z to A)"],
+                  ])()}`}
+                  subheader={match<void, string>([
+                    [() => orderBy !== "name", "Tap to sort from A to Z"],
+                    [() => sortOrder === "ASC", "Tap to sort from Z to A"],
+                    [() => sortOrder === "DESC", "Tap to sort from A to Z"],
+                  ])()}
+                  backgroundColor={COLOR.background}
+                  foregroundColor={COLOR.contrastText}
+                  avatar={match<void, Node>([
+                    [
+                      () => orderBy !== "name",
+                      <HorizontalRuleIcon key={null} />,
+                    ],
+                    [
+                      () => sortOrder === "ASC",
+                      <ArrowDownwardIcon key={null} />,
+                    ],
+                    [
+                      () => sortOrder === "DESC",
+                      <ArrowUpwardIcon key={null} />,
+                    ],
+                  ])()}
+                  onClick={() => {
+                    setSortMenuAnchorEl(null);
+                    if (orderBy === "name") {
+                      if (sortOrder === "ASC") {
+                        setSortOrder("DESC");
+                      } else {
+                        setSortOrder("ASC");
+                      }
+                    } else {
+                      setOrderBy("name");
+                      setSortOrder("ASC");
+                    }
+                  }}
+                />
+                <NewMenuItem
+                  title={`Modification Date${match<void, string>([
+                    [() => orderBy !== "modificationDate", ""],
+                    [() => sortOrder === "ASC", " (Sorted oldest first)"],
+                    [() => sortOrder === "DESC", " (Sorted newest first)"],
+                  ])()}`}
+                  subheader={match<void, string>([
+                    [
+                      () => orderBy !== "modificationDate",
+                      "Tap to sort oldest first",
+                    ],
+                    [() => sortOrder === "ASC", "Tap to sort newest first"],
+                    [() => sortOrder === "DESC", "Tap to sort oldest first"],
+                  ])()}
+                  backgroundColor={COLOR.background}
+                  foregroundColor={COLOR.contrastText}
+                  avatar={match<void, Node>([
+                    [
+                      () => orderBy !== "modificationDate",
+                      <HorizontalRuleIcon key={null} />,
+                    ],
+                    [
+                      () => sortOrder === "ASC",
+                      <ArrowDownwardIcon key={null} />,
+                    ],
+                    [
+                      () => sortOrder === "DESC",
+                      <ArrowUpwardIcon key={null} />,
+                    ],
+                  ])()}
+                  onClick={() => {
+                    setSortMenuAnchorEl(null);
+                    if (orderBy === "modificationDate") {
+                      if (sortOrder === "ASC") {
+                        setSortOrder("DESC");
+                      } else {
+                        setSortOrder("ASC");
+                      }
+                    } else {
+                      setOrderBy("modificationDate");
+                      setSortOrder("ASC");
+                    }
+                  }}
+                />
+              </StyledMenu>
+            </Stack>
+          </Grid>
+          <Grid item sx={{ display: { xs: "none", md: "block" } }}>
+            <Divider orientation="horizontal" />
           </Grid>
           <Grid
             item
             container
             direction="row"
             sx={{
-              marginTop: 0.75,
+              /*
+               * This removes the gap between the listing and info panel and
+               * the divider so that the vertical divider separating the
+               * listing from the info panel reaches up and touches the
+               * horizontal one above. The listing and info panel then add
+               * their own whitespace.
+               */
+              pt: "0 !important",
+
               minHeight: 0,
               /*
                * This prevents content from being hidden underneath the
@@ -1186,240 +1383,42 @@ function GalleryMainPanel({
           >
             <Grid
               item
-              container
-              direction="column"
+              sx={{ overflowY: "auto", userSelect: "none", mt: 1 }}
               md={7}
               lg={8}
               xl={9}
-              sx={{
-                mt: 0.75,
-              }}
-              flexWrap="nowrap"
+              flexGrow={1}
               role="region"
               aria-label="files listing"
             >
-              <Grid item sx={{ maxWidth: "100% !important" }}>
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  alignItems="center"
-                  role="region"
-                  aria-label="files listing controls"
-                >
-                  <ActionsMenu
-                    refreshListing={refreshListing}
-                    section={selectedSection}
-                    folderId={folderId}
-                  />
-                  <Box sx={{ flexGrow: 1 }}></Box>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    startIcon={<TreeIcon />}
-                    onClick={(e) => {
-                      setViewMenuAnchorEl(e.target);
-                    }}
-                    aria-haspopup="menu"
-                    aria-expanded={viewMenuAnchorEl ? "true" : "false"}
-                  >
-                    Views
-                  </Button>
-                  <StyledMenu
-                    open={Boolean(viewMenuAnchorEl)}
-                    anchorEl={viewMenuAnchorEl}
-                    onClose={() => setViewMenuAnchorEl(null)}
-                    MenuListProps={{
-                      disablePadding: true,
-                      "aria-label": "view options",
-                    }}
-                  >
-                    <NewMenuItem
-                      title="Grid"
-                      subheader="Browse by thumbnail previews."
-                      backgroundColor={COLOR.background}
-                      foregroundColor={COLOR.contrastText}
-                      avatar={<GridIcon />}
-                      onClick={() => {
-                        setViewMode("grid");
-                        setViewMenuAnchorEl(null);
-                        selection.clear();
-                      }}
+              {viewMode === "tree" &&
+                FetchingData.match(galleryListing, {
+                  loading: () => <></>,
+                  error: (error) => <>{error}</>,
+                  success: (listing) => (
+                    <TreeView
+                      listing={listing}
+                      path={path}
+                      selectedSection={selectedSection}
+                      refreshListing={refreshListing}
+                      sortOrder={sortOrder}
+                      orderBy={orderBy}
+                      foldersOnly={false}
                     />
-                    <NewMenuItem
-                      title="Tree"
-                      subheader="View and manage folder hierarchy."
-                      backgroundColor={COLOR.background}
-                      foregroundColor={COLOR.contrastText}
-                      avatar={<TreeIcon />}
-                      onClick={() => {
-                        setViewMode("tree");
-                        setViewMenuAnchorEl(null);
-                        selection.clear();
-                      }}
-                    />
-                    <NewMenuItem
-                      title="Carousel"
-                      subheader="Flick through all files to find one."
-                      backgroundColor={COLOR.background}
-                      foregroundColor={COLOR.contrastText}
-                      avatar={<ViewCarouselIcon />}
-                      onClick={() => {
-                        setViewMode("carousel");
-                        setViewMenuAnchorEl(null);
-                        /*
-                         * We don't clear the selection because we want
-                         * carousel view to default to the selected file,
-                         * if there is one
-                         */
-                      }}
-                    />
-                  </StyledMenu>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    startIcon={<SwapVertIcon />}
-                    onClick={(e) => {
-                      setSortMenuAnchorEl(e.target);
-                    }}
-                    aria-haspopup="menu"
-                    aria-expanded={sortMenuAnchorEl ? "true" : "false"}
-                  >
-                    Sort
-                  </Button>
-                  <StyledMenu
-                    open={Boolean(sortMenuAnchorEl)}
-                    anchorEl={sortMenuAnchorEl}
-                    onClose={() => setSortMenuAnchorEl(null)}
-                    MenuListProps={{
-                      disablePadding: true,
-                      "aria-label": "sort listing",
-                    }}
-                  >
-                    <NewMenuItem
-                      title={`Name${match<void, string>([
-                        [() => orderBy !== "name", ""],
-                        [() => sortOrder === "ASC", " (Sorted from A to Z)"],
-                        [() => sortOrder === "DESC", " (Sorted from Z to A)"],
-                      ])()}`}
-                      subheader={match<void, string>([
-                        [() => orderBy !== "name", "Tap to sort from A to Z"],
-                        [() => sortOrder === "ASC", "Tap to sort from Z to A"],
-                        [() => sortOrder === "DESC", "Tap to sort from A to Z"],
-                      ])()}
-                      backgroundColor={COLOR.background}
-                      foregroundColor={COLOR.contrastText}
-                      avatar={match<void, Node>([
-                        [
-                          () => orderBy !== "name",
-                          <HorizontalRuleIcon key={null} />,
-                        ],
-                        [
-                          () => sortOrder === "ASC",
-                          <ArrowDownwardIcon key={null} />,
-                        ],
-                        [
-                          () => sortOrder === "DESC",
-                          <ArrowUpwardIcon key={null} />,
-                        ],
-                      ])()}
-                      onClick={() => {
-                        setSortMenuAnchorEl(null);
-                        if (orderBy === "name") {
-                          if (sortOrder === "ASC") {
-                            setSortOrder("DESC");
-                          } else {
-                            setSortOrder("ASC");
-                          }
-                        } else {
-                          setOrderBy("name");
-                          setSortOrder("ASC");
-                        }
-                      }}
-                    />
-                    <NewMenuItem
-                      title={`Modification Date${match<void, string>([
-                        [() => orderBy !== "modificationDate", ""],
-                        [() => sortOrder === "ASC", " (Sorted oldest first)"],
-                        [() => sortOrder === "DESC", " (Sorted newest first)"],
-                      ])()}`}
-                      subheader={match<void, string>([
-                        [
-                          () => orderBy !== "modificationDate",
-                          "Tap to sort oldest first",
-                        ],
-                        [() => sortOrder === "ASC", "Tap to sort newest first"],
-                        [
-                          () => sortOrder === "DESC",
-                          "Tap to sort oldest first",
-                        ],
-                      ])()}
-                      backgroundColor={COLOR.background}
-                      foregroundColor={COLOR.contrastText}
-                      avatar={match<void, Node>([
-                        [
-                          () => orderBy !== "modificationDate",
-                          <HorizontalRuleIcon key={null} />,
-                        ],
-                        [
-                          () => sortOrder === "ASC",
-                          <ArrowDownwardIcon key={null} />,
-                        ],
-                        [
-                          () => sortOrder === "DESC",
-                          <ArrowUpwardIcon key={null} />,
-                        ],
-                      ])()}
-                      onClick={() => {
-                        setSortMenuAnchorEl(null);
-                        if (orderBy === "modificationDate") {
-                          if (sortOrder === "ASC") {
-                            setSortOrder("DESC");
-                          } else {
-                            setSortOrder("ASC");
-                          }
-                        } else {
-                          setOrderBy("modificationDate");
-                          setSortOrder("ASC");
-                        }
-                      }}
-                    />
-                  </StyledMenu>
-                </Stack>
-              </Grid>
-              <Grid
-                item
-                sx={{ overflowY: "auto", mt: 1, userSelect: "none" }}
-                flexGrow={1}
-              >
-                {viewMode === "tree" &&
-                  FetchingData.match(galleryListing, {
-                    loading: () => <></>,
-                    error: (error) => <>{error}</>,
-                    success: (listing) => (
-                      <TreeView
-                        listing={listing}
-                        path={path}
-                        selectedSection={selectedSection}
-                        refreshListing={refreshListing}
-                        sortOrder={sortOrder}
-                        orderBy={orderBy}
-                        foldersOnly={false}
-                      />
-                    ),
-                  })}
-                {viewMode === "grid" &&
-                  FetchingData.match(galleryListing, {
-                    loading: () => <></>,
-                    error: (error) => <>{error}</>,
-                    success: (listing) => <GridView listing={listing} />,
-                  })}
-                {viewMode === "carousel" &&
-                  FetchingData.match(galleryListing, {
-                    loading: () => <></>,
-                    error: (error) => <>{error}</>,
-                    success: (listing) => <Carousel listing={listing} />,
-                  })}
-              </Grid>
+                  ),
+                })}
+              {viewMode === "grid" &&
+                FetchingData.match(galleryListing, {
+                  loading: () => <></>,
+                  error: (error) => <>{error}</>,
+                  success: (listing) => <GridView listing={listing} />,
+                })}
+              {viewMode === "carousel" &&
+                FetchingData.match(galleryListing, {
+                  loading: () => <></>,
+                  error: (error) => <>{error}</>,
+                  success: (listing) => <Carousel listing={listing} />,
+                })}
             </Grid>
             <Grid item sx={{ mx: 1.5, display: { xs: "none", md: "block" } }}>
               <Divider orientation="vertical" />

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -7,6 +7,7 @@ import { styled } from "@mui/material/styles";
 import {
   COLOR,
   gallerySectionLabel,
+  gallerySectionIcon,
   type GallerySection,
   GALLERY_SECTION,
 } from "../common";
@@ -16,23 +17,9 @@ import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import { darken } from "@mui/system";
-import { FontAwesomeIcon as FaIcon } from "@fortawesome/react-fontawesome";
-import ChemistryIcon from "../chemistryIcon";
 import Divider from "@mui/material/Divider";
 import Button from "@mui/material/Button";
 import Menu from "@mui/material/Menu";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-  faImage,
-  faFilm,
-  faFile,
-  faFileInvoice,
-  faDatabase,
-  faShapes,
-  faCircleDown,
-  faVolumeLow,
-} from "@fortawesome/free-solid-svg-icons";
-import { faNoteSticky } from "@fortawesome/free-regular-svg-icons";
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import AddIcon from "@mui/icons-material/Add";
@@ -59,15 +46,6 @@ import ValidatingSubmitButton, {
   IsValid,
   IsInvalid,
 } from "../../../components/ValidatingSubmitButton";
-library.add(faImage);
-library.add(faFilm);
-library.add(faFile);
-library.add(faFileInvoice);
-library.add(faDatabase);
-library.add(faShapes);
-library.add(faNoteSticky);
-library.add(faCircleDown);
-library.add(faVolumeLow);
 
 const StyledMenu = styled(Menu)(({ open }) => ({
   "& .MuiPaper-root": {
@@ -560,7 +538,7 @@ const Sidebar = ({
           <List sx={{ position: "static" }}>
             <DrawerTab
               label={gallerySectionLabel.Images}
-              icon={<FaIcon icon="image" />}
+              icon={gallerySectionIcon.Images}
               index={0}
               tabIndex={getTabIndex(0)}
               ref={(node) => {
@@ -577,7 +555,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Audios}
-              icon={<FaIcon icon="volume-low" />}
+              icon={gallerySectionIcon.Audios}
               index={1}
               tabIndex={getTabIndex(1)}
               ref={(node) => {
@@ -594,7 +572,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Videos}
-              icon={<FaIcon icon="film" />}
+              icon={gallerySectionIcon.Videos}
               index={2}
               tabIndex={getTabIndex(2)}
               ref={(node) => {
@@ -611,7 +589,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Documents}
-              icon={<FaIcon icon="file" />}
+              icon={gallerySectionIcon.Documents}
               index={3}
               tabIndex={getTabIndex(3)}
               ref={(node) => {
@@ -628,7 +606,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Chemistry}
-              icon={<ChemistryIcon />}
+              icon={gallerySectionIcon.Chemistry}
               index={4}
               tabIndex={getTabIndex(4)}
               ref={(node) => {
@@ -645,7 +623,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.DMPs}
-              icon={<FaIcon icon="file-invoice" />}
+              icon={gallerySectionIcon.DMPs}
               index={5}
               tabIndex={getTabIndex(5)}
               ref={(node) => {
@@ -662,7 +640,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Snippets}
-              icon={<FaIcon icon="fa-regular fa-note-sticky" />}
+              icon={gallerySectionIcon.Snippets}
               index={6}
               tabIndex={getTabIndex(6)}
               ref={(node) => {
@@ -679,7 +657,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Miscellaneous}
-              icon={<FaIcon icon="shapes" />}
+              icon={gallerySectionIcon.Miscellaneous}
               index={7}
               tabIndex={getTabIndex(7)}
               ref={(node) => {
@@ -699,7 +677,7 @@ const Sidebar = ({
           <List sx={{ position: "static" }}>
             <DrawerTab
               label={gallerySectionLabel.PdfDocuments}
-              icon={<FaIcon icon="fa-circle-down" />}
+              icon={gallerySectionIcon.PdfDocuments}
               index={8}
               tabIndex={getTabIndex(8)}
               ref={(node) => {


### PR DESCRIPTION
To make the important information more obvious and show how information is related through visual hierarchies, this change tweaks how the new gallery is organised somewhat. It places the listing controls above both the listing and the info panel, changes the breadcrumbs into a series of chips/pills, and alters the typographical styles of the info panel subheadings.