### PR TITLE
RSDEV-386 Move new Gallery search out of app bar

### DIFF
--- a/src/main/webapp/ui/src/accentedTheme.js
+++ b/src/main/webapp/ui/src/accentedTheme.js
@@ -19,8 +19,6 @@ import { iconButtonClasses } from "@mui/material/IconButton";
 import { outlinedInputClasses } from "@mui/material/OutlinedInput";
 import { gridClasses } from "@mui/x-data-grid";
 import { alertTitleClasses } from "@mui/material/AlertTitle";
-import { checkboxClasses } from "@mui/material/Checkbox";
-import { radioClasses } from "@mui/material/Radio";
 import { chipClasses } from "@mui/material/Chip";
 import { formLabelClasses } from "@mui/material/FormLabel";
 import { inputLabelClasses } from "@mui/material/InputLabel";
@@ -524,6 +522,21 @@ export default function createAccentedTheme(accent: AccentColor): { ... } {
                   fontWeight: 700,
                   fontSize: "0.8125rem",
                   lineHeight: "20px",
+                },
+              },
+              [`&.${outlinedInputClasses.disabled}`]: {
+                borderColor: disabledColor,
+                [`& .${outlinedInputClasses.notchedOutline}`]: {
+                  borderColor: disabledColor,
+                },
+                [`& .${inputAdornmentClasses.root}`]: {
+                  borderRightColor: disabledColor,
+                  color: disabledColor,
+                },
+                "&:hover": {
+                  [`& .${outlinedInputClasses.notchedOutline}`]: {
+                    borderColor: `${disabledColor} !important`,
+                  },
                 },
               },
             },

--- a/src/main/webapp/ui/src/eln/gallery/components/AppBar.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/AppBar.js
@@ -5,57 +5,25 @@ import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import IconButton from "@mui/material/IconButton";
 import Box from "@mui/material/Box";
-import useViewportDimensions from "../../../util/useViewportDimensions";
 import Typography from "@mui/material/Typography";
 import MenuIcon from "@mui/icons-material/Menu";
 import IconButtonWithTooltip from "../../../components/IconButtonWithTooltip";
-import SearchIcon from "@mui/icons-material/Search";
-import TextField from "@mui/material/TextField";
-import InputAdornment from "@mui/material/InputAdornment";
-import { styled } from "@mui/material/styles";
-import CloseIcon from "@mui/icons-material/Close";
 import AccessibilityTips from "../../../components/AccessibilityTips";
 import HelpDocs from "../../../components/Help/HelpDocs";
 import HelpIcon from "@mui/icons-material/Help";
 import { observer } from "mobx-react-lite";
 
