### PR TITLE
RSDEV-641 Add a loading spinner to new notebook dialog's submit button

### DIFF
--- a/src/main/webapp/ui/src/Toolbar/Workspace/Misc/NewNotebook.js
+++ b/src/main/webapp/ui/src/Toolbar/Workspace/Misc/NewNotebook.js
@@ -8,11 +8,13 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
+import SubmitSpinnerButton from "../../../components/SubmitSpinnerButton";
 
 export default function NewNotebook() {
   const [open, setOpen] = React.useState(false);
   const [name, setName] = React.useState("");
   const [error, setError] = React.useState(null);
+  const [loading, setLoading] = React.useState(false);
 
   useEffect(() => {
     $(document).on("click", "#createNotebook", () => {
@@ -31,6 +33,7 @@ export default function NewNotebook() {
   }
 
   function handleSubmit() {
+    setLoading(true);
     let form = $("<form></form>");
     form.attr("method", "POST");
     form.attr(
@@ -88,13 +91,12 @@ export default function NewNotebook() {
         >
           Cancel
         </Button>
-        <Button
+        <SubmitSpinnerButton
+          label="Create"
+          loading={loading}
+          disabled={loading}
           onClick={validateForm}
-          color="primary"
-          data-test-id="new-notebook-submit"
-        >
-          Create
-        </Button>
+        />
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
This just back ports the submit button component that we now use across the new parts of the codebase to the old new-notebook dialog.