### PR TITLE
Data grid with radio selection

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.js
+++ b/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.js
@@ -15,11 +15,9 @@ import InvApiService from "../../common/InvApiService";
 import { doNotAwait } from "../../util/Util";
 import { DataGridColumn } from "../../util/table";
 import {
-  DataGrid,
   GridToolbarContainer,
   GridToolbarColumnsButton,
 } from "@mui/x-data-grid";
-import Radio from "@mui/material/Radio";
 import useViewportDimensions from "../../util/useViewportDimensions";
 import * as ArrayUtils from "../../util/ArrayUtils";
 import * as Parsers from "../../util/parsers";
@@ -35,6 +33,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import { type LinkableRecord } from "../../stores/definitions/LinkableRecord";
 import docLinks from "../../assets/DocLinks";
 import { ACCENT_COLOR } from "../../assets/branding/fieldmark";
+import { DataGridWithRadioSelection } from "../../components/DataGridWithRadioSelection";
 
 /**
  * This class allows us to provide a link to the newly created container in the
@@ -284,31 +283,8 @@ export default function FieldmarkImportDialog({
               </Typography>
             </Grid>
             <Grid item>
-              <DataGrid
+              <DataGridWithRadioSelection
                 columns={[
-                  {
-                    field: "radio",
-                    headerName: "Select",
-                    renderCell: (params: { row: Notebook, ... }) => (
-                      <Radio
-                        color="primary"
-                        value={
-                          selectedNotebook?.metadata.project_id ===
-                          params.row.metadata.project_id
-                        }
-                        checked={
-                          selectedNotebook?.metadata.project_id ===
-                          params.row.metadata.project_id
-                        }
-                        inputProps={{ "aria-label": "Notebook selection" }}
-                      />
-                    ),
-                    hideable: false,
-                    width: 70,
-                    flex: 0,
-                    disableColumnMenu: true,
-                    sortable: false,
-                  },
                   DataGridColumn.newColumnWithFieldName<_, Notebook>("name", {
                     headerName: "Name",
                     flex: 1,
@@ -368,6 +344,17 @@ export default function FieldmarkImportDialog({
                   },
                 }}
                 rows={notebooks ?? []}
+                selectedRowId={selectedNotebook?.metadata.project_id}
+                onSelectionChange={(newSelectionId) => {
+                  ArrayUtils.find(
+                    (n) => n.metadata.project_id === newSelectionId,
+                    notebooks ?? []
+                  )
+                  .do((newlySelectedNotebook) => {
+                    setSelectedNotebook(newlySelectedNotebook);
+                  });
+                }}
+                selectRadioAriaLabelFunc={(row) => `Select notebook: ${row.name}`}
                 disableColumnFilter
                 hideFooter
                 autoHeight
@@ -388,21 +375,6 @@ export default function FieldmarkImportDialog({
                   },
                 }}
                 getRowId={(row) => row.metadata.project_id}
-                onRowSelectionModelChange={(
-                  newSelection: $ReadOnlyArray<string>
-                ) => {
-                  ArrayUtils.head(newSelection)
-                    .toOptional()
-                    .flatMap((selectedId) =>
-                      ArrayUtils.find(
-                        (n) => n.metadata.project_id === selectedId,
-                        notebooks ?? []
-                      )
-                    )
-                    .do((newlySelectedNotebook) => {
-                      setSelectedNotebook(newlySelectedNotebook);
-                    });
-                }}
               />
             </Grid>
           </Grid>

--- a/src/main/webapp/ui/src/components/DataGridWithRadioSelection.js.flow
+++ b/src/main/webapp/ui/src/components/DataGridWithRadioSelection.js.flow
@@ -1,0 +1,34 @@
+//@flow
+
+import { type Node, type ElementConfig } from "react";
+import { DataGrid } from "@mui/x-data-grid";
+
+declare export function DataGridWithRadioSelection<
+    Row,
+    ColumnNames: string,
+    Id: mixed,
+    ToolbarProps: { ... },
+    Value: mixed,
+    SortableColumnNames: ColumnNames,
+    LoadingOverlayProps: { ... },
+  >({|
+  onSelectionChange: (Id) => void,
+  selectedRowId?: Id,
+  selectRadioAriaLabelFunc: (Row) => string,
+  ...$Diff<
+    ElementConfig<typeof DataGrid<
+    Row,
+    ColumnNames,
+    Id,
+    ToolbarProps,
+    Value,
+    SortableColumnNames,
+    LoadingOverlayProps,
+  >>,
+    {|
+      checkboxSelection: mixed,
+      disableMultipleRowSelection: mixed,
+      rowSelectionModel: mixed,
+      onRowSelectionModelChange: mixed,
+    |}>
+|}): Node;

--- a/src/main/webapp/ui/src/components/DataGridWithRadioSelection.spec.tsx
+++ b/src/main/webapp/ui/src/components/DataGridWithRadioSelection.spec.tsx
@@ -1,0 +1,458 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import React from "react";
+import {
+  DataGridWithRadioSelectionExample,
+  ControlledDataGridWithRadioSelectionExample,
+  DataGridWithFeatures,
+} from "./DataGridWithRadioSelection.story";
+import { GridRowId } from "@mui/x-data-grid";
+
+const createSelectionChangeSpy = () => {
+  let lastSelectedId: GridRowId | null = null;
+
+  const handler = (id: GridRowId) => {
+    lastSelectedId = id;
+  };
+
+  const getLastSelectedId = () => lastSelectedId;
+
+  return {
+    handler,
+    getLastSelectedId,
+  };
+};
+
+const feature = test.extend<{
+  Given: {
+    "the data grid with radio selection is rendered": () => Promise<void>;
+    "the data grid with controlled selection is rendered": (params?: {
+      selectedRowId?: GridRowId | null;
+    }) => Promise<{ spy: ReturnType<typeof createSelectionChangeSpy> }>;
+    "the data grid with additional features is rendered": () => Promise<void>;
+  };
+  When: {
+    "the user clicks on the radio button for row {i}": ({
+      i,
+    }: {
+      i: number;
+    }) => Promise<void>;
+    "the user clicks on row {i}": ({ i }: { i: number }) => Promise<void>;
+    "the user tabs to focus the grid": () => Promise<void>;
+    "the user tabs to the radio button for row {i}": ({
+      i,
+    }: {
+      i: number;
+    }) => Promise<void>;
+    "the user presses the space key": () => Promise<void>;
+    "the user clicks the reset selection button": () => Promise<void>;
+    "the user clicks the 'Select Row 2' button": () => Promise<void>;
+    "the user clicks the sort button for column {field}": ({
+      field,
+    }: {
+      field: string;
+    }) => Promise<void>;
+    "the user changes the page size to {size}": ({
+      size,
+    }: {
+      size: number;
+    }) => Promise<void>;
+    "the user navigates to the next page": () => Promise<void>;
+    "the user navigates to the previous page": () => Promise<void>;
+  };
+  Then: {
+    "the row {i} should be selected": ({ i }: { i: number }) => Promise<void>;
+    "the row {i} should not be selected": ({
+      i,
+    }: {
+      i: number;
+    }) => Promise<void>;
+    "the selection indicator should show {id}": ({
+      id,
+    }: {
+      id: number | null;
+    }) => Promise<void>;
+    "no rows should be selected": () => Promise<void>;
+    "the radio button for row {i} should have focus": ({
+      i,
+    }: {
+      i: number;
+    }) => Promise<void>;
+    "the radio button for row {i} should have the aria-label {ariaLabel}": ({
+      i,
+    }: {
+      i: number;
+      ariaLabel: string;
+    }) => Promise<void>;
+    "the {spy} should have been called with {id}": ({
+      id,
+      spy,
+    }: {
+      id: number;
+      spy: ReturnType<typeof createSelectionChangeSpy>;
+    }) => void;
+    "the radio column should be the first column": () => Promise<void>;
+  };
+}>({
+  Given: async ({ mount }, use) => {
+    await use({
+      "the data grid with radio selection is rendered": async () => {
+        await mount(<DataGridWithRadioSelectionExample />);
+      },
+      "the data grid with controlled selection is rendered": async ({
+        selectedRowId = null,
+      } = {}) => {
+        const selectionChangeSpy = createSelectionChangeSpy();
+        await mount(
+          <ControlledDataGridWithRadioSelectionExample
+            initialSelectedRowId={selectedRowId}
+            onSelectionChangeSpy={selectionChangeSpy.handler}
+          />
+        );
+        return { spy: selectionChangeSpy };
+      },
+      "the data grid with additional features is rendered": async () => {
+        await mount(<DataGridWithFeatures />);
+      },
+    });
+  },
+  When: async ({ page }, use) => {
+    await use({
+      "the user clicks on the radio button for row {i}": async ({ i }) => {
+        await page
+          .getByRole("row")
+          .nth(i + 1)
+          .getByRole("radio")
+          .click();
+      },
+      "the user clicks on row {i}": async ({ i }) => {
+        await page
+          .getByRole("row")
+          .nth(i + 1)
+          .getByRole("gridcell")
+          // Click on a cell in the row (not the radio button)
+          .nth(2)
+          .click();
+      },
+      "the user tabs to focus the grid": async () => {
+        await page.keyboard.press("Tab");
+      },
+      "the user tabs to the radio button for row {i}": async ({ i }) => {
+        // Repeatedly press Tab until the radio button for the specified row is focused
+        let found = false;
+        const maxTabs = 20; // Safety limit to prevent infinite loops
+        let tabCount = 0;
+
+        while (!found && tabCount < maxTabs) {
+          await page.keyboard.press("Tab");
+
+          found = await page
+            .getByRole("row")
+            .nth(i + 1)
+            .getByRole("radio")
+            .evaluate((radio) => document.activeElement === radio);
+
+          tabCount++;
+        }
+      },
+      "the user presses the space key": async () => {
+        await page.keyboard.press("Space");
+      },
+      "the user clicks the reset selection button": async () => {
+        await page.getByRole("button", { name: /Reset Selection/i }).click();
+      },
+      "the user clicks the 'Select Row 2' button": async () => {
+        await page.getByRole("button", { name: /Select Row 2/i }).click();
+      },
+      "the user clicks the sort button for column {field}": async ({
+        field,
+      }) => {
+        await page.getByRole("columnheader", { name: field }).click();
+      },
+      "the user changes the page size to {size}": async ({ size }) => {
+        await page.getByRole("combobox", { name: /Rows per page/i }).click();
+        await page
+          .getByRole("listbox")
+          .getByRole("option", { name: `${size}` })
+          .click();
+      },
+      "the user navigates to the next page": async () => {
+        await page.getByRole("button", { name: /Go to next page/i }).click();
+      },
+      "the user navigates to the previous page": async () => {
+        await page
+          .getByRole("button", { name: /Go to previous page/i })
+          .click();
+      },
+    });
+  },
+  Then: async ({ page }, use) => {
+    await use({
+      "the row {i} should be selected": async ({ i }) => {
+        await expect(
+          page
+            .getByRole("row")
+            .nth(i + 1)
+            .getByRole("radio")
+        ).toBeChecked();
+        await expect(page.getByRole("row").nth(i + 1)).toHaveAttribute(
+          "aria-selected",
+          "true"
+        );
+      },
+      "the row {i} should not be selected": async ({ i }) => {
+        await expect(
+          page
+            .getByRole("row")
+            .nth(i + 1)
+            .getByRole("radio")
+        ).not.toBeChecked();
+        await expect(page.getByRole("row").nth(i + 1)).not.toHaveAttribute(
+          "aria-selected",
+          "true"
+        );
+      },
+      "the selection indicator should show {id}": async ({ id }) => {
+        if (id === null) {
+          await expect(page.getByTestId("selection-indicator")).toHaveText(
+            "Nothing selected"
+          );
+        } else {
+          await expect(page.getByTestId("selection-indicator")).toHaveText(
+            `Selected ID: ${id}`
+          );
+        }
+      },
+      "no rows should be selected": async () => {
+        await expect(page.getByRole("radio", { checked: true })).toHaveCount(0);
+      },
+      "the radio button for row {i} should have focus": async ({ i }) => {
+        expect(
+          await page
+            .getByRole("row")
+            .nth(i + 1)
+            .getByRole("radio")
+            .evaluate((radio) => document.activeElement === radio)
+        ).toBe(true);
+      },
+      "the radio button for row {i} should have the aria-label {ariaLabel}":
+        async ({ i, ariaLabel }) => {
+          const row = page.getByRole("row").nth(i + 1);
+          await expect(row.getByRole("radio")).toHaveAttribute(
+            "aria-label",
+            ariaLabel
+          );
+        },
+      "the {spy} should have been called with {id}": ({ id, spy }) => {
+        expect(spy.getLastSelectedId()).toBe(id);
+      },
+      "the radio column should be the first column": async () => {
+        await expect(page.getByRole("columnheader").first()).toHaveText(
+          "Select"
+        );
+        const rows = await page.getByRole("row").all();
+        // Skip the first row (header row)
+        for (const row of rows.slice(1)) {
+          await expect(
+            row.getByRole("gridcell").first().getByRole("radio")
+          ).toBeVisible();
+        }
+      },
+    });
+  },
+});
+
+test.describe("DataGridWithRadioSelection", () => {
+  test.describe("Basic Rendering and Initial State", () => {
+    feature(
+      "Component renders with radio selection column as first column",
+      async ({ Given, Then }) => {
+        await Given["the data grid with radio selection is rendered"]();
+        await Then["the radio column should be the first column"]();
+      }
+    );
+
+    feature("No row is selected by default", async ({ Given, Then }) => {
+      await Given["the data grid with radio selection is rendered"]();
+      await Then["no rows should be selected"]();
+      await Then["the selection indicator should show {id}"]({ id: null });
+    });
+
+    feature(
+      "Radio buttons have the correct ARIA labels",
+      async ({ Given, Then }) => {
+        await Given["the data grid with radio selection is rendered"]();
+        await Then[
+          "the radio button for row {i} should have the aria-label {ariaLabel}"
+        ]({ i: 0, ariaLabel: "Select John Doe" });
+      }
+    );
+  });
+
+  test.describe("Radio Selection Behavior", () => {
+    feature(
+      "Clicking a radio button selects the corresponding row",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with radio selection is rendered"]();
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 0,
+        });
+        await Then["the row {i} should be selected"]({ i: 0 });
+        await Then["the selection indicator should show {id}"]({ id: 1 });
+      }
+    );
+
+    feature(
+      "Selecting a new row deselects the previously selected row",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with radio selection is rendered"]();
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 0,
+        });
+        await Then["the row {i} should be selected"]({ i: 0 });
+
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 1,
+        });
+        await Then["the row {i} should be selected"]({ i: 1 });
+        await Then["the row {i} should not be selected"]({ i: 0 });
+        await Then["the selection indicator should show {id}"]({ id: 2 });
+      }
+    );
+
+    feature(
+      "Clicking on a row cell maintains the selection state",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with radio selection is rendered"]();
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 0,
+        });
+        await When["the user clicks on row {i}"]({ i: 1 });
+
+        // Selection should remain on row 1
+        await Then["the row {i} should be selected"]({ i: 0 });
+        await Then["the selection indicator should show {id}"]({ id: 1 });
+      }
+    );
+  });
+
+  test.describe("Controlled vs Uncontrolled Mode", () => {
+    feature(
+      "Uncontrolled mode manages internal selection state",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with radio selection is rendered"]();
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 0,
+        });
+        await Then["the row {i} should be selected"]({ i: 0 });
+
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 1,
+        });
+        await Then["the row {i} should be selected"]({ i: 1 });
+      }
+    );
+
+    feature(
+      "Controlled mode reflects external selection state",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with controlled selection is rendered"]({
+          selectedRowId: 1,
+        });
+        await Then["the row {i} should be selected"]({ i: 0 });
+
+        // External state change
+        await When["the user clicks the reset selection button"]();
+        await Then["no rows should be selected"]();
+
+        await When["the user clicks the 'Select Row 2' button"]();
+        await Then["the row {i} should be selected"]({ i: 1 });
+      }
+    );
+
+    feature(
+      "onSelectionChange callback is called with correct row ID",
+      async ({ Given, When, Then }) => {
+        const { spy } = await Given[
+          "the data grid with controlled selection is rendered"
+        ]();
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 2,
+        });
+        Then["the {spy} should have been called with {id}"]({
+          id: 3,
+          spy,
+        });
+        await Then["the row {i} should be selected"]({ i: 2 });
+      }
+    );
+  });
+
+  test.describe("Keyboard Navigation and Accessibility", () => {
+    feature("Users can tab to radio buttons", async ({ Given, When, Then }) => {
+      await Given["the data grid with radio selection is rendered"]();
+      await When["the user tabs to the radio button for row {i}"]({ i: 0 });
+      await Then["the radio button for row {i} should have focus"]({ i: 0 });
+    });
+
+    feature(
+      "Users can select rows using keyboard",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with radio selection is rendered"]();
+        await When["the user tabs to the radio button for row {i}"]({ i: 0 });
+        await When["the user presses the space key"]();
+        await Then["the row {i} should be selected"]({ i: 0 });
+      }
+    );
+  });
+
+  test.describe("Integration with MUI DataGrid Features", () => {
+    feature(
+      "Sorting works correctly with radio selection",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with additional features is rendered"]();
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 0,
+        });
+        await Then["the row {i} should be selected"]({ i: 0 });
+        await When["the user clicks the sort button for column {field}"]({
+          field: "age",
+        });
+
+        // Selection should now move to the third row, as John is the oldest
+        await Then["the row {i} should be selected"]({ i: 2 });
+      }
+    );
+
+    feature(
+      "Pagination works correctly with radio selection",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with additional features is rendered"]();
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 0,
+        });
+        await Then["the row {i} should be selected"]({ i: 0 });
+        await When["the user navigates to the next page"]();
+
+        // Selection should be maintained in the data model, even if row is not visible
+        await Then["the selection indicator should show {id}"]({ id: 1 });
+
+        // When returning to first page, the selection should still be there
+        await When["the user navigates to the previous page"]();
+        await Then["the row {i} should be selected"]({ i: 0 });
+      }
+    );
+
+    feature(
+      "Changing page size works correctly with radio selection",
+      async ({ Given, When, Then }) => {
+        await Given["the data grid with additional features is rendered"]();
+        await When["the user clicks on the radio button for row {i}"]({
+          i: 2,
+        });
+        await Then["the row {i} should be selected"]({ i: 2 });
+        await When["the user changes the page size to {size}"]({ size: 5 });
+        await Then["the row {i} should be selected"]({ i: 2 });
+      }
+    );
+  });
+});

--- a/src/main/webapp/ui/src/components/DataGridWithRadioSelection.story.tsx
+++ b/src/main/webapp/ui/src/components/DataGridWithRadioSelection.story.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import { DataGridWithRadioSelection } from "./DataGridWithRadioSelection";
-import { GridColDef, GridRowId } from "@mui/x-data-grid";
+import {
+  GridColDef,
+  GridRowId,
+  GridToolbarContainer,
+  GridToolbarExportContainer,
+  useGridApiContext,
+} from "@mui/x-data-grid";
+import MenuItem from "@mui/material/MenuItem";
 
 const rows = [
   { id: 1, firstName: "John", lastName: "Doe", age: 35 },
@@ -125,6 +132,47 @@ export function DataGridWithFeatures() {
           ? `Selected ID: ${lastSelectedId}`
           : "Nothing selected"}
       </div>
+    </div>
+  );
+}
+
+const CsvExportToolbar = () => {
+  const apiRef = useGridApiContext();
+
+  return (
+    <GridToolbarContainer sx={{ width: "100%" }}>
+      <GridToolbarExportContainer>
+        <MenuItem
+          onClick={() => {
+            apiRef.current?.exportDataAsCsv({
+              allColumns: true,
+            });
+          }}
+        >
+          Export to CSV
+        </MenuItem>
+      </GridToolbarExportContainer>
+    </GridToolbarContainer>
+  );
+};
+
+/**
+ * For testing how export to CSV export works with the custom selection
+ */
+export function DataGridWithExportToCsv() {
+  return (
+    <div style={{ height: 400, width: "100%" }}>
+      <DataGridWithRadioSelection
+        rows={rows}
+        columns={columns}
+        onSelectionChange={() => {}}
+        selectRadioAriaLabelFunc={(row) =>
+          `Select ${row.firstName} ${row.lastName}`
+        }
+        slots={{
+          toolbar: CsvExportToolbar,
+        }}
+      />
     </div>
   );
 }

