### PR TITLE
Playwright component testing experimenting, using BDD style keywords to structure the tests

### DIFF
--- a/src/main/webapp/ui/.eslintrc
+++ b/src/main/webapp/ui/.eslintrc
@@ -97,6 +97,10 @@
     "no-constant-binary-expression": "error",
     "no-duplicate-imports": "warn",
     "no-else-return": ["error", { "allowElseIf": false }],
+
+    // playwright relies on empty patterns being used to destructure fixtures
+    "no-empty-pattern": "off",
+
     "no-eval": "error",
     "no-implicit-coercion": "error",
     "no-implied-eval": "error",

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
@@ -50,6 +50,7 @@ const feature = test.extend<{
     }) => Promise<void>;
     "A request to set a verification password is shown": () => Promise<void>;
     "A request to set a verification password is not shown": () => Promise<void>;
+    "the usage should be shown in human-readable format": () => Promise<void>;
   };
 }>({
   Given: async ({ mount, router }, use) => {
@@ -166,6 +167,22 @@ const feature = test.extend<{
           )
         ).toBeVisible();
       },
+      "the usage should be shown in human-readable format": async () => {
+        const grid = page.getByRole("grid");
+        await expect(grid).toBeVisible();
+
+        const columnHeadings = grid.getByRole("columnheader");
+        const headings = await columnHeadings.allTextContents();
+        const usageIndex = headings.findIndex((heading) => heading === "Usage");
+        expect(usageIndex).toBeGreaterThan(-1);
+
+        await expect(
+          grid.getByRole("row").nth(2).getByRole("gridcell").nth(usageIndex)
+        ).toHaveText("362.01 kB");
+        await expect(
+          grid.getByRole("row").nth(3).getByRole("gridcell").nth(usageIndex)
+        ).toHaveText("0 B");
+      },
     });
   },
 });
@@ -193,6 +210,16 @@ test.beforeEach(async ({ page, router }) => {
       body: JSON.stringify(USER_LISTING),
     });
   });
