### PR TITLE
RSDEV-613: fix rare problem on duplicating doc shared into notebook

### DIFF
--- a/src/main/java/com/researchspace/service/RecordManager.java
+++ b/src/main/java/com/researchspace/service/RecordManager.java
@@ -631,8 +631,18 @@ public interface RecordManager {
    */
   Long getRecordCountForUser(RecordTypeFilter recordTypes, User user);
 
+  List<Long> getAllNonTemplateNonTemporaryStrucDocIdsOwnedByUser(User user);
+
   List<BaseRecord> getOntologyTagsFilesForUserCalled(User user, String userTagsontologyDocument);
 
   List<StructuredDocument> getontologyDocumentsCreatedInPastThirtyMinutesByCurrentUser(
       String uName);
+
+  /**
+   * This method added to address support-522 ticket: Assuming the document has just one parent,
+   * this parent is updated to be a document owner's Workspace, with appropriate permission change.
+   *
+   * @return whether the move/permission change action was successful
+   */
+  boolean forceMoveDocumentToOwnerWorkspace(StructuredDocument userDoc);
 }

--- a/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
@@ -184,13 +184,17 @@ public class RecordManagerImpl implements RecordManager {
       for (RecordToFolder rtf : original.getParents()) {
         if (rtf.getUserName().equals(user.getUsername())) {
           parent = rtf.getFolder();
-          if (!parent.isSharedFolder()) {
+          if (!parent.isSharedFolder() && !isFolderANotebookSharedWithCurrentUser(parent, user)) {
             return parent;
           }
         }
       }
     }
     return parent;
+  }
+
+  private boolean isFolderANotebookSharedWithCurrentUser(Folder folder, User user) {
+    return folder.isNotebook() && !user.getUsername().equals(folder.getOwner().getUsername());
   }
 
   /** Convenience method to get a subclass of record already cast to the appropriate type. */

--- a/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
@@ -194,7 +194,7 @@ public class RecordManagerImpl implements RecordManager {
   }
 
   private boolean isFolderANotebookSharedWithCurrentUser(Folder folder, User user) {
-    return folder.isNotebook() && !user.getUsername().equals(folder.getOwner().getUsername());
+    return folder.isNotebook() && !user.equals(folder.getOwner());
   }
 
   /** Convenience method to get a subclass of record already cast to the appropriate type. */
@@ -1331,6 +1331,11 @@ public class RecordManagerImpl implements RecordManager {
   }
 
   @Override