-const StyledCloseIcon = styled(CloseIcon)(({ theme }) => ({
-  color: theme.palette.standardIcon.main,
-  height: 20,
-  width: 20,
-}));
-
 type GalleryAppBarArgs = {|
-  appliedSearchTerm: string,
-  setAppliedSearchTerm: (string) => void,
   setDrawerOpen: (boolean) => void,
-  hideSearch: boolean,
   drawerOpen: boolean,
   sidebarId: string,
 |};
 
 function GalleryAppBar({
-  appliedSearchTerm,
-  setAppliedSearchTerm,
-  hideSearch,
   setDrawerOpen,
   drawerOpen,
   sidebarId,
 }: GalleryAppBarArgs): Node {
-  const { isViewportVerySmall, isViewportSmall } = useViewportDimensions();
-  const [showTextfield, setShowTextfield] = React.useState(false);
-  const searchTextfield = React.useRef();
-
-  /*
-   * We use a copy of the search term string so that edits the user makes are
-   * not immediately passed to useGalleryListing which will immediately make a
-   * network call.
-   */
-  const [searchTerm, setSearchTerm] = React.useState("");
-  React.useEffect(() => {
-    setSearchTerm(appliedSearchTerm);
-  }, [appliedSearchTerm]);
-
   return (
     <AppBar position="relative" open={true} aria-label="page header">
       <Toolbar variant="dense">
@@ -69,87 +37,10 @@ function GalleryAppBar({
         >
           <MenuIcon />
         </IconButton>
-        {(!isViewportVerySmall || !showTextfield) && (
-          <Typography variant="h6" noWrap component="h2">
-            Gallery
-          </Typography>
-        )}
-        <Box flexGrow={isViewportVerySmall && showTextfield ? 0 : 1}></Box>
-        {isViewportVerySmall && !showTextfield && (
-          <IconButtonWithTooltip
-            size="small"
-            onClick={() => {
-              setShowTextfield(true);
-              setTimeout(() => {
-                searchTextfield.current?.focus();
-              }, 0);
-            }}
-            icon={<SearchIcon />}
-            title="Search this folder"
-          />
-        )}
-        {!hideSearch && (
-          <Box
-            mx={1}
-            sx={{
-              flexGrow: isViewportSmall ? 1 : 0,
-              display: !isViewportVerySmall || showTextfield ? "block" : "none",
-            }}
-          >
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                setAppliedSearchTerm(searchTerm);
-                setShowTextfield(searchTerm !== "");
-              }}
-            >
-              <TextField
-                placeholder="Search"
-                sx={{
-                  /*
-                   * This is so that it doesn't obscure the "Gallery" heading on
-                   * very small mobile viewports. 300px is arbitrary width that
-                   * does is smaller enough to not cause any overlapping issues.
-                   */
-                  maxWidth: isViewportSmall ? "100%" : 300,
-                  width: isViewportSmall ? "100%" : 300,
-                }}
-                value={searchTerm}
-                onChange={({ currentTarget: { value } }) =>
-                  setSearchTerm(value)
-                }
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <SearchIcon />
-                    </InputAdornment>
-                  ),
-                  endAdornment:
-                    searchTerm !== "" ? (
-                      <IconButtonWithTooltip
-                        title="Clear"
-                        icon={<StyledCloseIcon />}
-                        size="small"
-                        onClick={() => {
-                          setSearchTerm("");
-                          setAppliedSearchTerm("");
-                          setShowTextfield(false);
-                        }}
-                      />
-                    ) : null,
-                }}
-                inputProps={{
-                  ref: searchTextfield,
-                  onBlur: () => {
-                    setSearchTerm(appliedSearchTerm);
-                    setShowTextfield(appliedSearchTerm !== "");
-                  },
-                  "aria-label": "Search current folder",
-                }}
-              />
-            </form>
-          </Box>
-        )}
+        <Typography variant="h6" noWrap component="h2">
+          Gallery
+        </Typography>
+        <Box flexGrow={1}></Box>
         <Box ml={1}>
           <AccessibilityTips
             elementType="dialog"

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -84,6 +84,11 @@ import { useFolderOpen } from "./OpenFolderProvider";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Chip from "@mui/material/Chip";
 import Badge from "@mui/material/Badge";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import IconButtonWithTooltip from "../../../components/IconButtonWithTooltip";
+import CloseIcon from "@mui/icons-material/Close";
+import SearchIcon from "@mui/icons-material/Search";
 
 function useIsBeingMoved(): (
   file: GalleryFile,
@@ -1119,6 +1124,58 @@ const GridView = observer(
   }
 );
 
