### PR TITLE
RSDEV-562 Don't format filesize in CSV

### DIFF
--- a/src/main/webapp/ui/src/eln/sysadmin/users/__tests__/table.test.js
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/__tests__/table.test.js
@@ -1,0 +1,61 @@
+/*
+ * @jest-environment jsdom
+ */
+//@flow
+/* eslint-env jest */
+import React from "react";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { UsersPage } from "..";
+import { ThemeProvider } from "@mui/material/styles";
+import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
+import materialTheme from "../../../../theme";
+import MockAdapter from "axios-mock-adapter";
+import * as axios from "axios";
+import USER_LISTING from "./userListing";
+import PDF_CONFIG from "./pdfConfig";
+import { render, within } from "../../../../__tests__/customQueries";
+
+window.RS = { newFileStoresExportEnabled: false };
+
+const mockAxios = new MockAdapter(axios);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("Table Listing", () => {
+  test("Usage should be shown in human-readable format", async () => {
+    mockAxios.onGet("system/ajax/jsonList").reply(200, { ...USER_LISTING });
+
+    mockAxios
+      .onGet("/userform/ajax/preference?preference=UI_JSON_SETTINGS")
+      .reply(200, {});
+    mockAxios.onPost("/userform/ajax/preference").reply(200, {});
+    mockAxios
+      .onGet("/export/ajax/defaultPDFConfig")
+      .reply(200, { ...PDF_CONFIG });
+
+    render(
+      <StyledEngineProvider injectFirst>
+        <ThemeProvider theme={materialTheme}>
+          <UsersPage />
+        </ThemeProvider>
+      </StyledEngineProvider>
+    );
+
+    const grid = await screen.findByRole("grid");
+    await waitFor(() =>
+      expect(within(grid).getAllByRole("row").length).toBeGreaterThan(1)
+    );
+
+    expect(
+      await within(grid).findTableCell({ columnHeading: "Usage", rowIndex: 1 })
+    ).toHaveTextContent("362.01 kB");
+    expect(
+      await within(grid).findTableCell({ columnHeading: "Usage", rowIndex: 2 })
+    ).toHaveTextContent("0 B");
+  });
+});

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.js
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.js
@@ -1574,7 +1574,7 @@ export const UsersPage = (): Node => {
     ),
     DataGridColumn.newColumnWithValueMapper<User, _>(
       "fileUsage",
-      (fileUsage) => fileUsage,
+      (fileUsage) => `${fileUsage}`,
       {
         headerName: "Usage",
         flex: 1,

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.js
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.js
@@ -1572,15 +1572,11 @@ export const UsersPage = (): Node => {
         flex: 1,
       }
     ),
-    DataGridColumn.newColumnWithValueMapper<User, _>(
-      "fileUsage",
-      (fileUsage) => `${fileUsage}`,
-      {
-        headerName: "Usage",
-        flex: 1,
-        renderCell: (params: { value: number }) => formatFileSize(params.value),
-      }
-    ),
+    DataGridColumn.newColumnWithFieldName<User, _>("fileUsage", {
+      headerName: "Usage",
+      flex: 1,
+      renderCell: (params: { value: number }) => formatFileSize(params.value),
+    }),
     DataGridColumn.newColumnWithFieldName<User, _>("lastLogin", {
       headerName: "Last Login",
       flex: 1,

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.js
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.js
@@ -1574,10 +1574,11 @@ export const UsersPage = (): Node => {
     ),
     DataGridColumn.newColumnWithValueMapper<User, _>(
       "fileUsage",
-      (fileUsage) => formatFileSize(fileUsage),
+      (fileUsage) => fileUsage,
       {
         headerName: "Usage",
         flex: 1,
+        renderCell: (params: { value: number }) => formatFileSize(params.value),
       }
     ),
     DataGridColumn.newColumnWithFieldName<User, _>("lastLogin", {


### PR DESCRIPTION
CSV export should include the precise byte count, rather than a human-friendly string, so that the column can be sorted in spreadsheet software.