+  public List<Long> getAllNonTemplateNonTemporaryStrucDocIdsOwnedByUser(User user) {
+    return recordDao.getAllNonTemplateNonTemporaryStrucDocIdsOwnedByUser(user);
+  }
+
+  @Override
   public List<BaseRecord> getOntologyTagsFilesForUserCalled(
       User user, String userTagsontologyDocument) {
     return recordDao.getOntologyTagsFilesForUserCalled(user, userTagsontologyDocument);
@@ -1340,5 +1345,25 @@ public class RecordManagerImpl implements RecordManager {
   public List<StructuredDocument> getontologyDocumentsCreatedInPastThirtyMinutesByCurrentUser(
       String uName) {
     return recordDao.getontologyDocumentsCreatedInPastThirtyMinutesByCurrentUser(uName);
+  }
+
+  @Override
+  public boolean forceMoveDocumentToOwnerWorkspace(StructuredDocument userDoc) {
+    User owner = userDoc.getOwner();
+    Folder ownerWorkspace = owner.getRootFolder();
+
+    if (userDoc.hasSingleParent()) {
+      userDoc.setSharingACL(ownerWorkspace.getSharingACL());
+      recordDao.save(userDoc);
+
+      RecordToFolder recToFolder = userDoc.getParents().iterator().next();
+      recordDao.updateRecordToFolder(recToFolder, ownerWorkspace.getId());
+
+      log.warn(
+          "executed forceMoveDocumentToOwnerWorkspace for doc " + userDoc.getGlobalIdentifier());
+      return true;
+    }
+
+    return false;
   }
 }

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminDevOpsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminDevOpsController.java
@@ -1,0 +1,86 @@
+package com.researchspace.webapp.controller;
+
+import com.researchspace.model.User;
+import com.researchspace.model.record.Folder;
+import com.researchspace.model.record.StructuredDocument;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * A controller allowing RSpace Sysadmin or IT Support team to execute some code fixes that should
+ * be applied at runtime, rather than on upgrade/startup.
+ */
+@Controller("sysAdminDevopsController")
+@RequestMapping("/system/devops")
+public class SysAdminDevOpsController extends BaseController {
+
+  /**
+   * This is to fix SUPPORT-522 issue i.e. problem with duplication of document shared into
+   * somebody else's notebook, where the copy was sometimes ending inside shard notebook.
+   *
+   * The code locates such problematic copies belonging to the particular user, and
+   * moves them out of notebook into user's own Workspace.
+   *
+   * This code is intended to be triggered from browser, by sysadmin who is logged into RSpace
+   * by navigating to the particular endpoint. E.g. to run the code for user with id 4,
+   * login as sysadmin and navigate browser to:
+   * <rspace>/system/devops/ajax/support-552/4
+   * then
+   * <rspace>/system/devops/ajax/support-552/4?update=true
+   */
+  @GetMapping("/ajax/support-522/{userId}")
+  @ResponseBody
+  public String getSupportPage(
+      @PathVariable Long userId, @RequestParam(value = "update", required = false) boolean update) {
+    assertSubjectIsSysadmin();
+
+    User user = userManager.get(userId);
+    String result = "Starting SUPPORT-552 fix process for user: " + user.getUsername() + ".<br />\n";
+
+    List<Long> allDocIds = recordManager.getAllNonTemplateNonTemporaryStrucDocIdsOwnedByUser(user);
+    result += "Found total of " + allDocIds.size() + " documents owned by the user.<br />\n";
+
+    int foundCount = 0;
+    int movedCount = 0;
+    for (Long userDocId : allDocIds) {
+      StructuredDocument userDoc = recordManager.get(userDocId).asStrucDoc();
+      Folder parentFolder = userDoc.getParent();
+      if (parentFolder != null && parentFolder.isNotebook()) {
+        if (!userDoc.getOwner().equals(parentFolder.getOwner())) {
+          result += "Found a problematic doc: " + userDoc.getGlobalIdentifier() + ".<br />\n";
+          foundCount++;
+          if (update) {
+            boolean moved = recordManager.forceMoveDocumentToOwnerWorkspace(userDoc);
+            if (moved) {
+              movedCount++;
+            }
+          }
+        }
+      }
+    }
+
+    if (foundCount == 0) {
+      result += "No problematic documents found for the user.<br />\n";
+    } else {
+      if (update) {
+        result +=
+            "Updated " + movedCount + " docs (out of " + foundCount
+                + " that should be updated).<br />\n";
+      } else {
+        result += "To update problematic documents call the current URL with '?update=true' suffix";
+      }
+    }
+
+    return result;
+  }
+
+  private void assertSubjectIsSysadmin() {
+    User user = userManager.getAuthenticatedUserInSession();
+    assertUserIsSysAdmin(user);
+  }
+}

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminDevOpsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminDevOpsController.java
@@ -20,17 +20,15 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class SysAdminDevOpsController extends BaseController {
 
   /**
-   * This is to fix SUPPORT-522 issue i.e. problem with duplication of document shared into
-   * somebody else's notebook, where the copy was sometimes ending inside shard notebook.
+   * This is to fix SUPPORT-522 issue i.e. problem with duplication of document shared into somebody
+   * else's notebook, where the copy was sometimes ending inside shard notebook.
    *
-   * The code locates such problematic copies belonging to the particular user, and
-   * moves them out of notebook into user's own Workspace.
+   * <p>The code locates such problematic copies belonging to the particular user, and moves them
+   * out of notebook into user's own Workspace.
    *
-   * This code is intended to be triggered from browser, by sysadmin who is logged into RSpace
-   * by navigating to the particular endpoint. E.g. to run the code for user with id 4,
-   * login as sysadmin and navigate browser to:
-   * <rspace>/system/devops/ajax/support-552/4
-   * then
+   * <p>This code is intended to be triggered from browser, by sysadmin who is logged into RSpace by
+   * navigating to the particular endpoint. E.g. to run the code for user with id 4, login as
+   * sysadmin and navigate browser to: <rspace>/system/devops/ajax/support-552/4 then
    * <rspace>/system/devops/ajax/support-552/4?update=true
    */
   @GetMapping("/ajax/support-522/{userId}")
@@ -40,7 +38,8 @@ public class SysAdminDevOpsController extends BaseController {
     assertSubjectIsSysadmin();
 
     User user = userManager.get(userId);
-    String result = "Starting SUPPORT-552 fix process for user: " + user.getUsername() + ".<br />\n";
+    String result =
+        "Starting SUPPORT-552 fix process for user: " + user.getUsername() + ".<br />\n";
 
     List<Long> allDocIds = recordManager.getAllNonTemplateNonTemporaryStrucDocIdsOwnedByUser(user);
     result += "Found total of " + allDocIds.size() + " documents owned by the user.<br />\n";

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminDevOpsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminDevOpsController.java
@@ -28,8 +28,8 @@ public class SysAdminDevOpsController extends BaseController {
    *
    * <p>This code is intended to be triggered from browser, by sysadmin who is logged into RSpace by
    * navigating to the particular endpoint. E.g. to run the code for user with id 4, login as
-   * sysadmin and navigate browser to: <rspace>/system/devops/ajax/support-552/4 then
-   * <rspace>/system/devops/ajax/support-552/4?update=true
+   * sysadmin and navigate browser to: /system/devops/ajax/support-522/4, then eventually to
+   * /system/devops/ajax/support-522/4?update=true
    */
   @GetMapping("/ajax/support-522/{userId}")
   @ResponseBody

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminDevOpsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminDevOpsController.java
@@ -69,8 +69,7 @@ public class SysAdminDevOpsController extends BaseController {
     } else {
       if (update) {
         result +=
-            "Updated " + movedCount + " docs (out of " + foundCount
-                + " that should be updated).<br />\n";
+            "Updated " + movedCount + " docs (out of " + foundCount + " that should be updated)";
       } else {
         result += "To update problematic documents call the current URL with '?update=true' suffix";
       }

--- a/src/test/java/com/researchspace/webapp/controller/RecordManagerStub.java
+++ b/src/test/java/com/researchspace/webapp/controller/RecordManagerStub.java
@@ -390,6 +390,11 @@ public class RecordManagerStub implements RecordManager {
   }
 
   @Override
+  public List<Long> getAllNonTemplateNonTemporaryStrucDocIdsOwnedByUser(User user) {
+    return null;
+  }
+
+  @Override
   public List<BaseRecord> getOntologyTagsFilesForUserCalled(
       User user, String userTagsontologyDocument) {
     return null;
@@ -399,6 +404,11 @@ public class RecordManagerStub implements RecordManager {
   public List<StructuredDocument> getontologyDocumentsCreatedInPastThirtyMinutesByCurrentUser(
       String uName) {
     return null;
+  }
+
+  @Override
+  public boolean forceMoveDocumentToOwnerWorkspace(StructuredDocument userDoc) {
+    return false;
   }
 
   @Override


### PR DESCRIPTION
This PR fixes a problem described in RSDEV-613/SUPPORT-522: sometimes, when duplicating a document that is shared into somebody else's notebook, the copy is added not to the document owner's location, but to the shared notebook. Such misplaced copy has incorrect permissions (taken from the notebook's owner), so the copy owner cannot operate on it.

The root cause of the problem was in `RecordManager.getRecordParentPreferNonShared` method, which didn't consider the checked parent folder may be a shared notebook. This is now being checked, so the other user's notebook won't be confused with owner's Workspace location.

The 2nd part of the PR is the new `SysAdminDevOpsController` class, added as a way to trigger the fix for previously-created broken copies. After triggering `/system/devops/ajax/support-552/{userid}` (dry-run) and `<rspace>/system/devops/ajax/support-552/4?update=true` (actual run) endpoints, which sysadmin can do by just navigating to them (being logged into RSpace UI), the problematic document copies of a given user will be located and moved to the Workspace of that user. This is so the sysadmin can fix the problem when reported by the users, rather than silently during server startup, as the latter would be confusing to the users who may expect to find the copied document in shared notebook.