+const StyledCloseIcon = styled(CloseIcon)(({ theme }) => ({
+  color: theme.palette.standardIcon.main,
+  height: 20,
+  width: 20,
+}));
+
+function Search({
+  appliedSearchTerm,
+  setAppliedSearchTerm,
+}: {|
+  appliedSearchTerm: string,
+  setAppliedSearchTerm: (string) => void,
+|}) {
+  const [searchTerm, setSearchTerm] = React.useState(appliedSearchTerm);
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        setAppliedSearchTerm(searchTerm);
+      }}
+    >
+      <TextField
+        placeholder="Search"
+        value={searchTerm}
+        onChange={({ currentTarget: { value } }) => setSearchTerm(value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          ),
+          endAdornment:
+            searchTerm !== "" ? (
+              <IconButtonWithTooltip
+                title="Clear"
+                icon={<StyledCloseIcon />}
+                size="small"
+                onClick={() => {
+                  setSearchTerm("");
+                  setAppliedSearchTerm("");
+                }}
+              />
+            ) : null,
+        }}
+        inputProps={{
+          "aria-label": "Search current folder",
+        }}
+      />
+    </form>
+  );
+}
+
 type GalleryMainPanelArgs = {|
   selectedSection: GallerySection,
   path: $ReadOnlyArray<GalleryFile>,
@@ -1139,6 +1196,8 @@ type GalleryMainPanelArgs = {|
   orderBy: "name" | "modificationDate",
   setSortOrder: ("DESC" | "ASC") => void,
   setOrderBy: ("name" | "modificationDate") => void,
+  appliedSearchTerm: string,
+  setAppliedSearchTerm: (string) => void,
 |};
 
 function GalleryMainPanel({
@@ -1152,6 +1211,8 @@ function GalleryMainPanel({
   orderBy,
   setSortOrder,
   setOrderBy,
+  appliedSearchTerm,
+  setAppliedSearchTerm,
 }: GalleryMainPanelArgs): Node {
   const viewportDimensions = useViewportDimensions();
   const filestoresEnabled = useDeploymentProperty("netfilestores.enabled");
@@ -1275,12 +1336,20 @@ function GalleryMainPanel({
               sx={{ height: "100%", flexWrap: "nowrap" }}
               spacing={1}
             >
-              <Grid item sx={{ pt: "0 !important" }}>
-                <Path
-                  section={selectedSection}
-                  path={path}
-                  clearPath={clearPath}
-                />
+              <Grid item container sx={{ pt: "0 !important" }}>
+                <Grid item sx={{ flexGrow: 1 }}>
+                  <Path
+                    section={selectedSection}
+                    path={path}
+                    clearPath={clearPath}
+                  />
+                </Grid>
+                <Grid item>
+                  <Search
+                    appliedSearchTerm={appliedSearchTerm}
+                    setAppliedSearchTerm={setAppliedSearchTerm}
+                  />
+                </Grid>
               </Grid>
               <Grid item sx={{ maxWidth: "100% !important" }}>
                 <Stack

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1144,7 +1144,17 @@ function PathAndSearch({
   clearPath: () => void,
 |}) {
   const { isViewportVerySmall } = useViewportDimensions();
-  const [searchTerm, setSearchTerm] = React.useState(appliedSearchTerm);
+
+  /*
+   * We use a copy of the search term string so that edits the user makes are
+   * not immediately passed to useGalleryListing which will immediately make a
+   * network call.
+   */
+  const [searchTerm, setSearchTerm] = React.useState("");
+  React.useEffect(() => {
+    setSearchTerm(appliedSearchTerm);
+  }, [appliedSearchTerm]);
+
   const [searchOpen, setSearchOpen] = React.useState(false);
   const searchTextfield = React.useRef();
   return (

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1130,49 +1130,90 @@ const StyledCloseIcon = styled(CloseIcon)(({ theme }) => ({
   width: 20,
 }));
 
-function Search({
+function PathAndSearch({
   appliedSearchTerm,
   setAppliedSearchTerm,
+  selectedSection,
+  path,
+  clearPath,
 }: {|
   appliedSearchTerm: string,
   setAppliedSearchTerm: (string) => void,
+  selectedSection: GallerySection,
+  path: $ReadOnlyArray<GalleryFile>,
+  clearPath: () => void,
 |}) {
+  const { isViewportVerySmall } = useViewportDimensions();
   const [searchTerm, setSearchTerm] = React.useState(appliedSearchTerm);
+  const [searchOpen, setSearchOpen] = React.useState(false);
+  const searchTextfield = React.useRef();
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        setAppliedSearchTerm(searchTerm);
-      }}
+    <Grid
+      container
+      sx={{ pt: "0 !important", flexWrap: "nowrap" }}
+      spacing={1}
+      direction={searchOpen ? "column" : "row"}
     >
-      <TextField
-        placeholder="Search"
-        value={searchTerm}
-        onChange={({ currentTarget: { value } }) => setSearchTerm(value)}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <SearchIcon />
-            </InputAdornment>
-          ),
-          endAdornment:
-            searchTerm !== "" ? (
-              <IconButtonWithTooltip
-                title="Clear"
-                icon={<StyledCloseIcon />}
-                size="small"
-                onClick={() => {
-                  setSearchTerm("");
-                  setAppliedSearchTerm("");
-                }}
-              />
-            ) : null,
-        }}
-        inputProps={{
-          "aria-label": "Search current folder",
-        }}
-      />
-    </form>
+      <Grid item sx={{ flexGrow: 1, minWidth: 0 }}>
+        <Path section={selectedSection} path={path} clearPath={clearPath} />
+      </Grid>
+      {isViewportVerySmall && !searchOpen && (
+        <IconButtonWithTooltip
+          size="small"
+          onClick={() => {
+            setSearchOpen(true);
+            setTimeout(() => {
+              searchTextfield.current?.focus();
+            }, 0);
+          }}
+          icon={<SearchIcon />}
+          title="Search this folder"
+        />
+      )}
+      {(!isViewportVerySmall || searchOpen) && (
+        <Grid item>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              setAppliedSearchTerm(searchTerm);
+            }}
+          >
+            <TextField
+              placeholder="Search"
+              value={searchTerm}
+              onChange={({ currentTarget: { value } }) => setSearchTerm(value)}
+              sx={{
+                ...(searchOpen ? { width: "100%" } : {}),
+              }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon />
+                  </InputAdornment>
+                ),
+                endAdornment:
+                  searchTerm !== "" || searchOpen ? (
+                    <IconButtonWithTooltip
+                      title="Clear"
+                      icon={<StyledCloseIcon />}
+                      size="small"
+                      onClick={() => {
+                        setSearchTerm("");
+                        setAppliedSearchTerm("");
+                        setSearchOpen(false);
+                      }}
+                    />
+                  ) : null,
+              }}
+              inputProps={{
+                "aria-label": "Search current folder",
+                ref: searchTextfield,
+              }}
+            />
+          </form>
+        </Grid>
+      )}
+    </Grid>
   );
 }
 
