### PR TITLE
when inserting chemical from Gallery use generic template if chemistry is disabled

### DIFF
--- a/src/main/webapp/WEB-INF/pages/mediaGallery.jsp
+++ b/src/main/webapp/WEB-INF/pages/mediaGallery.jsp
@@ -9,8 +9,8 @@
  var oneDriveClientId = "${applicationScope['RS_DEPLOY_PROPS']['oneDriveClientId']}";
  var oneDriveRedirect = "${applicationScope['RS_DEPLOY_PROPS']['oneDriveRedirect']}";
  <c:if test="${not empty term}">
-               galleryOptionalSearchTermFromUrlParameter = '${term}';
-           </c:if>
+     galleryOptionalSearchTermFromUrlParameter = '${term}';
+ </c:if>
 </script>
 
 <link href="<c:url value='/scripts/jqueryFileTree/jqueryFileTree.css'/>" rel="stylesheet" />

--- a/src/main/webapp/scripts/pages/workspace/editor/documentEdit.js
+++ b/src/main/webapp/scripts/pages/workspace/editor/documentEdit.js
@@ -9,6 +9,7 @@ var autoSaveLastErrorStatus = -1;
 var autoSaveFailureCount = 0;
 var autoSaveSkipCount = 0;
 var autosaveRequestTimeout = 30000; // will increase on failed autosaves
+var chemistryAvailable = false;
 
 var unchangedContentCounter = 0;
 var isWorkspacePage = true;

--- a/src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js
+++ b/src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js
@@ -454,6 +454,8 @@ function initTinyMCE(selector) {
 		const omeroEnabled =  integrations.OMERO.enabled && integrations.OMERO.available && properties["omero.api.url"] !== "";
 		const joveEnabled =  integrations.JOVE.enabled && integrations.JOVE.available;
 
+		chemistryAvailable = integrations.CHEMISTRY.available;
+
 		// File repositories section
 		var enabledFileRepositories = "";
 		var fileRepositoriesMenu = "";

--- a/src/main/webapp/scripts/pages/workspace/mediaGalleryManager.js
+++ b/src/main/webapp/scripts/pages/workspace/mediaGalleryManager.js
@@ -765,7 +765,6 @@ function generateIconSrc(type, extension, thumbnailId, id) {
       iconSrc = "/images/icons/audioIcon.png";
     }
   } else if (type == 'Documents' || type == 'Miscellaneous' || type == 'DMPs') {
-	
     var iconSrc = "";
     if(type == 'Documents' & id != null) {
 	   let suffix = (thumbnailId!=null)?thumbnailId:"none";
@@ -783,7 +782,11 @@ function generateIconSrc(type, extension, thumbnailId, id) {
       iconSrc = RS.getIconPathForExtension(extension);
     }
   } else if (type == MEDIA_TYPE_CHEMISTRY) {
-    iconSrc = createURL("/gallery/getChemThumbnail/" + id);
+    if (chemistryAvailable) {
+      iconSrc = createURL("/gallery/getChemThumbnail/" + id);
+    } else {
+      iconSrc = RS.getIconPathForExtension(extension);
+    }
   }
   return iconSrc;
 }
@@ -1070,7 +1073,11 @@ function addFromGallery(data) {
       insertGenericDoc(mediaTypeSelectedVal, data);
       break;
     case MEDIA_TYPE_CHEMISTRY:
-      insertChemistryFileFromGallery(mediaTypeSelectedVal, data);
+      if (chemistryAvailable) {
+        insertChemistryFileFromGallery(mediaTypeSelectedVal, data);
+      } else {
+        insertGenericDoc(mediaTypeSelectedVal, data);
+      }
       break;
     case MEDIA_TYPE_SNIPPETS:
       insertSnippetFromGallery(data);
@@ -1183,8 +1190,8 @@ function insertAVFromGallery(mediaType, data) {
  * @param data - the record information for an item(returned by getRecordInformation)
  */
 function insertGenericDoc(mediaType, data) {
-  var templateId = (mediaType == MEDIA_TYPE_MISCDOCS) ?
-    "#insertedMiscdocTemplate" : "#insertedDocumentTemplate";
+  var templateId = (mediaType == MEDIA_TYPE_DOCS) ?
+      "#insertedDocumentTemplate" : "#insertedMiscdocTemplate";
   var fieldId = getFieldIdFromTextFieldId(tinymce.activeEditor.id);
   var selected = (data != null) ? data : $('.selectable input:checked').parents('div.selectable');
   var fromPaste = (data != null);


### PR DESCRIPTION
This PR fixes the problem of inserting attachment from chemical subgallery into tinymce, when chemistry is not available (disabled on System->Configuration screen). The behaviour is now consistent with drag&drop - if chemical file is used, the generic (miscellaneous) attachment template is used, with ring icon. Previously the code tried to do a chemical conversion, and when that failed, it was inserting a fragment that looked broken.

This can be tested on https://rsdev-585-insert-from-chem-gallery-4.researchspace.com/

