### PR TITLE
RSDEV-434 Alter layout of new Gallery page

### DIFF
--- a/src/main/webapp/ui/flow-typed/mui.js
+++ b/src/main/webapp/ui/flow-typed/mui.js
@@ -143,6 +143,7 @@ declare module "@mui/x-data-grid" {
       noRowsLabel?: string,
     |},
     onCellKeyDown?: (Row, KeyboardEvent) => void,
+    sx?: { ... }
   |}): Node;
 
   declare export function GridToolbarContainer({|

--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -653,6 +653,12 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
               textTransform: "uppercase",
               borderBottom: accentedBorder,
             },
+            h4: {
+              fontWeight: 700,
+              textTransform: "uppercase",
+              fontSize: "0.9rem",
+              letterSpacing: "0.01em",
+            },
           },
         },
         MuiLink: {

--- a/src/main/webapp/ui/src/eln/gallery/chemistryIcon.js
+++ b/src/main/webapp/ui/src/eln/gallery/chemistryIcon.js
@@ -1,4 +1,4 @@
-//@flow
+//@flow strict
 
 import React, { type Node } from "react";
 import SvgIcon from "@mui/material/SvgIcon";

--- a/src/main/webapp/ui/src/eln/gallery/common.js
+++ b/src/main/webapp/ui/src/eln/gallery/common.js
@@ -1,8 +1,33 @@
 //@flow strict
 
+import React, { type Node } from "react";
 import { COLORS as baseThemeColors } from "../../theme";
 import Result from "../../util/result";
 import * as Parsers from "../../util/parsers";
+import ChemistryIcon from "./chemistryIcon";
+import FilestoreIcon from "./filestoreIcon";
+import { FontAwesomeIcon as FaIcon } from "@fortawesome/react-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import {
+  faImage,
+  faFilm,
+  faFile,
+  faFileInvoice,
+  faDatabase,
+  faShapes,
+  faCircleDown,
+  faVolumeLow,
+} from "@fortawesome/free-solid-svg-icons";
+import { faNoteSticky } from "@fortawesome/free-regular-svg-icons";
+library.add(faImage);
+library.add(faFilm);
+library.add(faFile);
+library.add(faFileInvoice);
+library.add(faDatabase);
+library.add(faShapes);
+library.add(faNoteSticky);
+library.add(faCircleDown);
+library.add(faVolumeLow);
 
 export type GallerySection =
   | "Images"