--- a/src/main/webapp/ui/src/components/DataGridWithRadioSelection.story.tsx
+++ b/src/main/webapp/ui/src/components/DataGridWithRadioSelection.story.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { DataGridWithRadioSelection } from "./DataGridWithRadioSelection";
+import { GridColDef, GridRowId } from "@mui/x-data-grid";
+
+const rows = [
+  { id: 1, firstName: "John", lastName: "Doe", age: 35 },
+  { id: 2, firstName: "Jane", lastName: "Smith", age: 28 },
+  { id: 3, firstName: "Bob", lastName: "Johnson", age: 42 },
+  { id: 4, firstName: "Alice", lastName: "Williams", age: 31 },
+  { id: 5, firstName: "Charlie", lastName: "Brown", age: 45 },
+];
+
+const columns: GridColDef[] = [
+  { field: "firstName", headerName: "First Name", width: 150 },
+  { field: "lastName", headerName: "Last Name", width: 150 },
+  { field: "age", headerName: "Age", type: "number", width: 90 },
+];
+
+/**
+ * Basic uncontrolled example of DataGridWithRadioSelection
+ */
+export function DataGridWithRadioSelectionExample() {
+  const [lastSelectedId, setLastSelectedId] = React.useState<GridRowId | null>(
+    null
+  );
+
+  const handleSelectionChange = (selectedId: GridRowId) => {
+    setLastSelectedId(selectedId);
+    console.log(`Row ${selectedId} selected`);
+  };
+
+  return (
+    <div style={{ height: 400, width: "100%" }}>
+      <DataGridWithRadioSelection
+        rows={rows}
+        columns={columns}
+        onSelectionChange={handleSelectionChange}
+        selectRadioAriaLabelFunc={(row) =>
+          `Select ${row.firstName} ${row.lastName}`
+        }
+        data-testid="data-grid"
+      />
+      <div data-testid="selection-indicator">
+        {lastSelectedId !== null
+          ? `Selected ID: ${lastSelectedId}`
+          : "Nothing selected"}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Controlled example of DataGridWithRadioSelection
+ */
+export function ControlledDataGridWithRadioSelectionExample({
+  initialSelectedRowId = null,
+  onSelectionChangeSpy = () => {},
+}: {
+  initialSelectedRowId?: GridRowId | null;
+  onSelectionChangeSpy?: (selectedId: GridRowId) => void;
+}) {
+  const [selectedRowId, setSelectedRowId] = React.useState<GridRowId | null>(
+    initialSelectedRowId
+  );
+
+  const handleSelectionChange = (selectedId: GridRowId) => {
+    setSelectedRowId(selectedId);
+    onSelectionChangeSpy(selectedId);
+  };
+
+  return (
+    <div style={{ height: 400, width: "100%" }}>
+      <DataGridWithRadioSelection
+        rows={rows}
+        columns={columns}
+        onSelectionChange={handleSelectionChange}
+        selectedRowId={selectedRowId}
+        selectRadioAriaLabelFunc={(row) =>
+          `Select ${row.firstName} ${row.lastName}`
+        }
+        data-testid="controlled-data-grid"
+      />
+      <div data-testid="selection-indicator">
+        {selectedRowId !== null
+          ? `Selected ID: ${selectedRowId}`
+          : "Nothing selected"}
+      </div>
+      <button onClick={() => setSelectedRowId(null)}>Reset Selection</button>
+      <button onClick={() => setSelectedRowId(2)}>Select Row 2</button>
+    </div>
+  );
+}
+
+/**
+ * Example with sorting and filtering enabled
+ */
+export function DataGridWithFeatures() {
+  const [lastSelectedId, setLastSelectedId] = React.useState<GridRowId | null>(
+    null
+  );
+
+  const handleSelectionChange = (selectedId: GridRowId) => {
+    setLastSelectedId(selectedId);
+  };
+
+  return (
+    <div style={{ height: 400, width: "100%" }}>
+      <DataGridWithRadioSelection
+        rows={rows}
+        columns={columns}
+        onSelectionChange={handleSelectionChange}
+        selectRadioAriaLabelFunc={(row) =>
+          `Select ${row.firstName} ${row.lastName}`
+        }
+        initialState={{
+          pagination: {
+            paginationModel: { pageSize: 3 },
+          },
+        }}
+        pageSizeOptions={[3, 5]}
+        data-testid="featured-data-grid"
+      />
+      <div data-testid="selection-indicator">
+        {lastSelectedId !== null
+          ? `Selected ID: ${lastSelectedId}`
+          : "Nothing selected"}
+      </div>
+    </div>
+  );
+}

--- a/src/main/webapp/ui/src/components/DataGridWithRadioSelection.tsx
+++ b/src/main/webapp/ui/src/components/DataGridWithRadioSelection.tsx
@@ -90,8 +90,17 @@ export function DataGridWithRadioSelection({
               }
               handleSelectionChange(params.id);
             }}
-            aria-label={selectRadioAriaLabelFunc(params.row)}
+            inputProps={{
+              "aria-label": selectRadioAriaLabelFunc(params.row),
+            }}
             onClick={(e) => e.stopPropagation()} // Prevent row selection on click
+            onKeyDown={(e) => {
+              if (e.key === " " || e.key === "Spacebar") {
+                e.preventDefault();
+                e.stopPropagation();
+                handleSelectionChange(params.id);
+              }
+            }}
           />
         );
       },