@@ -1336,25 +1377,14 @@ function GalleryMainPanel({
               sx={{ height: "100%", flexWrap: "nowrap" }}
               spacing={1}
             >
-              <Grid
-                item
-                container
-                sx={{ pt: "0 !important", flexWrap: "nowrap" }}
-                spacing={1}
-              >
-                <Grid item sx={{ flexGrow: 1, minWidth: 0 }}>
-                  <Path
-                    section={selectedSection}
-                    path={path}
-                    clearPath={clearPath}
-                  />
-                </Grid>
-                <Grid item>
-                  <Search
-                    appliedSearchTerm={appliedSearchTerm}
-                    setAppliedSearchTerm={setAppliedSearchTerm}
-                  />
-                </Grid>
+              <Grid item>
+                <PathAndSearch
+                  appliedSearchTerm={appliedSearchTerm}
+                  setAppliedSearchTerm={setAppliedSearchTerm}
+                  selectedSection={selectedSection}
+                  path={path}
+                  clearPath={clearPath}
+                />
               </Grid>
               <Grid item sx={{ maxWidth: "100% !important" }}>
                 <Stack

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1131,110 +1131,114 @@ const StyledCloseIcon = styled(CloseIcon)(({ theme }) => ({
   width: 20,
 }));
 
-function PathAndSearch({
-  appliedSearchTerm,
-  setAppliedSearchTerm,
-  selectedSection,
-  path,
-  clearPath,
-}: {|
-  appliedSearchTerm: string,
-  setAppliedSearchTerm: (string) => void,
-  selectedSection: GallerySection,
-  path: $ReadOnlyArray<GalleryFile>,
-  clearPath: () => void,
-|}) {
-  const { isViewportVerySmall } = useViewportDimensions();
+const PathAndSearch = observer(
+  ({
+    appliedSearchTerm,
+    setAppliedSearchTerm,
+    selectedSection,
+    path,
+    clearPath,
+  }: {|
+    appliedSearchTerm: string,
+    setAppliedSearchTerm: (string) => void,
+    selectedSection: GallerySection,
+    path: $ReadOnlyArray<GalleryFile>,
+    clearPath: () => void,
+  |}) => {
+    const { isViewportVerySmall } = useViewportDimensions();
 
-  /*
-   * We use a copy of the search term string so that edits the user makes are
-   * not immediately passed to useGalleryListing which will immediately make a
-   * network call.
-   */
-  const [searchTerm, setSearchTerm] = React.useState("");
-  React.useEffect(() => {
-    setSearchTerm(appliedSearchTerm);
-  }, [appliedSearchTerm]);
+    /*
+     * We use a copy of the search term string so that edits the user makes are
+     * not immediately passed to useGalleryListing which will immediately make a
+     * network call.
+     */
+    const [searchTerm, setSearchTerm] = React.useState("");
+    React.useEffect(() => {
+      setSearchTerm(appliedSearchTerm);
+    }, [appliedSearchTerm]);
 
-  /*
-   * On the smallest viewports, we only show the search textfield when it is
-   * requested, hiding it behind an icon button. The ref allows us to focus the
-   * text field when it is opened , triggering the virtual keyboard.
-   */
-  const [searchOpen, setSearchOpen] = React.useState(false);
-  const searchTextfield = React.useRef();
+    /*
+     * On the smallest viewports, we only show the search textfield when it is
+     * requested, hiding it behind an icon button. The ref allows us to focus the
+     * text field when it is opened , triggering the virtual keyboard.
+     */
+    const [searchOpen, setSearchOpen] = React.useState(false);
+    const searchTextfield = React.useRef();
 
-  return (
-    <Grid
-      container
-      sx={{ pt: "0 !important", flexWrap: "nowrap" }}
-      spacing={1}
-      direction={searchOpen ? "column" : "row"}
-    >
-      <Grid item sx={{ flexGrow: 1, minWidth: 0 }}>
-        <Path section={selectedSection} path={path} clearPath={clearPath} />
-      </Grid>
-      {isViewportVerySmall && !searchOpen && (
-        <IconButtonWithTooltip
-          size="small"
-          onClick={() => {
-            setSearchOpen(true);
-            setTimeout(() => {
-              searchTextfield.current?.focus();
-            }, 0);
-          }}
-          icon={<SearchIcon />}
-          title="Search this folder"
-          disabled={selectedSection === GALLERY_SECTION.NETWORKFILES}
-        />
-      )}
-      {(!isViewportVerySmall || searchOpen) && (
-        <Grid item>
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              setAppliedSearchTerm(searchTerm);
-            }}
-          >
-            <TextField
-              disabled={selectedSection === GALLERY_SECTION.NETWORKFILES}
-              placeholder="Search"
-              value={searchTerm}
-              onChange={({ currentTarget: { value } }) => setSearchTerm(value)}
-              sx={{
-                ...(searchOpen ? { width: "100%" } : {}),
-              }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon />
-                  </InputAdornment>
-                ),
-                endAdornment:
-                  searchTerm !== "" || searchOpen ? (
-                    <IconButtonWithTooltip
-                      title="Clear"
-                      icon={<StyledCloseIcon />}
-                      size="small"
-                      onClick={() => {
-                        setSearchTerm("");
-                        setAppliedSearchTerm("");
-                        setSearchOpen(false);
-                      }}
-                    />
-                  ) : null,
-              }}
-              inputProps={{
-                "aria-label": "Search current folder",
-                ref: searchTextfield,
-              }}
-            />
-          </form>
+    return (
+      <Grid
+        container
+        sx={{ pt: "0 !important", flexWrap: "nowrap" }}
+        spacing={1}
+        direction={searchOpen ? "column" : "row"}
+      >
+        <Grid item sx={{ flexGrow: 1, minWidth: 0 }}>
+          <Path section={selectedSection} path={path} clearPath={clearPath} />
         </Grid>
-      )}
-    </Grid>
-  );
-}
+        {isViewportVerySmall && !searchOpen && (
+          <IconButtonWithTooltip
+            size="small"
+            onClick={() => {
+              setSearchOpen(true);
+              setTimeout(() => {
+                searchTextfield.current?.focus();
+              }, 0);
+            }}
+            icon={<SearchIcon />}
+            title="Search this folder"
+            disabled={selectedSection === GALLERY_SECTION.NETWORKFILES}
+          />
+        )}
+        {(!isViewportVerySmall || searchOpen) && (
+          <Grid item>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                setAppliedSearchTerm(searchTerm);
+              }}
+            >
+              <TextField
+                disabled={selectedSection === GALLERY_SECTION.NETWORKFILES}
+                placeholder="Search"
+                value={searchTerm}
+                onChange={({ currentTarget: { value } }) =>
+                  setSearchTerm(value)
+                }
+                sx={{
+                  ...(searchOpen ? { width: "100%" } : {}),
+                }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon />
+                    </InputAdornment>
+                  ),
+                  endAdornment:
+                    searchTerm !== "" || searchOpen ? (
+                      <IconButtonWithTooltip
+                        title="Clear"
+                        icon={<StyledCloseIcon />}
+                        size="small"
+                        onClick={() => {
+                          setSearchTerm("");
+                          setAppliedSearchTerm("");
+                          setSearchOpen(false);
+                        }}
+                      />
+                    ) : null,
+                }}
+                inputProps={{
+                  "aria-label": "Search current folder",
+                  ref: searchTextfield,
+                }}
+              />
+            </form>
+          </Grid>
+        )}
+      </Grid>
+    );
+  }
+);
 
 type GalleryMainPanelArgs = {|
   selectedSection: GallerySection,

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1156,8 +1156,14 @@ function PathAndSearch({
     setSearchTerm(appliedSearchTerm);
   }, [appliedSearchTerm]);
 
+  /*
+   * On the smallest viewports, we only show the search textfield when it is
+   * requested, hiding it behind an icon button. The ref allows us to focus the
+   * text field when it is opened , triggering the virtual keyboard.
+   */
   const [searchOpen, setSearchOpen] = React.useState(false);
   const searchTextfield = React.useRef();
+
   return (
     <Grid
       container

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -17,6 +17,7 @@ import {
   SELECTED_OR_FOCUS_BORDER,
   SELECTED_OR_FOCUS_BLUE,
   type GallerySection,
+  GALLERY_SECTION,
 } from "../common";
 import { styled, alpha } from "@mui/material/styles";
 import useViewportDimensions from "../../../util/useViewportDimensions";
@@ -1167,62 +1168,67 @@ function PathAndSearch({
       <Grid item sx={{ flexGrow: 1, minWidth: 0 }}>
         <Path section={selectedSection} path={path} clearPath={clearPath} />
       </Grid>
-      {isViewportVerySmall && !searchOpen && (
-        <IconButtonWithTooltip
-          size="small"
-          onClick={() => {
-            setSearchOpen(true);
-            setTimeout(() => {
-              searchTextfield.current?.focus();
-            }, 0);
-          }}
-          icon={<SearchIcon />}
-          title="Search this folder"
-        />
-      )}
-      {(!isViewportVerySmall || searchOpen) && (
-        <Grid item>
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              setAppliedSearchTerm(searchTerm);
+      {isViewportVerySmall &&
+        !searchOpen &&
+        selectedSection !== GALLERY_SECTION.NETWORKFILES && (
+          <IconButtonWithTooltip
+            size="small"
+            onClick={() => {
+              setSearchOpen(true);
+              setTimeout(() => {
+                searchTextfield.current?.focus();
+              }, 0);
             }}
-          >
-            <TextField
-              placeholder="Search"
-              value={searchTerm}
-              onChange={({ currentTarget: { value } }) => setSearchTerm(value)}
-              sx={{
-                ...(searchOpen ? { width: "100%" } : {}),
+            icon={<SearchIcon />}
+            title="Search this folder"
+          />
+        )}
+      {(!isViewportVerySmall || searchOpen) &&
+        selectedSection !== GALLERY_SECTION.NETWORKFILES && (
+          <Grid item>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                setAppliedSearchTerm(searchTerm);
               }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon />
-                  </InputAdornment>
-                ),
-                endAdornment:
-                  searchTerm !== "" || searchOpen ? (
-                    <IconButtonWithTooltip
-                      title="Clear"
-                      icon={<StyledCloseIcon />}
-                      size="small"
-                      onClick={() => {
-                        setSearchTerm("");
-                        setAppliedSearchTerm("");
-                        setSearchOpen(false);
-                      }}
-                    />
-                  ) : null,
-              }}
-              inputProps={{
-                "aria-label": "Search current folder",
-                ref: searchTextfield,
-              }}
-            />
-          </form>
-        </Grid>
-      )}
+            >
+              <TextField
+                placeholder="Search"
+                value={searchTerm}
+                onChange={({ currentTarget: { value } }) =>
+                  setSearchTerm(value)
+                }
+                sx={{
+                  ...(searchOpen ? { width: "100%" } : {}),
+                }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon />
+                    </InputAdornment>
+                  ),
+                  endAdornment:
+                    searchTerm !== "" || searchOpen ? (
+                      <IconButtonWithTooltip
+                        title="Clear"
+                        icon={<StyledCloseIcon />}
+                        size="small"
+                        onClick={() => {
+                          setSearchTerm("");
+                          setAppliedSearchTerm("");
+                          setSearchOpen(false);
+                        }}
+                      />
+                    ) : null,
+                }}
+                inputProps={{
+                  "aria-label": "Search current folder",
+                  ref: searchTextfield,
+                }}
+              />
+            </form>
+          </Grid>
+        )}
     </Grid>
   );
 }

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1336,8 +1336,13 @@ function GalleryMainPanel({
               sx={{ height: "100%", flexWrap: "nowrap" }}
               spacing={1}
             >
-              <Grid item container sx={{ pt: "0 !important" }}>
-                <Grid item sx={{ flexGrow: 1 }}>
+              <Grid
+                item
+                container
+                sx={{ pt: "0 !important", flexWrap: "nowrap" }}
+                spacing={1}
+              >
+                <Grid item sx={{ flexGrow: 1, minWidth: 0 }}>
                   <Path
                     section={selectedSection}
                     path={path}

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1174,67 +1174,64 @@ function PathAndSearch({
       <Grid item sx={{ flexGrow: 1, minWidth: 0 }}>
         <Path section={selectedSection} path={path} clearPath={clearPath} />
       </Grid>
-      {isViewportVerySmall &&
-        !searchOpen &&
-        selectedSection !== GALLERY_SECTION.NETWORKFILES && (
-          <IconButtonWithTooltip
-            size="small"
-            onClick={() => {
-              setSearchOpen(true);
-              setTimeout(() => {
-                searchTextfield.current?.focus();
-              }, 0);
+      {isViewportVerySmall && !searchOpen && (
+        <IconButtonWithTooltip
+          size="small"
+          onClick={() => {
+            setSearchOpen(true);
+            setTimeout(() => {
+              searchTextfield.current?.focus();
+            }, 0);
+          }}
+          icon={<SearchIcon />}
+          title="Search this folder"
+          disabled={selectedSection === GALLERY_SECTION.NETWORKFILES}
+        />
+      )}
+      {(!isViewportVerySmall || searchOpen) && (
+        <Grid item>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              setAppliedSearchTerm(searchTerm);
             }}
-            icon={<SearchIcon />}
-            title="Search this folder"
-          />
-        )}
-      {(!isViewportVerySmall || searchOpen) &&
-        selectedSection !== GALLERY_SECTION.NETWORKFILES && (
-          <Grid item>
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                setAppliedSearchTerm(searchTerm);
+          >
+            <TextField
+              disabled={selectedSection === GALLERY_SECTION.NETWORKFILES}
+              placeholder="Search"
+              value={searchTerm}
+              onChange={({ currentTarget: { value } }) => setSearchTerm(value)}
+              sx={{
+                ...(searchOpen ? { width: "100%" } : {}),
               }}
-            >
-              <TextField
-                placeholder="Search"
-                value={searchTerm}
-                onChange={({ currentTarget: { value } }) =>
-                  setSearchTerm(value)
-                }
-                sx={{
-                  ...(searchOpen ? { width: "100%" } : {}),
-                }}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <SearchIcon />
-                    </InputAdornment>
-                  ),
-                  endAdornment:
-                    searchTerm !== "" || searchOpen ? (
-                      <IconButtonWithTooltip
-                        title="Clear"
-                        icon={<StyledCloseIcon />}
-                        size="small"
-                        onClick={() => {
-                          setSearchTerm("");
-                          setAppliedSearchTerm("");
-                          setSearchOpen(false);
-                        }}
-                      />
-                    ) : null,
-                }}
-                inputProps={{
-                  "aria-label": "Search current folder",
-                  ref: searchTextfield,
-                }}
-              />
-            </form>
-          </Grid>
-        )}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon />
+                  </InputAdornment>
+                ),
+                endAdornment:
+                  searchTerm !== "" || searchOpen ? (
+                    <IconButtonWithTooltip
+                      title="Clear"
+                      icon={<StyledCloseIcon />}
+                      size="small"
+                      onClick={() => {
+                        setSearchTerm("");
+                        setAppliedSearchTerm("");
+                        setSearchOpen(false);
+                      }}
+                    />
+                  ) : null,
+              }}
+              inputProps={{
+                "aria-label": "Search current folder",
+                ref: searchTextfield,
+              }}
+            />
+          </form>
+        </Grid>
+      )}
     </Grid>
   );
 }