@@ -61,6 +86,19 @@ export const gallerySectionLabel = {
   Snippets: "Snippets",
   Miscellaneous: "Miscellaneous",
   PdfDocuments: "Exports",
+};
+
+export const gallerySectionIcon: { [string]: Node } = {
+  Images: <FaIcon icon="image" />,
+  Audios: <FaIcon icon="volume-low" />,
+  Videos: <FaIcon icon="film" />,
+  Documents: <FaIcon icon="file" />,
+  Chemistry: <ChemistryIcon />,
+  DMPs: <FaIcon icon="file-invoice" />,
+  NetworkFiles: <FilestoreIcon />,
+  Snippets: <FaIcon icon="fa-regular fa-note-sticky" />,
+  Miscellaneous: <FaIcon icon="shapes" />,
+  PdfDocuments: <FaIcon icon="fa-circle-down" />,
 };
 
 export const gallerySectionCollectiveNoun = {

--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.js
@@ -290,7 +290,7 @@ const NameFieldForLargeViewports = styled(
   [`& .${outlinedInputClasses.root}`]: {
     border: "none",
     borderRadius: "4px",
-    fontSize: "1.23rem", // to be the same height as the adjacent button
+    fontSize: "1.4rem", // to be the same height as the adjacent button
     marginTop: theme.spacing(0.5),
     marginBottom: theme.spacing(0.5),
     transition: "all .3s ease-in-out",
@@ -517,6 +517,7 @@ const InfoPanelContent = ({
             ),
         ]}
         sx={{
+          pl: 2,
           "& dd.below": {
             justifySelf: "start",
             width: "100%",
@@ -524,7 +525,7 @@ const InfoPanelContent = ({
         }}
       />
       <Box component="section" sx={{ mt: 0.5 }}>
-        <Typography variant="h6" component="h4">
+        <Typography variant="h4" component="h4">
           Details
         </Typography>
         <DescriptionList
@@ -566,6 +567,9 @@ const InfoPanelContent = ({
                 ]
               : []),
           ]}
+          sx={{
+            pl: 2,
+          }}
         />
       </Box>
       {file.linkedDocuments}

--- a/src/main/webapp/ui/src/eln/gallery/components/LinkedDocumentsPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/LinkedDocumentsPanel.js
@@ -41,7 +41,7 @@ export const LinkedDocumentsPanel: ComponentType<{| file: GalleryFile |}> = ({
       sx={{ mt: 0.5, "--DataGrid-overlayHeight": "40px" }}
       flexGrow={1}
     >
-      <Typography variant="h6" component="h4">
+      <Typography variant="h4" component="h4">
         Linked Documents
       </Typography>
       <DataGrid
@@ -77,6 +77,9 @@ export const LinkedDocumentsPanel: ComponentType<{| file: GalleryFile |}> = ({
         }}
         loading={linkedDocuments.loading}
         getRowId={(row) => row.id}
+        sx={{
+          ml: 2,
+        }}
       />
     </Box>
   );

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.js
@@ -2,33 +2,22 @@
 
 import React, { type Node, type ComponentType } from "react";
 import Box from "@mui/material/Box";
-import { Drawer } from "../../../components/DialogBoundary";
+import { Drawer, Menu } from "../../../components/DialogBoundary";
 import { styled } from "@mui/material/styles";
-import { COLOR, gallerySectionLabel, type GallerySection } from "../common";
+import {
+  COLOR,
+  gallerySectionLabel,
+  gallerySectionIcon,
+  type GallerySection,
+} from "../common";
 import List from "@mui/material/List";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import { darken } from "@mui/system";
-import { FontAwesomeIcon as FaIcon } from "@fortawesome/react-fontawesome";
-import ChemistryIcon from "../chemistryIcon";
-import FilestoreIcon from "../filestoreIcon";
 import Divider from "@mui/material/Divider";
 import Button from "@mui/material/Button";
-import { Menu } from "../../../components/DialogBoundary";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-  faImage,
-  faFilm,
-  faFile,
-  faFileInvoice,
-  faDatabase,
-  faShapes,
-  faCircleDown,
-  faVolumeLow,
-} from "@fortawesome/free-solid-svg-icons";
-import { faNoteSticky } from "@fortawesome/free-regular-svg-icons";
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import AddIcon from "@mui/icons-material/Add";
@@ -57,16 +46,6 @@ import ValidatingSubmitButton, {
 } from "../../../components/ValidatingSubmitButton";
 import Result from "../../../util/result";
 import DnsIcon from "@mui/icons-material/Dns";
-library.add(faImage);
-library.add(faFilm);
-library.add(faFile);
-library.add(faFileInvoice);
-library.add(faDatabase);
-library.add(faShapes);
-library.add(faNoteSticky);
-library.add(faCircleDown);
-library.add(faVolumeLow);
-library.add(faDatabase);
 import axios, { type Axios } from "axios";
 import useOauthToken from "../../../common/useOauthToken";
 import * as Parsers from "../../../util/parsers";
@@ -626,7 +605,7 @@ const Sidebar = ({
           <List sx={{ position: "static" }}>
             <DrawerTab
               label={gallerySectionLabel.Images}
-              icon={<FaIcon icon="image" />}
+              icon={gallerySectionIcon.Images}
               index={0}
               tabIndex={getTabIndex(0)}
               ref={(node) => {
@@ -642,7 +621,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Audios}
-              icon={<FaIcon icon="volume-low" />}
+              icon={gallerySectionIcon.Audios}
               index={1}
               tabIndex={getTabIndex(1)}
               ref={(node) => {
@@ -658,7 +637,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Videos}
-              icon={<FaIcon icon="film" />}
+              icon={gallerySectionIcon.Videos}
               index={2}
               tabIndex={getTabIndex(2)}
               ref={(node) => {
@@ -674,7 +653,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Documents}
-              icon={<FaIcon icon="file" />}
+              icon={gallerySectionIcon.Documents}
               index={3}
               tabIndex={getTabIndex(3)}
               ref={(node) => {
@@ -690,7 +669,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Chemistry}
-              icon={<ChemistryIcon />}
+              icon={gallerySectionIcon.Chemistry}
               index={4}
               tabIndex={getTabIndex(4)}
               ref={(node) => {
@@ -706,7 +685,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.DMPs}
-              icon={<FaIcon icon="file-invoice" />}
+              icon={gallerySectionIcon.DMPs}
               index={5}
               tabIndex={getTabIndex(5)}
               ref={(node) => {
@@ -722,7 +701,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Snippets}
-              icon={<FaIcon icon="fa-regular fa-note-sticky" />}
+              icon={gallerySectionIcon.Snippets}
               index={6}
               tabIndex={getTabIndex(6)}
               ref={(node) => {
@@ -738,7 +717,7 @@ const Sidebar = ({
             />
             <DrawerTab
               label={gallerySectionLabel.Miscellaneous}
-              icon={<FaIcon icon="shapes" />}
+              icon={gallerySectionIcon.Miscellaneous}
               index={7}
               tabIndex={getTabIndex(7)}
               ref={(node) => {
@@ -759,7 +738,7 @@ const Sidebar = ({
                 <DrawerTab
                   key={null}
                   label={gallerySectionLabel.NetworkFiles}
-                  icon={<FilestoreIcon />}
+                  icon={gallerySectionIcon.NetworkFiles}
                   index={7}
                   tabIndex={getTabIndex(7)}
                   ref={(node) => {
@@ -780,7 +759,7 @@ const Sidebar = ({
           <List sx={{ position: "static" }}>
             <DrawerTab
               label={gallerySectionLabel.PdfDocuments}
-              icon={<FaIcon icon="fa-circle-down" />}
+              icon={gallerySectionIcon.PdfDocuments}
               index={8}
               tabIndex={getTabIndex(8)}
               ref={(node) => {

--- a/src/main/webapp/ui/src/eln/gallery/filestoreIcon.js
+++ b/src/main/webapp/ui/src/eln/gallery/filestoreIcon.js
@@ -1,4 +1,4 @@
-//@flow
+//@flow strict
 
 import React, { type Node } from "react";
 import SvgIcon from "@mui/material/SvgIcon";


### PR DESCRIPTION
To make the important information more obvious and show how information is related through visual hierarchies, this change tweaks how the new gallery is organised somewhat. It places the listing controls above both the listing and the info panel, changes the breadcrumbs into a series of chips/pills, and alters the typographical styles of the info panel subheadings.