### PR TITLE
RSDEV-445: improved share/unshare performance, especially when sharing with large group

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1710,7 +1710,7 @@
     </dependency>
     <dependency>
         <groupId>com.github.rspace-os</groupId>
-        <artifactId>rspace-core-model</artifactId>
+        <artifactId>rspace-core-model-rsdev-441</artifactId>
         <version>${rspace-core-model.version}</version>
         <exclusions>
           <exclusion>
@@ -1737,7 +1737,7 @@
     </dependency>
     <dependency>
         <groupId>com.github.rspace-os</groupId>
-        <artifactId>rspace-core-model</artifactId>
+        <artifactId>rspace-core-model-rsdev-441</artifactId>
         <version>${rspace-core-model.version}</version>
         <scope>test</scope>
         <type>test-jar</type>
@@ -3004,7 +3004,7 @@
     <jstl.version>1.1.2</jstl.version>
     <lucene.version>5.5.5</lucene.version>
     <netty.version>4.1.63.Final</netty.version>
-    <rspace-core-model.version>2.4.1</rspace-core-model.version>
+    <rspace-core-model.version>2.6.0</rspace-core-model.version>
     <servlet.version>3.1.0</servlet.version>
     <sitemesh.version>2.4.2</sitemesh.version>
     <urlrewrite.version>4.0.3</urlrewrite.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1710,7 +1710,7 @@
     </dependency>
     <dependency>
         <groupId>com.github.rspace-os</groupId>
-        <artifactId>rspace-core-model-rsdev-441</artifactId>
+        <artifactId>rspace-core-model</artifactId>
         <version>${rspace-core-model.version}</version>
         <exclusions>
           <exclusion>
@@ -1737,7 +1737,7 @@
     </dependency>
     <dependency>
         <groupId>com.github.rspace-os</groupId>
-        <artifactId>rspace-core-model-rsdev-441</artifactId>
+        <artifactId>rspace-core-model</artifactId>
         <version>${rspace-core-model.version}</version>
         <scope>test</scope>
         <type>test-jar</type>
@@ -3004,7 +3004,7 @@
     <jstl.version>1.1.2</jstl.version>
     <lucene.version>5.5.5</lucene.version>
     <netty.version>4.1.63.Final</netty.version>
-    <rspace-core-model.version>2.6.0</rspace-core-model.version>
+    <rspace-core-model.version>2.4.1</rspace-core-model.version>
     <servlet.version>3.1.0</servlet.version>
     <sitemesh.version>2.4.2</sitemesh.version>
     <urlrewrite.version>4.0.3</urlrewrite.version>

--- a/src/main/java/com/researchspace/dao/RecordGroupSharingDao.java
+++ b/src/main/java/com/researchspace/dao/RecordGroupSharingDao.java
@@ -10,6 +10,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.record.BaseRecord;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /** Accesses state of records shared within a group. */
 public interface RecordGroupSharingDao extends GenericDao<RecordGroupSharing, Long> {
@@ -177,7 +178,7 @@ public interface RecordGroupSharingDao extends GenericDao<RecordGroupSharing, Lo
    * @param recordId
    * @return
    */
-  List<RecordGroupSharing> findByRecordAndUserOrGroup(Long userOrGroupId, Long recordId);
+  Optional<RecordGroupSharing> findByRecordAndUserOrGroup(Long userOrGroupId, Long recordId);
 
   ISearchResults<RecordGroupSharing> listAllPublishedRecords(
       PaginationCriteria<RecordGroupSharing> pcg);

--- a/src/main/java/com/researchspace/dao/hibernate/RecordGroupSharingDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/RecordGroupSharingDaoHibernateImpl.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
@@ -113,7 +114,7 @@ public class RecordGroupSharingDaoHibernateImpl
   }
 
   @Override
-  public List<RecordGroupSharing> findByRecordAndUserOrGroup(Long userOrGroupId, Long recordId) {
+  public Optional<RecordGroupSharing> findByRecordAndUserOrGroup(Long userOrGroupId, Long recordId) {
     Query<RecordGroupSharing> query =
         getSession()
             .createQuery(
@@ -121,7 +122,7 @@ public class RecordGroupSharingDaoHibernateImpl
                 RecordGroupSharing.class);
     query.setParameter("id", userOrGroupId);
     query.setParameter("recordId", recordId);
-    return query.list();
+    return query.uniqueResultOptional();
   }
 
   @Override

--- a/src/main/java/com/researchspace/dao/hibernate/RecordGroupSharingDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/RecordGroupSharingDaoHibernateImpl.java
@@ -114,7 +114,8 @@ public class RecordGroupSharingDaoHibernateImpl
   }
 
   @Override