+});
+
+test.describe("Table Listing", () => {
+  feature(
+    "Usage should be in a human-readable format",
+    async ({ Given, When, Then }) => {
+      await Given["the sysadmin is on the users page"]();
+      await Then["the usage should be shown in human-readable format"]();
+    }
+  );
 });
 
 test.describe("Grant User PI role", () => {

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
@@ -20,14 +20,23 @@ const feature = test.extend<{
     "a CSV export of the selected rows is downloaded": () => Promise<Download>;
   };
   Then: {
-    "it should have a precise usage column": (csv: Download) => Promise<void>;
-    "it should have the same number of columns as are available to view, except for 'Full Name'": (
-      csv: Download
-    ) => Promise<void>;
-    "it should have {count} rows": (
-      csv: Download,
-      { count }: { count: number }
-    ) => Promise<void>;
+    "{CSV} should have a precise usage column": ({
+      csv,
+    }: {
+      csv: Download;
+    }) => Promise<void>;
+    "{CSV} should have the same number of columns as are available to view, except for 'Full Name'": ({
+      csv,
+    }: {
+      csv: Download;
+    }) => Promise<void>;
+    "{CSV} should have {count} rows": ({
+      csv,
+      count,
+    }: {
+      csv: Download;
+      count: number;
+    }) => Promise<void>;
   };
 }>({
   Given: async ({ mount }, use) => {
@@ -81,14 +90,14 @@ const feature = test.extend<{
   },
   Then: async ({ page }, use) => {
     await use({
-      "it should have a precise usage column": async (csv: Download) => {
+      "{CSV} should have a precise usage column": async ({ csv }) => {
         const path = await csv.path();
         const fileContents = await fs.readFile(path, "utf8");
         expect(fileContents).toContain("362006");
         expect(fileContents).not.toContain("362.01 kB");
       },
-      "it should have the same number of columns as are available to view, except for 'Full Name'":
-        async (csv: Download) => {
+      "{CSV} should have the same number of columns as are available to view, except for 'Full Name'":
+        async ({ csv }) => {
           await page.getByRole("button", { name: /Select columns/ }).click();
           const numberOfColumns = await page
             .getByRole("checkbox", {
@@ -101,10 +110,7 @@ const feature = test.extend<{
           const header = lines[0].split(",");
           expect(header.length).toBe(numberOfColumns);
         },
-      "it should have {count} rows": async (
-        csv: Download,
-        { count }: { count: number }
-      ) => {
+      "{CSV} should have {count} rows": async ({ csv, count }) => {
         const path = await csv.path();
         const fileContents = await fs.readFile(path, "utf8");
         const lines = fileContents.split("\n");
@@ -264,8 +270,8 @@ test.describe("CSV Export", () => {
       async ({ Given, When, Then }) => {
         await Given["the sysadmin is on the users page"]();
         // Note that no selection is made
-        const download = await When["a CSV export is downloaded"]();
-        await Then["it should have {count} rows"](download, { count: 10 });
+        const csv = await When["a CSV export is downloaded"]();
+        await Then["{CSV} should have {count} rows"]({ csv, count: 10 });
       }
     );
     feature(
@@ -273,10 +279,10 @@ test.describe("CSV Export", () => {
       async ({ Given, When, Then }) => {
         await Given["the sysadmin is on the users page"]();
         await When["one row is selected"]();
-        const download = await When[
+        const csv = await When[
           "a CSV export of the selected rows is downloaded"
         ]();
-        await Then["it should have {count} rows"](download, { count: 1 });
+        await Then["{CSV} should have {count} rows"]({ csv, count: 1 });
       }
     );
   });
@@ -285,10 +291,10 @@ test.describe("CSV Export", () => {
       "All of the columns should be included in the CSV file.",
       async ({ Given, When, Then }) => {
         await Given["the sysadmin is on the users page"]();
-        const download = await When["a CSV export is downloaded"]();
+        const csv = await When["a CSV export is downloaded"]();
         await Then[
-          "it should have the same number of columns as are available to view, except for 'Full Name'"
-        ](download);
+          "{CSV} should have the same number of columns as are available to view, except for 'Full Name'"
+        ]({ csv });
         /*
          * Full Name is not included in the CSV file because it is a derived
          * column from the first and last name columns. It is provided as a
@@ -300,8 +306,8 @@ test.describe("CSV Export", () => {
       "The usage column should be a precise number.",
       async ({ Given, When, Then }) => {
         await Given["the sysadmin is on the users page"]();
-        const download = await When["a CSV export is downloaded"]();
-        await Then["it should have a precise usage column"](download);
+        const csv = await When["a CSV export is downloaded"]();
+        await Then["{CSV} should have a precise usage column"]({ csv });
         /*
          * Because the CSV file can then be imported into a spreadsheet program
          * and the usage column will be formatted as a number, for sorting and

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
@@ -24,8 +24,10 @@ const feature = test.extend<{
     "it should have the same number of columns as are available to view, except for 'Full Name'": (
       csv: Download
     ) => Promise<void>;
-    "it should have a single row": (csv: Download) => Promise<void>;
-    "it should have ten rows": (csv: Download) => Promise<void>;
+    "it should have {count} rows": (
+      csv: Download,
+      { count }: { count: number }
+    ) => Promise<void>;
   };
 }>({
   Given: async ({ mount }, use) => {
@@ -99,17 +101,14 @@ const feature = test.extend<{
           const header = lines[0].split(",");
           expect(header.length).toBe(numberOfColumns);
         },
-      "it should have a single row": async (csv: Download) => {
+      "it should have {count} rows": async (
+        csv: Download,
+        { count }: { count: number }
+      ) => {
         const path = await csv.path();
         const fileContents = await fs.readFile(path, "utf8");
         const lines = fileContents.split("\n");
-        expect(lines.length).toBe(2);
-      },
-      "it should have ten rows": async (csv: Download) => {
-        const path = await csv.path();
-        const fileContents = await fs.readFile(path, "utf8");
-        const lines = fileContents.split("\n");
-        expect(lines.length).toBe(11);
+        expect(lines.length).toBe(count + 1);
       },
     });
   },
@@ -266,7 +265,7 @@ test.describe("CSV Export", () => {
         await Given["the sysadmin is on the users page"]();
         // Note that no selection is made
         const download = await When["a CSV export is downloaded"]();
-        await Then["it should have ten rows"](download);
+        await Then["it should have {count} rows"](download, { count: 10 });
       }
     );
     feature(
@@ -277,7 +276,7 @@ test.describe("CSV Export", () => {
         const download = await When[
           "a CSV export of the selected rows is downloaded"
         ]();
-        await Then["it should have a single row"](download);
+        await Then["it should have {count} rows"](download, { count: 1 });
       }
     );
   });

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
@@ -25,6 +25,7 @@ const feature = test.extend<{
       csv: Download
     ) => Promise<void>;
     "it should have a single row": (csv: Download) => Promise<void>;
+    "it should have ten rows": (csv: Download) => Promise<void>;
   };
 }>({
   Given: async ({ mount }, use) => {
@@ -103,6 +104,12 @@ const feature = test.extend<{
         const fileContents = await fs.readFile(path, "utf8");
         const lines = fileContents.split("\n");
         expect(lines.length).toBe(2);
+      },
+      "it should have ten rows": async (csv: Download) => {
+        const path = await csv.path();
+        const fileContents = await fs.readFile(path, "utf8");
+        const lines = fileContents.split("\n");
+        expect(lines.length).toBe(11);
       },
     });
   },
@@ -253,32 +260,15 @@ test.describe("Accessibility", () => {
 
 test.describe("CSV Export", () => {
   test.describe("Selection", () => {
-    test("When no rows are selected, every row of the current page should be included in the export", async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <StyledEngineProvider injectFirst>
-          <ThemeProvider theme={materialTheme}>
-            <UsersPage />
-          </ThemeProvider>
-        </StyledEngineProvider>
-      );
-
-      page.on("download", async (download) => {
-        const path = await download.path();
-        const fileContents = await fs.readFile(path, "utf8");
-        const lines = fileContents.split("\n");
-        expect(lines.length).toBe(11);
-      });
-
-      await page.getByRole("button", { name: /Export/ }).click();
-      await page
-        .getByRole("menuitem", {
-          name: /Export this page of rows to CSV/,
-        })
-        .click();
-    });
+    feature(
+      "When no rows are selected, every row of the current page should be included in the export",
+      async ({ Given, When, Then }) => {
+        await Given["the sysadmin is on the users page"]();
+        // Note that no selection is made
+        const download = await When["a CSV export is downloaded"]();
+        await Then["it should have ten rows"](download);
+      }
+    );
     feature(
       "When one row is selected, just it should be included in the export",
       async ({ Given, When, Then }) => {

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.spec.tsx
@@ -250,55 +250,52 @@ test.describe("CSV Export", () => {
         .click();
     });
     const test2 = test.extend<{
-      GivenTheSysadminIsOnTheUsersPage: () => Promise<void>;
-      WhenACsvExportIsDownloaded: () => Promise<Download>;
-      ThenItShouldHaveAPreciseUsageColumn: (csv: Download) => Promise<void>;
+      steps: {
+        "Given the sysadmin is on the users page": () => Promise<void>;
+        "When a CSV export is downloaded": () => Promise<Download>;
+        "Then it should have a precise usage column": (
+          csv: Download
+        ) => Promise<void>;
+      };
     }>({
-      GivenTheSysadminIsOnTheUsersPage: async ({ mount }, use) => {
-        await use(async () => {
-          await mount(
-            <StyledEngineProvider injectFirst>
-              <ThemeProvider theme={materialTheme}>
-                <UsersPage />
-              </ThemeProvider>
-            </StyledEngineProvider>
-          );
-        });
-      },
-      WhenACsvExportIsDownloaded: async ({ page }, use) => {
-        await use(async (): Promise<Download> => {
-          await page.getByRole("button", { name: /Export/ }).click();
-          const [download] = await Promise.all([
-            page.waitForEvent("download"),
-            page
-              .getByRole("menuitem", {
-                name: /Export this page of rows to CSV/,
-              })
-              .click(),
-          ]);
-          return download;
-        });
-      },
-      ThenItShouldHaveAPreciseUsageColumn: async (_fixtures, use) => {
-        await use(async (csv: Download) => {
-          const path = await csv.path();
-          const fileContents = await fs.readFile(path, "utf8");
-          expect(fileContents).toContain("362006");
-          expect(fileContents).not.toContain("362.01 kB");
+      steps: async ({ mount, page }, use) => {
+        await use({
+          "Given the sysadmin is on the users page": async () => {
+            await mount(
+              <StyledEngineProvider injectFirst>
+                <ThemeProvider theme={materialTheme}>
+                  <UsersPage />
+                </ThemeProvider>
+              </StyledEngineProvider>
+            );
+          },
+          "When a CSV export is downloaded": async (): Promise<Download> => {
+            await page.getByRole("button", { name: /Export/ }).click();
+            const [download] = await Promise.all([
+              page.waitForEvent("download"),
+              page
+                .getByRole("menuitem", {
+                  name: /Export this page of rows to CSV/,
+                })
+                .click(),
+            ]);
+            return download;
+          },
+          "Then it should have a precise usage column": async (
+            csv: Download
+          ) => {
+            const path = await csv.path();
+            const fileContents = await fs.readFile(path, "utf8");
+            expect(fileContents).toContain("362006");
+            expect(fileContents).not.toContain("362.01 kB");
+          },
         });
       },
     });
-    test2(
-      "The usage column should be a precise number.",
-      async ({
-        GivenTheSysadminIsOnTheUsersPage,
-        WhenACsvExportIsDownloaded,
-        ThenItShouldHaveAPreciseUsageColumn,
-      }) => {
-        await GivenTheSysadminIsOnTheUsersPage();
-        const download = await WhenACsvExportIsDownloaded();
-        await ThenItShouldHaveAPreciseUsageColumn(download);
-      }
-    );
+    test2("The usage column should be a precise number.", async ({ steps }) => {
+      await steps["Given the sysadmin is on the users page"]();
+      const download = await steps["When a CSV export is downloaded"]();
+      await steps["Then it should have a precise usage column"](download);
+    });
   });
 });


### PR DESCRIPTION
This is an experiment to structure the playwright component tests in such a way that the non-coders in the team can feasibly read the tests to understand the behaviour of the system. To do this, the keywords for the gherkin syntax of BDD are re-used to break the tests down into a series of re-usable steps