### PR TITLE
RSDEV-570 Add aria-current support to AccentMenuItem

### DIFF
--- a/src/main/webapp/ui/src/components/AccentMenuItem.js.flow
+++ b/src/main/webapp/ui/src/components/AccentMenuItem.js.flow
@@ -29,4 +29,6 @@ declare export default function AccentMenuItem({|
    */
   autoFocus?: boolean,
   tabIndex?: number,
+
+  current?: boolean | "page" | "step" | "location" | "date" | "time",
 |}): Node;

--- a/src/main/webapp/ui/src/components/AccentMenuItem.tsx
+++ b/src/main/webapp/ui/src/components/AccentMenuItem.tsx
@@ -35,6 +35,17 @@ type AccentMenuItemArgs = {
    */
   autoFocus?: boolean;
   tabIndex?: number;
+
+  /*
+   * Use this property to indicate that this menu item is the "current" item.
+   * It will be styled with a slightly different background colour, and so may
+   * not be obvious to all users, but will be exposed to screen readers as the
+   * aria-current attribute. To find out more about what it means for an menu
+   * item to be "current", see https://www.w3.org/TR/wai-aria-1.1/#aria-current.
+   * Examples include the current page in a navigation menu, the current tab in
+   * a tabbed interface, the applied sort order in a list, etc.
+   */
+  current?: boolean | "page" | "step" | "location" | "date" | "time";
 };
 
 /**
@@ -67,6 +78,7 @@ export default styled(
         titleTypographyProps,
         component = "li",
         href,
+        current,
       },
       ref
     ) => (
@@ -82,6 +94,15 @@ export default styled(
         aria-haspopup={ariaHasPopup}
         component={component}
         href={href}
+        selected={
+          current === true ||
+          current === "page" ||
+          current === "step" ||
+          current === "location" ||
+          current === "date" ||
+          current === "time"
+        }
+        aria-current={current}
       >
         <CardHeader
           title={title}
@@ -120,10 +141,16 @@ export default styled(
       padding: 0,
       borderRadius: "2px",
       border: prefersMoreContrast ? "2px solid #000" : "none",
-      backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.24),
+      backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.12),
       transition: "background-color ease-in-out .2s",
       "&:hover": {
         backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.36),
+      },
+      "&.Mui-selected": {
+        backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.5),
+        "&:hover": {
+          backgroundColor: prefersMoreContrast ? "#fff" : alpha(bg, 0.72),
+        },
       },
       "& .MuiCardHeader-root": {
         padding: theme.spacing(compact ? 1 : 2),

--- a/src/main/webapp/ui/src/components/AppBar/index.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/index.tsx
@@ -555,6 +555,7 @@ function GalleryAppBar({
                   window.location.href = "/workspace";
                   handleAppMenuClose();
                 }}
+                current={currentPage === "Workspace" ? "page" : false}
               />
               <AccentMenuItem
                 title="Gallery"
@@ -566,6 +567,7 @@ function GalleryAppBar({
                   window.location.href = "/gallery";
                   handleAppMenuClose();
                 }}
+                current={currentPage === "Gallery" ? "page" : false}
               />
               {showInventory && (
                 <AccentMenuItem
@@ -578,6 +580,7 @@ function GalleryAppBar({
                     window.location.href = "/inventory";
                     handleAppMenuClose();
                   }}
+                  current={currentPage === "Inventory" ? "page" : false}
                 />
               )}
               <AccentMenuItem
@@ -592,6 +595,7 @@ function GalleryAppBar({
                     : "/userform";
                   setAccountMenuAnchorEl(null);
                 }}
+                current={currentPage === "My RSpace" ? "page" : false}
               />
               {showSystem && (
                 <AccentMenuItem
@@ -604,6 +608,7 @@ function GalleryAppBar({
                     window.location.href = "/system";
                     handleAppMenuClose();
                   }}
+                  current={currentPage === "System" ? "page" : false}
                 />
               )}
             </Menu>

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.js
@@ -1513,6 +1513,7 @@ function GalleryMainPanel({
                     setViewMode("grid");
                     selection.clear();
                   }}
+                  current={viewMode === "grid"}
                 />
                 <AccentMenuItem
                   title="Tree"
@@ -1524,6 +1525,7 @@ function GalleryMainPanel({
                     setViewMode("tree");
                     selection.clear();
                   }}
+                  current={viewMode === "tree"}
                 />
                 <AccentMenuItem
                   title="Carousel"
@@ -1539,6 +1541,7 @@ function GalleryMainPanel({
                      * if there is one
                      */
                   }}
+                  current={viewMode === "carousel"}
                 />
               </StyledMenu>
               <Button
@@ -1613,6 +1616,7 @@ function GalleryMainPanel({
                     });
                   }}
                   titleTypographyProps={{ sx: { whiteSpace: "break-spaces" } }}
+                  current={orderBy === "name"}
                 />
                 <AccentMenuItem
                   title={`Modification Date${match<void, string>([
@@ -1667,6 +1671,7 @@ function GalleryMainPanel({
                     });
                   }}
                   titleTypographyProps={{ sx: { whiteSpace: "break-spaces" } }}
+                  current={orderBy === "modificationDate"}
                 />
               </StyledMenu>
             </Stack>


### PR DESCRIPTION
This change adds support for aria-current to the AccentMenuItem component, utilising the prop in the nav app bar and the gallery to enhance the accessibility of the menus that use the AccentMenuItem component.

This change was pulled out of RSDEV-570, as it requires the use of the current marker for menus.