### PR TITLE
Various tweaks to refreshing of listings in new gallery

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useGalleryListing.test.js
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useGalleryListing.test.js
@@ -37,9 +37,6 @@ function WrapperComponent() {
       if (listing.tag === "empty") {
         return listing.reason;
       }
-      if (listing.tag === "refreshing") {
-        return "refreshing";
-      }
       return (
         <div>
           There are {listing.list.length} results.

--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useGalleryListing.test.js
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useGalleryListing.test.js
@@ -33,10 +33,14 @@ function WrapperComponent() {
   return FetchingData.match(galleryListing, {
     loading: () => "loading",
     error: () => "error",
-    success: (listing) =>
-      listing.tag === "empty" ? (
-        listing.reason
-      ) : (
+    success: (listing) => {
+      if (listing.tag === "empty") {
+        return listing.reason;
+      }
+      if (listing.tag === "refreshing") {
+        return "refreshing";
+      }
+      return (
         <div>
           There are {listing.list.length} results.
           {listing.loadMore
@@ -54,7 +58,8 @@ function WrapperComponent() {
             Refresh
           </button>
         </div>
-      ),
+      );
+    },
   });
 }
 

--- a/src/main/webapp/ui/src/eln/gallery/components/Carousel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Carousel.js
@@ -372,6 +372,11 @@ type CarouselArgs = {
         list: $ReadOnlyArray<GalleryFile>,
         totalHits: number,
         loadMore: Optional<() => Promise<void>>,
+      |}
+    | {|
+        tag: "refreshing",
+        totalHits: number,
+        list: $ReadOnlyArray<GalleryFile>,
       |},
 };
 

--- a/src/main/webapp/ui/src/eln/gallery/components/Carousel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/Carousel.js
@@ -366,17 +366,13 @@ const Preview = ({
 
 type CarouselArgs = {
   listing:
-    | {| tag: "empty", reason: string |}
+    | {| tag: "empty", reason: string, refreshing: boolean |}
     | {|
         tag: "list",
         list: $ReadOnlyArray<GalleryFile>,
         totalHits: number,
         loadMore: Optional<() => Promise<void>>,
-      |}
-    | {|
-        tag: "refreshing",
-        totalHits: number,
-        list: $ReadOnlyArray<GalleryFile>,
+        refreshing: boolean,
       |},
 };
 
@@ -443,7 +439,13 @@ export default function Carousel({ listing }: CarouselArgs): Node {
   }, [visibleIndex, listing]);
 
   if (listing.tag === "empty")
-    return <PlaceholderLabel>{listing.reason}</PlaceholderLabel>;
+    return (
+      <PlaceholderLabel>
+        {listing.refreshing
+          ? "Refreshing..."
+          : listing.reason ?? "There are no folders."}
+      </PlaceholderLabel>
+    );
   return (
     <Grid
       container

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -316,17 +316,13 @@ const GridView = observer(
     listing,
   }: {|
     listing:
-      | {| tag: "empty", reason: string |}
+      | {| tag: "empty", reason: string, refreshing: boolean |}
       | {|
           tag: "list",
           list: $ReadOnlyArray<GalleryFile>,
           totalHits: number,
           loadMore: Optional<() => Promise<void>>,
-        |}
-      | {|
-          tag: "refreshing",
-          totalHits: number,
-          list: $ReadOnlyArray<GalleryFile>,
+          refreshing: boolean,
         |},
   |}) => {
     const dndContext = useDndContext();
@@ -397,7 +393,11 @@ const GridView = observer(
             }
           >
             <div>
-              <PlaceholderLabel>{listing.reason}</PlaceholderLabel>
+              <PlaceholderLabel>
+                {listing.refreshing
+                  ? "Refreshing..."
+                  : listing.reason ?? "There are no folders."}
+              </PlaceholderLabel>
             </div>
           </Fade>
         </div>
@@ -617,7 +617,7 @@ const GridView = observer(
           ))}
         </Grid>
         {listing.loadMore
-          ?.map((loadMore) => (
+          .map((loadMore) => (
             <Box key={null} sx={{ mt: 1 }}>
               <LoadMoreButton onClick={loadMore} />
             </Box>
@@ -1060,17 +1060,13 @@ type GalleryMainPanelArgs = {|
   path: $ReadOnlyArray<GalleryFile>,
   clearPath: () => void,
   galleryListing: FetchingData.Fetched<
-    | {| tag: "empty", reason: string |}
+    | {| tag: "empty", reason: string, refreshing: boolean |}
     | {|
         tag: "list",
         list: $ReadOnlyArray<GalleryFile>,
         totalHits: number,
         loadMore: Optional<() => Promise<void>>,
-      |}
-    | {|
-        tag: "refreshing",
-        totalHits: number,
-        list: $ReadOnlyArray<GalleryFile>,
+        refreshing: boolean,
       |}
   >,
   folderId: FetchingData.Fetched<Id>,

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -322,6 +322,11 @@ const GridView = observer(
           list: $ReadOnlyArray<GalleryFile>,
           totalHits: number,
           loadMore: Optional<() => Promise<void>>,
+        |}
+      | {|
+          tag: "refreshing",
+          totalHits: number,
+          list: $ReadOnlyArray<GalleryFile>,
         |},
   |}) => {
     const dndContext = useDndContext();
@@ -612,7 +617,7 @@ const GridView = observer(
           ))}
         </Grid>
         {listing.loadMore
-          .map((loadMore) => (
+          ?.map((loadMore) => (
             <Box key={null} sx={{ mt: 1 }}>
               <LoadMoreButton onClick={loadMore} />
             </Box>
@@ -1061,6 +1066,11 @@ type GalleryMainPanelArgs = {|
         list: $ReadOnlyArray<GalleryFile>,
         totalHits: number,
         loadMore: Optional<() => Promise<void>>,
+      |}
+    | {|
+        tag: "refreshing",
+        totalHits: number,
+        list: $ReadOnlyArray<GalleryFile>,
       |}
   >,
   folderId: FetchingData.Fetched<Id>,

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -167,7 +167,7 @@ const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
               ) : null
             )}
             {listing.loadMore
-              ?.map((loadMore) => <LoadMoreButton onClick={loadMore} />)
+              .map((loadMore) => <LoadMoreButton onClick={loadMore} />)
               .orElse(null)}
           </>
         ) : null,
@@ -394,17 +394,13 @@ type TreeViewArgs = {|
    * states and doesn't lose the expanded state when the listing is refreshed.
    */
   listing: FetchingData.Fetched<
-    | {| tag: "empty", reason: string |}
+    | {| tag: "empty", reason: string, refreshing: boolean |}
     | {|
         tag: "list",
         list: $ReadOnlyArray<GalleryFile>,
         totalHits: number,
         loadMore: Optional<() => Promise<void>>,
-      |}
-    | {|
-        tag: "refreshing",
-        totalHits: number,
-        list: $ReadOnlyArray<GalleryFile>,
+        refreshing: boolean,
       |}
   >,
   path: $ReadOnlyArray<GalleryFile>,
@@ -478,7 +474,9 @@ const TreeView = ({
             >
               <div>
                 <PlaceholderLabel>
-                  {listing.reason ?? "There are no folders."}
+                  {listing.refreshing
+                    ? "Refreshing..."
+                    : listing.reason ?? "There are no folders."}
                 </PlaceholderLabel>
               </div>
             </Fade>
@@ -615,12 +613,12 @@ const TreeView = ({
                 orderBy={orderBy}
                 foldersOnly={foldersOnly}
                 disabled={filter(file) === "disabled"}
-                refeshing={listing.tag === "refreshing"}
+                refeshing={listing.refreshing}
               />
             ) : null
           )}
           {listing.loadMore
-            ?.map((loadMore) => <LoadMoreButton onClick={loadMore} />)
+            .map((loadMore) => <LoadMoreButton onClick={loadMore} />)
             .orElse(null)}
         </SimpleTreeView>
       );

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -478,9 +478,6 @@ const TreeView = ({
       .orElseGet(() => new Map<string, GalleryFile>());
   });
 
-  // maybe we shouldn't unmount when loading occurs
-  // but instead pass an incrementing value to trigger refreshListing
-  // in each of the tree items. Otherwise subsequent pages will not be loaded.
   return FetchingData.match(listing, {
     loading: () => <PlaceholderLabel>Loading...</PlaceholderLabel>,
     error: (error) => <PlaceholderLabel>{error}</PlaceholderLabel>,

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -95,6 +95,27 @@ type TreeItemContentArgs = {|
   sortOrder: "DESC" | "ASC",
   orderBy: "name" | "modificationDate",
   foldersOnly: boolean,
+
+  /**
+   * If true, then the listing is being refreshed and so the tree view should
+   * trigger a refresh of its listing.
+   *
+   * Note that after a refresh is comlete we do not always keep the user's
+   * selection (e.g. after duplicating a file) for two reasons:
+   *
+   *   1. When the root listing refreshes, if there are any selected files that
+   *      are not in the new listing then the selection is cleared. This is to
+   *      ensure that the selection does not include any now deleted files.
+   *      However, this means that if the selection includes a file that is
+   *      within a folder then it too will trigger this selection clearing.
+   *
+   *   2. If the user has just duplicated a folder, then the new folder will
+   *      fetch its contents by calling `useGalleryListing`'s `getGalleryFiles`
+   *      which triggers a clearing of the selection. All of the other folders
+   *      will call their `refreshListing` functions but we have to call
+   *      `getGalleryFiles` to get the new folder's contents in the first
+   *      instance.
+   */
   refeshing: boolean,
 |};
 

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.js
@@ -144,6 +144,12 @@ const TreeItemContent: ComponentType<TreeItemContentArgs> = observer(
       });
 
     React.useEffect(() => {
+      /*
+       * Note that if the user has just deleted this folder, then refreshing
+       * the listing will fail. The logic in `useGalleryListing` will ignore
+       * the error and then this tree node will be removed when the parent
+       * folder is done refreshing.
+       */
       if (refeshing) void refreshingThisListing();
     }, [refeshing]);
 

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -1297,6 +1297,11 @@ export function useGalleryListing({
          * such scenarios include when duplicating the last file in a page; the
          * selected one will become the first file of the next page that the user
          * needs to load by tapping the "Load More" button.
+         *
+         * This has the downside of losing the selection when the user is using
+         * tree view as if the selected file is within another folder then this
+         * logic will not find the whole selection in the root listing and
+         * clear the selection.
          */
         const newFilesIds = new Set(newFiles.map(({ id }) => id));
         if (selection.asSet().some((f) => !newFilesIds.has(f.id)))

--- a/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
+++ b/src/main/webapp/ui/src/eln/gallery/useGalleryListing.js
@@ -737,17 +737,13 @@ export function useGalleryListing({
   foldersOnly?: boolean,
 |}): {|
   galleryListing: FetchingData.Fetched<
-    | {| tag: "empty", reason: string |}
+    | {| tag: "empty", reason: string, refreshing: boolean |}
     | {|
         tag: "list",
         totalHits: number,
         list: $ReadOnlyArray<GalleryFile>,
         loadMore: Optional<() => Promise<void>>,
-      |}
-    | {|
-        tag: "refreshing",
-        totalHits: number,
-        list: $ReadOnlyArray<GalleryFile>,
+        refreshing: boolean,
       |}
   >,
   refreshListing: () => Promise<void>,
@@ -1241,23 +1237,19 @@ export function useGalleryListing({
   return {
     galleryListing: {
       tag: "success",
-      value: refreshing
-        ? {
-            tag: "refreshing",
-            list: galleryListing,
-            totalHits,
-          }
-        : galleryListing.length > 0
-        ? {
-            tag: "list",
-            list: galleryListing,
-            totalHits,
-            loadMore:
-              page + 1 < totalPages
-                ? Optional.present(loadMore)
-                : Optional.empty(),
-          }
-        : { tag: "empty", reason: emptyReason() },
+      value:
+        galleryListing.length > 0
+          ? {
+              tag: "list",
+              list: galleryListing,
+              totalHits,
+              loadMore:
+                page + 1 < totalPages
+                  ? Optional.present(loadMore)
+                  : Optional.empty(),
+              refreshing,
+            }
+          : { tag: "empty", reason: emptyReason(), refreshing },
     },
     path,
     setPath,


### PR DESCRIPTION
After the user has performed an action, we need to refresh the UI to show the new state of their files and folders. Commit 8d05363d4d ensured that the refreshListing function set and unset the loading flag, thereby causing the listing components to be unmounted and remounted; which would result in all of the tree view nodes fetching their state again.

This, however, had a not-insignificant downside: in grid view, the listing would vanish and then re-appear after the refresh. Given that after any particular action most of the listing will remain unchanged (with just the odd file being deleted, duplicated, renamed, etc), it would be better if the content stayed visible and only updated once the new listing had been fetched.

This change fixes this by introducing a new flag to differentiate when a listing is being fetched for the first time (still using `loading`) versus being refreshed. As such, the UI components can keep showing the previous listing until the new one has been fetched. Tree view watches for the changes to this `refreshing` flag and triggers `refreshListing` on each of its sub-listings when the flag changes from false to true.

This in turn caused another issue: when deleting a folder, tree view would attempt to refresh its contents before the parent folder would remove it from the DOM. We make no attempt to prevent this network request, but instead catch it -- expecting that any attempt to refresh a listing that fails with an error message that mentions a **deleted folder** is just fine and should be ignored.

There are further minor issues around selection not being persisted across refreshes in tree view that are harder to solve whilst keeping logic that is needed to clear the selection in other parts of the UI. These cases are documented instead.