### PR TITLE
RSDEV-665: chemical search performance fixes 

### DIFF
--- a/src/main/java/com/researchspace/dao/RSChemElementDao.java
+++ b/src/main/java/com/researchspace/dao/RSChemElementDao.java
@@ -8,7 +8,7 @@ public interface RSChemElementDao extends GenericDao<RSChemElement, Long> {
 
   List<RSChemElement> getAllChemElementsFromField(Long fieldId);
 
-  List<RSChemElement> getChemElementsForChemIds(List<Long> chemIds);
+  List<RSChemElement> getChemElementsForReadOnlyAndClearDBSession(List<Long> chemIds);
 
   /**
    * Get the List of {@link RSChemElement} that matches the given EcatChemistryFile Id

--- a/src/main/java/com/researchspace/dao/hibernate/RSChemElementDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/RSChemElementDaoHibernate.java
@@ -7,6 +7,7 @@ import com.researchspace.model.RSChemElement;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
+import org.hibernate.annotations.QueryHints;
 import org.hibernate.query.Query;
 import org.springframework.stereotype.Repository;
 
@@ -32,7 +33,7 @@ public class RSChemElementDaoHibernate extends GenericDaoHibernate<RSChemElement
     return sq.list();
   }
 
-  public List<RSChemElement> getChemElementsForChemIds(List<Long> chemIds) {
+  public List<RSChemElement> getChemElementsForReadOnlyAndClearDBSession(List<Long> chemIds) {
     List<RSChemElement> result = new ArrayList<>();
     if (!CollectionUtils.isEmpty(chemIds)) {
       Query<RSChemElement> chemicalQuery =
@@ -40,7 +41,9 @@ public class RSChemElementDaoHibernate extends GenericDaoHibernate<RSChemElement
               .createQuery(
                   " from RSChemElement chem where chem.id in (:chemicalIds) ", RSChemElement.class);
       chemicalQuery.setParameterList("chemicalIds", chemIds);
+      chemicalQuery.setHint(QueryHints.READ_ONLY, true);
       result.addAll(chemicalQuery.list());
+      getSession().clear();
     }
     return result;
   }

--- a/src/test/java/com/researchspace/service/RSChemElementMgrTest.java
+++ b/src/test/java/com/researchspace/service/RSChemElementMgrTest.java
@@ -145,9 +145,9 @@ public class RSChemElementMgrTest {
 
     // no cutoff, db query page size set to 3 - chemDao should be queried twice
     chemElementManager.setChemSearchChemIdsPageSize(3);
-    when(chemDao.getChemElementsForChemIds(res.getChemicalHits().subList(0, 3)))
+    when(chemDao.getChemElementsForReadOnlyAndClearDBSession(res.getChemicalHits().subList(0, 3)))
         .thenReturn(List.of(chemElement1, chemElement2, chemElement3));
-    when(chemDao.getChemElementsForChemIds(res.getChemicalHits().subList(3, 4)))
+    when(chemDao.getChemElementsForReadOnlyAndClearDBSession(res.getChemicalHits().subList(3, 4)))
         .thenReturn(List.of(chemElement4));
     List<ChemSearchedItem> searchHits = chemElementManager.search("", "", 10, user);
     assertEquals(4, searchHits.size());
@@ -158,17 +158,20 @@ public class RSChemElementMgrTest {
 
     /* reduce db query pagination to 1, with cutoff at 2 - the chemDao should only be called twice,
     i.e. paginated db queries should stop as soon as searchResultLimit is reached */
-    when(chemDao.getChemElementsForChemIds(res.getChemicalHits().subList(0, 1)))
+    when(chemDao.getChemElementsForReadOnlyAndClearDBSession(res.getChemicalHits().subList(0, 1)))
         .thenReturn(List.of(chemElement1));
-    when(chemDao.getChemElementsForChemIds(res.getChemicalHits().subList(1, 2)))
+    when(chemDao.getChemElementsForReadOnlyAndClearDBSession(res.getChemicalHits().subList(1, 2)))
         .thenReturn(List.of(chemElement2));
     chemElementManager.setChemSearchChemIdsPageSize(1);
     searchHits = chemElementManager.search("", "", 2, user);
     assertEquals(2, searchHits.size());
     // verify no further calls after cutoff
-    verify(chemDao, times(1)).getChemElementsForChemIds(res.getChemicalHits().subList(0, 1));
-    verify(chemDao, times(1)).getChemElementsForChemIds(res.getChemicalHits().subList(1, 2));
-    verify(chemDao, never()).getChemElementsForChemIds(res.getChemicalHits().subList(2, 3));
+    verify(chemDao, times(1))
+        .getChemElementsForReadOnlyAndClearDBSession(res.getChemicalHits().subList(0, 1));
+    verify(chemDao, times(1))
+        .getChemElementsForReadOnlyAndClearDBSession(res.getChemicalHits().subList(1, 2));
+    verify(chemDao, never())
+        .getChemElementsForReadOnlyAndClearDBSession(res.getChemicalHits().subList(2, 3));
   }
 
   @Test
@@ -329,7 +332,8 @@ public class RSChemElementMgrTest {
         ChemicalSearchResultsDTO.builder().chemicalHits(results).totalHits(1).build();
 
     when(chemistryProvider.search(anyString(), anyString())).thenReturn(res);
-    when(chemDao.getChemElementsForChemIds(res.getChemicalHits())).thenReturn(List.of(chemElement));
+    when(chemDao.getChemElementsForReadOnlyAndClearDBSession(res.getChemicalHits()))
+        .thenReturn(List.of(chemElement));
     return chemElementManager.search("ignored", "ignored", 10, user).size();
   }
 }


### PR DESCRIPTION
## Description ##

This PR makes a few changes to RSpace-side of collecting chemical search results:
* main change is that `RSChemElementDaoHibernate` now calls `getSession().clear();` after collecting a set of chemistry results, which stops possible out-of-memory exception, which could happen when method was called multiple times during processing single search request
* another minor performance change on DAO level is using `READ_ONLY` query hint, that is fine as we only read the results (i.e. show them on search results page)
* on manager level, in `RSChemElementManagerImpl.getFilteredChemSearchedItems()` method, the order of checks is reverted when checking if given document, which contains a matching chemical hit, should be displayed to the user.


## Design decisions

The first two changes shouldn't be controversial, but on the reversed order of checks during filtering the results:

Previously the first check was to parse the field content to ensure the linked chemical element is surely there, then the second check was done to ensure the user has permission to see the document. But in real searches, the field almost always contains the linked chem item, while searching user quite often doesn't have permission to see the given document. Reversing the check should therefore speed-up search for significant number of users.