-  public Optional<RecordGroupSharing> findByRecordAndUserOrGroup(Long userOrGroupId, Long recordId) {
+  public Optional<RecordGroupSharing> findByRecordAndUserOrGroup(
+      Long userOrGroupId, Long recordId) {
     Query<RecordGroupSharing> query =
         getSession()
             .createQuery(

--- a/src/main/java/com/researchspace/service/AutoshareManager.java
+++ b/src/main/java/com/researchspace/service/AutoshareManager.java
@@ -7,6 +7,7 @@ import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.model.views.ServiceOperationResultCollection;
+import java.util.List;
 import java.util.concurrent.Future;
 import org.springframework.scheduling.annotation.Async;
 
@@ -18,12 +19,13 @@ import org.springframework.scheduling.annotation.Async;
 public interface AutoshareManager {
 
   /**
-   * Shares item into autoshare folder, creating the folder if need be.
+   * Shares item into autoshare folder of all groups where user is autosharing. Creates the
+   * autoshared folder if need be.
    *
    * <p>This method should be used to autoshare when a document is created. It shouldn't be used for
    * bulk autosharing (e.g. scanning and updating all shared items)
    */
-  ServiceOperationResult<RecordGroupSharing> shareRecord(BaseRecord toShare, User subject);
+  ServiceOperationResult<List<RecordGroupSharing>> shareRecord(BaseRecord toShare, User subject);
 
   /**
    * Shares all previously unshared notebooks and documents into the user's autoshare target folder.

--- a/src/main/java/com/researchspace/service/AutoshareManager.java
+++ b/src/main/java/com/researchspace/service/AutoshareManager.java
@@ -7,7 +7,6 @@ import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.model.views.ServiceOperationResultCollection;
-import java.util.Set;
 import java.util.concurrent.Future;
 import org.springframework.scheduling.annotation.Async;
 
@@ -24,7 +23,7 @@ public interface AutoshareManager {
    * <p>This method should be used to autoshare when a document is created. It shouldn't be used for
    * bulk autosharing (e.g. scanning and updating all shared items)
    */
-  ServiceOperationResult<Set<RecordGroupSharing>> shareRecord(BaseRecord toShare, User subject);
+  ServiceOperationResult<RecordGroupSharing> shareRecord(BaseRecord toShare, User subject);
 
   /**
    * Shares all previously unshared notebooks and documents into the user's autoshare target folder.

--- a/src/main/java/com/researchspace/service/RecordSharingManager.java
+++ b/src/main/java/com/researchspace/service/RecordSharingManager.java
@@ -13,7 +13,6 @@ import com.researchspace.model.record.RSPath;
 import com.researchspace.model.views.ServiceOperationResult;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /** Services for sharing records with other users/ groups. */
 public interface RecordSharingManager {
@@ -86,11 +85,11 @@ public interface RecordSharingManager {
    *     subject, but might be someone who is accepting an invitation to share.
    * @param recordToShareId
    * @param sharingConfigs An array of ShareConfigElement
-   * @return The shared record and operation result
+   * @return result of the share operation, and 1st RecordGroupSharing result
    * @throws IllegalAddChildOperation, AuthorizationException if an attempt is made by non-owner to
    *     share, or if the recordToShareId is not a notebook or document.
    */
-  ServiceOperationResult<Set<RecordGroupSharing>> shareRecord(
+  ServiceOperationResult<RecordGroupSharing> shareRecord(
       User sharing, Long recordToShareId, ShareConfigElement[] sharingConfigs)
       throws IllegalAddChildOperation;
 

--- a/src/main/java/com/researchspace/service/RecordSharingManager.java
+++ b/src/main/java/com/researchspace/service/RecordSharingManager.java
@@ -73,7 +73,7 @@ public interface RecordSharingManager {
   List<RecordGroupSharing> getRecordSharingInfo(Long recordId);
 
   /**
-   * Shares a record under the control of <code>sharing</code> with 1 or more groups.<br>
+   * Shares a record under the control of <code>sharing</code> with 1 or more users or groups.<br>
    * This user should have permission to share the record. This method will:
    *
    * <ul>
@@ -85,11 +85,11 @@ public interface RecordSharingManager {
    *     subject, but might be someone who is accepting an invitation to share.
    * @param recordToShareId
    * @param sharingConfigs An array of ShareConfigElement
-   * @return result of the share operation, and 1st RecordGroupSharing result
+   * @return result of the share operation with created RecordGroupSharing entities
    * @throws IllegalAddChildOperation, AuthorizationException if an attempt is made by non-owner to
    *     share, or if the recordToShareId is not a notebook or document.
    */
-  ServiceOperationResult<RecordGroupSharing> shareRecord(
+  ServiceOperationResult<List<RecordGroupSharing>> shareRecord(
       User sharing, Long recordToShareId, ShareConfigElement[] sharingConfigs)
       throws IllegalAddChildOperation;
 

--- a/src/main/java/com/researchspace/service/cloud/impl/ShareRecordRequestHandler.java
+++ b/src/main/java/com/researchspace/service/cloud/impl/ShareRecordRequestHandler.java
@@ -13,7 +13,6 @@ import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.service.RecordSharingManager;
 import com.researchspace.service.impl.AbstractRSpaceRequestUpdateHandler;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,10 +56,10 @@ public class ShareRecordRequestHandler extends AbstractRSpaceRequestUpdateHandle
     values[0].setUserId(target.getId());
     values[0].setOperation(permission);
 
-    ServiceOperationResult<Set<RecordGroupSharing>> sharingResult =
+    ServiceOperationResult<RecordGroupSharing> sharingResult =
         sharingManager.shareRecord(originator, record.getId(), values);
     if (sharingResult.isSucceeded()) {
-      BaseRecord shared = sharingResult.getEntity().iterator().next().getShared();
+      BaseRecord shared = sharingResult.getEntity().getShared();
       auditService.notify(new ShareRecordAuditEvent(originator, shared, values));
     }
     permissnUtils.notifyUserOrGroupToRefreshCache(target);

--- a/src/main/java/com/researchspace/service/cloud/impl/ShareRecordRequestHandler.java
+++ b/src/main/java/com/researchspace/service/cloud/impl/ShareRecordRequestHandler.java
@@ -13,6 +13,7 @@ import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.service.RecordSharingManager;
 import com.researchspace.service.impl.AbstractRSpaceRequestUpdateHandler;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,10 +57,10 @@ public class ShareRecordRequestHandler extends AbstractRSpaceRequestUpdateHandle
     values[0].setUserId(target.getId());
     values[0].setOperation(permission);
 
-    ServiceOperationResult<RecordGroupSharing> sharingResult =
+    ServiceOperationResult<List<RecordGroupSharing>> sharingResult =
         sharingManager.shareRecord(originator, record.getId(), values);
     if (sharingResult.isSucceeded()) {
-      BaseRecord shared = sharingResult.getEntity().getShared();
+      BaseRecord shared = sharingResult.getEntity().get(0).getShared();
       auditService.notify(new ShareRecordAuditEvent(originator, shared, values));
     }
     permissnUtils.notifyUserOrGroupToRefreshCache(target);

--- a/src/main/java/com/researchspace/service/impl/AutoshareManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/AutoshareManagerImpl.java
@@ -105,7 +105,7 @@ public class AutoshareManagerImpl implements AutoshareManager {
         continue;
       }
       Long target = grp.getUserGroupForUser(subject).getAutoShareFolder().getId();
-      ShareConfigElement element = createShareConfig(grp, target);
+      ShareConfigElement element = createShareConfigForAutosharing(grp, target);
       shareConfigsList.add(element);
     }
     ServiceOperationResult<RecordGroupSharing> shareResult;
@@ -131,7 +131,7 @@ public class AutoshareManagerImpl implements AutoshareManager {
     return shareResult;
   }
 
-  private ShareConfigElement createShareConfig(Group grp, Long target) {
+  private ShareConfigElement createShareConfigForAutosharing(Group grp, Long target) {
     ShareConfigElement element = new ShareConfigElement(grp.getId(), "read");
     element.setGroupFolderId(target);
     element.setAutoshare(true);
@@ -194,7 +194,8 @@ public class AutoshareManagerImpl implements AutoshareManager {
         new ServiceOperationResultCollection<>();
 
     for (Long idLong : itemsToShare) {
-      ShareConfigElement element = createShareConfig(grpToShareWith, destinationFolder.getId());
+      ShareConfigElement element =
+          createShareConfigForAutosharing(grpToShareWith, destinationFolder.getId());
       ShareConfigElement[] configs = new ShareConfigElement[] {element};
 
       try {

--- a/src/main/java/com/researchspace/service/impl/AutoshareManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/AutoshareManagerImpl.java
@@ -80,8 +80,7 @@ public class AutoshareManagerImpl implements AutoshareManager {
    */
   @Override
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public ServiceOperationResult<Set<RecordGroupSharing>> shareRecord(
-      BaseRecord toShare, User subject) {
+  public ServiceOperationResult<RecordGroupSharing> shareRecord(BaseRecord toShare, User subject) {
 
     if (!toShare.isAutosharable()) {
       String message =
@@ -109,7 +108,7 @@ public class AutoshareManagerImpl implements AutoshareManager {
       ShareConfigElement element = createShareConfig(grp, target);
       shareConfigsList.add(element);
     }
-    ServiceOperationResult<Set<RecordGroupSharing>> shareResult;
+    ServiceOperationResult<RecordGroupSharing> shareResult;
 
     // share, if there is something to share
     if (shareConfigsList.size() > 0) {
@@ -118,7 +117,7 @@ public class AutoshareManagerImpl implements AutoshareManager {
       // let sharing manager decide whether to share or not
       shareResult = recordSharingMgr.shareRecord(subject, toShare.getId(), configs);
       if (shareResult.isSucceeded()) {
-        RecordGroupSharing rgs = shareResult.getEntity().iterator().next();
+        RecordGroupSharing rgs = shareResult.getEntity();
         notifyAuditTrail(subject, configs, rgs);
       }
     } else {
@@ -199,15 +198,15 @@ public class AutoshareManagerImpl implements AutoshareManager {
       ShareConfigElement[] configs = new ShareConfigElement[] {element};
 
       try {
-        ServiceOperationResult<Set<RecordGroupSharing>> sharingResult =
+        ServiceOperationResult<RecordGroupSharing> sharingResult =
             recordSharingMgr.shareRecord(subject, idLong, configs);
         if (sharingResult.isSucceeded()) {
-          RecordGroupSharing rgs = sharingResult.getEntity().iterator().next();
+          RecordGroupSharing rgs = sharingResult.getEntity();
           notifyAuditTrail(subject, configs, rgs);
           rc.addResult(rgs);
         } else {
-          if (!sharingResult.getEntity().isEmpty()) {
-            rc.addFailure(sharingResult.getEntity().iterator().next());
+          if (sharingResult.getEntity() != null) {
+            rc.addFailure(sharingResult.getEntity());
           }
         }
       } catch (Exception e) {

--- a/src/main/java/com/researchspace/service/impl/AutoshareManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/AutoshareManagerImpl.java
@@ -73,14 +73,15 @@ public class AutoshareManagerImpl implements AutoshareManager {
   }
 
   /**
-   * Performs sharing a single record in a new transaction. This is needed in case this is called
-   * from a TransactionEventListener to ensure clean separation between a creation event and an
-   * autoshare event, and ensure creation occurs OK even if there is a subsequent problem in
-   * sharing.
+   * Performs sharing a single record, into all user's autoshare groups, in a new transaction. This
+   * is needed in case this is called from a TransactionEventListener to ensure clean separation
+   * between a creation event and an autoshare event, and ensure creation occurs OK even if there is
+   * a subsequent problem in sharing.
    */
   @Override
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public ServiceOperationResult<RecordGroupSharing> shareRecord(BaseRecord toShare, User subject) {
+  public ServiceOperationResult<List<RecordGroupSharing>> shareRecord(
+      BaseRecord toShare, User subject) {
 
     if (!toShare.isAutosharable()) {
       String message =
@@ -108,17 +109,15 @@ public class AutoshareManagerImpl implements AutoshareManager {
       ShareConfigElement element = createShareConfigForAutosharing(grp, target);
       shareConfigsList.add(element);
     }
-    ServiceOperationResult<RecordGroupSharing> shareResult;
+    ServiceOperationResult<List<RecordGroupSharing>> shareResult;
 
     // share, if there is something to share
     if (shareConfigsList.size() > 0) {
       ShareConfigElement[] configs = new ShareConfigElement[shareConfigsList.size()];
       shareConfigsList.toArray(configs);
-      // let sharing manager decide whether to share or not
       shareResult = recordSharingMgr.shareRecord(subject, toShare.getId(), configs);
       if (shareResult.isSucceeded()) {
-        RecordGroupSharing rgs = shareResult.getEntity();
-        notifyAuditTrail(subject, configs, rgs);
+        notifyAuditTrail(subject, configs, shareResult.getEntity().get(0).getShared());
       }
     } else {
       String msgString =
@@ -139,8 +138,8 @@ public class AutoshareManagerImpl implements AutoshareManager {
   }
 
   private void notifyAuditTrail(
-      User subject, ShareConfigElement[] configs, RecordGroupSharing rgs) {
-    auditService.notify(new ShareRecordAuditEvent(subject, rgs.getShared(), configs));
+      User subject, ShareConfigElement[] configs, BaseRecord sharedRecord) {
+    auditService.notify(new ShareRecordAuditEvent(subject, sharedRecord, configs));
   }
 
   @Override
@@ -199,15 +198,15 @@ public class AutoshareManagerImpl implements AutoshareManager {
       ShareConfigElement[] configs = new ShareConfigElement[] {element};
 
       try {
-        ServiceOperationResult<RecordGroupSharing> sharingResult =
+        ServiceOperationResult<List<RecordGroupSharing>> sharingResult =
             recordSharingMgr.shareRecord(subject, idLong, configs);
         if (sharingResult.isSucceeded()) {
-          RecordGroupSharing rgs = sharingResult.getEntity();
-          notifyAuditTrail(subject, configs, rgs);
+          RecordGroupSharing rgs = sharingResult.getEntity().get(0);
+          notifyAuditTrail(subject, configs, rgs.getShared());
           rc.addResult(rgs);
         } else {
-          if (sharingResult.getEntity() != null) {
-            rc.addFailure(sharingResult.getEntity());
+          if (!sharingResult.getEntity().isEmpty()) {
+            rc.addFailure(sharingResult.getEntity().get(0));
           }
         }
       } catch (Exception e) {

--- a/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
@@ -63,6 +63,7 @@ import com.researchspace.service.RecordSharingManager;
 import com.researchspace.service.ShareRecordMessageOrRequestDTO;
 import com.researchspace.service.UserFolderCreator;
 import com.researchspace.service.UserManager;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -674,7 +675,9 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
         aclPolicy = ACLPropagationPolicy.SHARE_INTO_NOTEBOOK_POLICY;
       }
       // either add to individual shared folder, or lab group shared folder.
+      log.info("before addChild:" + Instant.now().toString());
       folderToShareInto.addChild(docOrNotebook, ChildAddPolicy.DEFAULT, subject, aclPolicy);
+      log.info("after addChild:" + Instant.now().toString());
       saveRecordOrFolder(docOrNotebook);
       folderDao.save(folderToShareInto);
       log.info(
@@ -777,6 +780,7 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
         }
       }
 
+      log.info("doUnshare-beforeUsersLoop:" + Instant.now().toString());
       Set<Folder> deletedFrom = new HashSet<>();
       // now we remove this shared item from other users's shared folders
       for (Long id : users) {
@@ -794,12 +798,15 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
           deletedFrom.add(sharedGrpFolderRoot);
         }
       }
+      log.info("doUnshare-afterUsersLoop:" + Instant.now().toString());
     }
     return unshared;
   }
 
   private void removeUnsharedChild(Folder sharedParent, BaseRecord toUnshare) {
+    log.info("before removeChild:" + Instant.now().toString());
     sharedParent.removeChild(toUnshare);
+    log.info("after removeChild:" + Instant.now().toString());
     folderDao.save(sharedParent);
     saveRecordOrFolder(toUnshare);
   }

--- a/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
@@ -528,6 +528,7 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
     String usernameInSession = SecurityUtils.getSubject().getPrincipal().toString();
     User userInSession = userDao.getUserByUsername(usernameInSession);
 
+    log.info("doSharing start:" + Instant.now().toString());
     if (toShareWith.isUser()) {
       boolean sysAdminUnsharingAPublicLink = false;
       boolean communityAdminUnsharingACommunityMemberPublication = false;
@@ -656,8 +657,11 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
 
     // set of folders we'll share into, so we don't do this twice.
     Set<Folder> foldersToShareInto = new HashSet<>();
+    log.info("foldersToShareIntoLoop collecting start:" + Instant.now().toString());
     for (Long id : userIds) {
+      log.info("foldersToShareIntoLoop1:" + Instant.now().toString());
       User user = initUserAndCheckSubjectCanShareWith(id, subject);
+      log.info("foldersToShareIntoLoop2:" + Instant.now().toString());
       Folder folderToShareInto = selectedTargetFolder;
       if (folderToShareInto == null && !user.hasRole(Role.ANONYMOUS_ROLE)) {
         folderToShareInto = getTopLevelSharingFolder(subject, toShareWith, user, docOrNotebook);
@@ -667,7 +671,9 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
       } else {
         saveRecordOrFolder(docOrNotebook);
       }
+      log.info("foldersToShareIntoLoop3:" + Instant.now().toString());
     }
+    log.info("foldersToShareIntoLoop collecting end:" + Instant.now().toString());
 
     for (Folder folderToShareInto : foldersToShareInto) {
       ACLPropagationPolicy aclPolicy = ACLPropagationPolicy.DEFAULT_POLICY;
@@ -686,6 +692,7 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
           folderToShareInto.getId());
     }
     allShared.add(rgs);
+    log.info("doSharing end:" + Instant.now().toString());
     return allShared;
   }
 

--- a/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
@@ -236,7 +236,7 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
   }
 
   @Override
-  public ServiceOperationResult<Set<RecordGroupSharing>> shareRecord(
+  public ServiceOperationResult<RecordGroupSharing> shareRecord(
       User subject, Long recordToShareId, ShareConfigElement[] sharingConfigs)
       throws IllegalAddChildOperation {
 
@@ -281,7 +281,8 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
       commMgr.notify(
           subject, recordOrNotebook, cfg, createSharingMessage(subject, recordOrNotebook));
     }
-    return new ServiceOperationResult<>(shared, !shared.isEmpty());
+    RecordGroupSharing firstRecordGroupShare = shared.isEmpty() ? null : shared.iterator().next();
+    return new ServiceOperationResult<>(firstRecordGroupShare, !shared.isEmpty());
   }
 
   private String createSharingMessage(User subject, BaseRecord recordOrNotebook) {
@@ -429,11 +430,11 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
    * Helper method with common code param share
    *
    * @param subject
-   * @param recordId
+   * @param recordOrNotebook
    * @param groupShareCfgs
    * @param share true= sharing, false = unsharing
-   * @return operation result, whether the record was shared/unshared with at least one from
-   *     selected sharees
+   * @return operation result (whether the record was shared/unshared with at least one from
+   *     selected sharees) with set of created recordGroupSharings
    * @throws IllegalAddChildOperation
    */
   private Set<RecordGroupSharing> doRecordOrNotebookShare(
@@ -507,7 +508,7 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
 
   /**
    * @param subject
-   * @param groupShareCfgs
+   * @param groupShareCfg
    * @param share
    * @param userIds
    * @param docOrNotebook

--- a/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
@@ -431,8 +431,7 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
    * @param recordOrNotebook
    * @param groupShareCfgs
    * @param share true= sharing, false = unsharing
-   * @return operation result (whether the record was shared/unshared with at least one from
-   *     selected sharees) with set of created/removed recordGroupSharings
+   * @return a list of created/removed recordGroupSharings
    * @throws IllegalAddChildOperation
    */
   private List<RecordGroupSharing> doRecordOrNotebookShare(
@@ -522,8 +521,8 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
 
     log.info("Sharing doc [{}] with [{}]", docOrNotebook.getId(), toShareWith.getDisplayName());
 
-    /* calculate target folder; it could be pointed to by user in share dialog when sharing with group,
-     * if not it will default to top-level share folder for individual or group share */
+    /* calculate target folder for this doSharing run; target folder may be specified by the user
+     * when sharing with group, otherwise defaults to top-level of individual/group share folder */
     Folder selectedTargetFolder = null;
     boolean isShareWithAnonyomusUser = false;
     if (isGroupShare) {

--- a/src/main/java/com/researchspace/service/impl/SharingHandlerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SharingHandlerImpl.java
@@ -44,16 +44,16 @@ public class SharingHandlerImpl implements SharingHandler {
         new ServiceOperationResultCollection<>();
     for (Long id : shareConfig.getIdsToShare()) {
       try {
-        ServiceOperationResult<RecordGroupSharing> sharingResult =
+        ServiceOperationResult<List<RecordGroupSharing>> sharingResult =
             sharingManager.shareRecord(sharer, id, shareConfig.getValues());
         if (sharingResult.isSucceeded()) {
-          RecordGroupSharing rgs = sharingResult.getEntity();
+          RecordGroupSharing rgs = sharingResult.getEntity().get(0);
           auditService.notify(
               new ShareRecordAuditEvent(sharer, rgs.getShared(), shareConfig.getValues()));
           rc.addResult(rgs);
         } else {
-          if (sharingResult.getEntity() != null) {
-            rc.addFailure(sharingResult.getEntity());
+          if (!sharingResult.getEntity().isEmpty()) {
+            rc.addFailure(sharingResult.getEntity().get(0));
           }
         }
       } catch (IllegalAddChildOperation | AuthorizationException | IllegalArgumentException e) {

--- a/src/main/java/com/researchspace/service/impl/SharingHandlerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SharingHandlerImpl.java
@@ -23,7 +23,6 @@ import com.researchspace.service.SharingHandler;
 import com.researchspace.service.UserManager;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.authz.AuthorizationException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,16 +44,16 @@ public class SharingHandlerImpl implements SharingHandler {
         new ServiceOperationResultCollection<>();
     for (Long id : shareConfig.getIdsToShare()) {
       try {
-        ServiceOperationResult<Set<RecordGroupSharing>> sharingResult =
+        ServiceOperationResult<RecordGroupSharing> sharingResult =
             sharingManager.shareRecord(sharer, id, shareConfig.getValues());
         if (sharingResult.isSucceeded()) {
-          RecordGroupSharing rgs = sharingResult.getEntity().iterator().next();
+          RecordGroupSharing rgs = sharingResult.getEntity();
           auditService.notify(
               new ShareRecordAuditEvent(sharer, rgs.getShared(), shareConfig.getValues()));
           rc.addResult(rgs);
         } else {
-          if (!sharingResult.getEntity().isEmpty()) {
-            rc.addFailure(sharingResult.getEntity().iterator().next());
+          if (sharingResult.getEntity() != null) {
+            rc.addFailure(sharingResult.getEntity());
           }
         }
       } catch (IllegalAddChildOperation | AuthorizationException | IllegalArgumentException e) {

--- a/src/main/java/com/researchspace/service/listeners/RecordAutoshareListener.java
+++ b/src/main/java/com/researchspace/service/listeners/RecordAutoshareListener.java
@@ -120,7 +120,7 @@ public class RecordAutoshareListener {
         .filter(BaseRecord::isNotebook)
         .map(br -> autoshareMgr.shareRecord(br, subject))
         .filter(ServiceOperationResult::isSucceeded)
-        .map(sor -> sor.getEntity().iterator().next().getShared())
+        .map(sor -> sor.getEntity().getShared())
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/researchspace/service/listeners/RecordAutoshareListener.java
+++ b/src/main/java/com/researchspace/service/listeners/RecordAutoshareListener.java
@@ -120,7 +120,7 @@ public class RecordAutoshareListener {
         .filter(BaseRecord::isNotebook)
         .map(br -> autoshareMgr.shareRecord(br, subject))
         .filter(ServiceOperationResult::isSucceeded)
-        .map(sor -> sor.getEntity().getShared())
+        .map(sor -> sor.getEntity().get(0).getShared())
         .collect(Collectors.toList());
   }
 }

--- a/src/test/java/com/researchspace/service/RecordManagerTest.java
+++ b/src/test/java/com/researchspace/service/RecordManagerTest.java
@@ -451,7 +451,7 @@ public class RecordManagerTest extends SpringTransactionalTest {
     assertEquals(pi.getRootFolder().getId(), doc.getParent().getId());
 
     // share a document with group
-    doc = shareRecordWithGroup(pi, gp, doc).getEntity().getShared().asStrucDoc();
+    doc = shareRecordWithGroup(pi, gp, doc).getShared().asStrucDoc();
     assertEquals(2, doc.getParents().size());
 
     // copy the doc and assert it's in the right folder

--- a/src/test/java/com/researchspace/service/RecordManagerTest.java
+++ b/src/test/java/com/researchspace/service/RecordManagerTest.java
@@ -451,7 +451,7 @@ public class RecordManagerTest extends SpringTransactionalTest {
     assertEquals(pi.getRootFolder().getId(), doc.getParent().getId());
 
     // share a document with group
-    doc = shareRecordWithGroup(pi, gp, doc).getEntity().iterator().next().getShared().asStrucDoc();
+    doc = shareRecordWithGroup(pi, gp, doc).getEntity().getShared().asStrucDoc();
     assertEquals(2, doc.getParents().size());
 
     // copy the doc and assert it's in the right folder

--- a/src/test/java/com/researchspace/service/RecordSharingManagerIT.java
+++ b/src/test/java/com/researchspace/service/RecordSharingManagerIT.java
@@ -32,7 +32,6 @@ import com.researchspace.testutils.SpringTransactionalTest;
 import com.researchspace.testutils.TestGroup;
 import java.io.FileNotFoundException;
 import java.util.List;
-import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -306,9 +305,9 @@ public class RecordSharingManagerIT extends RealTransactionSpringTestBase {
     withU2.setUserId(u2.getId());
     withU2.setOperation("read");
 
-    ServiceOperationResult<Set<RecordGroupSharing>> result =
+    ServiceOperationResult<RecordGroupSharing> result =
         sharingMgr.shareRecord(u1, doc1.getId(), new ShareConfigElement[] {withGroup, withU2});
-    assertEquals(2, result.getEntity().size());
+    assertTrue(result.isSucceeded());
 
     doc1 = recordMgr.get(doc1.getId()).asStrucDoc();
     assertTrue(doc1.getParentFolders().contains(targetFolder));

--- a/src/test/java/com/researchspace/service/RecordSharingManagerIT.java
+++ b/src/test/java/com/researchspace/service/RecordSharingManagerIT.java
@@ -305,9 +305,10 @@ public class RecordSharingManagerIT extends RealTransactionSpringTestBase {
     withU2.setUserId(u2.getId());
     withU2.setOperation("read");
 
-    ServiceOperationResult<RecordGroupSharing> result =
+    ServiceOperationResult<List<RecordGroupSharing>> result =
         sharingMgr.shareRecord(u1, doc1.getId(), new ShareConfigElement[] {withGroup, withU2});
     assertTrue(result.isSucceeded());
+    assertEquals(2, result.getEntity().size());
 
     doc1 = recordMgr.get(doc1.getId()).asStrucDoc();
     assertTrue(doc1.getParentFolders().contains(targetFolder));

--- a/src/test/java/com/researchspace/service/RecordSharingTest.java
+++ b/src/test/java/com/researchspace/service/RecordSharingTest.java
@@ -132,9 +132,8 @@ public class RecordSharingTest extends SpringTransactionalTest {
     assertEquals(3, userDoc.getShortestPathToParent(groupFolder).size());
   }
 
-  private StructuredDocument extractDoc(
-      ServiceOperationResult<Set<RecordGroupSharing>> shareRecord) {
-    return shareRecord.getEntity().iterator().next().getShared().asStrucDoc();
+  private StructuredDocument extractDoc(ServiceOperationResult<RecordGroupSharing> shareRecord) {
+    return shareRecord.getEntity().getShared().asStrucDoc();
   }
 
   @Test
@@ -552,7 +551,7 @@ public class RecordSharingTest extends SpringTransactionalTest {
     // only one can be set
     gsCommand.setUserId(other.getId());
 
-    ServiceOperationResult<Set<RecordGroupSharing>> sharedRecord =
+    ServiceOperationResult<RecordGroupSharing> sharedRecord =
         sharingMgr.shareRecord(
             userDao.get(piUser.getId()),
             recordToShare.getId(),

--- a/src/test/java/com/researchspace/service/RecordSharingTest.java
+++ b/src/test/java/com/researchspace/service/RecordSharingTest.java
@@ -132,8 +132,9 @@ public class RecordSharingTest extends SpringTransactionalTest {
     assertEquals(3, userDoc.getShortestPathToParent(groupFolder).size());
   }
 
-  private StructuredDocument extractDoc(ServiceOperationResult<RecordGroupSharing> shareRecord) {
-    return shareRecord.getEntity().getShared().asStrucDoc();
+  private StructuredDocument extractDoc(
+      ServiceOperationResult<List<RecordGroupSharing>> shareRecord) {
+    return shareRecord.getEntity().get(0).getShared().asStrucDoc();
   }
 
   @Test
@@ -551,7 +552,7 @@ public class RecordSharingTest extends SpringTransactionalTest {
     // only one can be set
     gsCommand.setUserId(other.getId());
 
-    ServiceOperationResult<RecordGroupSharing> sharedRecord =
+    ServiceOperationResult<List<RecordGroupSharing>> sharedRecord =
         sharingMgr.shareRecord(
             userDao.get(piUser.getId()),
             recordToShare.getId(),

--- a/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
+++ b/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
@@ -1129,11 +1129,17 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
    * @param user - must be a group member, probably the doc owner
    * @param group - the group to share with, must be initialised with sharing folders etc
    * @param sd The document to share.
+   * @return RecordGroupSharing entity created as a result of sharing
    */
-  protected ServiceOperationResult<RecordGroupSharing> shareRecordWithGroup(
+  protected RecordGroupSharing shareRecordWithGroup(
       final User user, Group group, StructuredDocument sd) {
-    return sharingMgr.shareRecord(
-        user, sd.getId(), new ShareConfigElement[] {new ShareConfigElement(group.getId(), "read")});
+    return sharingMgr
+        .shareRecord(
+            user,
+            sd.getId(),
+            new ShareConfigElement[] {new ShareConfigElement(group.getId(), "read")})
+        .getEntity()
+        .get(0);
   }
 
   /**
@@ -1153,9 +1159,11 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     cfg.setGroupid(group.getId());
     cfg.setOperation("read"); // doesn't matter, notebook permission will decide
 
-    ServiceOperationResult<RecordGroupSharing> shared =
+    ServiceOperationResult<List<RecordGroupSharing>> shared =
         sharingMgr.shareRecord(docOwner, record.getId(), new ShareConfigElement[] {cfg});
-    return shared.getEntity() == null ? Optional.empty() : Optional.ofNullable(shared.getEntity());
+    return shared.getEntity().isEmpty()
+        ? Optional.empty()
+        : Optional.ofNullable(shared.getEntity().get(0));
   }
 
   /**
@@ -1164,9 +1172,9 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
    * @param owner - must be a group member, probably the doc owner
    * @param sharee - the user to share with, must be initialised with sharing folders etc
    * @param toShare The document to share.
-   * @return
+   * @return entity created as a result of sharing action
    */
-  protected ServiceOperationResult<RecordGroupSharing> shareRecordWithUser(
+  protected RecordGroupSharing shareRecordWithUser(
       User owner, StructuredDocument toShare, User sharee) {
     return doShare(owner, sharee, toShare, false);
   }
@@ -1176,22 +1184,21 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
    *
    * @param owner - must be a group member, probably the doc owner
    * @param sharee - the user to share with, must be initialised with sharing folders etc
-   * @param toShare The document to share.
-   * @return
+   * @param toShare The document to share. @@return entity created as a result of sharing action
    */
-  protected ServiceOperationResult<RecordGroupSharing> shareRecordWithUserForEdit(
+  protected RecordGroupSharing shareRecordWithUserForEdit(
       User owner, StructuredDocument toShare, User sharee) {
     return doShare(owner, sharee, toShare, true);
   }
 
-  private ServiceOperationResult<RecordGroupSharing> doShare(
+  private RecordGroupSharing doShare(
       User owner, User sharee, StructuredDocument toShare, boolean write) {
-    ShareConfigElement cfg = new ShareConfigElement(sharee.getId(), "read");
+    ShareConfigElement cfg = new ShareConfigElement(sharee.getId(), write ? "write" : "read");
     cfg.setUserId(sharee.getId());
-    if (write) {
-      cfg.setOperation("write");
-    }
-    return sharingMgr.shareRecord(owner, toShare.getId(), new ShareConfigElement[] {cfg});
+    return sharingMgr
+        .shareRecord(owner, toShare.getId(), new ShareConfigElement[] {cfg})
+        .getEntity()
+        .get(0);
   }
 
   /**
@@ -1344,10 +1351,11 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
         .map(br -> (Notebook) br);
   }
 
-  private Optional<BaseRecord> extractDoc(ServiceOperationResult<RecordGroupSharing> shareRecord) {
-    return shareRecord.getEntity() == null
+  private Optional<BaseRecord> extractDoc(
+      ServiceOperationResult<List<RecordGroupSharing>> shareRecord) {
+    return shareRecord.getEntity().isEmpty()
         ? Optional.empty()
-        : Optional.ofNullable(shareRecord.getEntity().getShared());
+        : Optional.ofNullable(shareRecord.getEntity().get(0).getShared());
   }
 
   /**

--- a/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
+++ b/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
@@ -1130,7 +1130,7 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
    * @param group - the group to share with, must be initialised with sharing folders etc
    * @param sd The document to share.
    */
-  protected ServiceOperationResult<Set<RecordGroupSharing>> shareRecordWithGroup(
+  protected ServiceOperationResult<RecordGroupSharing> shareRecordWithGroup(
       final User user, Group group, StructuredDocument sd) {
     return sharingMgr.shareRecord(
         user, sd.getId(), new ShareConfigElement[] {new ShareConfigElement(group.getId(), "read")});
@@ -1153,11 +1153,9 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     cfg.setGroupid(group.getId());
     cfg.setOperation("read"); // doesn't matter, notebook permission will decide
 
-    ServiceOperationResult<Set<RecordGroupSharing>> shared =
+    ServiceOperationResult<RecordGroupSharing> shared =
         sharingMgr.shareRecord(docOwner, record.getId(), new ShareConfigElement[] {cfg});
-    return shared.getEntity().isEmpty()
-        ? Optional.empty()
-        : Optional.ofNullable(shared.getEntity().iterator().next());
+    return shared.getEntity() == null ? Optional.empty() : Optional.ofNullable(shared.getEntity());
   }
 
   /**
@@ -1168,7 +1166,7 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
    * @param toShare The document to share.
    * @return
    */
-  protected ServiceOperationResult<Set<RecordGroupSharing>> shareRecordWithUser(
+  protected ServiceOperationResult<RecordGroupSharing> shareRecordWithUser(
       User owner, StructuredDocument toShare, User sharee) {
     return doShare(owner, sharee, toShare, false);
   }
@@ -1181,12 +1179,12 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
    * @param toShare The document to share.
    * @return
    */
-  protected ServiceOperationResult<Set<RecordGroupSharing>> shareRecordWithUserForEdit(
+  protected ServiceOperationResult<RecordGroupSharing> shareRecordWithUserForEdit(
       User owner, StructuredDocument toShare, User sharee) {
     return doShare(owner, sharee, toShare, true);
   }
 
-  private ServiceOperationResult<Set<RecordGroupSharing>> doShare(
+  private ServiceOperationResult<RecordGroupSharing> doShare(
       User owner, User sharee, StructuredDocument toShare, boolean write) {
     ShareConfigElement cfg = new ShareConfigElement(sharee.getId(), "read");
     cfg.setUserId(sharee.getId());
@@ -1346,11 +1344,10 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
         .map(br -> (Notebook) br);
   }
 
-  private Optional<BaseRecord> extractDoc(
-      ServiceOperationResult<Set<RecordGroupSharing>> shareRecord) {
-    return shareRecord.getEntity().isEmpty()
+  private Optional<BaseRecord> extractDoc(ServiceOperationResult<RecordGroupSharing> shareRecord) {
+    return shareRecord.getEntity() == null
         ? Optional.empty()
-        : Optional.ofNullable(shareRecord.getEntity().iterator().next().getShared());
+        : Optional.ofNullable(shareRecord.getEntity().getShared());
   }
 
   /**


### PR DESCRIPTION
The PR changes some internals of share/unshare action, to fix performance problem noticed when sharing with group of tens of users. The found bottleneck was in a fragment that was trying to establish into which shared folder the newly shared record should be placed. 

When sharing with a group, the old code was getting list of all members of the group and then was checking a) if the sharing user is allowed to share with every member of the group and b) what is the shared group folder of that group member. The loop there seems unnecessary, as a) when we establish that user is allowed to share with a group, we don't need to check it for every group member b) the same group's shared folder is referenced by individual shared folders of every group member, so it's enough to find one shared group folder.

Note - there is currently RSDEV-447 raised about a problem with sharing permissions, I'll tackle it separately. For this PR, let's just look into the rest of the logic. 