--- a/src/main/webapp/ui/src/components/DataGridWithRadioSelection.tsx
+++ b/src/main/webapp/ui/src/components/DataGridWithRadioSelection.tsx
@@ -10,7 +10,11 @@ import {
 import { Radio } from "@mui/material";
 
 /**
- * A DataGrid, where the first column is a Radio field for selecting a single column
+ * A DataGrid, where the first column is a Radio field for selecting a single
+ * column. MUI's DataGrid supports checkbox-based selection by setting the
+ * `checkboxSelection` prop and whilst the `disableMultipleRowSelection` does
+ * what it suggests it does not change the checkboxes to radio buttons, which is
+ * the more semantic UI element for singular selection.
  */
 export function DataGridWithRadioSelection({
   columns,
@@ -19,8 +23,21 @@ export function DataGridWithRadioSelection({
   selectRadioAriaLabelFunc,
   ...props
 }: {
+  /*
+   * The list of other columns to which the selection column with be prepended.
+   */
   columns: GridColDef[];
+
+  /*
+   * When the selection changes, this function will be called.
+   */
   onSelectionChange: (selectedId: GridRowId) => void;
+
+  /*
+   * Each of the radio buttons should have an aria-label that describes what the
+   * UI element is for to those using screen readers. This function allows
+   * callers to specify a label that is specific to each row e.g. "Select Foo"
+   */
   selectRadioAriaLabelFunc: (col: GridRenderCellParams["row"]) => string;
 } & Omit<
   React.ComponentProps<typeof DataGrid>,

--- a/src/main/webapp/ui/src/components/DataGridWithRadioSelection.tsx
+++ b/src/main/webapp/ui/src/components/DataGridWithRadioSelection.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import {
+  DataGrid,
+  GRID_CHECKBOX_SELECTION_COL_DEF,
+  GridColDef,
+  GridRenderCellParams,
+  GridRowId,
+  useGridApiRef,
+} from "@mui/x-data-grid";
+import { Radio } from "@mui/material";
+
+/**
+ * A DataGrid, where the first column is a Radio field for selecting a single column
+ */
+export function DataGridWithRadioSelection({
+  columns,
+  onSelectionChange,
+  localeText,
+  selectRadioAriaLabelFunc,
+  ...props
+}: {
+  columns: GridColDef[];
+  onSelectionChange: (selectedId: GridRowId) => void;
+  selectRadioAriaLabelFunc: (col: GridRenderCellParams["row"]) => string;
+} & Omit<
+  React.ComponentProps<typeof DataGrid>,
+  | "columns"
+  | "checkboxSelection"
+  | "disableMultipleRowSelection"
+  | "rowSelectionModel"
+  | "onRowSelectionModelChange"
+>) {
+  const apiRef = useGridApiRef();
+  const [selectedRowId, setSelectedRowId] = React.useState<GridRowId | null>(
+    null
+  );
+
+  const radioSelectionColumn: GridColDef = React.useMemo(
+    () => ({
+      ...GRID_CHECKBOX_SELECTION_COL_DEF,
+      renderHeader: () => "Select",
+      renderCell: (params: GridRenderCellParams) => {
+        const isSelected = selectedRowId === params.id;
+
+        return (
+          <Radio
+            color="primary"
+            checked={isSelected}
+            onChange={(event: unknown, selected: boolean | null) => {
+              if (selected === null) {
+                setSelectedRowId(null);
+                return;
+              }
+              setSelectedRowId(params.id);
+              onSelectionChange(params.id);
+            }}
+            aria-label={selectRadioAriaLabelFunc(params.row)}
+            onClick={(e) => e.stopPropagation()} // Prevent row selection on click
+          />
+        );
+      },
+      width: 70,
+      flex: 0,
+      hideable: false,
+      disableMenuColumn: true,
+    }),
+    [onSelectionChange, selectedRowId, selectRadioAriaLabelFunc]
+  );
+
+  const allColumns = React.useMemo(() => {
+    return [radioSelectionColumn, ...columns];
+  }, [radioSelectionColumn, columns]);
+
+  return (
+    <DataGrid
+      apiRef={apiRef}
+      columns={allColumns}
+      checkboxSelection
+      disableMultipleRowSelection
+      rowSelectionModel={selectedRowId === null ? [] : [selectedRowId]}
+      localeText={{
+        checkboxSelectionHeaderName: "Select",
+        ...(localeText ?? {}),
+      }}
+      {...props}
+    />
+  );
+}

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.spec.tsx
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.spec.tsx
@@ -104,7 +104,7 @@ test("Importing a selected DMP should call the import endpoint.", async ({
   await expect(page.getByRole("dialog")).toBeVisible();
   await expect(page.getByText("foo")).toBeVisible();
 
-  const cell = page.getByRole("gridcell", { name: "Plan selection" }).first();
+  const cell = page.getByRole("gridcell", { name: "Select plan: Foo" }).first();
   await cell.getByRole("radio").click();
 
   const [request] = await Promise.all([

--- a/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.tsx
+++ b/src/main/webapp/ui/src/eln-dmp-integration/Argos/DMPDialog.tsx
@@ -32,12 +32,12 @@ import docLinks from "../../assets/DocLinks";
 import Link from "@mui/material/Link";
 import createAccentedTheme from "../../accentedTheme";
 import { ThemeProvider } from "@mui/material/styles";
-import { DataGrid, GridRowSelectionModel } from "@mui/x-data-grid";
-import Radio from "@mui/material/Radio";
+import { GridRowId } from "@mui/x-data-grid";
 import Stack from "@mui/material/Stack";
 import DialogTitle from "@mui/material/DialogTitle";
 import AppBar from "../../components/AppBar";
 import { ACCENT_COLOR } from "../../assets/branding/argos";
+import { DataGridWithRadioSelection } from "../../components/DataGridWithRadioSelection";
 
 const CustomTablePagination = withStyles<
   React.ComponentProps<typeof TablePagination> & { component?: string },
@@ -513,25 +513,8 @@ function DMPDialogContent({
             />
           </Grid>
           <Grid item sx={{ overflowY: "auto" }} flexGrow={1}>
-            <DataGrid
+            <DataGridWithRadioSelection
               columns={[
-                {
-                  field: "radio",
-                  headerName: "Select",
-                  renderCell: (params: { row: PlanSummary }) => (
-                    <Radio
-                      color="primary"
-                      value={selectedPlan?.id === params.row.id}
-                      checked={selectedPlan?.id === params.row.id}
-                      inputProps={{ "aria-label": "Plan selection" }}
-                    />
-                  ),
-                  hideable: false,
-                  width: 70,
-                  flex: 0,
-                  disableColumnMenu: true,
-                  sortable: false,
-                },
                 DataGridColumn.newColumnWithFieldName<"label", PlanSummary>(
                   "label",
                   {
@@ -579,6 +562,11 @@ function DMPDialogContent({
                 ),
               ]}
               rows={fetching ? [] : DMPs}
+              selectedRowId={selectedPlan?.id}
+              onSelectionChange={(newSelectionId: GridRowId) => {
+                setSelectedPlan(DMPs.find((d) => d.id === newSelectionId) ?? null);
+              }}
+              selectRadioAriaLabelFunc={(row) => `Select plan: ${row.label}`}
               initialState={{
                 columns: {
                   columnVisibilityModel: {
@@ -600,15 +588,6 @@ function DMPDialogContent({
               }}
               loading={fetching}
               getRowId={(row) => row.id}
-              onRowSelectionModelChange={(
-                newSelection: GridRowSelectionModel
-              ) => {
-                if (newSelection[0]) {
-                  setSelectedPlan(
-                    DMPs.find((d) => d.id === newSelection[0]) ?? null
-                  );
-                }
-              }}
               getRowHeight={() => "auto"}
               onCellKeyDown={({ id }, e) => {
                 if (e.key === " " || e.key === "Enter") {

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.tsx
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.tsx
@@ -23,12 +23,12 @@ import Link from "@mui/material/Link";
 import AppBar from "../../components/AppBar";
 import docLinks from "../../assets/DocLinks";
 import Stack from "@mui/material/Stack";
-import { DataGrid, GridRowSelectionModel } from "@mui/x-data-grid";
+import { GridRowId } from "@mui/x-data-grid";
 import { DataGridColumn } from "../../util/table";
-import Radio from "@mui/material/Radio";
 import DOMPurify from "dompurify";
 import { mapNullable } from "../../util/Util";
 import { ACCENT_COLOR } from "../../assets/branding/dmptool";
+import { DataGridWithRadioSelection } from "../../components/DataGridWithRadioSelection";
 
 const CustomDialog = withStyles<
   { fullScreen: boolean } & React.ComponentProps<typeof Dialog>,
@@ -220,25 +220,8 @@ function DMPDialogContent({
             <ScopeField getDMPs={getDMPs} />
           </Grid>
           <Grid item sx={{ overflowY: "auto" }} flexGrow={1}>
-            <DataGrid
+            <DataGridWithRadioSelection
               columns={[
-                {
-                  field: "radio",
-                  headerName: "Select",
-                  renderCell: (params: { row: Plan }) => (
-                    <Radio
-                      color="primary"
-                      value={selectedPlan?.id === params.row.id}
-                      checked={selectedPlan?.id === params.row.id}
-                      inputProps={{ "aria-label": "Plan selection" }}
-                    />
-                  ),
-                  hideable: false,
-                  width: 70,
-                  flex: 0,
-                  disableColumnMenu: true,
-                  sortable: false,
-                },
                 DataGridColumn.newColumnWithFieldName<"title", Plan>("title", {
                   headerName: "Title",
                   flex: 1,
@@ -292,6 +275,11 @@ function DMPDialogContent({
                 ),
               ]}
               rows={fetching ? [] : DMPs}
+              selectedRowId={selectedPlan?.id}
+              onSelectionChange={(newSelectionId: GridRowId) => {
+                setSelectedPlan(DMPs.find((d) => d.id === newSelectionId));
+              }}
+              selectRadioAriaLabelFunc={(row) => `Select plan: ${row.title}`}
               initialState={{
                 columns: {
                   columnVisibilityModel: {
@@ -313,13 +301,6 @@ function DMPDialogContent({
               }}
               loading={fetching}
               getRowId={(row) => row.id}
-              onRowSelectionModelChange={(
-                newSelection: GridRowSelectionModel
-              ) => {
-                if (newSelection[0]) {
-                  setSelectedPlan(DMPs.find((d) => d.id === newSelection[0]));
-                }
-              }}
               getRowHeight={() => "auto"}
               onCellKeyDown={({ id }, e) => {
                 if (e.key === " " || e.key === "Enter") {


### PR DESCRIPTION
## Description ##
This change introduces a new react component -- DataGridWithRadioSelection -- that provides a generalised mechanism for providing a table from which the user must select a single row. This is more robust than the solutions used in DMPonline, DMPTool, and Argos dialogs whilst also reducing duplication.

## Testing notes
The four dialogs have not yet been tested and the code AI generated, so they definitely need testing.

I've tested on Fieldmark, by mocking the network call that lists its notebooks
