### PR TITLE
RSDEV-550: disable chemistry on startup

### DIFF
--- a/src/main/java/com/axiope/service/cfg/BaseConfig.java
+++ b/src/main/java/com/axiope/service/cfg/BaseConfig.java
@@ -207,6 +207,7 @@ import com.researchspace.service.impl.SanityChecker;
 import com.researchspace.service.impl.SharingHandlerImpl;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import com.researchspace.service.impl.SysadminUserCreationHandlerImpl;
+import com.researchspace.service.impl.SystemConfigurationInitialisor;
 import com.researchspace.service.impl.SystemPropertyPermissionManagerImpl;
 import com.researchspace.service.impl.UserContentUpdater;
 import com.researchspace.service.impl.UserContentUpdaterImpl;
@@ -497,6 +498,11 @@ public abstract class BaseConfig {
   @Bean(name = "sharedSnippetsFolderCreator")
   public IApplicationInitialisor sharedSnippetsFolderCreator() {
     return new GroupSharedSnippetsFolderAppInitialiser();
+  }
+
+  @Bean
+  public IApplicationInitialisor systemConfigurationUpdater() {
+    return new SystemConfigurationInitialisor();
   }
 
   @Bean

--- a/src/main/java/com/axiope/service/cfg/ProductionConfig.java
+++ b/src/main/java/com/axiope/service/cfg/ProductionConfig.java
@@ -171,6 +171,7 @@ public class ProductionConfig extends BaseConfig {
     inits.add(customForms());
     // should be last
     inits.add(dBDataIntegrityChecker());
+    inits.add(systemConfigurationUpdater());
     inits.add(sharedSnippetsFolderCreator());
     inits.add(sanityChecker());
     mgr.setApplicationInitialisors(inits);

--- a/src/main/java/com/axiope/service/cfg/TestAppConfig.java
+++ b/src/main/java/com/axiope/service/cfg/TestAppConfig.java
@@ -136,6 +136,7 @@ public class TestAppConfig extends BaseConfig {
     inits.add(devGrpSetup());
     inits.add(integrationsHandlerInitialisor());
     inits.add(dBDataIntegrityChecker());
+    inits.add(systemConfigurationUpdater());
     inits.add(customForms());
     inits.add(sharedSnippetsFolderCreator());
     inits.add(sanityChecker()); // must be last

--- a/src/main/java/com/researchspace/api/v1/controller/SystemSettingsApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SystemSettingsApiController.java
@@ -8,6 +8,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.permissions.SecurityLogger;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.webapp.integrations.datacite.DataCiteConnector;
 import java.util.Map;
 import javax.servlet.ServletRequest;
@@ -81,22 +82,26 @@ public class SystemSettingsApiController extends BaseApiController implements Sy
 
     if (incomingDataciteSettings.getEnabled() != null
         && !incomingDataciteSettings.getEnabled().equals(currentSettings.getEnabled())) {
-      sysPropertyMgr.save("datacite.enabled", incomingDataciteSettings.getEnabled(), subject);
+      sysPropertyMgr.save(
+          SystemPropertyName.DATACITE_ENABLED, incomingDataciteSettings.getEnabled(), subject);
       dataCiteSettingsUpdated = true;
     }
     if (incomingDataciteSettings.getServerUrl() != null
         && !incomingDataciteSettings.getServerUrl().equals(currentSettings.getServerUrl())) {
-      sysPropertyMgr.save("datacite.server.url", incomingDataciteSettings.getServerUrl(), subject);
+      sysPropertyMgr.save(
+          SystemPropertyName.DATACITE_SERVER_URL, incomingDataciteSettings.getServerUrl(), subject);
       dataCiteSettingsUpdated = true;
     }
     if (incomingDataciteSettings.getUsername() != null
         && !incomingDataciteSettings.getUsername().equals(currentSettings.getUsername())) {
-      sysPropertyMgr.save("datacite.username", incomingDataciteSettings.getUsername(), subject);
+      sysPropertyMgr.save(
+          SystemPropertyName.DATACITE_USERNAME, incomingDataciteSettings.getUsername(), subject);
       dataCiteSettingsUpdated = true;
     }
     if (incomingDataciteSettings.getPassword() != null
         && !incomingDataciteSettings.getPassword().equals(currentSettings.getPassword())) {
-      sysPropertyMgr.save("datacite.password", incomingDataciteSettings.getPassword(), subject);
+      sysPropertyMgr.save(
+          SystemPropertyName.DATACITE_PASSWORD, incomingDataciteSettings.getPassword(), subject);
       dataCiteSettingsUpdated = true;
     }
     if (incomingDataciteSettings.getRepositoryPrefix() != null
@@ -104,7 +109,9 @@ public class SystemSettingsApiController extends BaseApiController implements Sy
             .getRepositoryPrefix()
             .equals(currentSettings.getRepositoryPrefix())) {
       sysPropertyMgr.save(
-          "datacite.repositoryPrefix", incomingDataciteSettings.getRepositoryPrefix(), subject);
+          SystemPropertyName.DATACITE_REPOSITORY_PREFIX,
+          incomingDataciteSettings.getRepositoryPrefix(),
+          subject);
       dataCiteSettingsUpdated = true;
     }
 

--- a/src/main/java/com/researchspace/service/SystemPropertyManager.java
+++ b/src/main/java/com/researchspace/service/SystemPropertyManager.java
@@ -1,6 +1,8 @@
 package com.researchspace.service;
 
 import com.researchspace.model.User;
+import com.researchspace.model.preference.HierarchicalPermission;
+import com.researchspace.model.preference.Preference;
 import com.researchspace.model.preference.SettingsType;
 import com.researchspace.model.system.SystemProperty;
 import com.researchspace.model.system.SystemPropertyValue;
@@ -21,18 +23,26 @@ public interface SystemPropertyManager extends GenericManager<SystemPropertyValu
   SystemPropertyValue save(Long sysPropertyValueId, String newValue, User subject);
 
   /**
-   * @param propertyUniqueName
+   * @param name
    * @param newValue
+   * @param subject
    * @return the updated SystemPropertyValue, or <code>null</code> if a property with <code>
    *     propertyUniqueName</code> doesn't exist
    * @throws IllegalArgumentException if <code>newValue</code> is not compatible with the underlying
    *     {@link SystemProperty} type
    */
+  SystemPropertyValue save(SystemPropertyName name, HierarchicalPermission newValue, User subject);
+
+  SystemPropertyValue save(SystemPropertyName name, String newValue, User subject);
+
+  SystemPropertyValue save(Preference preference, String newValue, User subject);
+
+  @Deprecated // use strongly-typed save method variant
   SystemPropertyValue save(String propertyUniqueName, String newValue, User subject);
 
   /**
-   * @param SystemPropertyValue the value to update
-   * @param User subject
+   * @param value the value to update
+   * @param subject
    * @return the updated SystemPropertyValue
    * @throws IllegalArgumentException if <code>newValue</code> is not compatible with the underlying
    *     {@link SystemProperty} type
@@ -52,6 +62,11 @@ public interface SystemPropertyManager extends GenericManager<SystemPropertyValu
    * @param name
    * @return a {@link SystemPropertyValue}
    */
+  SystemPropertyValue findByName(SystemPropertyName name);
+
+  SystemPropertyValue findByName(Preference name);
+
+  @Deprecated // use strongly-typed findByName method variant
   SystemPropertyValue findByName(String name);
 
   /**

--- a/src/main/java/com/researchspace/service/SystemPropertyName.java
+++ b/src/main/java/com/researchspace/service/SystemPropertyName.java
@@ -1,0 +1,32 @@
+package com.researchspace.service;
+
+import lombok.Getter;
+
+@Getter
+public enum SystemPropertyName {
+  API_AVAILABLE("api.available"),
+  BOX_AVAILABLE("box.available"),
+  CHEMISTRY_AVAILABLE("chemistry.available"),
+  DATACITE_ENABLED("datacite.enabled"),
+  DATACITE_SERVER_URL("datacite.server.url"),
+  DATACITE_USERNAME("datacite.username"),
+  DATACITE_PASSWORD("datacite.password"),
+  DATACITE_REPOSITORY_PREFIX("datacite.repositoryPrefix"),
+  DROPBOX_AVAILABLE("dropbox.available"),
+  DROPBOX_LINKING_ENABLED("dropbox.linking.enabled"),
+  GOOGLE_DRIVE_AVAILABLE("googledrive.available"),
+  GROUP_AUTOSHARING_AVAILABLE("group_autosharing.available"),
+  ORCID_AVAILABLE("orcid.available"),
+  PUBLIC_LAST_LOGIN_AVAILABLE("publicLastLogin.available"),
+  PUBLIC_SHARING("public_sharing"),
+  PUBLICDOCS_ALLOW_SEO("publicdocs_allow_seo"),
+  RSPACE_ROR("rspaceinstance.ror"),
+  SLACK_AVAILABLE("slack.available"),
+  SNAPGENE_AVAILABLE("snapgene.available");
+
+  private String propertyName;
+
+  private SystemPropertyName(String propertyName) {
+    this.propertyName = propertyName;
+  }
+}

--- a/src/main/java/com/researchspace/service/impl/RoRServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RoRServiceManagerImpl.java
@@ -6,6 +6,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.RoRService;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import java.util.Iterator;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,6 @@ import org.springframework.util.StringUtils;
 @Service
 public class RoRServiceManagerImpl implements RoRService {
 
-  public static final String RORPROPERTYNAME = "rspaceinstance.ror";
   private final RoRClient rorClient;
   private final SystemPropertyManager systemPropertyManager;
 
@@ -31,7 +31,7 @@ public class RoRServiceManagerImpl implements RoRService {
 
   @Override
   public String getSystemRoRValue() {
-    SystemPropertyValue ror = systemPropertyManager.findByName(RORPROPERTYNAME);
+    SystemPropertyValue ror = systemPropertyManager.findByName(SystemPropertyName.RSPACE_ROR);
     if (ror != null) {
       return ror.getValue();
     }
@@ -40,7 +40,7 @@ public class RoRServiceManagerImpl implements RoRService {
 
   @Override
   public String getRorNameForSystemRoRValue() {
-    SystemPropertyValue ror = systemPropertyManager.findByName(RORPROPERTYNAME);
+    SystemPropertyValue ror = systemPropertyManager.findByName(SystemPropertyName.RSPACE_ROR);
     String rorID = ror.getValue();
     if (!StringUtils.hasText(rorID)) {
       return "";
@@ -63,6 +63,6 @@ public class RoRServiceManagerImpl implements RoRService {
 
   @Override
   public void updateSystemRoRValue(String rorID, User updater) {
-    systemPropertyManager.save(RORPROPERTYNAME, rorID, updater);
+    systemPropertyManager.save(SystemPropertyName.RSPACE_ROR, rorID, updater);
   }
 }

--- a/src/main/java/com/researchspace/service/impl/SystemConfigurationInitialisor.java
+++ b/src/main/java/com/researchspace/service/impl/SystemConfigurationInitialisor.java
@@ -1,0 +1,67 @@
+package com.researchspace.service.impl;
+
+import com.researchspace.model.system.SystemPropertyValue;
+import com.researchspace.service.IApplicationInitialisor;
+import com.researchspace.service.SystemPropertyManager;
+import lombok.AccessLevel;
+import lombok.Setter;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+/** Applies changes to System -> Configuration options on RSpace startup */
+@Component("SystemConfigurationInitialisor")
+public class SystemConfigurationInitialisor implements IApplicationInitialisor {
+
+  private Logger log = LoggerFactory.getLogger(AbstractAppInitializor.class);
+
+  @Value("${chemistry.provider}")
+  @Setter(AccessLevel.PACKAGE)
+  private String chemistryProvider;
+
+  @Value("${chemistry.service.url}")
+  @Setter(AccessLevel.PACKAGE)
+  private String chemistryServiceUrl;
+
+  @Autowired
+  @Setter(AccessLevel.PACKAGE)
+  private SystemPropertyManager systemPropertyManager;
+
+  @Override
+  public void onInitialAppDeployment() {}
+
+  @Override
+  public void onAppVersionUpdate() {}
+
+  @Override
+  public void onAppStartup(ApplicationContext applicationContext) {
+
+    disableChemistryIfNoChemistryProvider();
+  }
+
+  private void disableChemistryIfNoChemistryProvider() {
+
+    if (StringUtils.isEmpty(chemistryProvider) || StringUtils.isEmpty(chemistryServiceUrl)) {
+      SystemPropertyValue chemistryAvailableValue =
+          systemPropertyManager.findByName("chemistry.available");
+      boolean isChemistryDisabled = "DENIED".equals(chemistryAvailableValue.getValue());
+
+      if (!isChemistryDisabled) {
+        log.info(
+            "chemistry.provider: {}, chemistryServiceUrl: {}, chemistryAvailable: {}",
+            chemistryProvider,
+            chemistryServiceUrl,
+            chemistryAvailableValue.getValue());
+
+        /* passing 'null' as subject - this works because saving new value of 'chemistry.available'
+         * doesn't trigger any side effect requiring authenticated user */
+        systemPropertyManager.save("chemistry.available", "DENIED", null);
+        log.info("chemistry.available system property changed to 'DENIED'");
+      }
+    }
+  }
+}

--- a/src/main/java/com/researchspace/service/impl/SystemConfigurationInitialisor.java
+++ b/src/main/java/com/researchspace/service/impl/SystemConfigurationInitialisor.java
@@ -1,8 +1,10 @@
 package com.researchspace.service.impl;
 
+import com.researchspace.model.preference.HierarchicalPermission;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.IApplicationInitialisor;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import lombok.AccessLevel;
 import lombok.Setter;
 import org.apache.commons.lang.StringUtils;
@@ -47,8 +49,9 @@ public class SystemConfigurationInitialisor implements IApplicationInitialisor {
 
     if (StringUtils.isEmpty(chemistryProvider) || StringUtils.isEmpty(chemistryServiceUrl)) {
       SystemPropertyValue chemistryAvailableValue =
-          systemPropertyManager.findByName("chemistry.available");
-      boolean isChemistryDisabled = "DENIED".equals(chemistryAvailableValue.getValue());
+          systemPropertyManager.findByName(SystemPropertyName.CHEMISTRY_AVAILABLE);
+      boolean isChemistryDisabled =
+          HierarchicalPermission.DENIED.name().equals(chemistryAvailableValue.getValue());
 
       if (!isChemistryDisabled) {
         log.info(
@@ -59,7 +62,8 @@ public class SystemConfigurationInitialisor implements IApplicationInitialisor {
 
         /* passing 'null' as subject - this works because saving new value of 'chemistry.available'
          * doesn't trigger any side effect requiring authenticated user */
-        systemPropertyManager.save("chemistry.available", "DENIED", null);
+        systemPropertyManager.save(
+            SystemPropertyName.CHEMISTRY_AVAILABLE, HierarchicalPermission.DENIED, null);
         log.info("chemistry.available system property changed to 'DENIED'");
       }
     }

--- a/src/main/java/com/researchspace/service/impl/SystemPropertyManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SystemPropertyManagerImpl.java
@@ -12,11 +12,14 @@ import com.researchspace.model.Community;
 import com.researchspace.model.Group;
 import com.researchspace.model.GroupType;
 import com.researchspace.model.User;
+import com.researchspace.model.preference.HierarchicalPermission;
+import com.researchspace.model.preference.Preference;
 import com.researchspace.model.system.SystemProperty;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.CommunityServiceManager;
 import com.researchspace.service.GroupManager;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -60,6 +63,28 @@ public class SystemPropertyManagerImpl extends GenericManagerImpl<SystemProperty
   public SystemPropertyValue save(Long sysPropertyValueId, String newValue, User subject) {
     SystemPropertyValue spv = syspropdao.get(sysPropertyValueId);
     return doSave(spv.getProperty().getName(), newValue, spv, subject);
+  }
+
+  @Override
+  @CachePut(key = "#name.propertyName")
+  @CacheEvict(allEntries = true, value = INTEGRATION_INFO)
+  public SystemPropertyValue save(
+      SystemPropertyName name, HierarchicalPermission newValue, User subject) {
+    return save(name.getPropertyName(), newValue.name(), subject);
+  }
+
+  @Override
+  @CachePut(key = "#name.propertyName")
+  @CacheEvict(allEntries = true, value = INTEGRATION_INFO)
+  public SystemPropertyValue save(SystemPropertyName name, String newValue, User subject) {
+    return save(name.getPropertyName(), newValue, subject);
+  }
+
+  @Override
+  @CachePut(key = "#preference.name")
+  @CacheEvict(allEntries = true, value = INTEGRATION_INFO)
+  public SystemPropertyValue save(Preference preference, String newValue, User subject) {
+    return save(preference.name(), newValue, subject);
   }
 
   @Override
@@ -182,7 +207,18 @@ public class SystemPropertyManagerImpl extends GenericManagerImpl<SystemProperty
   }
 
   @Override
-  @Cacheable(key = "#name")
+  @Cacheable(key = "#name.propertyName")
+  public SystemPropertyValue findByName(SystemPropertyName name) {
+    return findByName(name.getPropertyName());
+  }
+
+  @Override
+  @Cacheable(key = "#preference.name")
+  public SystemPropertyValue findByName(Preference preference) {
+    return findByName(preference.name());
+  }
+
+  @Override
   public SystemPropertyValue findByName(String name) {
     return syspropdao.findByPropertyNameAndCommunity(name, null);
   }

--- a/src/main/java/com/researchspace/webapp/controller/DeploymentPropertiesController.java
+++ b/src/main/java/com/researchspace/webapp/controller/DeploymentPropertiesController.java
@@ -3,6 +3,7 @@ package com.researchspace.webapp.controller;
 import com.researchspace.model.User;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,8 +21,6 @@ import org.springframework.web.servlet.ModelAndView;
 @Controller
 @RequestMapping("/deploymentproperties*")
 public class DeploymentPropertiesController extends BaseController {
-
-  public static final String SNAPGENE_AVAILABLE = "snapgene.available";
 
   @Autowired private SystemPropertyManager sysPropertyMgr;
 
@@ -216,8 +215,12 @@ public class DeploymentPropertiesController extends BaseController {
     properties.put("egnyte.available", rc.get("egnyte.available").getValue());
     properties.put("egnyte.client.id", egnyteClientId);
 
-    properties.put("chemistry.available", rc.get("chemistry.available").getValue());
-    properties.put(SNAPGENE_AVAILABLE, rc.get(SNAPGENE_AVAILABLE).getValue());
+    properties.put(
+        SystemPropertyName.CHEMISTRY_AVAILABLE.getPropertyName(),
+        rc.get(SystemPropertyName.CHEMISTRY_AVAILABLE.getPropertyName()).getValue());
+    properties.put(
+        SystemPropertyName.SNAPGENE_AVAILABLE.getPropertyName(),
+        rc.get(SystemPropertyName.SNAPGENE_AVAILABLE.getPropertyName()).getValue());
 
     properties.put("baseURL", baseURL);
 

--- a/src/main/java/com/researchspace/webapp/integrations/snapgene/DNAViewerController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/snapgene/DNAViewerController.java
@@ -1,7 +1,6 @@
 package com.researchspace.webapp.integrations.snapgene;
 
 import static com.researchspace.model.preference.HierarchicalPermission.ALLOWED;
-import static com.researchspace.webapp.controller.DeploymentPropertiesController.SNAPGENE_AVAILABLE;
 import static org.apache.commons.lang3.StringUtils.join;
 
 import com.researchspace.apiutils.ApiError;
@@ -12,6 +11,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.record.Record;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.snapgene.wclient.SnapgeneWSClient;
 import com.researchspace.webapp.controller.BaseController;
 import com.researchspace.zmq.snapgene.requests.EnzymeSet;
@@ -64,7 +64,10 @@ public class DNAViewerController extends BaseController {
   public ResponseEntity<String> status() {
     if (ALLOWED
         .name()
-        .equals(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE).getValue())) {
+        .equals(
+            systemPropertyManagerImpl
+                .findByName(SystemPropertyName.SNAPGENE_AVAILABLE)
+                .getValue())) {
       Either<ApiError, String> result = snapgeneClient.status();
       ResponseEntity<String> statusResponse =
           result

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -462,11 +462,13 @@ dmponline.client.scope=read
 ## threshold in seconds to trigger connection refresh
 # dmponline.client.token.expire.threshold=120
 
-
 # Default RSpace Microservices URL Endpoints
 #aspose.web.url=https://ms-doc-prod.researchspace.com
 #snapgene.web.url=https://ms-dna-prod.researchspace.com
-#chemistry.web.url=https://ms-chem-prod.researchspace.com
+
+chemistry.provider=
+chemistry.service.url=
+chemistry.service.indexOnStartup=false
 
 default.user.password=user1234
 default.admin.password=admin1234

--- a/src/test/java/com/researchspace/api/v1/controller/API_MVC_TestBase.java
+++ b/src/test/java/com/researchspace/api/v1/controller/API_MVC_TestBase.java
@@ -13,7 +13,9 @@ import com.researchspace.api.v1.model.ApiJob;
 import com.researchspace.apiutils.ApiError;
 import com.researchspace.core.util.JacksonUtil;
 import com.researchspace.model.User;
+import com.researchspace.model.preference.HierarchicalPermission;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.webapp.controller.MVCTestBase;
 import java.io.ByteArrayInputStream;
 import java.security.Principal;
@@ -38,14 +40,12 @@ public class API_MVC_TestBase extends MVCTestBase {
 
   static final String STATUS = "/status";
 
-  static final String API_AVAILABLE = "api.available";
-
   protected void enableAPI(User apiUser) {
-    sysPropMgr.save(API_AVAILABLE, "ALLOWED", apiUser);
+    sysPropMgr.save(SystemPropertyName.API_AVAILABLE, HierarchicalPermission.ALLOWED, apiUser);
   }
 
   protected void disableAPI(User apiUser) {
-    sysPropMgr.save(API_AVAILABLE, "DENIED", apiUser);
+    sysPropMgr.save(SystemPropertyName.API_AVAILABLE, HierarchicalPermission.DENIED, apiUser);
   }
 
   /**

--- a/src/test/java/com/researchspace/service/GroupManagerTest.java
+++ b/src/test/java/com/researchspace/service/GroupManagerTest.java
@@ -732,7 +732,7 @@ public class GroupManagerTest extends SpringTransactionalTest {
     // Let's enable this functionality
     User sysadmin = logoutAndLoginAsSysAdmin();
     systemPropertyManager.save(
-        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP.name(),
+        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP,
         HierarchicalPermission.ALLOWED.name(),
         sysadmin);
 
@@ -781,7 +781,7 @@ public class GroupManagerTest extends SpringTransactionalTest {
     // Let's enable this functionality
     User sysadmin = logoutAndLoginAsSysAdmin();
     systemPropertyManager.save(
-        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP.name(),
+        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP,
         HierarchicalPermission.ALLOWED.name(),
         sysadmin);
 
@@ -816,7 +816,7 @@ public class GroupManagerTest extends SpringTransactionalTest {
     // Let's disable this functionality
     logoutAndLoginAsSysAdmin();
     systemPropertyManager.save(
-        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP.name(),
+        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP,
         HierarchicalPermission.DENIED.name(),
         sysadmin);
 
@@ -830,7 +830,7 @@ public class GroupManagerTest extends SpringTransactionalTest {
     // Let's enable this functionality
     User sysadmin = logoutAndLoginAsSysAdmin();
     systemPropertyManager.save(
-        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP.name(),
+        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP,
         HierarchicalPermission.ALLOWED.name(),
         sysadmin);
 
@@ -854,7 +854,7 @@ public class GroupManagerTest extends SpringTransactionalTest {
     Community community = createAndSaveCommunity(admin, getRandomAlphabeticString("community"));
     community = communityMgr.addGroupToCommunity(grp.getId(), community.getId(), admin);
     saveSystemPropertyValue(
-        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP.name(),
+        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP,
         HierarchicalPermission.ALLOWED,
         community,
         admin);
@@ -875,7 +875,7 @@ public class GroupManagerTest extends SpringTransactionalTest {
     // Let's disable this functionality on community level
     logoutAndLoginAs(admin);
     saveSystemPropertyValue(
-        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP.name(),
+        Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP,
         HierarchicalPermission.DENIED,
         community,
         admin);
@@ -920,12 +920,12 @@ public class GroupManagerTest extends SpringTransactionalTest {
   }
 
   private void saveSystemPropertyValue(
-      String property, HierarchicalPermission permission, Community community, User admin) {
+      Preference preference, HierarchicalPermission permission, Community community, User admin) {
     SystemPropertyValue systemPropertyValue =
-        systemPropertyManager.findByNameAndCommunity(property, community.getId());
+        systemPropertyManager.findByNameAndCommunity(preference.name(), community.getId());
 
     if (systemPropertyValue == null) {
-      SystemProperty systemProperty = systemPropertyManager.findByName(property).getProperty();
+      SystemProperty systemProperty = systemPropertyManager.findByName(preference).getProperty();
       systemPropertyValue =
           new SystemPropertyValue(systemProperty, permission.toString(), community);
     } else {

--- a/src/test/java/com/researchspace/service/IntegrationsHandlerCachingTest.java
+++ b/src/test/java/com/researchspace/service/IntegrationsHandlerCachingTest.java
@@ -92,10 +92,11 @@ public class IntegrationsHandlerCachingTest extends SpringTransactionalTest {
   // this should expire the cache for everyone.
   private void assertThatUpdatingAvailabilityTriggersCacheRefresh(
       User user, String propertyToUpdate, IntegrationInfo reloaded) {
-    SystemPropertyValue dropboxAvailable = sysPropMger.findByName("dropbox.available");
+    SystemPropertyValue dropboxAvailable =
+        sysPropMger.findByName(SystemPropertyName.DROPBOX_AVAILABLE);
     // save by name
     sysPropMger.save(
-        dropboxAvailable.getProperty().getName(),
+        SystemPropertyName.DROPBOX_AVAILABLE,
         dropboxAvailable.getValue(),
         user); // doesn't matter if value is different; just saving will trigger cache invalidation
     IntegrationInfo dropboxAvailableReloaded =
@@ -113,7 +114,8 @@ public class IntegrationsHandlerCachingTest extends SpringTransactionalTest {
     assertThat(dropboxAvailableReloaded3, not(sameInstance(dropboxAvailableReloaded2)));
 
     // now let's update a child property; should refresh all properties
-    SystemPropertyValue dropboxLinking = sysPropMger.findByName("dropbox.linking.enabled");
+    SystemPropertyValue dropboxLinking =
+        sysPropMger.findByName(SystemPropertyName.DROPBOX_LINKING_ENABLED);
     sysPropMger.save(dropboxLinking, user);
     IntegrationInfo dropboxAvailableReloaded4 =
         integrationsHandler.getIntegration(user, propertyToUpdate);

--- a/src/test/java/com/researchspace/service/SystemPropertyManagerIT.java
+++ b/src/test/java/com/researchspace/service/SystemPropertyManagerIT.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 // Most of these tests are about enabling system features hierarchically described in RSPAC-1185
 public class SystemPropertyManagerIT extends RealTransactionSpringTestBase {
-  private static final String BOX_AVAILABLE = "box.available";
 
   private @Autowired SystemPropertyManager sysPropMgr;
   private @Autowired SystemPropertyPermissionManager systemPropertyPermissionUtils;
@@ -38,18 +37,25 @@ public class SystemPropertyManagerIT extends RealTransactionSpringTestBase {
   public void enablingSystemPropertyNullHandling() {
     subject = logoutAndLoginAsSysAdmin();
     // Enable Ecat on system admin level
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.ALLOWED.toString(), subject);
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, subject);
 
     // In case of a null user, isPropertyAllowed will check system admin level property only
-    assertTrue(systemPropertyPermissionUtils.isPropertyAllowed((User) null, BOX_AVAILABLE));
+    assertTrue(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            (User) null, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
 
     // DENIED_BY_DEFAULT -> not available
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT.toString(), subject);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed((User) null, BOX_AVAILABLE));
+    sysPropMgr.save(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, subject);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            (User) null, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
 
     // DENIED -> not available
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED.toString(), subject);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed((User) null, BOX_AVAILABLE));
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, subject);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            (User) null, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
   }
 
   @Test
@@ -59,14 +65,21 @@ public class SystemPropertyManagerIT extends RealTransactionSpringTestBase {
     User user = createAndSaveUser(getRandomAlphabeticString("anyUser"));
     subject = logoutAndLoginAsSysAdmin();
     // Enable Ecat on system admin level
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.ALLOWED.toString(), subject);
-    assertTrue(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, subject);
+    assertTrue(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // DENIED_BY_DEFAULT -> not available
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT.toString(), subject);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    sysPropMgr.save(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, subject);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // DENIED -> not available
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED.toString(), subject);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, subject);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
   }
 
   @Test
@@ -86,58 +99,99 @@ public class SystemPropertyManagerIT extends RealTransactionSpringTestBase {
     // No community wide setting
 
     // System wide allowed
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.ALLOWED.toString(), subject);
-    assertTrue(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, subject);
+    assertTrue(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // System wide denied by default
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT.toString(), subject);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    sysPropMgr.save(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, subject);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // System wide denied
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED.toString(), subject);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, subject);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
 
     // Community wide settings
 
     // System wide allowed
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.ALLOWED.toString(), subject);
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, subject);
 
     // Community wide allowed
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, subject);
-    assertTrue(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, subject);
+    assertTrue(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied by default
     saveSystemPropertyValue(
-        BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+        SystemPropertyName.BOX_AVAILABLE,
+        HierarchicalPermission.DENIED_BY_DEFAULT,
+        community,
+        sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
 
     // System wide denied by default
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT.toString(), sysadmin);
+    sysPropMgr.save(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, sysadmin);
 
     // Community wide allowed
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
-    assertTrue(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
+    assertTrue(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied by default
     saveSystemPropertyValue(
-        BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+        SystemPropertyName.BOX_AVAILABLE,
+        HierarchicalPermission.DENIED_BY_DEFAULT,
+        community,
+        sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
 
     // System wide denied
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED.toString(), sysadmin);
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, sysadmin);
 
     // Community wide allowed
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied by default
     saveSystemPropertyValue(
-        BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+        SystemPropertyName.BOX_AVAILABLE,
+        HierarchicalPermission.DENIED_BY_DEFAULT,
+        community,
+        sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(user, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            user, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
   }
 
   @Test
@@ -157,67 +211,111 @@ public class SystemPropertyManagerIT extends RealTransactionSpringTestBase {
     // No community wide setting
 
     // System wide allowed
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.ALLOWED.toString(), sysadmin);
-    assertTrue(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, sysadmin);
+    assertTrue(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // System wide denied by default
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT.toString(), sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    sysPropMgr.save(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // System wide denied
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED.toString(), sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
 
     // Community wide settings
 
     // System wide allowed
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.ALLOWED.toString(), sysadmin);
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, sysadmin);
 
     // Community wide allowed
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
-    assertTrue(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
+    assertTrue(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied by default
     saveSystemPropertyValue(
-        BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+        SystemPropertyName.BOX_AVAILABLE,
+        HierarchicalPermission.DENIED_BY_DEFAULT,
+        community,
+        sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
 
     // System wide denied by default
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT.toString(), sysadmin);
+    sysPropMgr.save(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, sysadmin);
 
     // Community wide allowed
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
-    assertTrue(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
+    assertTrue(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied by default
     saveSystemPropertyValue(
-        BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+        SystemPropertyName.BOX_AVAILABLE,
+        HierarchicalPermission.DENIED_BY_DEFAULT,
+        community,
+        sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
 
     // System wide denied
-    sysPropMgr.save(BOX_AVAILABLE, HierarchicalPermission.DENIED.toString(), sysadmin);
+    sysPropMgr.save(SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, sysadmin);
 
     // Community wide allowed
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.ALLOWED, community, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied by default
     saveSystemPropertyValue(
-        BOX_AVAILABLE, HierarchicalPermission.DENIED_BY_DEFAULT, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+        SystemPropertyName.BOX_AVAILABLE,
+        HierarchicalPermission.DENIED_BY_DEFAULT,
+        community,
+        sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
     // Community wide denied
-    saveSystemPropertyValue(BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
-    assertFalse(systemPropertyPermissionUtils.isPropertyAllowed(group, BOX_AVAILABLE));
+    saveSystemPropertyValue(
+        SystemPropertyName.BOX_AVAILABLE, HierarchicalPermission.DENIED, community, sysadmin);
+    assertFalse(
+        systemPropertyPermissionUtils.isPropertyAllowed(
+            group, SystemPropertyName.BOX_AVAILABLE.getPropertyName()));
   }
 
   private void saveSystemPropertyValue(
-      String property, HierarchicalPermission permission, Community community, User subject2) {
+      SystemPropertyName name,
+      HierarchicalPermission permission,
+      Community community,
+      User subject2) {
     SystemPropertyValue systemPropertyValue =
-        sysPropMgr.findByNameAndCommunity(property, community.getId());
+        sysPropMgr.findByNameAndCommunity(name.getPropertyName(), community.getId());
 
     if (systemPropertyValue == null) {
-      SystemProperty systemProperty = sysPropMgr.findByName(property).getProperty();
+      SystemProperty systemProperty = sysPropMgr.findByName(name).getProperty();
       systemPropertyValue =
           new SystemPropertyValue(systemProperty, permission.toString(), community);
     } else {

--- a/src/test/java/com/researchspace/service/SystemPropertyManagerTest.java
+++ b/src/test/java/com/researchspace/service/SystemPropertyManagerTest.java
@@ -18,8 +18,6 @@ import org.springframework.dao.DataAccessException;
 
 public class SystemPropertyManagerTest extends SpringTransactionalTest {
 
-  private static final String GOOGLE_DRIVE_AVAILABLE = "googledrive.available";
-
   private @Autowired SystemPropertyManager sysPropMgr;
   private final long parentId = -1L;
   private final long childId = -2L;
@@ -68,20 +66,19 @@ public class SystemPropertyManagerTest extends SpringTransactionalTest {
 
   @Test
   public void findByName() {
-    assertNotNull(sysPropMgr.findByName(GOOGLE_DRIVE_AVAILABLE));
-    assertNull(sysPropMgr.findByName("xxx"));
+    assertNotNull(sysPropMgr.findByName(SystemPropertyName.GOOGLE_DRIVE_AVAILABLE));
   }
 
   @Test
   public void cachingBehaviour() {
     User sysadmin = logoutAndLoginAsSysAdmin();
     // calling get twice returns identical(cached) object
-    SystemPropertyValue original = sysPropMgr.findByName(GOOGLE_DRIVE_AVAILABLE);
-    SystemPropertyValue cached = sysPropMgr.findByName(GOOGLE_DRIVE_AVAILABLE);
+    SystemPropertyValue original = sysPropMgr.findByName(SystemPropertyName.GOOGLE_DRIVE_AVAILABLE);
+    SystemPropertyValue cached = sysPropMgr.findByName(SystemPropertyName.GOOGLE_DRIVE_AVAILABLE);
     assertThat(original, sameInstance(cached));
     // now save, which will update the cache with a new object instance
     sysPropMgr.save(cached.getProperty().getName(), reverse(original.getValue()), sysadmin);
-    SystemPropertyValue reloaded = sysPropMgr.findByName(GOOGLE_DRIVE_AVAILABLE);
+    SystemPropertyValue reloaded = sysPropMgr.findByName(SystemPropertyName.GOOGLE_DRIVE_AVAILABLE);
     assertThat(reloaded, not(sameInstance(cached)));
     // assert value is updated
     assertEquals(reloaded.getValue(), reverse(original.getValue()));

--- a/src/test/java/com/researchspace/service/UserProfileManagerTest.java
+++ b/src/test/java/com/researchspace/service/UserProfileManagerTest.java
@@ -7,6 +7,7 @@ import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.SignupSource;
 import com.researchspace.model.User;
 import com.researchspace.model.UserProfile;
+import com.researchspace.model.preference.HierarchicalPermission;
 import com.researchspace.model.views.PublicUserList;
 import com.researchspace.testutils.SpringTransactionalTest;
 import java.util.HashMap;
@@ -44,7 +45,7 @@ public class UserProfileManagerTest extends SpringTransactionalTest {
 
     // set orcid id for new user
     User sysadmin = logoutAndLoginAsSysAdmin();
-    sysPropMgr.save("orcid.available", "ALLOWED", sysadmin);
+    sysPropMgr.save(SystemPropertyName.ORCID_AVAILABLE, HierarchicalPermission.ALLOWED, sysadmin);
     String testOrcidId = "testOrcidId";
     Map<String, String> newOptions = new HashMap<>();
     newOptions.put("ORCID_ID", testOrcidId);

--- a/src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java
+++ b/src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java
@@ -44,6 +44,7 @@ import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.CommunityServiceManager;
 import com.researchspace.service.IRepositoryConfigFactory;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.service.SystemPropertyPermissionManager;
 import com.researchspace.service.UserAppConfigManager;
 import com.researchspace.service.UserConnectionManager;
@@ -179,7 +180,8 @@ public class IntegrationsHandlerTest {
     SystemPropertyValue expectedDropboxAvailableProp =
         new SystemPropertyValue(new SystemProperty(null), "true");
     when(userMgr.getPreferenceForUser(subject, Preference.DROPBOX)).thenReturn(expectedDropboxPref);
-    when(sysPropMgr.findByName("dropbox.available")).thenReturn(expectedDropboxAvailableProp);
+    when(sysPropMgr.findByName(SystemPropertyName.DROPBOX_AVAILABLE.getPropertyName()))
+        .thenReturn(expectedDropboxAvailableProp);
 
     assertNotNull(handler.updateIntegrationInfo(subject, info));
   }
@@ -204,7 +206,8 @@ public class IntegrationsHandlerTest {
     when(userMgr.getPreferenceForUser(subject, Preference.BOX_LINK_TYPE))
         .thenReturn(expectedBoxLinkTypePref);
     when(userMgr.getPreferenceForUser(subject, Preference.BOX)).thenReturn(expectedBoxPref);
-    when(sysPropMgr.findByName("box.available")).thenReturn(expectedBoxAvailableProp);
+    when(sysPropMgr.findByName(SystemPropertyName.BOX_AVAILABLE.getPropertyName()))
+        .thenReturn(expectedBoxAvailableProp);
 
     handler.updateIntegrationInfo(subject, info);
 
@@ -297,7 +300,8 @@ public class IntegrationsHandlerTest {
   @Test
   public void getBoxOptions() {
     SystemPropertyValue boxAvailable = getSystemPropertyValueAllowed("box.available");
-    when(sysPropMgr.findByName("box.available")).thenReturn(boxAvailable);
+    when(sysPropMgr.findByName(SystemPropertyName.BOX_AVAILABLE.getPropertyName()))
+        .thenReturn(boxAvailable);
 
     UserPreference boxEnablement = new UserPreference(Preference.BOX, subject, "true");
     when(userMgr.getPreferenceForUser(subject, Preference.BOX)).thenReturn(boxEnablement);
@@ -312,7 +316,7 @@ public class IntegrationsHandlerTest {
   @Test
   public void getSlackOptions() {
     SystemPropertyValue slackAvailable = getSystemPropertyValueAllowed("slack.available");
-    when(sysPropMgr.findByName("slack.available")).thenReturn(slackAvailable);
+    when(sysPropMgr.findByName(SystemPropertyName.SLACK_AVAILABLE)).thenReturn(slackAvailable);
 
     IntegrationInfo info = handler.getIntegration(subject, SLACK_APP_NAME);
     Map<String, Object> options = info.getOptions();

--- a/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
+++ b/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
@@ -1,0 +1,51 @@
+package com.researchspace.service.impl;
+
+import static org.mockito.Mockito.when;
+
+import com.researchspace.model.system.SystemPropertyValue;
+import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.testutils.SpringTransactionalTest;
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class SystemConfigurationInitializorTest extends SpringTransactionalTest {
+
+  public @Rule MockitoRule mockito = MockitoJUnit.rule();
+
+  @Mock private SystemPropertyManager mockSystemPropertyManager;
+
+  private SystemConfigurationInitialisor systemConfigurationInitializor;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+
+    systemConfigurationInitializor = new SystemConfigurationInitialisor();
+    systemConfigurationInitializor.setSystemPropertyManager(mockSystemPropertyManager);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+  }
+
+  @Test
+  public void testOnAppStartupUpdateChemistrySetting() throws IOException {
+
+    when(mockSystemPropertyManager.findByName("chemistry.available"))
+        .thenReturn(new SystemPropertyValue(null, "ALLOWED"));
+
+    //
+    systemConfigurationInitializor.setChemistryProvider("");
+    systemConfigurationInitializor.setChemistryServiceUrl("");
+    systemConfigurationInitializor.onAppStartup(null);
+
+    //  verify(mockChemistryClient, Mockito.never()).save(Mockito.any(), Mockito.any());
+  }
+}

--- a/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
+++ b/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
@@ -1,9 +1,13 @@
 package com.researchspace.service.impl;
 
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.researchspace.model.preference.HierarchicalPermission;
+import com.researchspace.model.system.SystemProperty;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.testutils.SpringTransactionalTest;
 import java.io.IOException;
 import org.junit.After;
@@ -11,6 +15,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -20,14 +25,14 @@ public class SystemConfigurationInitializorTest extends SpringTransactionalTest 
 
   @Mock private SystemPropertyManager mockSystemPropertyManager;
 
-  private SystemConfigurationInitialisor systemConfigurationInitializor;
+  private SystemConfigurationInitialisor systemConfigurationInitialisor;
 
   @Before
   public void setUp() throws Exception {
     super.setUp();
 
-    systemConfigurationInitializor = new SystemConfigurationInitialisor();
-    systemConfigurationInitializor.setSystemPropertyManager(mockSystemPropertyManager);
+    systemConfigurationInitialisor = new SystemConfigurationInitialisor();
+    systemConfigurationInitialisor.setSystemPropertyManager(mockSystemPropertyManager);
   }
 
   @After
@@ -38,14 +43,39 @@ public class SystemConfigurationInitializorTest extends SpringTransactionalTest 
   @Test
   public void testOnAppStartupUpdateChemistrySetting() throws IOException {
 
-    when(mockSystemPropertyManager.findByName("chemistry.available"))
-        .thenReturn(new SystemPropertyValue(null, "ALLOWED"));
+    // 1. simulate chemistry properties being not configured
+    systemConfigurationInitialisor.setChemistryProvider("");
+    systemConfigurationInitialisor.setChemistryServiceUrl("");
 
-    //
-    systemConfigurationInitializor.setChemistryProvider("");
-    systemConfigurationInitializor.setChemistryServiceUrl("");
-    systemConfigurationInitializor.onAppStartup(null);
+    // if system setting is already 'DENIED' do nothing
+    when(mockSystemPropertyManager.findByName(SystemPropertyName.CHEMISTRY_AVAILABLE))
+        .thenReturn(
+            new SystemPropertyValue(
+                new SystemProperty(null), HierarchicalPermission.DENIED.name()));
+    systemConfigurationInitialisor.onAppStartup(null);
+    verify(mockSystemPropertyManager, Mockito.never())
+        .save(Mockito.any(), (HierarchicalPermission) Mockito.any(), Mockito.any());
 
-    //  verify(mockChemistryClient, Mockito.never()).save(Mockito.any(), Mockito.any());
+    // if system setting is 'ALLOWED', update to 'DENIED'
+    when(mockSystemPropertyManager.findByName(SystemPropertyName.CHEMISTRY_AVAILABLE))
+        .thenReturn(
+            new SystemPropertyValue(
+                new SystemProperty(null), HierarchicalPermission.ALLOWED.name()));
+    systemConfigurationInitialisor.onAppStartup(null);
+    verify(mockSystemPropertyManager, Mockito.times(1))
+        .save(Mockito.any(), (HierarchicalPermission) Mockito.any(), Mockito.any());
+
+    // 2. simulate chemistry properties being configured
+    systemConfigurationInitialisor.setChemistryProvider("indigo");
+    systemConfigurationInitialisor.setChemistryServiceUrl("http://indigoService:8090");
+
+    // system setting is 'ALLOWED' and properties are configured - do nothing
+    when(mockSystemPropertyManager.findByName(SystemPropertyName.CHEMISTRY_AVAILABLE))
+        .thenReturn(
+            new SystemPropertyValue(
+                new SystemProperty(null), HierarchicalPermission.ALLOWED.name()));
+    systemConfigurationInitialisor.onAppStartup(null);
+    verify(mockSystemPropertyManager, Mockito.times(1))
+        .save(Mockito.any(), (HierarchicalPermission) Mockito.any(), Mockito.any());
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/GroupControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/GroupControllerMVCIT.java
@@ -37,6 +37,7 @@ import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.testutils.TestGroup;
 import java.util.List;
 import java.util.Map;
@@ -851,8 +852,7 @@ public class GroupControllerMVCIT extends MVCTestBase {
   }
 
   private void enablePiEditAll(User sysadmin) {
-    SystemPropertyValue val =
-        sysPropMgr.findByName(Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP.toString().toLowerCase());
+    SystemPropertyValue val = sysPropMgr.findByName(Preference.PI_CAN_EDIT_ALL_WORK_IN_LABGROUP);
     val.setValue(HierarchicalPermission.ALLOWED.name());
     sysPropMgr.save(val, sysadmin);
   }
@@ -1029,14 +1029,20 @@ public class GroupControllerMVCIT extends MVCTestBase {
     User pi = group.getOwner();
 
     logoutAndLoginAs(getSysAdminUser(), SYS_ADMIN_PWD);
-    sysPropMgr.save("group_autosharing.available", "DENIED", getSysAdminUser());
+    sysPropMgr.save(
+        SystemPropertyName.GROUP_AUTOSHARING_AVAILABLE,
+        HierarchicalPermission.DENIED,
+        getSysAdminUser());
 
     // PIs and lab admins with view all can no longer change group-wide autoshare status
     requestAndAssertAutoshare(group, pi, true, false);
 
     // revert back, as the setting persists between test runs
     logoutAndLoginAs(getSysAdminUser(), SYS_ADMIN_PWD);
-    sysPropMgr.save("group_autosharing.available", "ALLOWED", getSysAdminUser());
+    sysPropMgr.save(
+        SystemPropertyName.GROUP_AUTOSHARING_AVAILABLE,
+        HierarchicalPermission.ALLOWED,
+        getSysAdminUser());
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/controller/RoRSysAdminControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/RoRSysAdminControllerMVCIT.java
@@ -1,6 +1,5 @@
 package com.researchspace.webapp.controller;
 
-import static com.researchspace.service.impl.RoRServiceManagerImpl.RORPROPERTYNAME;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -13,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.JsonNode;
 import com.researchspace.model.User;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.service.impl.ConditionalTestRunner;
 import com.researchspace.service.impl.RunIfSystemPropertyDefined;
 import java.util.ArrayList;
@@ -55,7 +55,7 @@ public class RoRSysAdminControllerMVCIT extends MVCTestBase {
   @Before
   public void setup() throws Exception {
     super.setUp();
-    systemPropertyManager.save(RORPROPERTYNAME, "", getSysAdminUser());
+    systemPropertyManager.save(SystemPropertyName.RSPACE_ROR, "", getSysAdminUser());
   }
 
   @After

--- a/src/test/java/com/researchspace/webapp/controller/SystemAndDeploymentPropsControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/SystemAndDeploymentPropsControllerMVCIT.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import com.researchspace.model.preference.HierarchicalPermission;
+import com.researchspace.service.SystemPropertyName;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
@@ -17,8 +18,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.web.servlet.MvcResult;
 
 public class SystemAndDeploymentPropsControllerMVCIT extends MVCTestBase {
-
-  private static final String DROPBOX_AVAILABLE = "dropbox.available";
 
   @Value("${egnyte.client.id}")
   private String egnyteClientId;
@@ -43,7 +42,7 @@ public class SystemAndDeploymentPropsControllerMVCIT extends MVCTestBase {
     final int MIN_PROPERTY_COUNT = 7; // from rspac861
     assertTrue(data.keySet().size() >= MIN_PROPERTY_COUNT);
     // assert properties are merged from DB...
-    assertNotNull(data.get(DROPBOX_AVAILABLE));
+    assertNotNull(data.get(SystemPropertyName.DROPBOX_AVAILABLE.getPropertyName()));
     // .. and property files
     assertNotNull(data.get("baseURL"));
   }
@@ -53,7 +52,9 @@ public class SystemAndDeploymentPropsControllerMVCIT extends MVCTestBase {
     logoutAndLoginAsCommunityAdmin(); // can be anyone,
     MvcResult res =
         mockMvc
-            .perform(get("/deploymentproperties/ajax/property").param("name", DROPBOX_AVAILABLE))
+            .perform(
+                get("/deploymentproperties/ajax/property")
+                    .param("name", SystemPropertyName.DROPBOX_AVAILABLE.getPropertyName()))
             .andReturn();
     String result = res.getResponse().getContentAsString();
     HierarchicalPermission.valueOf(result);

--- a/src/test/java/com/researchspace/webapp/controller/UserProfileControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/UserProfileControllerMVCIT.java
@@ -45,12 +45,14 @@ import com.researchspace.model.events.UserAccountEvent;
 import com.researchspace.model.field.ErrorList;
 import com.researchspace.model.frontend.OAuthAppInfo;
 import com.researchspace.model.frontend.PublicOAuthApps;
+import com.researchspace.model.preference.HierarchicalPermission;
 import com.researchspace.model.preference.Preference;
 import com.researchspace.model.preference.PreferenceCategory;
 import com.researchspace.model.preference.SettingsType;
 import com.researchspace.model.record.Folder;
 import com.researchspace.service.GroupManager;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.service.UserProfileManager;
 import com.researchspace.testutils.RSpaceTestUtils;
 import com.researchspace.testutils.TestGroup;
@@ -906,7 +908,10 @@ public class UserProfileControllerMVCIT extends MVCTestBase {
     User targetMember = tg.u1();
 
     logoutAndLoginAs(getSysAdminUser(), SYS_ADMIN_PWD);
-    systemPropertyManager.save("group_autosharing.available", "DENIED", getSysAdminUser());
+    systemPropertyManager.save(
+        SystemPropertyName.GROUP_AUTOSHARING_AVAILABLE,
+        HierarchicalPermission.DENIED,
+        getSysAdminUser());
 
     // PIs and lab admins with view all can no longer change the autoshare status for their non-pi
     // members
@@ -917,7 +922,10 @@ public class UserProfileControllerMVCIT extends MVCTestBase {
 
     // revert back, as the setting persists between test runs
     logoutAndLoginAs(getSysAdminUser(), SYS_ADMIN_PWD);
-    systemPropertyManager.save("group_autosharing.available", "ALLOWED", getSysAdminUser());
+    systemPropertyManager.save(
+        SystemPropertyName.GROUP_AUTOSHARING_AVAILABLE,
+        HierarchicalPermission.ALLOWED,
+        getSysAdminUser());
   }
 
   // Attempt to set individual autoshare status for the targetUser as subject
@@ -999,11 +1007,17 @@ public class UserProfileControllerMVCIT extends MVCTestBase {
   }
 
   private void allowPublicLastLogin() {
-    systemPropertyManager.save("publicLastLogin.available", "ALLOWED", getSysAdminUser());
+    systemPropertyManager.save(
+        SystemPropertyName.PUBLIC_LAST_LOGIN_AVAILABLE,
+        HierarchicalPermission.ALLOWED,
+        getSysAdminUser());
   }
 
   private void denyPublicLastLogin() {
-    systemPropertyManager.save("publicLastLogin.available", "DENIED", getSysAdminUser());
+    systemPropertyManager.save(
+        SystemPropertyName.PUBLIC_LAST_LOGIN_AVAILABLE,
+        HierarchicalPermission.DENIED,
+        getSysAdminUser());
   }
 
   private MvcResult getMiniProfile(User profileUser) throws Exception {

--- a/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
@@ -25,6 +25,7 @@ import com.researchspace.model.audit.AuditedRecord;
 import com.researchspace.model.audittrail.AuditTrailService;
 import com.researchspace.model.dtos.FormMenu;
 import com.researchspace.model.dtos.WorkspaceSettings;
+import com.researchspace.model.preference.HierarchicalPermission;
 import com.researchspace.model.preference.Preference;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.DetailedRecordInformation;
@@ -44,6 +45,7 @@ import com.researchspace.service.RecordDeletionManager;
 import com.researchspace.service.RecordFavoritesManager;
 import com.researchspace.service.RecordManager;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.service.UserManager;
 import com.researchspace.service.impl.CustomFormAppInitialiser;
 import com.researchspace.service.impl.RecordDeletionManagerImpl.DeletionSettings;
@@ -149,10 +151,12 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
   private void setupSystemPropertyForPublishAllowedAndSeoAllowed() {
     sysadmin1 = workspaceController.getUserByUsername("sysadmin1");
-    existingPublicSharingValue = systemPropertyManager.findByName("public_sharing");
-    existingPublicSharingValue.setValue("ALLOWED");
-    existingPublicSeoValue = systemPropertyManager.findByName("publicdocs_allow_seo");
-    existingPublicSeoValue.setValue("ALLOWED");
+    existingPublicSharingValue =
+        systemPropertyManager.findByName(SystemPropertyName.PUBLIC_SHARING);
+    existingPublicSharingValue.setValue(HierarchicalPermission.ALLOWED.name());
+    existingPublicSeoValue =
+        systemPropertyManager.findByName(SystemPropertyName.PUBLICDOCS_ALLOW_SEO);
+    existingPublicSeoValue.setValue(HierarchicalPermission.ALLOWED.name());
     systemPropertyManager.save(existingPublicSharingValue, sysadmin1);
     systemPropertyManager.save(existingPublicSeoValue, sysadmin1);
   }

--- a/src/test/java/com/researchspace/webapp/integrations/orcid/OrcidControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/orcid/OrcidControllerTest.java
@@ -6,9 +6,11 @@ import static org.junit.Assert.assertTrue;
 
 import com.researchspace.model.User;
 import com.researchspace.model.dto.IntegrationInfo;
+import com.researchspace.model.preference.HierarchicalPermission;
 import com.researchspace.repository.spi.IdentifierScheme;
 import com.researchspace.service.IntegrationsHandler;
 import com.researchspace.service.SystemPropertyManager;
+import com.researchspace.service.SystemPropertyName;
 import com.researchspace.service.UserExternalIdResolver;
 import com.researchspace.testutils.RSpaceTestUtils;
 import com.researchspace.testutils.SpringTransactionalTest;
@@ -28,7 +30,8 @@ public class OrcidControllerTest extends SpringTransactionalTest {
   public void setUp() throws Exception {
     super.setUp();
     User sysadmin = logoutAndLoginAsSysAdmin();
-    systemPropertyManager.save("orcid.available", "ALLOWED", sysadmin);
+    systemPropertyManager.save(
+        SystemPropertyName.ORCID_AVAILABLE, HierarchicalPermission.ALLOWED, sysadmin);
     RSpaceTestUtils.logout();
   }
 

--- a/src/test/java/com/researchspace/webapp/integrations/snapgene/DNAViewerControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/snapgene/DNAViewerControllerTest.java
@@ -6,7 +6,7 @@ import static com.researchspace.model.preference.HierarchicalPermission.ALLOWED;
 import static com.researchspace.model.preference.HierarchicalPermission.DENIED;
 import static com.researchspace.model.preference.HierarchicalPermission.DENIED_BY_DEFAULT;
 import static com.researchspace.model.record.TestFactory.createAFileProperty;
-import static com.researchspace.webapp.controller.DeploymentPropertiesController.SNAPGENE_AVAILABLE;
+import static com.researchspace.service.SystemPropertyName.SNAPGENE_AVAILABLE;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
The main functional change in this PR is adding `SystemConfigurationInitialisor` class (and test), which runs on RSpace startup and checks if deployment properties connected to chemistry are configured. If these are not configured, the initializor disables 'chemistry.available' system setting (visible on System -> Configuration -> Settings page). Disabling that setting means users will not be able to use chemistry features, which is what we want as the features won't work without proper configuratino - that's different from old chemaxon engine, where even misconfigured setup still allowed chemical calculations being run, as most of them was based on chemaxon libraries bundled within RSpace.

But then, when working on the PR, I've noticed that backend code that tries to read/update system settings does operate on string names of the properties (rather than strong-typing) and these string names are generally copied across the code. That does seem to be error-prone and not a great practise, so I've added an enum class `SystemPropertyName` that collects system settings used by back-end code, and I've added strong-typed `findByName` and `save` methods to `SystemPropertyManager`. 
There is a bit of extra complexity coming from the fact that some historical settings are hardcoded in `Preference` class, and some code does actually want to operate on weakly-typed setting names, but hopefully the PR is a step forward. The code also tries to use `HierarchicalPermission` enum rather than `ALLOWED`/`DENIED` string values.
