### PR TITLE
RSDEV-268 Link to additional server properties docs

### DIFF
--- a/src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp
@@ -2,7 +2,10 @@
 
 <div id="systemSettingsView">
 
-    <div style="margin: 5px;"><spring:message code="system.settings.header.info" /></div>
+    <div style="margin: 5px;">
+      <spring:message code="system.settings.header.info" />
+      Some settings can only be adjusted by IT staff with with access to the server environment, for more information about additional settings see: <a href="https://documentation.researchspace.com/article/6i9j335fy1-additional-server-properties-settings" rel="noreferrer">Additional Server Properties / Settings</a>
+    </div>
 
     <div id="systemSettingsList">
         <div id="settingsLoadingMsg">


### PR DESCRIPTION
This change tweaks the text at the top of the sysadmin config page to make clear to sysadmins that some configurations options are made via changes to the deployment properties and other config files, rather than solely through the web-based UI.

This change does not modify `system.settings.header.info` so as to not change the community admin settings dialog

![image](https://github.com/user-attachments/assets/68c56679-1a2e-46da-a0e3-81206f68fc9e)
