### PR TITLE
RSDEV-528: Fix DMPtool DMP not updated after exporting RSpace archive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1888,7 +1888,7 @@
     <dependency>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>dmptool-java-client</artifactId>
-        <version>0.2.0</version>
+        <version>RSDEV-528-client-SNAPSHOT</version>
         <exclusions>
             <exclusion>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1888,7 +1888,7 @@
     <dependency>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>dmptool-java-client</artifactId>
-        <version>RSDEV-528-client-SNAPSHOT</version>
+        <version>0.2.1</version>
         <exclusions>
             <exclusion>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Depending PR: https://github.com/rspace-os/dmptool-java-client/pull/7

AWS instance: http://dmponline-test.researchspace.com/ (mapped to http://rsdev-528-web-5.researchspace.com)
