### PR TITLE
add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Description ##
+***REQUIRED***
+- ***brief description of the change***
+- ***don't repeat too much information that's already included in the jira/github issue***
+- ***if the change includes any UI updates, include screenshots or screen recordings if you think it adds value***
+
+## Design decisions
+***OPTIONAL***
+- ***if there were any particular design decisions made, list them here***
+
+## Testing notes
+***OPTIONAL***
+- ***if there are any particular pre-requisites or instructions for manual testing, list them here***


### PR DESCRIPTION
## Description ##
This PR add a pull request template which will be the default when creating a PR. It ensures we are aligned on the information that should be included, especially with outside contributors. The 3 sections are Description to add some background to the change, Design Decisions as an optional section to discuss approach and any potential alternatives, and Testing notes (optional) for any key information or pre-requisites needed for testing the changes.

In addition to this template, I think we should
1. Link Jira and Github, so that when a branch name has the jira id as the start of the title, the jira ticket is linked in the PR. We can do the same for Github issues for open-source contributors. This makes it easier for reviewers to find the original ticket, and saves repeating information in the PR.
2. Link Jenkins to Github, so that when a PR is run, we can trigger a full build on Jenkins. The PR will only be mergable when there is a succesful build in Jenkins.

Let me know what you think about 1 and 2 and I can create tickets if we think it's a good idea.

## Design decisions
I specificially tried to not add too much information to this template to keep it generic enough for all of the types of changes that can be made, but maybe there is more information that should be included?