--- a/src/main/webapp/ui/src/eln/gallery/components/__tests__/MainPanel.test.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/__tests__/MainPanel.test.js
@@ -68,6 +68,8 @@ describe("MainPanel", () => {
             orderBy="modificationDate"
             setSortOrder={() => {}}
             setOrderBy={() => {}}
+            appliedSearchTerm=""
+            setAppliedSearchTerm={() => {}}
           />
         </ThemeProvider>
       </BrowserRouter>

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -69,9 +69,6 @@ const WholePage = styled(() => {
         <CallableAsposePreview>
           <OpenFolderProvider setPath={setPath}>
             <AppBar
-              appliedSearchTerm={appliedSearchTerm}
-              setAppliedSearchTerm={setAppliedSearchTerm}
-              hideSearch={selectedSection === "NetworkFiles"}
               setDrawerOpen={setDrawerOpen}
               drawerOpen={drawerOpen}
               sidebarId={sidebarId}

--- a/src/main/webapp/ui/src/eln/gallery/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/index.js
@@ -114,6 +114,8 @@ const WholePage = styled(() => {
                   orderBy={orderBy}
                   setSortOrder={setSortOrder}
                   setOrderBy={setOrderBy}
+                  appliedSearchTerm={appliedSearchTerm}
+                  setAppliedSearchTerm={setAppliedSearchTerm}
                 />
               </Box>
             </Box>

--- a/src/main/webapp/ui/src/eln/gallery/picker/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/picker/index.js
@@ -141,9 +141,6 @@ const Picker = observer(
                 aria-label="Gallery Picker"
               >
                 <AppBar
-                  appliedSearchTerm={appliedSearchTerm}
-                  setAppliedSearchTerm={setAppliedSearchTerm}
-                  hideSearch={selectedSection === "NetworkFiles"}
                   setDrawerOpen={setDrawerOpen}
                   drawerOpen={drawerOpen}
                   sidebarId={sidebarId}

--- a/src/main/webapp/ui/src/eln/gallery/picker/index.js
+++ b/src/main/webapp/ui/src/eln/gallery/picker/index.js
@@ -180,6 +180,8 @@ const Picker = observer(
                       orderBy={orderBy}
                       setSortOrder={setSortOrder}
                       setOrderBy={setOrderBy}
+                      appliedSearchTerm={appliedSearchTerm}
+                      setAppliedSearchTerm={setAppliedSearchTerm}
                     />
                     <DialogActions>
                       <Button onClick={() => onClose()}>Cancel</Button>


### PR DESCRIPTION
With the app bar being rolled out across more of the product to provide a unified navigation mechanism, including the search box in the app bar on the new gallery page suggests that the search is applied to the whole product. In reality, it is only applied to the current folder of the current gallery section, so it is best placed outside of the app bar.