### PR TITLE
RSDEV-518 Add support for IGSNs to print action

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/ContextMenu/PrintBarcodeAction.js
+++ b/src/main/webapp/ui/src/Inventory/components/ContextMenu/PrintBarcodeAction.js
@@ -2,7 +2,6 @@
 
 import React, { type ComponentType, forwardRef, useState } from "react";
 import useStores from "../../../stores/use-stores";
-import { mkAlert } from "../../../stores/contexts/Alert";
 import ContextMenuAction, {
   type ContextMenuRenderOptions,
 } from "./ContextMenuAction";
@@ -24,9 +23,8 @@ const PrintBarcodeAction: ComponentType<PrintBarcodeActionArgs> = forwardRef(
     { as, closeMenu, disabled, selectedResults }: PrintBarcodeActionArgs,
     ref
   ) => {
-    const { uiStore, searchStore } = useStores();
+    const { searchStore } = useStores();
 
-    const [previewImages, setPreviewImages] = useState<Array<string>>([]);
     const [showPrintDialog, setShowPrintDialog] = useState(false);
 
     const disabledHelp = match<void, string>([
@@ -48,38 +46,8 @@ const PrintBarcodeAction: ComponentType<PrintBarcodeActionArgs> = forwardRef(
       [() => true, ""],
     ])();
 
-    const barcodes = selectedResults.map((r) => r.barcodes[0]);
-
-    // check for b as barcodes[0] is undefined in public view
-    const imgUrlsAvailable = barcodes.every((b) => b && b.imageUrl);
-
-    const getImageUrls = async (): Promise<Array<string> | void> => {
-      if (imgUrlsAvailable) {
-        const images = await Promise.all(barcodes.map((b) => b.fetchImage()));
-        const imageUrls = images.map((img) => URL.createObjectURL(img));
-        return imageUrls;
-      }
-    };
-
     const handleOpen = () => {
-      try {
-        void getImageUrls().then((imageUrls) => {
-          if (imageUrls && imageUrls.length > 0) {
-            setPreviewImages(imageUrls);
-          }
-        });
-      } catch (e) {
-        uiStore.addAlert(
-          mkAlert({
-            title: "Unable to retrieve barcode images.",
-            message: e.message || "",
-            variant: "error",
-            isInfinite: true,
-          })
-        );
-      } finally {
-        setShowPrintDialog(true);
-      }
+      setShowPrintDialog(true);
     };
 
     return (
@@ -98,7 +66,6 @@ const PrintBarcodeAction: ComponentType<PrintBarcodeActionArgs> = forwardRef(
                 showPrintDialog={showPrintDialog}
                 onClose={() => setShowPrintDialog(false)}
                 printType="contextMenu"
-                imageLinks={previewImages}
                 itemsToPrint={selectedResults}
                 closeMenu={closeMenu}
               />

--- a/src/main/webapp/ui/src/Inventory/components/ContextMenu/PrintBarcodeAction.js
+++ b/src/main/webapp/ui/src/Inventory/components/ContextMenu/PrintBarcodeAction.js
@@ -23,7 +23,7 @@ const PrintBarcodeAction: ComponentType<PrintBarcodeActionArgs> = forwardRef(
     { as, closeMenu, disabled, selectedResults }: PrintBarcodeActionArgs,
     ref
   ) => {
-    const { searchStore } = useStores();
+    const { searchStore, trackingStore } = useStores();
 
     const [showPrintDialog, setShowPrintDialog] = useState(false);
 
@@ -48,6 +48,7 @@ const PrintBarcodeAction: ComponentType<PrintBarcodeActionArgs> = forwardRef(
 
     const handleOpen = () => {
       setShowPrintDialog(true);
+      trackingStore.trackEvent("user:open:printDialog:inventoryContextMenu");
     };
 
     return (

--- a/src/main/webapp/ui/src/Inventory/components/ContextMenu/PrintBarcodeAction.js
+++ b/src/main/webapp/ui/src/Inventory/components/ContextMenu/PrintBarcodeAction.js
@@ -99,7 +99,7 @@ const PrintBarcodeAction: ComponentType<PrintBarcodeActionArgs> = forwardRef(
                 onClose={() => setShowPrintDialog(false)}
                 printType="contextMenu"
                 imageLinks={previewImages}
-                itemsToPrint={selectedResults.map((s) => [s.barcodes[0], s])}
+                itemsToPrint={selectedResults}
                 closeMenu={closeMenu}
               />
             )}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/FieldCard.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/FieldCard.js
@@ -39,7 +39,7 @@ import IconButtonWithTooltip from "../../../../components/IconButtonWithTooltip"
 import ImagePreview from "../../../../components/ImagePreview";
 import PreviewIcon from "@mui/icons-material/Visibility";
 import NoPreviewIcon from "@mui/icons-material/VisibilityOff";
-import PrintDialog from "../../Print/PrintDialog";
+import PrintDialog from "./PrintDialog";
 import PrintIcon from "@mui/icons-material/Print";
 import PrintDisabledIcon from "@mui/icons-material/PrintDisabled";
 import Grid from "@mui/material/Grid";

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintContents.js
@@ -1,0 +1,254 @@
+//@flow
+
+import React, { forwardRef, type ComponentType } from "react";
+import { type BarcodeRecord } from "../../../../stores/definitions/Barcode";
+import { type PrintOptions, type PrintType } from "./PrintDialog";
+import { makeStyles } from "tss-react/mui";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import { toTitleCase } from "../../../../util/Util";
+import clsx from "clsx";
+import { type InventoryRecord } from "../../../../stores/definitions/InventoryRecord";
+import ContainerModel from "../../../../stores/models/ContainerModel";
+import SubSampleModel from "../../../../stores/models/SubSampleModel";
+
+const itemPxWidths = {
+  small: "110px",
+  full: "220px",
+};
+
+const itemMmWidths = {
+  small: "19mm",
+  large: "38mm",
+};
+
+const useStyles = makeStyles()((theme) => ({
+  // display mode of wrapper classes necessary for page breaks behaviour to work
+  contentsWrapper: {
+    // grid (not block) if generic printer
+    margin: theme.spacing(0),
+  },
+  block: {
+    display: "block",
+  }, // for Zebra printing (no grid with page breaks)
+  printItemWrapper: {
+    display: "inline-block",
+    border: "1px dotted #ccc",
+    margin: theme.spacing(0.25),
+    "@media print": {
+      pageBreakInside: "avoid",
+      img: { breakInside: "avoid" },
+    },
+  },
+  /* for screen mode */
+  smallPx: {
+    width: itemPxWidths.small,
+    maxWidth: itemPxWidths.small,
+    padding: theme.spacing(0.25),
+  },
+  largePx: {
+    width: itemPxWidths.full,
+    maxWidth: itemPxWidths.full,
+    padding: theme.spacing(0.25),
+  },
+  /* for grid/generic mode */
+  smallMm: {
+    width: itemMmWidths.small,
+    maxWidth: itemMmWidths.small,
+    padding: theme.spacing(0.25),
+  },
+  largeMm: {
+    width: itemMmWidths.large,
+    maxWidth: itemMmWidths.large,
+    padding: theme.spacing(0.5),
+  },
+  /* for single/zebra mode */
+  singlePc: {
+    width: "90%",
+    maxWidth: "90%",
+    padding: theme.spacing(0.25),
+  },
+  bottomSpaced: {
+    marginBottom: theme.spacing(0),
+  },
+  centeredSelf: {
+    alignSelf: "center",
+    marginTop: theme.spacing(0.25),
+  },
+  centeredText: {
+    textAlign: "center",
+  },
+  wrappingText: {
+    // "break-word" deprecated but seems to help safari 16 on mac
+    wordBreak: "break-word",
+  },
+  smallText: { fontSize: "11px" },
+  pageBreak: {
+    "@media print": {
+      breakAfter: "always",
+      // on basic layout, singlePrint doesn't page-break without the following
+      pageBreakAfter: "always",
+    },
+  },
+}));
+
+type Target = "screen" | "multiplePrint" | "singlePrint";
+
+type PrintContentsArgs = {|
+  printOptions: PrintOptions,
+  printType: PrintType,
+  itemsToPrint: Array<[BarcodeRecord, InventoryRecord]>, // LoM ...
+  imageLinks?: Array<string>,
+  target: Target,
+|};
+
+type PreviewPrintItemArgs = {|
+  index: number,
+  printOptions: PrintOptions,
+  printType: PrintType,
+  item: BarcodeRecord, // LoM ...
+  itemOwner: InventoryRecord,
+  imageLinks?: Array<string>,
+  forPrint?: boolean, // false for screen preview
+  target: Target,
+|};
+
+export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
+  index,
+  printOptions,
+  printType,
+  item,
+  itemOwner,
+  imageLinks,
+  target,
+}) => {
+  const isBarcodePrint = ["contextMenu", "barcodeLabel"].includes(printType);
+  const { printerType, printLayout, printSize } = printOptions;
+
+  const recordString = `${toTitleCase(itemOwner.type)} - ${itemOwner.name}`;
+
+  const now = new Date();
+
+  const { classes } = useStyles();
+  const sizePerTarget = () =>
+    target === "screen" && printSize === "SMALL"
+      ? classes.smallPx
+      : target === "screen" && printSize === "LARGE"
+      ? classes.largePx
+      : target === "multiplePrint" && printSize === "SMALL"
+      ? classes.smallMm
+      : target === "multiplePrint" && printSize === "LARGE"
+      ? classes.largeMm
+      : classes.singlePc; // no small and large for singlePrint case
+  return (
+    isBarcodePrint && (
+      <>
+        <div className={clsx(classes.printItemWrapper, sizePerTarget())}>
+          <Grid
+            container
+            direction="column"
+            spacing={1}
+            className={classes.wrappingText}
+          >
+            {imageLinks && (
+              <>
+                <img
+                  className={classes.centeredSelf}
+                  src={imageLinks[index]}
+                  title="Barcode Image"
+                  width="75%"
+                />
+                <Grid
+                  item
+                  className={clsx(classes.centeredText, classes.bottomSpaced)}
+                >
+                  {target === "singlePrint" ? (
+                    itemOwner.globalId
+                  ) : (
+                    <Typography variant={"h6"}>{itemOwner.globalId}</Typography>
+                  )}
+                </Grid>
+              </>
+            )}
+            {printLayout === "FULL" && (
+              <Grid item>
+                <Grid
+                  container
+                  direction="column"
+                  spacing={1}
+                  className={clsx(classes.centeredText, classes.smallText)}
+                >
+                  <Grid item>{item.description.split("//")[1]}</Grid>
+                  <Grid item>
+                    <strong>Item:</strong>
+                    <br />
+                    {recordString}
+                  </Grid>
+                  <Grid item>
+                    <strong>Location:</strong>{" "}
+                    {itemOwner instanceof ContainerModel ||
+                    itemOwner instanceof SubSampleModel
+                      ? itemOwner.immediateParentContainer?.globalId || "-"
+                      : "-"}
+                  </Grid>
+                  <Grid item>
+                    <strong>Created:</strong>
+                    <br />
+                    {now.toLocaleString()}
+                  </Grid>
+                </Grid>
+              </Grid>
+            )}
+          </Grid>
+        </div>
+        {/* force page break after item (when wrapper in display block) */}
+        {printerType === "LABEL" && <div className={classes.pageBreak}></div>}
+      </>
+    )
+  );
+};
+
+const PrintContents: ComponentType<PrintContentsArgs> = forwardRef(
+  (
+    {
+      printOptions,
+      printType,
+      itemsToPrint,
+      imageLinks,
+      target,
+    }: PrintContentsArgs,
+    ref
+  ) => {
+    const { classes } = useStyles();
+    return (
+      <Grid
+        ref={ref}
+        container
+        spacing={1}
+        className={clsx(
+          classes.contentsWrapper,
+          // using display block to insert page breaks for label printers
+          printOptions.printerType === "LABEL" && classes.block
+        )}
+      >
+        {itemsToPrint.map(([item, itemOwner], i) => (
+          <Grid item key={i}>
+            <PreviewPrintItem
+              index={i}
+              printOptions={printOptions}
+              printType={printType}
+              item={item}
+              itemOwner={itemOwner}
+              imageLinks={imageLinks}
+              target={target}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    );
+  }
+);
+
+PrintContents.displayName = "PrintContents";
+export default PrintContents;
+

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintContents.js
@@ -193,7 +193,7 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                       : "-"}
                   </Grid>
                   <Grid item>
-                    <strong>Created:</strong>
+                    <strong>Printed:</strong>
                     <br />
                     {now.toLocaleString()}
                   </Grid>

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintContents.js
@@ -188,8 +188,7 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                     <strong>Location:</strong>{" "}
                     {itemOwner instanceof ContainerModel ||
                     itemOwner instanceof SubSampleModel
-                      ? `${window.location.origin}${itemOwner.immediateParentContainer?.permalinkURL}` ||
-                        "-"
+                      ? itemOwner.immediateParentContainer?.globalId ?? "-"
                       : "-"}
                   </Grid>
                   <Grid item>

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintContents.js
@@ -188,7 +188,8 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                     <strong>Location:</strong>{" "}
                     {itemOwner instanceof ContainerModel ||
                     itemOwner instanceof SubSampleModel
-                      ? itemOwner.immediateParentContainer?.globalId || "-"
+                      ? `${window.location.origin}${itemOwner.immediateParentContainer?.permalinkURL}` ||
+                        "-"
                       : "-"}
                   </Grid>
                   <Grid item>
@@ -251,4 +252,3 @@ const PrintContents: ComponentType<PrintContentsArgs> = forwardRef(
 
 PrintContents.displayName = "PrintContents";
 export default PrintContents;
-

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintDialog.js
@@ -1,0 +1,363 @@
+//@flow
+
+import React, { useState, useRef, type Node, type ComponentType } from "react";
+import { observer } from "mobx-react-lite";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import ContextDialog from "../../ContextMenu/ContextDialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import FormControl from "@mui/material/FormControl";
+import FormLabel from "@mui/material/FormLabel";
+import RadioField, {
+  type RadioOption,
+} from "../../../../components/Inputs/RadioField";
+import Typography from "@mui/material/Typography";
+import { makeStyles } from "tss-react/mui";
+import useStores from "../../../../stores/use-stores";
+import { type InventoryRecord } from "../../../../stores/definitions/InventoryRecord";
+import Alert from "@mui/material/Alert";
+import { type BarcodeRecord } from "../../../../stores/definitions/Barcode";
+import PrintContents, { PreviewPrintItem } from "../../Print/PrintContents";
+import ReactToPrint from "react-to-print";
+import docLinks from "../../../../assets/DocLinks";
+import clsx from "clsx";
+import { mkAlert } from "../../../../stores/contexts/Alert";
+import { useIsSingleColumnLayout } from "../../Layout/Layout2x1";
+import { type PrintOptions } from "../../Print/PrintDialog";
+
+const useStyles = makeStyles()((theme) => ({
+  optionModuleWrapper: {
+    border: `1px solid ${theme.palette.sidebar.selected.bg}`,
+    borderRadius: theme.spacing(0.5),
+    padding: theme.spacing(1),
+    marginBottom: theme.spacing(2),
+  },
+  rowWrapper: {
+    display: "flex",
+    flexDirection: "row",
+    width: "100%",
+    justifyContent: "space-between",
+  },
+  columnWrapper: {
+    display: "flex",
+    flexDirection: "column-reverse",
+    alignItems: "center",
+    width: "100%",
+  },
+  fullWidth: { width: "100%" },
+  halfWidth: { width: "50%" },
+  previewWrapper: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    margin: theme.spacing(0.5),
+  },
+  centered: {
+    textAlign: "center",
+    marginBottom: theme.spacing(1),
+  },
+  topSpaced: { marginTop: theme.spacing(1) },
+  hidden: { display: "none" },
+}));
+
+export type PrinterType = "GENERIC" | "LABEL";
+export type PrintLayout = "BASIC" | "FULL";
+export type PrintSize = "SMALL" | "LARGE";
+
+/**
+ * PrintDialog is intended to be used - in the future - for more than barcodes
+ * itemsToPrint are connected to printType
+ * last 2 print types are probably going to be implemented later
+ */
+
+export type PrintType =
+  | "barcodeLabel"
+  | "contextMenu"
+  | "recordDetails"
+  | "listOfMaterials";
+
+type PrintDialogArgs = {|
+  showPrintDialog: boolean,
+  onClose: () => void,
+  imageLinks: Array<string>,
+  printType: PrintType,
+  itemsToPrint: Array<[BarcodeRecord, InventoryRecord]>, // LoM ...
+  printerType?: PrinterType,
+  printSize?: PrintSize,
+  /* n/a for non-contextMenu cases */
+  closeMenu?: () => void,
+|};
+
+type OptionsWrapperArgs = {|
+  printOptions: PrintOptions,
+  setPrintOptions: (PrintOptions) => void,
+  printType: PrintType,
+|};
+
+export const PrintOptionsWrapper = ({
+  printOptions,
+  setPrintOptions,
+}: OptionsWrapperArgs): Node => {
+  const isSingleColumnLayout = useIsSingleColumnLayout();
+  const { classes } = useStyles();
+
+  const printerTypeOptions: Array<RadioOption<PrinterType>> = [
+    { value: "GENERIC", label: "Standard Printer" },
+    { value: "LABEL", label: "Label Printer" },
+  ];
+
+  const printLayoutOptions: Array<RadioOption<PrintLayout>> = [
+    { value: "FULL", label: "Full" },
+    { value: "BASIC", label: "Basic" },
+  ];
+
+  const printSizeOptions: Array<RadioOption<PrintSize>> = [
+    { value: "LARGE", label: "Large" },
+    { value: "SMALL", label: "Small" },
+  ];
+
+  return (
+    <FormControl
+      component="fieldset"
+      className={isSingleColumnLayout ? classes.fullWidth : classes.halfWidth}
+    >
+      <Box className={classes.optionModuleWrapper}>
+        <FormLabel id="printer-type-radiogroup-label">Printer Type</FormLabel>
+        <RadioField
+          name={"Printer Type Options"}
+          value={printOptions.printerType}
+          onChange={({ target }) => {
+            if (target.value)
+              setPrintOptions({
+                ...printOptions,
+                printerType: target.value,
+              });
+          }}
+          options={printerTypeOptions}
+          disabled={false}
+          labelPlacement="bottom"
+          row
+          smallText={true}
+        />
+        {printOptions.printerType === "GENERIC" ? (
+          <Alert severity="info">
+            Print multiple labels per sheet (e.g. A4 / A3 / Letter).
+          </Alert>
+        ) : (
+          <Alert severity="info">
+            Print one label per sticker (Zebra printer).
+          </Alert>
+        )}
+      </Box>
+      <Box className={classes.optionModuleWrapper}>
+        <FormLabel id="print-layout-radiogroup-label">Print Layout</FormLabel>
+        <RadioField
+          name={"Print Layout Options"}
+          value={printOptions.printLayout}
+          onChange={({ target }) => {
+            if (target.value)
+              setPrintOptions({
+                ...printOptions,
+                printLayout: target.value,
+              });
+          }}
+          options={printLayoutOptions}
+          disabled={false}
+          labelPlacement="bottom"
+          row
+          smallText={true}
+        />
+        <Alert severity="info">
+          {printOptions.printLayout === "FULL"
+            ? `Barcode and record details${
+                printOptions.printerType === "LABEL"
+                  ? " (rectangular label required)."
+                  : "."
+              }`
+            : `Barcode and global ID${
+                printOptions.printerType === "LABEL"
+                  ? " (square or rectangular label)."
+                  : "."
+              }`}
+        </Alert>
+        {printOptions.printerType === "LABEL" && (
+          <Alert severity="info" className={classes.topSpaced}>
+            The label shape should match the selected layout. Also, you might
+            have problems when using Safari. Please check barcodes{" "}
+            <a
+              href={docLinks.barcodesPrinting}
+              target="_blank"
+              rel="noreferrer"
+            >
+              documentation
+            </a>
+            .
+          </Alert>
+        )}
+      </Box>
+      <Box className={classes.optionModuleWrapper}>
+        <FormLabel id="print-size-radiogroup-label">Print Size</FormLabel>
+        {printOptions.printerType === "GENERIC" && (
+          <RadioField
+            name={"Print Size Options"}
+            value={printOptions.printSize}
+            onChange={({ target }) => {
+              if (target.value)
+                setPrintOptions({
+                  ...printOptions,
+                  printSize: target.value,
+                });
+            }}
+            options={printSizeOptions}
+            disabled={false}
+            labelPlacement="bottom"
+            row
+            smallText={true}
+          />
+        )}
+        <Alert severity="info">
+          {printOptions.printerType === "LABEL"
+            ? "For label printers size is set automatically (to match a range of label sizes)."
+            : printOptions.printSize === "LARGE"
+            ? "Full width (4cm)."
+            : "Half width (2cm)."}
+        </Alert>
+      </Box>
+    </FormControl>
+  );
+};
+
+function PrintDialog({
+  showPrintDialog,
+  onClose,
+  imageLinks,
+  printType,
+  itemsToPrint,
+  printerType,
+  printSize,
+  closeMenu,
+}: PrintDialogArgs): Node {
+  const { classes } = useStyles();
+  const { uiStore } = useStores();
+  const isSingleColumnLayout = useIsSingleColumnLayout();
+  const componentToPrint = useRef<mixed>();
+  const barcodePrint = ["contextMenu", "barcodeLabel"].includes(printType);
+
+  const [item, itemOwner] = itemsToPrint[0];
+
+  const [printOptions, setPrintOptions] = useState<PrintOptions>({
+    printerType: printerType ?? "GENERIC",
+    printLayout: "FULL",
+    printSize: printSize ?? "LARGE",
+  });
+
+  const handleClose = () => {
+    onClose();
+    if (typeof closeMenu === "function") closeMenu();
+  };
+
+  const HelperText = () => (
+    <>
+      <Typography variant="body2" className={classes.centered}>
+        <strong>
+          Preview
+          {barcodePrint ? `: Barcode Label Layout` : ""}
+        </strong>
+      </Typography>
+    </>
+  );
+
+  return (
+    <ContextDialog
+      open={showPrintDialog}
+      onClose={handleClose}
+      fullWidth
+      maxWidth="lg"
+    >
+      <DialogTitle>Print Options</DialogTitle>
+      <DialogContent>
+        <Box
+          className={
+            isSingleColumnLayout ? classes.columnWrapper : classes.rowWrapper
+          }
+        >
+          <PrintOptionsWrapper
+            printOptions={printOptions}
+            setPrintOptions={setPrintOptions}
+            printType={printType}
+          />
+          <div
+            className={clsx(
+              classes.previewWrapper,
+              isSingleColumnLayout ? classes.fullWidth : classes.halfWidth
+            )}
+          >
+            <HelperText />
+            {/* we preview only one item, resulting from choice of print options */}
+            <PreviewPrintItem
+              index={0}
+              printOptions={printOptions}
+              printType={printType}
+              item={item}
+              itemOwner={itemOwner}
+              imageLinks={imageLinks}
+              target="screen"
+            />
+          </div>
+          {/* we need the whole component for ReactToPrint, but not visible here */}
+          <div className={classes.hidden}>
+            <PrintContents
+              ref={componentToPrint}
+              printOptions={printOptions}
+              printType={printType}
+              itemsToPrint={itemsToPrint}
+              imageLinks={imageLinks}
+              target={
+                printOptions.printerType === "GENERIC"
+                  ? "multiplePrint"
+                  : "singlePrint"
+              }
+            />
+          </div>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={false}>
+          Cancel
+        </Button>
+        <ReactToPrint
+          trigger={() => (
+            <Button
+              // do not add an onClick, it would be overwritten
+              color="primary"
+              variant="contained"
+              disableElevation
+              disabled={false}
+            >
+              {`Print selected (${itemsToPrint.length})`}
+            </Button>
+          )}
+          content={() => componentToPrint.current}
+          onAfterPrint={() => {
+            handleClose();
+          }}
+          onPrintError={(e) => {
+            uiStore.addAlert(
+              mkAlert({
+                title: "Print error.",
+                message: e.message || "",
+                variant: "error",
+                isInfinite: true,
+              })
+            );
+          }}
+        />
+      </DialogActions>
+    </ContextDialog>
+  );
+}
+
+export default (observer(PrintDialog): ComponentType<PrintDialogArgs>);
+

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintDialog.js
@@ -19,13 +19,12 @@ import useStores from "../../../../stores/use-stores";
 import { type InventoryRecord } from "../../../../stores/definitions/InventoryRecord";
 import Alert from "@mui/material/Alert";
 import { type BarcodeRecord } from "../../../../stores/definitions/Barcode";
-import PrintContents, { PreviewPrintItem } from "../../Print/PrintContents";
+import PrintContents, { PreviewPrintItem } from "./PrintContents";
 import ReactToPrint from "react-to-print";
 import docLinks from "../../../../assets/DocLinks";
 import clsx from "clsx";
 import { mkAlert } from "../../../../stores/contexts/Alert";
 import { useIsSingleColumnLayout } from "../../Layout/Layout2x1";
-import { type PrintOptions } from "../../Print/PrintDialog";
 
 const useStyles = makeStyles()((theme) => ({
   optionModuleWrapper: {
@@ -65,6 +64,13 @@ const useStyles = makeStyles()((theme) => ({
 export type PrinterType = "GENERIC" | "LABEL";
 export type PrintLayout = "BASIC" | "FULL";
 export type PrintSize = "SMALL" | "LARGE";
+
+export type PrintOptions = {
+  printerType: PrinterType,
+  printLayout: PrintLayout,
+  printSize: PrintSize,
+};
+
 
 /**
  * PrintDialog is intended to be used - in the future - for more than barcodes

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Barcodes/PrintDialog.js
@@ -10,9 +10,6 @@ import ContextDialog from "../../ContextMenu/ContextDialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
-import RadioField, {
-  type RadioOption,
-} from "../../../../components/Inputs/RadioField";
 import Typography from "@mui/material/Typography";
 import { makeStyles } from "tss-react/mui";
 import useStores from "../../../../stores/use-stores";
@@ -25,14 +22,12 @@ import docLinks from "../../../../assets/DocLinks";
 import clsx from "clsx";
 import { mkAlert } from "../../../../stores/contexts/Alert";
 import { useIsSingleColumnLayout } from "../../Layout/Layout2x1";
+import RadioGroup from "@mui/material/RadioGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Radio from "@mui/material/Radio";
+import Stack from "@mui/material/Stack";
 
 const useStyles = makeStyles()((theme) => ({
-  optionModuleWrapper: {
-    border: `1px solid ${theme.palette.sidebar.selected.bg}`,
-    borderRadius: theme.spacing(0.5),
-    padding: theme.spacing(1),
-    marginBottom: theme.spacing(2),
-  },
   rowWrapper: {
     display: "flex",
     flexDirection: "row",
@@ -71,7 +66,6 @@ export type PrintOptions = {
   printSize: PrintSize,
 };
 
-
 /**
  * PrintDialog is intended to be used - in the future - for more than barcodes
  * itemsToPrint are connected to printType
@@ -109,128 +103,123 @@ export const PrintOptionsWrapper = ({
   const isSingleColumnLayout = useIsSingleColumnLayout();
   const { classes } = useStyles();
 
-  const printerTypeOptions: Array<RadioOption<PrinterType>> = [
-    { value: "GENERIC", label: "Standard Printer" },
-    { value: "LABEL", label: "Label Printer" },
-  ];
-
-  const printLayoutOptions: Array<RadioOption<PrintLayout>> = [
-    { value: "FULL", label: "Full" },
-    { value: "BASIC", label: "Basic" },
-  ];
-
-  const printSizeOptions: Array<RadioOption<PrintSize>> = [
-    { value: "LARGE", label: "Large" },
-    { value: "SMALL", label: "Small" },
-  ];
-
   return (
     <FormControl
       component="fieldset"
       className={isSingleColumnLayout ? classes.fullWidth : classes.halfWidth}
     >
-      <Box className={classes.optionModuleWrapper}>
-        <FormLabel id="printer-type-radiogroup-label">Printer Type</FormLabel>
-        <RadioField
-          name={"Printer Type Options"}
-          value={printOptions.printerType}
-          onChange={({ target }) => {
-            if (target.value)
-              setPrintOptions({
-                ...printOptions,
-                printerType: target.value,
-              });
-          }}
-          options={printerTypeOptions}
-          disabled={false}
-          labelPlacement="bottom"
-          row
-          smallText={true}
-        />
-        {printOptions.printerType === "GENERIC" ? (
-          <Alert severity="info">
-            Print multiple labels per sheet (e.g. A4 / A3 / Letter).
-          </Alert>
-        ) : (
-          <Alert severity="info">
-            Print one label per sticker (Zebra printer).
-          </Alert>
-        )}
-      </Box>
-      <Box className={classes.optionModuleWrapper}>
-        <FormLabel id="print-layout-radiogroup-label">Print Layout</FormLabel>
-        <RadioField
-          name={"Print Layout Options"}
-          value={printOptions.printLayout}
-          onChange={({ target }) => {
-            if (target.value)
-              setPrintOptions({
-                ...printOptions,
-                printLayout: target.value,
-              });
-          }}
-          options={printLayoutOptions}
-          disabled={false}
-          labelPlacement="bottom"
-          row
-          smallText={true}
-        />
-        <Alert severity="info">
-          {printOptions.printLayout === "FULL"
-            ? `Barcode and record details${
-                printOptions.printerType === "LABEL"
-                  ? " (rectangular label required)."
-                  : "."
-              }`
-            : `Barcode and global ID${
-                printOptions.printerType === "LABEL"
-                  ? " (square or rectangular label)."
-                  : "."
-              }`}
-        </Alert>
-        {printOptions.printerType === "LABEL" && (
-          <Alert severity="info" className={classes.topSpaced}>
-            The label shape should match the selected layout. Also, you might
-            have problems when using Safari. Please check barcodes{" "}
-            <a
-              href={docLinks.barcodesPrinting}
-              target="_blank"
-              rel="noreferrer"
-            >
-              documentation
-            </a>
-            .
-          </Alert>
-        )}
-      </Box>
-      <Box className={classes.optionModuleWrapper}>
-        <FormLabel id="print-size-radiogroup-label">Print Size</FormLabel>
-        {printOptions.printerType === "GENERIC" && (
-          <RadioField
-            name={"Print Size Options"}
-            value={printOptions.printSize}
+      <Stack spacing={3}>
+        <FormControl>
+          <FormLabel id="printer-type-radiogroup-label">Printer Type</FormLabel>
+          <RadioGroup
+            aria-labelledby="printer-type-radiogroup-label"
+            value={printOptions.printerType}
             onChange={({ target }) => {
               if (target.value)
                 setPrintOptions({
                   ...printOptions,
-                  printSize: target.value,
+                  printerType: target.value,
                 });
             }}
-            options={printSizeOptions}
-            disabled={false}
-            labelPlacement="bottom"
             row
-            smallText={true}
-          />
-        )}
-        <Alert severity="info">
-          {printOptions.printerType === "LABEL"
-            ? "For label printers size is set automatically (to match a range of label sizes)."
-            : printOptions.printSize === "LARGE"
-            ? "Full width (4cm)."
-            : "Half width (2cm)."}
-        </Alert>
-      </Box>
+          >
+            <FormControlLabel
+              value="GENERIC"
+              control={<Radio size="small" />}
+              label="Standard Printer"
+            />
+            <FormControlLabel
+              value="LABEL"
+              control={<Radio size="small" />}
+              label="Label Printer"
+            />
+          </RadioGroup>
+          {printOptions.printerType === "GENERIC" ? (
+            <Alert severity="info">
+              Print multiple labels per sheet (e.g. A4 / A3 / Letter).
+            </Alert>
+          ) : (
+            <Alert severity="info">
+              Print one label per sticker (Zebra printer).
+            </Alert>
+          )}
+        </FormControl>
+        <FormControl>
+          <FormLabel id="print-layout-radiogroup-label">Print Layout</FormLabel>
+          <RadioGroup
+            aria-labelledby="print-layout-radiogroup-label"
+            value={printOptions.printLayout}
+            onChange={({ target }) => {
+              if (target.value)
+                setPrintOptions({
+                  ...printOptions,
+                  printLayout: target.value,
+                });
+            }}
+            row
+          >
+            <FormControlLabel
+              value="FULL"
+              control={<Radio size="small" />}
+              label="Full"
+            />
+            <FormControlLabel
+              value="BASIC"
+              control={<Radio size="small" />}
+              label="Basic"
+            />
+          </RadioGroup>
+          {printOptions.printerType === "LABEL" && (
+            <Alert severity="info" className={classes.topSpaced}>
+              The label shape should match the selected layout. Also, you might
+              have problems when using Safari. Please check barcodes{" "}
+              <a
+                href={docLinks.barcodesPrinting}
+                target="_blank"
+                rel="noreferrer"
+              >
+                documentation
+              </a>
+              .
+            </Alert>
+          )}
+        </FormControl>
+        <FormControl>
+          <FormLabel id="print-size-radiogroup-label">Print Size</FormLabel>
+          {printOptions.printerType === "GENERIC" && (
+            <RadioGroup
+              aria-labelledby="print-size-radiogroup-label"
+              value={printOptions.printSize}
+              onChange={({ target }) => {
+                if (target.value)
+                  setPrintOptions({
+                    ...printOptions,
+                    printSize: target.value,
+                  });
+              }}
+              row
+            >
+              <FormControlLabel
+                value="LARGE"
+                control={<Radio size="small" />}
+                label="Large"
+              />
+              <FormControlLabel
+                value="SMALL"
+                control={<Radio size="small" />}
+                label="Small"
+              />
+            </RadioGroup>
+          )}
+          <Alert severity="info">
+            {printOptions.printerType === "LABEL"
+              ? "For label printers size is set automatically (to match a range of label sizes)."
+              : printOptions.printSize === "LARGE"
+              ? "Full width (4cm)."
+              : "Half width (2cm)."}
+          </Alert>
+        </FormControl>
+      </Stack>
     </FormControl>
   );
 };
@@ -366,4 +355,3 @@ function PrintDialog({
 }
 
 export default (observer(PrintDialog): ComponentType<PrintDialogArgs>);
-

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -263,8 +263,7 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                       <strong>Location:</strong>{" "}
                       {itemOwner instanceof ContainerModel ||
                       itemOwner instanceof SubSampleModel
-                        ? `${window.location.origin}/globalId/${itemOwner.immediateParentContainer?.globalId}` ??
-                          "-"
+                        ? itemOwner.immediateParentContainer?.globalId ?? "-"
                         : "-"}
                     </Grid>
                     <Grid item>

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -299,7 +299,7 @@ const PrintContents: ComponentType<PrintContentsArgs> = forwardRef(
       >
         {itemsToPrint.map(([barcode, itemOwner], i) => (
           <>
-            <Grid item key={`${i}.1`}>
+            <Grid item key={`${i}.1`} sx={printOptions.printCopies === "2" && target === "multiplePrint" ? { width: "50vw" } : {}}>
               <PreviewPrintItem
                 index={i}
                 printOptions={printOptions}

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -92,6 +92,12 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
+/*
+ * "screen"        - for previewing print on screen
+ * "multiplePrint" - for printing multiple items in a grid for a
+ *                   regular printer
+ * "singlePrint"   - for printing single items for a zebra printer
+ */
 type Target = "screen" | "multiplePrint" | "singlePrint";
 
 type PrintContentsArgs = {|
@@ -137,17 +143,24 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
   const now = new Date();
 
   const { classes } = useStyles();
-  const sizePerTarget = () =>
-    target === "screen" && printSize === "SMALL"
-      ? classes.smallPx
-      : target === "screen" && printSize === "LARGE"
-      ? classes.largePx
-      : target === "multiplePrint" && printSize === "SMALL"
-      ? classes.smallMm
-      : target === "multiplePrint" && printSize === "LARGE"
-      ? classes.largeMm
-      : classes.singlePc; // no small and large for singlePrint case
-  if (printOptions.printIdentifierType === "IGSN" && !itemOwner.identifiers[0]) {
+
+  const sizeClass = () => {
+    if (target === "screen") {
+      if (printSize === "SMALL") return classes.smallPx;
+      if (printSize === "LARGE") return classes.largePx;
+    }
+    if (target === "multiplePrint") {
+      if (printSize === "SMALL") return classes.smallMm;
+      if (printSize === "LARGE") return classes.largeMm;
+    }
+    // else singlePrint
+    return classes.singlePc;
+  };
+
+  if (
+    printOptions.printIdentifierType === "IGSN" &&
+    !itemOwner.identifiers[0]
+  ) {
     return null;
   }
   const header =
@@ -157,7 +170,7 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
   return (
     isBarcodePrint && (
       <>
-        <div className={clsx(classes.printItemWrapper, sizePerTarget())}>
+        <div className={clsx(classes.printItemWrapper, sizeClass())}>
           <Grid
             container
             direction="column"

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -107,7 +107,13 @@ type PreviewPrintItemArgs = {|
   printOptions: PrintOptions,
   printType: PrintType,
   item: BarcodeRecord, // LoM ...
+
+  /*
+   * If `printOptions.printIdentifierType` is "IGSN", then `itemOwner` MUST
+   * have at least one identifier. Do not render this component if it does not.
+   */
   itemOwner: InventoryRecord,
+
   imageLinks?: Array<string>,
   forPrint?: boolean, // false for screen preview
   target: Target,
@@ -140,6 +146,10 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
       : target === "multiplePrint" && printSize === "LARGE"
       ? classes.largeMm
       : classes.singlePc; // no small and large for singlePrint case
+  const header =
+    printOptions.printIdentifierType === "GLOBAL ID"
+      ? itemOwner.globalId
+      : `IGSN ID: ${itemOwner.identifiers[0].doi}`;
   return (
     isBarcodePrint && (
       <>
@@ -163,9 +173,9 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                   className={clsx(classes.centeredText, classes.bottomSpaced)}
                 >
                   {target === "singlePrint" ? (
-                    itemOwner.globalId
+                    header
                   ) : (
-                    <Typography variant={"h6"}>{itemOwner.globalId}</Typography>
+                    <Typography variant={"h6"}>{header}</Typography>
                   )}
                 </Grid>
               </>

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -1,7 +1,6 @@
 //@flow
 
 import React, { forwardRef, type ComponentType } from "react";
-import { type BarcodeRecord } from "../../../stores/definitions/Barcode";
 import { type PrintOptions, type PrintType } from "./PrintDialog";
 import { makeStyles } from "tss-react/mui";
 import Grid from "@mui/material/Grid";
@@ -112,7 +111,7 @@ type Target = "screen" | "multiplePrint" | "singlePrint";
 type PrintContentsArgs = {|
   printOptions: PrintOptions,
   printType: PrintType,
-  itemsToPrint: $ReadOnlyArray<[BarcodeRecord, InventoryRecord]>, // LoM ...
+  itemsToPrint: $ReadOnlyArray<InventoryRecord>,
   imageLinks?: $ReadOnlyArray<string>,
   target: Target,
 |};
@@ -121,7 +120,6 @@ type PreviewPrintItemArgs = {|
   index: number,
   printOptions: PrintOptions,
   printType: PrintType,
-  barcode: BarcodeRecord, // LoM ...
 
   /*
    * If `printOptions.printIdentifierType` is "IGSN", then `itemOwner` SHOULD
@@ -139,7 +137,6 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
   index,
   printOptions,
   printType,
-  barcode,
   itemOwner,
   imageLinks,
   target,
@@ -181,25 +178,31 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
     return null;
   }
   const header =
-    printOptions.printIdentifierType === "GLOBAL ID"
-      ? (
-        <>
-          <strong style={{
+    printOptions.printIdentifierType === "GLOBAL ID" ? (
+      <>
+        <strong
+          style={{
             fontSize: "0.8em",
-          }}>RSPACE GLOBAL ID</strong>
-          <br />
-          {itemOwner.globalId}
-        </>
-      )
-      : (
-        <>
-          <strong style={{
+          }}
+        >
+          RSPACE GLOBAL ID
+        </strong>
+        <br />
+        {itemOwner.globalId}
+      </>
+    ) : (
+      <>
+        <strong
+          style={{
             fontSize: "0.8em",
-          }}>IGSN</strong>
-          <br />
-          {itemOwner.identifiers[0].doi}
-        </>
-      );
+          }}
+        >
+          IGSN
+        </strong>
+        <br />
+        {itemOwner.identifiers[0].doi}
+      </>
+    );
   return (
     isBarcodePrint && (
       <>
@@ -232,21 +235,25 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                   p: 1,
                 }}
               >
-                <Grid
-                  item
-                  className={clsx(classes.bottomSpaced)}
-                >
+                <Grid item className={clsx(classes.bottomSpaced)}>
                   {target === "singlePrint" ? (
                     header
                   ) : (
-                    <Typography variant={"h6"} sx={{
-                      lineHeight: "1.1",
-                    }}>{header}</Typography>
+                    <Typography
+                      variant={"h6"}
+                      sx={{
+                        lineHeight: "1.1",
+                      }}
+                    >
+                      {header}
+                    </Typography>
                   )}
                 </Grid>
                 {printLayout === "FULL" && (
                   <>
-                    <Grid item>{`${window.location.origin}/globalId/${itemOwner.globalId ?? ""}`}</Grid>
+                    <Grid item>{`${window.location.origin}/globalId/${
+                      itemOwner.globalId ?? ""
+                    }`}</Grid>
                     <Grid item>
                       <strong>Item:</strong>{" "}
                       {printOptions.printCopies === "1" && <br />}
@@ -256,7 +263,7 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                       <strong>Location:</strong>{" "}
                       {itemOwner instanceof ContainerModel ||
                       itemOwner instanceof SubSampleModel
-                        ? `${window.location.origin}/globalId/${itemOwner.immediateParentContainer?.globalId}` ||
+                        ? `${window.location.origin}/globalId/${itemOwner.immediateParentContainer?.globalId}` ??
                           "-"
                         : "-"}
                     </Grid>
@@ -301,14 +308,21 @@ const PrintContents: ComponentType<PrintContentsArgs> = forwardRef(
           printOptions.printerType === "LABEL" && classes.block
         )}
       >
-        {itemsToPrint.map(([barcode, itemOwner], i) => (
+        {itemsToPrint.map((itemOwner, i) => (
           <>
-            <Grid item key={`${i}.1`} sx={printOptions.printCopies === "2" && target === "multiplePrint" ? { width: "50vw" } : {}}>
+            <Grid
+              item
+              key={`${i}.1`}
+              sx={
+                printOptions.printCopies === "2" && target === "multiplePrint"
+                  ? { width: "50vw" }
+                  : {}
+              }
+            >
               <PreviewPrintItem
                 index={i}
                 printOptions={printOptions}
                 printType={printType}
-                barcode={barcode}
                 itemOwner={itemOwner}
                 imageLinks={imageLinks}
                 target={target}
@@ -321,7 +335,6 @@ const PrintContents: ComponentType<PrintContentsArgs> = forwardRef(
                     index={i}
                     printOptions={printOptions}
                     printType={printType}
-                    barcode={barcode}
                     itemOwner={itemOwner}
                     imageLinks={imageLinks}
                     target={target}

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -59,11 +59,13 @@ const useStyles = makeStyles()((theme) => ({
   smallPxHorz: {
     height: itemPxHeight.small,
     maxHeight: itemPxHeight.small,
+    maxWidth: "47vw",
     padding: theme.spacing(0.25),
   },
   largePxHorz: {
     height: itemPxHeight.full,
     maxHeight: itemPxHeight.full,
+    maxWidth: "47vw",
     padding: theme.spacing(0.25),
   },
   /* for grid/generic mode */
@@ -80,11 +82,13 @@ const useStyles = makeStyles()((theme) => ({
   smallMmHorz: {
     height: itemMmSize.small,
     maxHeight: itemMmSize.small,
+    maxWidth: "47vw",
     padding: theme.spacing(0.25),
   },
   largeMmHorz: {
     height: itemMmSize.large,
     maxHeight: itemMmSize.large,
+    maxWidth: "47vw",
     padding: theme.spacing(0.5),
   },
   /* for single/zebra mode */
@@ -95,13 +99,6 @@ const useStyles = makeStyles()((theme) => ({
   },
   bottomSpaced: {
     marginBottom: theme.spacing(0),
-  },
-  centeredSelf: {
-    alignSelf: "center",
-    marginTop: theme.spacing(0.25),
-  },
-  centeredText: {
-    textAlign: "center",
   },
   wrappingText: {
     // "break-word" deprecated but seems to help safari 16 on mac
@@ -198,8 +195,24 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
   }
   const header =
     printOptions.printIdentifierType === "GLOBAL ID"
-      ? itemOwner.globalId
-      : `IGSN ID: ${itemOwner.identifiers[0].doi}`;
+      ? (
+        <>
+          <strong style={{
+            fontSize: "0.8em",
+          }}>RSPACE GLOBAL ID</strong>
+          <br />
+          {itemOwner.globalId}
+        </>
+      )
+      : (
+        <>
+          <strong style={{
+            fontSize: "0.8em",
+          }}>IGSN</strong>
+          <br />
+          {itemOwner.identifiers[0].doi}
+        </>
+      );
   return (
     isBarcodePrint && (
       <>
@@ -208,18 +221,16 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
             container
             direction={printOptions.printCopies === "2" ? "row" : "column"}
             flexWrap="nowrap"
-            spacing={1}
             className={classes.wrappingText}
           >
             {imageLinks && (
               <Grid item>
                 <img
-                  className={classes.centeredSelf}
                   src={imageLinks[index]}
                   title="Barcode Image"
                   {...(printOptions.printCopies === "1"
                     ? { width: "75%" }
-                    : { height: "75%" })}
+                    : { height: "80%" })}
                 />
               </Grid>
             )}
@@ -227,24 +238,30 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
               <Grid
                 container
                 direction="column"
-                spacing={1}
-                className={clsx(classes.centeredText, classes.smallText)}
+                spacing={0.5}
+                className={clsx(classes.smallText)}
+                sx={{
+                  lineHeight: "1.2",
+                  p: 1,
+                }}
               >
                 <Grid
                   item
-                  className={clsx(classes.centeredText, classes.bottomSpaced)}
+                  className={clsx(classes.bottomSpaced)}
                 >
                   {target === "singlePrint" ? (
                     header
                   ) : (
-                    <Typography variant={"h6"}>{header}</Typography>
+                    <Typography variant={"h6"} sx={{
+                      lineHeight: "1.1",
+                    }}>{header}</Typography>
                   )}
                 </Grid>
                 {printLayout === "FULL" && (
                   <>
-                    <Grid item>{barcode.description.split("//")[1]}</Grid>
+                    <Grid item>{`${window.location.origin}/globalId/${itemOwner.globalId ?? ""}`}</Grid>
                     <Grid item>
-                      <strong>Item:</strong>
+                      <strong>Item:</strong>{" "}
                       {printOptions.printCopies === "1" && <br />}
                       {recordString}
                     </Grid>
@@ -252,12 +269,12 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                       <strong>Location:</strong>{" "}
                       {itemOwner instanceof ContainerModel ||
                       itemOwner instanceof SubSampleModel
-                        ? `${window.location.origin}${itemOwner.immediateParentContainer?.permalinkURL}` ||
+                        ? `${window.location.origin}/globalId/${itemOwner.immediateParentContainer?.globalId}` ||
                           "-"
                         : "-"}
                     </Grid>
                     <Grid item>
-                      <strong>Printed:</strong>
+                      <strong>Printed:</strong>{" "}
                       {printOptions.printCopies === "1" && <br />}
                       {now.toLocaleString()}
                     </Grid>

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -98,7 +98,7 @@ type PrintContentsArgs = {|
   printOptions: PrintOptions,
   printType: PrintType,
   itemsToPrint: $ReadOnlyArray<[BarcodeRecord, InventoryRecord]>, // LoM ...
-  imageLinks?: Array<string>,
+  imageLinks?: $ReadOnlyArray<string>,
   target: Target,
 |};
 
@@ -114,7 +114,7 @@ type PreviewPrintItemArgs = {|
    */
   itemOwner: InventoryRecord,
 
-  imageLinks?: Array<string>,
+  imageLinks?: $ReadOnlyArray<string>,
   forPrint?: boolean, // false for screen preview
   target: Target,
 |};

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -109,8 +109,9 @@ type PreviewPrintItemArgs = {|
   barcode: BarcodeRecord, // LoM ...
 
   /*
-   * If `printOptions.printIdentifierType` is "IGSN", then `itemOwner` MUST
-   * have at least one identifier. Do not render this component if it does not.
+   * If `printOptions.printIdentifierType` is "IGSN", then `itemOwner` SHOULD
+   * have at least one identifier. If it does not then nothing will be
+   * rendered.
    */
   itemOwner: InventoryRecord,
 
@@ -146,6 +147,9 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
       : target === "multiplePrint" && printSize === "LARGE"
       ? classes.largeMm
       : classes.singlePc; // no small and large for singlePrint case
+  if (printOptions.printIdentifierType === "IGSN" && !itemOwner.identifiers[0]) {
+    return null;
+  }
   const header =
     printOptions.printIdentifierType === "GLOBAL ID"
       ? itemOwner.globalId

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -207,7 +207,7 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                       : "-"}
                   </Grid>
                   <Grid item>
-                    <strong>Created:</strong>
+                    <strong>Printed:</strong>
                     <br />
                     {now.toLocaleString()}
                   </Grid>

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -17,11 +17,6 @@ const itemPxWidth = {
   full: "220px",
 };
 
-const itemPxHeight = {
-  small: "150px",
-  full: "150px",
-};
-
 const itemMmSize = {
   small: "19mm",
   large: "38mm",
@@ -57,14 +52,10 @@ const useStyles = makeStyles()((theme) => ({
     padding: theme.spacing(0.25),
   },
   smallPxHorz: {
-    height: itemPxHeight.small,
-    maxHeight: itemPxHeight.small,
     maxWidth: "47vw",
     padding: theme.spacing(0.25),
   },
   largePxHorz: {
-    height: itemPxHeight.full,
-    maxHeight: itemPxHeight.full,
     maxWidth: "47vw",
     padding: theme.spacing(0.25),
   },
@@ -80,14 +71,10 @@ const useStyles = makeStyles()((theme) => ({
     padding: theme.spacing(0.5),
   },
   smallMmHorz: {
-    height: itemMmSize.small,
-    maxHeight: itemMmSize.small,
     maxWidth: "47vw",
     padding: theme.spacing(0.25),
   },
   largeMmHorz: {
-    height: itemMmSize.large,
-    maxHeight: itemMmSize.large,
     maxWidth: "47vw",
     padding: theme.spacing(0.5),
   },

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -198,7 +198,8 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                     <strong>Location:</strong>{" "}
                     {itemOwner instanceof ContainerModel ||
                     itemOwner instanceof SubSampleModel
-                      ? itemOwner.immediateParentContainer?.globalId || "-"
+                      ? `${window.location.origin}${itemOwner.immediateParentContainer?.permalinkURL}` ||
+                        "-"
                       : "-"}
                   </Grid>
                   <Grid item>

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -106,7 +106,7 @@ type PreviewPrintItemArgs = {|
   index: number,
   printOptions: PrintOptions,
   printType: PrintType,
-  item: BarcodeRecord, // LoM ...
+  barcode: BarcodeRecord, // LoM ...
 
   /*
    * If `printOptions.printIdentifierType` is "IGSN", then `itemOwner` MUST
@@ -123,7 +123,7 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
   index,
   printOptions,
   printType,
-  item,
+  barcode,
   itemOwner,
   imageLinks,
   target,
@@ -188,7 +188,7 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                   spacing={1}
                   className={clsx(classes.centeredText, classes.smallText)}
                 >
-                  <Grid item>{item.description.split("//")[1]}</Grid>
+                  <Grid item>{barcode.description.split("//")[1]}</Grid>
                   <Grid item>
                     <strong>Item:</strong>
                     <br />
@@ -241,14 +241,14 @@ const PrintContents: ComponentType<PrintContentsArgs> = forwardRef(
           printOptions.printerType === "LABEL" && classes.block
         )}
       >
-        {itemsToPrint.map(([item, itemOwner], i) => (
+        {itemsToPrint.map(([barcode, itemOwner], i) => (
           <>
             <Grid item key={`${i}.1`}>
               <PreviewPrintItem
                 index={i}
                 printOptions={printOptions}
                 printType={printType}
-                item={item}
+                barcode={barcode}
                 itemOwner={itemOwner}
                 imageLinks={imageLinks}
                 target={target}
@@ -261,7 +261,7 @@ const PrintContents: ComponentType<PrintContentsArgs> = forwardRef(
                     index={i}
                     printOptions={printOptions}
                     printType={printType}
-                    item={item}
+                    barcode={barcode}
                     itemOwner={itemOwner}
                     imageLinks={imageLinks}
                     target={target}

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -232,18 +232,37 @@ const PrintContents: ComponentType<PrintContentsArgs> = forwardRef(
         )}
       >
         {itemsToPrint.map(([item, itemOwner], i) => (
-          <Grid item key={i}>
-            <PreviewPrintItem
-              index={i}
-              printOptions={printOptions}
-              printType={printType}
-              item={item}
-              itemOwner={itemOwner}
-              imageLinks={imageLinks}
-              target={target}
-            />
-          </Grid>
+          <>
+            <Grid item key={`${i}.1`}>
+              <PreviewPrintItem
+                index={i}
+                printOptions={printOptions}
+                printType={printType}
+                item={item}
+                itemOwner={itemOwner}
+                imageLinks={imageLinks}
+                target={target}
+              />
+            </Grid>
+            {printOptions.printCopies === "2" && (
+              <>
+                <Grid item key={`${i}.2`}>
+                  <PreviewPrintItem
+                    index={i}
+                    printOptions={printOptions}
+                    printType={printType}
+                    item={item}
+                    itemOwner={itemOwner}
+                    imageLinks={imageLinks}
+                    target={target}
+                  />
+                </Grid>
+                <Grid item sx={{ width: "100%" }}></Grid>
+              </>
+            )}
+          </>
         ))}
+        ;
       </Grid>
     );
   }

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -97,7 +97,7 @@ type Target = "screen" | "multiplePrint" | "singlePrint";
 type PrintContentsArgs = {|
   printOptions: PrintOptions,
   printType: PrintType,
-  itemsToPrint: Array<[BarcodeRecord, InventoryRecord]>, // LoM ...
+  itemsToPrint: $ReadOnlyArray<[BarcodeRecord, InventoryRecord]>, // LoM ...
   imageLinks?: Array<string>,
   target: Target,
 |};

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintContents.js
@@ -12,12 +12,17 @@ import { type InventoryRecord } from "../../../stores/definitions/InventoryRecor
 import ContainerModel from "../../../stores/models/ContainerModel";
 import SubSampleModel from "../../../stores/models/SubSampleModel";
 
-const itemPxWidths = {
+const itemPxWidth = {
   small: "110px",
   full: "220px",
 };
 
-const itemMmWidths = {
+const itemPxHeight = {
+  small: "150px",
+  full: "150px",
+};
+
+const itemMmSize = {
   small: "19mm",
   large: "38mm",
 };
@@ -42,24 +47,44 @@ const useStyles = makeStyles()((theme) => ({
   },
   /* for screen mode */
   smallPx: {
-    width: itemPxWidths.small,
-    maxWidth: itemPxWidths.small,
+    width: itemPxWidth.small,
+    maxWidth: itemPxWidth.small,
     padding: theme.spacing(0.25),
   },
   largePx: {
-    width: itemPxWidths.full,
-    maxWidth: itemPxWidths.full,
+    width: itemPxWidth.full,
+    maxWidth: itemPxWidth.full,
+    padding: theme.spacing(0.25),
+  },
+  smallPxHorz: {
+    height: itemPxHeight.small,
+    maxHeight: itemPxHeight.small,
+    padding: theme.spacing(0.25),
+  },
+  largePxHorz: {
+    height: itemPxHeight.full,
+    maxHeight: itemPxHeight.full,
     padding: theme.spacing(0.25),
   },
   /* for grid/generic mode */
   smallMm: {
-    width: itemMmWidths.small,
-    maxWidth: itemMmWidths.small,
+    width: itemMmSize.small,
+    maxWidth: itemMmSize.small,
     padding: theme.spacing(0.25),
   },
   largeMm: {
-    width: itemMmWidths.large,
-    maxWidth: itemMmWidths.large,
+    width: itemMmSize.large,
+    maxWidth: itemMmSize.large,
+    padding: theme.spacing(0.5),
+  },
+  smallMmHorz: {
+    height: itemMmSize.small,
+    maxHeight: itemMmSize.small,
+    padding: theme.spacing(0.25),
+  },
+  largeMmHorz: {
+    height: itemMmSize.large,
+    maxHeight: itemMmSize.large,
     padding: theme.spacing(0.5),
   },
   /* for single/zebra mode */
@@ -146,10 +171,18 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
 
   const sizeClass = () => {
     if (target === "screen") {
+      if (printOptions.printCopies === "2") {
+        if (printSize === "SMALL") return classes.smallPxHorz;
+        if (printSize === "LARGE") return classes.largePxHorz;
+      }
       if (printSize === "SMALL") return classes.smallPx;
       if (printSize === "LARGE") return classes.largePx;
     }
     if (target === "multiplePrint") {
+      if (printOptions.printCopies === "2") {
+        if (printSize === "SMALL") return classes.smallMmHorz;
+        if (printSize === "LARGE") return classes.largeMmHorz;
+      }
       if (printSize === "SMALL") return classes.smallMm;
       if (printSize === "LARGE") return classes.largeMm;
     }
@@ -173,18 +206,30 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
         <div className={clsx(classes.printItemWrapper, sizeClass())}>
           <Grid
             container
-            direction="column"
+            direction={printOptions.printCopies === "2" ? "row" : "column"}
+            flexWrap="nowrap"
             spacing={1}
             className={classes.wrappingText}
           >
             {imageLinks && (
-              <>
+              <Grid item>
                 <img
                   className={classes.centeredSelf}
                   src={imageLinks[index]}
                   title="Barcode Image"
-                  width="75%"
+                  {...(printOptions.printCopies === "1"
+                    ? { width: "75%" }
+                    : { height: "75%" })}
                 />
+              </Grid>
+            )}
+            <Grid item>
+              <Grid
+                container
+                direction="column"
+                spacing={1}
+                className={clsx(classes.centeredText, classes.smallText)}
+              >
                 <Grid
                   item
                   className={clsx(classes.centeredText, classes.bottomSpaced)}
@@ -195,38 +240,31 @@ export const PreviewPrintItem: ComponentType<PreviewPrintItemArgs> = ({
                     <Typography variant={"h6"}>{header}</Typography>
                   )}
                 </Grid>
-              </>
-            )}
-            {printLayout === "FULL" && (
-              <Grid item>
-                <Grid
-                  container
-                  direction="column"
-                  spacing={1}
-                  className={clsx(classes.centeredText, classes.smallText)}
-                >
-                  <Grid item>{barcode.description.split("//")[1]}</Grid>
-                  <Grid item>
-                    <strong>Item:</strong>
-                    <br />
-                    {recordString}
-                  </Grid>
-                  <Grid item>
-                    <strong>Location:</strong>{" "}
-                    {itemOwner instanceof ContainerModel ||
-                    itemOwner instanceof SubSampleModel
-                      ? `${window.location.origin}${itemOwner.immediateParentContainer?.permalinkURL}` ||
-                        "-"
-                      : "-"}
-                  </Grid>
-                  <Grid item>
-                    <strong>Printed:</strong>
-                    <br />
-                    {now.toLocaleString()}
-                  </Grid>
-                </Grid>
+                {printLayout === "FULL" && (
+                  <>
+                    <Grid item>{barcode.description.split("//")[1]}</Grid>
+                    <Grid item>
+                      <strong>Item:</strong>
+                      {printOptions.printCopies === "1" && <br />}
+                      {recordString}
+                    </Grid>
+                    <Grid item>
+                      <strong>Location:</strong>{" "}
+                      {itemOwner instanceof ContainerModel ||
+                      itemOwner instanceof SubSampleModel
+                        ? `${window.location.origin}${itemOwner.immediateParentContainer?.permalinkURL}` ||
+                          "-"
+                        : "-"}
+                    </Grid>
+                    <Grid item>
+                      <strong>Printed:</strong>
+                      {printOptions.printCopies === "1" && <br />}
+                      {now.toLocaleString()}
+                    </Grid>
+                  </>
+                )}
               </Grid>
-            )}
+            </Grid>
           </Grid>
         </div>
         {/* force page break after item (when wrapper in display block) */}

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
@@ -104,7 +104,7 @@ type PrintDialogArgs = {|
   onClose: () => void,
   imageLinks: Array<string>,
   printType: PrintType,
-  itemsToPrint: Array<[BarcodeRecord, InventoryRecord]>, // LoM ...
+  itemsToPrint: $ReadOnlyArray<InventoryRecord>,
   printerType?: PrinterType,
   printSize?: PrintSize,
   /* n/a for non-contextMenu cases */
@@ -112,7 +112,7 @@ type PrintDialogArgs = {|
 |};
 
 type OptionsWrapperArgs = {|
-  itemsToPrint: Array<[BarcodeRecord, InventoryRecord]>,
+  itemsToPrint: $ReadOnlyArray<[BarcodeRecord, InventoryRecord]>,
   printOptions: PrintOptions,
   setPrintOptions: (PrintOptions) => void,
   printType: PrintType,
@@ -340,6 +340,11 @@ function PrintDialog({
   const componentToPrint = useRef<mixed>();
   const barcodePrint = ["contextMenu", "barcodeLabel"].includes(printType);
 
+  const itemsAndTheirBarcodes: $ReadOnlyArray<[ BarcodeRecord, InventoryRecord ]> = itemsToPrint.map((record) => [
+    record.barcodes[0],
+    record,
+  ]);
+
   const [printOptions, setPrintOptions] = useState<PrintOptions>({
     printIdentifierType: "GLOBAL ID",
     printerType: printerType ?? "GENERIC",
@@ -379,7 +384,7 @@ function PrintDialog({
           }
         >
           <PrintOptionsWrapper
-            itemsToPrint={itemsToPrint}
+            itemsToPrint={itemsAndTheirBarcodes}
             printOptions={printOptions}
             setPrintOptions={setPrintOptions}
             printType={printType}
@@ -393,9 +398,9 @@ function PrintDialog({
             <HelperText />
             {/* we preview only one item, resulting from choice of print options */}
             {printOptions.printIdentifierType === "IGSN" &&
-            itemsToPrint.some(([_, record]) => record.identifiers.length === 0)
+            itemsToPrint.some((record) => record.identifiers.length === 0)
               ? "Please resolve error."
-              : ArrayUtils.head(itemsToPrint)
+              : ArrayUtils.head(itemsAndTheirBarcodes)
                   .map(([barcode, inventoryRecord]) => (
                     <PreviewPrintItem
                       index={0}
@@ -415,7 +420,7 @@ function PrintDialog({
               ref={componentToPrint}
               printOptions={printOptions}
               printType={printType}
-              itemsToPrint={itemsToPrint}
+              itemsToPrint={itemsAndTheirBarcodes}
               imageLinks={imageLinks}
               target={
                 printOptions.printerType === "GENERIC"
@@ -440,7 +445,7 @@ function PrintDialog({
               disabled={
                 printOptions.printIdentifierType === "IGSN" &&
                 itemsToPrint.some(
-                  ([_, record]) => record.identifiers.length === 0
+                  (record) => record.identifiers.length === 0
                 )
               }
             >

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
@@ -10,9 +10,9 @@ import ContextDialog from "../ContextMenu/ContextDialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
-import RadioField, {
-  type RadioOption,
-} from "../../../components/Inputs/RadioField";
+import RadioGroup from "@mui/material/RadioGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Radio from "@mui/material/Radio";
 import Typography from "@mui/material/Typography";
 import { makeStyles } from "tss-react/mui";
 import useStores from "../../../stores/use-stores";
@@ -27,14 +27,9 @@ import { mkAlert } from "../../../stores/contexts/Alert";
 import { useIsSingleColumnLayout } from "../Layout/Layout2x1";
 import * as ArrayUtils from "../../../util/ArrayUtils";
 import ApiService from "../../../common/InvApiService";
+import Stack from "@mui/material/Stack";
 
 const useStyles = makeStyles()((theme) => ({
-  optionModuleWrapper: {
-    border: `1px solid ${theme.palette.sidebar.selected.bg}`,
-    borderRadius: theme.spacing(0.5),
-    padding: theme.spacing(1),
-    marginBottom: theme.spacing(2),
-  },
   rowWrapper: {
     display: "flex",
     flexDirection: "row",
@@ -126,200 +121,193 @@ export const PrintOptionsWrapper = ({
   const isSingleColumnLayout = useIsSingleColumnLayout();
   const { classes } = useStyles();
 
-  const printIdentifierTypeOptions: Array<RadioOption<"GLOBAL ID" | "IGSN">> = [
-    { value: "GLOBAL ID", label: "Global ID" },
-    { value: "IGSN", label: "IGSN" },
-  ];
-
-  const printerTypeOptions: Array<RadioOption<PrinterType>> = [
-    { value: "GENERIC", label: "Standard Printer" },
-    { value: "LABEL", label: "Label Printer" },
-  ];
-
-  const printLayoutOptions: Array<RadioOption<PrintLayout>> = [
-    { value: "FULL", label: "Full" },
-    { value: "BASIC", label: "Basic" },
-  ];
-
-  const printSizeOptions: Array<RadioOption<PrintSize>> = [
-    { value: "LARGE", label: "Large" },
-    { value: "SMALL", label: "Small" },
-  ];
-
-  /*
-   * Whilst the rest of the code handles any arbitrary number of copies, the
-   * UI only allows for 1 or 2 copies. This is because the only use case for
-   * multiple copies is for raffle books, where each identifier is printed
-   * twice. This is a common use case, and so is the only one that is
-   * implemented for now.
-   */
-  const printCopiesOptions: Array<RadioOption<"1" | "2">> = [
-    { value: "1", label: "Each identifier once" },
-    { value: "2", label: "Each identifier twice (raffle book)" },
-  ];
-
   return (
     <FormControl
       component="fieldset"
       className={isSingleColumnLayout ? classes.fullWidth : classes.halfWidth}
     >
-      <Box className={classes.optionModuleWrapper}>
-        <FormLabel id="identifiers-type-radiogroup-label">
-          Identifier Type
-        </FormLabel>
-        <RadioField
-          name={"Identifier Type Options"}
-          value={printOptions.printIdentifierType ?? "GLOBAL ID"}
-          onChange={({ target }) => {
-            if (target.value)
-              setPrintOptions({
-                ...printOptions,
-                printIdentifierType: target.value,
-              });
-          }}
-          options={printIdentifierTypeOptions}
-          disabled={false}
-          labelPlacement="bottom"
-          row
-          smallText={true}
-        />
-        {printOptions.printIdentifierType === "IGSN" &&
-          itemsToPrint.some(
-            ([_, record]) => record.identifiers.length === 0
-          ) && (
-            <Alert severity="error">
-              Some of the selected records do not have an IGSN.
+      <Stack spacing={3}>
+        <FormControl>
+          <FormLabel id="identifiers-type-radiogroup-label">
+            Identifier Type
+          </FormLabel>
+          <RadioGroup
+            aria-labelledby="identifiers-type-radiogroup-label"
+            value={printOptions.printIdentifierType}
+            onChange={({ target }) => {
+              if (target.value)
+                setPrintOptions({
+                  ...printOptions,
+                  printIdentifierType: target.value,
+                });
+            }}
+            row
+          >
+            <FormControlLabel
+              value="GLOBAL ID"
+              control={<Radio size="small" />}
+              label="Global ID"
+            />
+            <FormControlLabel
+              value="IGSN"
+              control={<Radio size="small" />}
+              label="IGSN"
+            />
+          </RadioGroup>
+          {printOptions.printIdentifierType === "IGSN" &&
+            itemsToPrint.some(
+              ([_, record]) => record.identifiers.length === 0
+            ) && (
+              <Alert severity="error">
+                Some of the selected records do not have an IGSN.
+              </Alert>
+            )}
+        </FormControl>
+        <FormControl>
+          <FormLabel id="printer-type-radiogroup-label">Printer Type</FormLabel>
+          <RadioGroup
+            aria-labelledby="printer-type-radiogroup-label"
+            value={printOptions.printerType}
+            onChange={({ target }) => {
+              if (target.value)
+                setPrintOptions({
+                  ...printOptions,
+                  printerType: target.value,
+                });
+            }}
+            row
+          >
+            <FormControlLabel
+              value="GENERIC"
+              control={<Radio size="small" />}
+              label="Standard Printer"
+            />
+            <FormControlLabel
+              value="LABEL"
+              control={<Radio size="small" />}
+              label="Label Printer"
+            />
+          </RadioGroup>
+          {printOptions.printerType === "GENERIC" ? (
+            <Alert severity="info">
+              Print multiple labels per sheet (e.g. A4 / A3 / Letter).
+            </Alert>
+          ) : (
+            <Alert severity="info">
+              Print one label per sticker (Zebra printer).
             </Alert>
           )}
-      </Box>
-      <Box className={classes.optionModuleWrapper}>
-        <FormLabel id="printer-type-radiogroup-label">Printer Type</FormLabel>
-        <RadioField
-          name={"Printer Type Options"}
-          value={printOptions.printerType}
-          onChange={({ target }) => {
-            if (target.value)
-              setPrintOptions({
-                ...printOptions,
-                printerType: target.value,
-              });
-          }}
-          options={printerTypeOptions}
-          disabled={false}
-          labelPlacement="bottom"
-          row
-          smallText={true}
-        />
-        {printOptions.printerType === "GENERIC" ? (
-          <Alert severity="info">
-            Print multiple labels per sheet (e.g. A4 / A3 / Letter).
-          </Alert>
-        ) : (
-          <Alert severity="info">
-            Print one label per sticker (Zebra printer).
-          </Alert>
-        )}
-      </Box>
-      <Box className={classes.optionModuleWrapper}>
-        <FormLabel id="print-layout-radiogroup-label">Print Layout</FormLabel>
-        <RadioField
-          name={"Print Layout Options"}
-          value={printOptions.printLayout}
-          onChange={({ target }) => {
-            if (target.value)
-              setPrintOptions({
-                ...printOptions,
-                printLayout: target.value,
-              });
-          }}
-          options={printLayoutOptions}
-          disabled={false}
-          labelPlacement="bottom"
-          row
-          smallText={true}
-        />
-        <Alert severity="info">
-          {printOptions.printLayout === "FULL"
-            ? `Barcode and record details${
-                printOptions.printerType === "LABEL"
-                  ? " (rectangular label required)."
-                  : "."
-              }`
-            : `Barcode and global ID${
-                printOptions.printerType === "LABEL"
-                  ? " (square or rectangular label)."
-                  : "."
-              }`}
-        </Alert>
-        {printOptions.printerType === "LABEL" && (
-          <Alert severity="info" className={classes.topSpaced}>
-            The label shape should match the selected layout. Also, you might
-            have problems when using Safari. Please check barcodes{" "}
-            <a
-              href={docLinks.barcodesPrinting}
-              target="_blank"
-              rel="noreferrer"
+        </FormControl>
+        <FormControl>
+          <FormLabel id="print-layout-radiogroup-label">Print Layout</FormLabel>
+          <RadioGroup
+            aria-labelledby="print-layout-radiogroup-label"
+            value={printOptions.printLayout}
+            onChange={({ target }) => {
+              if (target.value)
+                setPrintOptions({
+                  ...printOptions,
+                  printLayout: target.value,
+                });
+            }}
+            row
+          >
+            <FormControlLabel
+              value="FULL"
+              control={<Radio size="small" />}
+              label="Full"
+            />
+            <FormControlLabel
+              value="BASIC"
+              control={<Radio size="small" />}
+              label="Basic"
+            />
+          </RadioGroup>
+          {printOptions.printerType === "LABEL" && (
+            <Alert severity="info" className={classes.topSpaced}>
+              The label shape should match the selected layout. Also, you might
+              have problems when using Safari. Please check barcodes{" "}
+              <a
+                href={docLinks.barcodesPrinting}
+                target="_blank"
+                rel="noreferrer"
+              >
+                documentation
+              </a>
+              .
+            </Alert>
+          )}
+        </FormControl>
+        <FormControl>
+          <FormLabel id="print-size-radiogroup-label">Print Size</FormLabel>
+          {printOptions.printerType === "GENERIC" && (
+            <RadioGroup
+              aria-labelledby="print-size-radiogroup-label"
+              value={printOptions.printSize}
+              onChange={({ target }) => {
+                if (target.value)
+                  setPrintOptions({
+                    ...printOptions,
+                    printSize: target.value,
+                  });
+              }}
+              row
             >
-              documentation
-            </a>
-            .
-          </Alert>
-        )}
-      </Box>
-      <Box className={classes.optionModuleWrapper}>
-        <FormLabel id="print-size-radiogroup-label">Print Size</FormLabel>
-        {printOptions.printerType === "GENERIC" && (
-          <RadioField
-            name={"Print Size Options"}
-            value={printOptions.printSize}
-            onChange={({ target }) => {
-              if (target.value)
-                setPrintOptions({
-                  ...printOptions,
-                  printSize: target.value,
-                });
-            }}
-            options={printSizeOptions}
-            disabled={false}
-            labelPlacement="bottom"
-            row
-            smallText={true}
-          />
-        )}
-        <Alert severity="info">
-          {printOptions.printerType === "LABEL"
-            ? "For label printers size is set automatically (to match a range of label sizes)."
-            : printOptions.printSize === "LARGE"
-            ? "Full width (4cm)."
-            : "Half width (2cm)."}
-        </Alert>
-      </Box>
-      <Box className={classes.optionModuleWrapper}>
-        <FormLabel id="print-copties-radiogroup-label">Print Copies</FormLabel>
-        {printOptions.printerType === "GENERIC" && (
-          <RadioField
-            name={"Print Copies Options"}
-            value={printOptions.printCopies ?? "1"}
-            onChange={({ target }) => {
-              if (target.value)
-                setPrintOptions({
-                  ...printOptions,
-                  printCopies: target.value,
-                });
-            }}
-            options={printCopiesOptions}
-            disabled={false}
-            labelPlacement="bottom"
-            row
-            smallText={true}
-          />
-        )}
-        {printOptions.printerType === "LABEL" && (
+              <FormControlLabel
+                value="LARGE"
+                control={<Radio size="small" />}
+                label="Large"
+              />
+              <FormControlLabel
+                value="SMALL"
+                control={<Radio size="small" />}
+                label="Small"
+              />
+            </RadioGroup>
+          )}
           <Alert severity="info">
-            For label printers, the number of copies is set to 1 per item.
+            {printOptions.printerType === "LABEL"
+              ? "For label printers size is set automatically (to match a range of label sizes)."
+              : printOptions.printSize === "LARGE"
+              ? "Full width (4cm)."
+              : "Half width (2cm)."}
           </Alert>
-        )}
-      </Box>
+        </FormControl>
+        <FormControl>
+          <FormLabel id="print-copties-radiogroup-label">
+            Print Copies
+          </FormLabel>
+          {printOptions.printerType === "GENERIC" && (
+            <RadioGroup
+              aria-labelledby="print-copties-radiogroup-label"
+              value={printOptions.printCopies}
+              onChange={({ target }) => {
+                if (target.value)
+                  setPrintOptions({
+                    ...printOptions,
+                    printCopies: target.value,
+                  });
+              }}
+            >
+              <FormControlLabel
+                value="1"
+                control={<Radio size="small" />}
+                label="Each barcode once"
+              />
+              <FormControlLabel
+                value="2"
+                control={<Radio size="small" />}
+                label="Each barcode twice (raffle book)"
+              />
+            </RadioGroup>
+          )}
+          {printOptions.printerType === "LABEL" && (
+            <Alert severity="info">
+              For label printers, the number of copies is set to 1 per item.
+            </Alert>
+          )}
+        </FormControl>
+      </Stack>
     </FormControl>
   );
 };
@@ -339,10 +327,8 @@ function PrintDialog({
   const componentToPrint = useRef<mixed>();
   const barcodePrint = ["contextMenu", "barcodeLabel"].includes(printType);
 
-  const itemsAndTheirBarcodes: $ReadOnlyArray<[ BarcodeRecord, InventoryRecord ]> = itemsToPrint.map((record) => [
-    record.barcodes[0],
-    record,
-  ]);
+  const itemsAndTheirBarcodes: $ReadOnlyArray<
+    [BarcodeRecord, InventoryRecord]> = itemsToPrint.map((record) => [record.barcodes[0], record]);
 
   const [printOptions, setPrintOptions] = useState<PrintOptions>({
     printIdentifierType: "GLOBAL ID",
@@ -368,16 +354,20 @@ function PrintDialog({
     </>
   );
 
-  const [imageLinks, setImageLinks] = React.useState<$ReadOnlyArray<string>>([]);
+  const [imageLinks, setImageLinks] = React.useState<$ReadOnlyArray<string>>(
+    []
+  );
   React.useEffect(() => {
-    if (printOptions.printIdentifierType === "IGSN" && itemsToPrint.some(
-      (record) => record.identifiers.length === 0
-    )) {
+    if (
+      printOptions.printIdentifierType === "IGSN" &&
+      itemsToPrint.some((record) => record.identifiers.length === 0)
+    ) {
       return;
     }
-    if (printOptions.printIdentifierType === "GLOBAL ID" && itemsToPrint.some(
-      (record) => record.barcodes.length === 0
-    )) {
+    if (
+      printOptions.printIdentifierType === "GLOBAL ID" &&
+      itemsToPrint.some((record) => record.barcodes.length === 0)
+    ) {
       return;
     }
 
@@ -385,28 +375,34 @@ function PrintDialog({
 
     const getImageUrl = async (record: InventoryRecord) => {
       if (printOptions.printIdentifierType === "IGSN") {
-        const { data } = await ApiService.query<{||}, Blob>("/barcodes", new URLSearchParams({
-          content: `https://doi.org/${record.identifiers[0].doi}`,
-          barcodeType: "QR",
-        }), true);
+        const { data } = await ApiService.query<{||}, Blob>(
+          "/barcodes",
+          new URLSearchParams({
+            content: `https://doi.org/${record.identifiers[0].doi}`,
+            barcodeType: "QR",
+          }),
+          true
+        );
         const file = new File([data], "", { type: "image/png" });
         return URL.createObjectURL(file);
       }
       return URL.createObjectURL(await record.barcodes[0].fetchImage());
-    }
+    };
 
-    Promise.all(itemsToPrint.map(getImageUrl)).then((imageUrls) => {
-      setImageLinks(imageUrls);
-    }).catch((e) => {
-      uiStore.addAlert(
-        mkAlert({
-          title: "Unable to retrieve barcode images.",
-          message: e.message || "",
-          variant: "error",
-          isInfinite: true,
-        })
-      );
-    });
+    Promise.all(itemsToPrint.map(getImageUrl))
+      .then((imageUrls) => {
+        setImageLinks(imageUrls);
+      })
+      .catch((e) => {
+        uiStore.addAlert(
+          mkAlert({
+            title: "Unable to retrieve barcode images.",
+            message: e.message || "",
+            variant: "error",
+            isInfinite: true,
+          })
+        );
+      });
   }, [itemsToPrint, printOptions]);
 
   return (
@@ -443,6 +439,7 @@ function PrintDialog({
               : ArrayUtils.head(itemsAndTheirBarcodes)
                   .map(([barcode, inventoryRecord]) => (
                     <PreviewPrintItem
+                      key={inventoryRecord.globalId}
                       index={0}
                       printOptions={printOptions}
                       printType={printType}
@@ -484,9 +481,7 @@ function PrintDialog({
               disableElevation
               disabled={
                 printOptions.printIdentifierType === "IGSN" &&
-                itemsToPrint.some(
-                  (record) => record.identifiers.length === 0
-                )
+                itemsToPrint.some((record) => record.identifiers.length === 0)
               }
             >
               {`Print selected (${itemsToPrint.length})`}

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
@@ -239,41 +239,6 @@ export const PrintOptionsWrapper = ({
           )}
         </FormControl>
         <FormControl>
-          <FormLabel id="print-size-radiogroup-label">Print Size</FormLabel>
-          {printOptions.printerType === "GENERIC" && (
-            <RadioGroup
-              aria-labelledby="print-size-radiogroup-label"
-              value={printOptions.printSize}
-              onChange={({ target }) => {
-                if (target.value)
-                  setPrintOptions({
-                    ...printOptions,
-                    printSize: target.value,
-                  });
-              }}
-              row
-            >
-              <FormControlLabel
-                value="LARGE"
-                control={<Radio size="small" />}
-                label="Large"
-              />
-              <FormControlLabel
-                value="SMALL"
-                control={<Radio size="small" />}
-                label="Small"
-              />
-            </RadioGroup>
-          )}
-          <Alert severity="info">
-            {printOptions.printerType === "LABEL"
-              ? "For label printers size is set automatically (to match a range of label sizes)."
-              : printOptions.printSize === "LARGE"
-              ? "Full width (4cm)."
-              : "Half width (2cm)."}
-          </Alert>
-        </FormControl>
-        <FormControl>
           <FormLabel id="print-copties-radiogroup-label">
             Print Copies
           </FormLabel>
@@ -306,6 +271,43 @@ export const PrintOptionsWrapper = ({
               For label printers, the number of copies is set to 1 per item.
             </Alert>
           )}
+        </FormControl>
+        <FormControl>
+          <FormLabel id="print-size-radiogroup-label">Print Size</FormLabel>
+          {printOptions.printerType === "GENERIC" && printOptions.printCopies === "1" && (
+            <RadioGroup
+              aria-labelledby="print-size-radiogroup-label"
+              value={printOptions.printSize}
+              onChange={({ target }) => {
+                if (target.value)
+                  setPrintOptions({
+                    ...printOptions,
+                    printSize: target.value,
+                  });
+              }}
+              row
+            >
+              <FormControlLabel
+                value="LARGE"
+                control={<Radio size="small" />}
+                label="Large"
+              />
+              <FormControlLabel
+                value="SMALL"
+                control={<Radio size="small" />}
+                label="Small"
+              />
+            </RadioGroup>
+          )}
+          <Alert severity="info">
+            {printOptions.printerType === "LABEL"
+              ? "For label printers size is set automatically (to match a range of label sizes)."
+              : printOptions.printCopies === "2"
+              ? "Applying a horizontal layout."
+              : printOptions.printSize === "LARGE"
+              ? "Full width (4cm)."
+              : "Half width (2cm)."}
+          </Alert>
         </FormControl>
       </Stack>
     </FormControl>

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
@@ -25,6 +25,7 @@ import docLinks from "../../../assets/DocLinks";
 import clsx from "clsx";
 import { mkAlert } from "../../../stores/contexts/Alert";
 import { useIsSingleColumnLayout } from "../Layout/Layout2x1";
+import * as ArrayUtils from "../../../util/ArrayUtils";
 
 const useStyles = makeStyles()((theme) => ({
   optionModuleWrapper: {
@@ -339,8 +340,6 @@ function PrintDialog({
   const componentToPrint = useRef<mixed>();
   const barcodePrint = ["contextMenu", "barcodeLabel"].includes(printType);
 
-  const [item, itemOwner] = itemsToPrint[0];
-
   const [printOptions, setPrintOptions] = useState<PrintOptions>({
     printIdentifierType: "GLOBAL ID",
     printerType: printerType ?? "GENERIC",
@@ -394,21 +393,21 @@ function PrintDialog({
             <HelperText />
             {/* we preview only one item, resulting from choice of print options */}
             {printOptions.printIdentifierType === "IGSN" &&
-            itemsToPrint.some(
-              ([_, record]) => record.identifiers.length === 0
-            ) ? (
-              "Please resolve error."
-            ) : (
-              <PreviewPrintItem
-                index={0}
-                printOptions={printOptions}
-                printType={printType}
-                item={item}
-                itemOwner={itemOwner}
-                imageLinks={imageLinks}
-                target="screen"
-              />
-            )}
+            itemsToPrint.some(([_, record]) => record.identifiers.length === 0)
+              ? "Please resolve error."
+              : ArrayUtils.head(itemsToPrint)
+                  .map(([barcode, inventoryRecord]) => (
+                    <PreviewPrintItem
+                      index={0}
+                      printOptions={printOptions}
+                      printType={printType}
+                      item={barcode}
+                      itemOwner={inventoryRecord}
+                      imageLinks={imageLinks}
+                      target="screen"
+                    />
+                  ))
+                  .elseThrow()}
           </div>
           {/* we need the whole component for ReactToPrint, but not visible here */}
           <div className={classes.hidden}>

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
@@ -401,7 +401,7 @@ function PrintDialog({
                       index={0}
                       printOptions={printOptions}
                       printType={printType}
-                      item={barcode}
+                      barcode={barcode}
                       itemOwner={inventoryRecord}
                       imageLinks={imageLinks}
                       target="screen"

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
@@ -18,7 +18,6 @@ import { makeStyles } from "tss-react/mui";
 import useStores from "../../../stores/use-stores";
 import { type InventoryRecord } from "../../../stores/definitions/InventoryRecord";
 import Alert from "@mui/material/Alert";
-import { type BarcodeRecord } from "../../../stores/definitions/Barcode";
 import PrintContents, { PreviewPrintItem } from "./PrintContents";
 import ReactToPrint from "react-to-print";
 import docLinks from "../../../assets/DocLinks";
@@ -107,7 +106,7 @@ type PrintDialogArgs = {|
 |};
 
 type OptionsWrapperArgs = {|
-  itemsToPrint: $ReadOnlyArray<[BarcodeRecord, InventoryRecord]>,
+  itemsToPrint: $ReadOnlyArray<InventoryRecord>,
   printOptions: PrintOptions,
   setPrintOptions: (PrintOptions) => void,
   printType: PrintType,
@@ -155,9 +154,7 @@ export const PrintOptionsWrapper = ({
             />
           </RadioGroup>
           {printOptions.printIdentifierType === "IGSN" &&
-            itemsToPrint.some(
-              ([_, record]) => record.identifiers.length === 0
-            ) && (
+            itemsToPrint.some((record) => record.identifiers.length === 0) && (
               <Alert severity="error">
                 Some of the selected records do not have an IGSN.
               </Alert>
@@ -274,31 +271,32 @@ export const PrintOptionsWrapper = ({
         </FormControl>
         <FormControl>
           <FormLabel id="print-size-radiogroup-label">Print Size</FormLabel>
-          {printOptions.printerType === "GENERIC" && printOptions.printCopies === "1" && (
-            <RadioGroup
-              aria-labelledby="print-size-radiogroup-label"
-              value={printOptions.printSize}
-              onChange={({ target }) => {
-                if (target.value)
-                  setPrintOptions({
-                    ...printOptions,
-                    printSize: target.value,
-                  });
-              }}
-              row
-            >
-              <FormControlLabel
-                value="LARGE"
-                control={<Radio size="small" />}
-                label="Large"
-              />
-              <FormControlLabel
-                value="SMALL"
-                control={<Radio size="small" />}
-                label="Small"
-              />
-            </RadioGroup>
-          )}
+          {printOptions.printerType === "GENERIC" &&
+            printOptions.printCopies === "1" && (
+              <RadioGroup
+                aria-labelledby="print-size-radiogroup-label"
+                value={printOptions.printSize}
+                onChange={({ target }) => {
+                  if (target.value)
+                    setPrintOptions({
+                      ...printOptions,
+                      printSize: target.value,
+                    });
+                }}
+                row
+              >
+                <FormControlLabel
+                  value="LARGE"
+                  control={<Radio size="small" />}
+                  label="Large"
+                />
+                <FormControlLabel
+                  value="SMALL"
+                  control={<Radio size="small" />}
+                  label="Small"
+                />
+              </RadioGroup>
+            )}
           <Alert severity="info">
             {printOptions.printerType === "LABEL"
               ? "For label printers size is set automatically (to match a range of label sizes)."
@@ -328,9 +326,6 @@ function PrintDialog({
   const isSingleColumnLayout = useIsSingleColumnLayout();
   const componentToPrint = useRef<mixed>();
   const barcodePrint = ["contextMenu", "barcodeLabel"].includes(printType);
-
-  const itemsAndTheirBarcodes: $ReadOnlyArray<
-    [BarcodeRecord, InventoryRecord]> = itemsToPrint.map((record) => [record.barcodes[0], record]);
 
   const [printOptions, setPrintOptions] = useState<PrintOptions>({
     printIdentifierType: "GLOBAL ID",
@@ -422,7 +417,7 @@ function PrintDialog({
           }
         >
           <PrintOptionsWrapper
-            itemsToPrint={itemsAndTheirBarcodes}
+            itemsToPrint={itemsToPrint}
             printOptions={printOptions}
             setPrintOptions={setPrintOptions}
             printType={printType}
@@ -438,14 +433,13 @@ function PrintDialog({
             {printOptions.printIdentifierType === "IGSN" &&
             itemsToPrint.some((record) => record.identifiers.length === 0)
               ? "Please resolve error."
-              : ArrayUtils.head(itemsAndTheirBarcodes)
-                  .map(([barcode, inventoryRecord]) => (
+              : ArrayUtils.head(itemsToPrint)
+                  .map((inventoryRecord) => (
                     <PreviewPrintItem
                       key={inventoryRecord.globalId}
                       index={0}
                       printOptions={printOptions}
                       printType={printType}
-                      barcode={barcode}
                       itemOwner={inventoryRecord}
                       imageLinks={imageLinks}
                       target="screen"
@@ -459,7 +453,7 @@ function PrintDialog({
               ref={componentToPrint}
               printOptions={printOptions}
               printType={printType}
-              itemsToPrint={itemsAndTheirBarcodes}
+              itemsToPrint={itemsToPrint}
               imageLinks={imageLinks}
               target={
                 printOptions.printerType === "GENERIC"

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
@@ -69,6 +69,15 @@ export type PrintOptions = {
   printerType: PrinterType,
   printLayout: PrintLayout,
   printSize: PrintSize,
+
+  /*
+   * Each label can be printed multiple times (e.g. for raffle books).
+   * - If the number is 1 then the labels are printed in a grid layout. and if
+   * - If the number is 2 then each label is printed on its own row, wrapping
+   *   where necessary.
+   * - Any other numberical value is invalid.
+   */
+  printCopies?: "1" | "2",
 };
 
 /**
@@ -121,6 +130,18 @@ export const PrintOptionsWrapper = ({
   const printSizeOptions: Array<RadioOption<PrintSize>> = [
     { value: "LARGE", label: "Large" },
     { value: "SMALL", label: "Small" },
+  ];
+
+  /*
+   * Whilst the rest of the code handles any arbitrary number of copies, the
+   * UI only allows for 1 or 2 copies. This is because the only use case for
+   * multiple copies is for raffle books, where each identifier is printed
+   * twice. This is a common use case, and so is the only one that is
+   * implemented for now.
+   */
+  const printCopiesOptions: Array<RadioOption<"1" | "2">> = [
+    { value: "1", label: "Each identifier once" },
+    { value: "2", label: "Each identifier twice (raffle book)" },
   ];
 
   return (
@@ -230,6 +251,32 @@ export const PrintOptionsWrapper = ({
             : "Half width (2cm)."}
         </Alert>
       </Box>
+      <Box className={classes.optionModuleWrapper}>
+        <FormLabel id="print-copties-radiogroup-label">Print Copies</FormLabel>
+        {printOptions.printerType === "GENERIC" && (
+          <RadioField
+            name={"Print Copies Options"}
+            value={printOptions.printCopies ?? "1"}
+            onChange={({ target }) => {
+              if (target.value)
+                setPrintOptions({
+                  ...printOptions,
+                  printCopies: target.value,
+                });
+            }}
+            options={printCopiesOptions}
+            disabled={false}
+            labelPlacement="bottom"
+            row
+            smallText={true}
+          />
+        )}
+        {printOptions.printerType === "LABEL" && (
+        <Alert severity="info">
+          For label printers, the number of copies is set to 1 per item.
+        </Alert>
+        )}
+      </Box>
     </FormControl>
   );
 };
@@ -256,6 +303,7 @@ function PrintDialog({
     printerType: printerType ?? "GENERIC",
     printLayout: "FULL",
     printSize: printSize ?? "LARGE",
+    printCopies: "1",
   });
 
   const handleClose = () => {

--- a/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/PrintDialog.js
@@ -322,7 +322,7 @@ function PrintDialog({
   closeMenu,
 }: PrintDialogArgs): Node {
   const { classes } = useStyles();
-  const { uiStore } = useStores();
+  const { uiStore, trackingStore } = useStores();
   const isSingleColumnLayout = useIsSingleColumnLayout();
   const componentToPrint = useRef<mixed>();
   const barcodePrint = ["contextMenu", "barcodeLabel"].includes(printType);
@@ -486,6 +486,14 @@ function PrintDialog({
           content={() => componentToPrint.current}
           onAfterPrint={() => {
             handleClose();
+            trackingStore.trackEvent("user:print:barcodeLabel", {
+              count: itemsToPrint.length,
+              printIdentifierType: printOptions.printIdentifierType,
+              printerType: printOptions.printerType,
+              printLayout: printOptions.printLayout,
+              printSize: printOptions.printSize,
+              printCopies: printOptions.printCopies,
+            });
           }}
           onPrintError={(e) => {
             uiStore.addAlert(

--- a/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
@@ -19,6 +19,7 @@ import {
 } from "../../../../stores/stores/__tests__/RootStore/mocking";
 import { storesContext } from "../../../../stores/stores-context";
 import { type StoreContainer } from "../../../../stores/stores/RootStore";
+import "../../../../../__mocks__/createObjectURL";
 
 const mockRootStore = (mockedStores: ?MockStores): StoreContainer => {
   return makeMockRootStore({
@@ -52,7 +53,6 @@ describe("Print Tests", () => {
         <storesContext.Provider value={mockRootStore()}>
           <PrintDialog
             showPrintDialog={openDialog}
-            imageLinks={[]}
             printType={printType}
             itemsToPrint={[
               mockContainer

--- a/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
@@ -68,7 +68,7 @@ describe("Print Tests", () => {
     it("renders, has radio options for printerType, printMode, printSize (plus help text)", () => {
       render(<Dialog printType="contextMenu" />);
 
-      expect(screen.getAllByRole("radio")).toHaveLength(6);
+      expect(screen.getAllByRole("radio")).toHaveLength(8);
 
       const standardOption = screen.getByLabelText("Standard Printer");
       expect(standardOption).toBeInTheDocument();

--- a/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
@@ -68,7 +68,7 @@ describe("Print Tests", () => {
     it("renders, has radio options for printerType, printMode, printSize (plus help text)", () => {
       render(<Dialog printType="contextMenu" />);
 
-      expect(screen.getAllByRole("radio")).toHaveLength(8);
+      expect(screen.getAllByRole("radio")).toHaveLength(10);
 
       const standardOption = screen.getByLabelText("Standard Printer");
       expect(standardOption).toBeInTheDocument();

--- a/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
@@ -30,13 +30,14 @@ const mockRootStore = (mockedStores: ?MockStores): StoreContainer => {
 };
 
 const mockContainer = makeMockContainer();
+mockContainer.barcodes = [persistedBarcode1];
 
-let generatedBarcode1;
 if (mockContainer.globalId) {
-  generatedBarcode1 = generatedBarcode(
+  const generatedBarcode1 = generatedBarcode(
     mockContainer.recordType,
     mockContainer.globalId
   );
+  mockContainer.barcodes.push(generatedBarcode1);
 }
 
 describe("Print Tests", () => {
@@ -54,8 +55,7 @@ describe("Print Tests", () => {
             imageLinks={[]}
             printType={printType}
             itemsToPrint={[
-              [generatedBarcode1, mockContainer],
-              [persistedBarcode1, mockContainer],
+              mockContainer
             ]}
             onClose={() => {}}
           />

--- a/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
+++ b/src/main/webapp/ui/src/Inventory/components/Print/__tests__/PrintDialog.test.js
@@ -54,9 +54,7 @@ describe("Print Tests", () => {
           <PrintDialog
             showPrintDialog={openDialog}
             printType={printType}
-            itemsToPrint={[
-              mockContainer
-            ]}
+            itemsToPrint={[mockContainer]}
             onClose={() => {}}
           />
         </storesContext.Provider>
@@ -78,9 +76,6 @@ describe("Print Tests", () => {
       expect(labelOption).toBeInTheDocument();
       expect(labelOption).not.toBeChecked();
 
-      /* assert help text for default mode option, and preview header */
-      const defaultModeHint = "Barcode and record details.";
-      expect(screen.getByText(defaultModeHint)).toBeInTheDocument();
       const previewHeader = "Preview: Barcode Label Layout";
       expect(screen.getByText(previewHeader)).toBeInTheDocument();
     });


### PR DESCRIPTION
In Inventory, we have a mechanism of printing a record's QR code onto a label. This change re-uses this functionality for printing QR codes to IGSN DOIs in layout analogous to raffle books, wherein each IGSN is printed twice to aid with offline record keeping of used IGSNs.

This change
1. On all print outs, the Global Id of the parent container (labelled "Location") is replaced with the URL of the container, as that would be more useful on a printout.
2. Splits the functionality that allows for the printing of all of the barcodes associated with a particular record (figure 1) from that of the functionality for printing the first barcode associated with each record (figure 2). This is because the latter can be re-used for IGSNs given the 1-to-1 mapping between Inventory records and barcodes.
3. Additional options when printing for choosing Global ID or IGSN, and 1 or 2 copies of each label. Together, these allow for IGSNs to be printed in a raffle-book like format.

Figure 1:
<img width="278" alt="image" src="https://github.com/user-attachments/assets/dbeb9e28-940d-4bc9-8136-e5e5bc0202c1" />

Figure 2:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/f9b36b27-9a14-4e10-839a-73c183711703" />

