### PR TITLE
RSDEV-633 Save chemicals in copied documents to the chemistry service

### DIFF
--- a/src/main/java/com/researchspace/service/impl/DocumentCopyManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/DocumentCopyManagerImpl.java
@@ -156,7 +156,7 @@ public class DocumentCopyManagerImpl implements DocumentCopyManager {
           rsChemElementManager.save(copyChem, user);
         } catch (IOException e) {
           log.error(
-              "Problem saving chemical while duplicating document with id {}.",
+              "Problem saving chemical in document with id {}.",
               destRecord.getId(),
               e);
         }

--- a/src/main/java/com/researchspace/service/impl/DocumentCopyManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/DocumentCopyManagerImpl.java
@@ -5,7 +5,6 @@ import com.researchspace.dao.EcatImageAnnotationDao;
 import com.researchspace.dao.FieldDao;
 import com.researchspace.dao.FolderDao;
 import com.researchspace.dao.InternalLinkDao;
-import com.researchspace.dao.RSChemElementDao;
 import com.researchspace.dao.RSMathDao;
 import com.researchspace.dao.RecordDao;
 import com.researchspace.files.service.FileStore;
@@ -37,6 +36,7 @@ import com.researchspace.model.views.RecordCopyResult;
 import com.researchspace.service.DocumentCopyManager;
 import com.researchspace.service.FieldManager;
 import com.researchspace.service.FileDuplicateStrategy;
+import com.researchspace.service.RSChemElementManager;
 import com.researchspace.service.RequiresActiveLicense;
 import com.researchspace.service.ThumbnailManager;
 import com.researchspace.service.exceptions.RecordCopyException;
@@ -64,7 +64,7 @@ public class DocumentCopyManagerImpl implements DocumentCopyManager {
 
   private @Autowired EcatCommentDao ecatCommentDao;
   private @Autowired EcatImageAnnotationDao imageAnnotationDao;
-  private @Autowired RSChemElementDao rsChemElementDao;
+  private @Autowired RSChemElementManager rsChemElementManager;
   private @Autowired RSMathDao mathDao;
   private @Autowired FieldDao fieldDao;
   private @Autowired FieldManager fieldMgr;
@@ -152,7 +152,15 @@ public class DocumentCopyManagerImpl implements DocumentCopyManager {
         RSChemElement copyChem = origChem.shallowCopy();
         copyChem.setParentId(destFieldId);
         copyChem.setRecord(destRecord);
-        rsChemElementDao.save(copyChem);
+        try {
+          rsChemElementManager.save(copyChem, user);
+        } catch (IOException e) {
+          log.error(
+              "Problem saving chemical while duplicating document with id {}.",
+              destRecord.getId(),
+              e);
+        }
+
         chemOldKey2NewKey.put(origChem.getId(), copyChem.getId());
       }
     }

--- a/src/test/java/com/researchspace/chemistry/ChemistryDocumentCopyIT.java
+++ b/src/test/java/com/researchspace/chemistry/ChemistryDocumentCopyIT.java
@@ -1,0 +1,52 @@
+package com.researchspace.chemistry;
+
+import static org.junit.Assert.assertEquals;
+
+import com.researchspace.model.ChemSearchedItem;
+import com.researchspace.model.RSChemElement;
+import com.researchspace.model.User;
+import com.researchspace.model.record.RSForm;
+import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.service.RSChemElementManager;
+import com.researchspace.service.RecordManager;
+import com.researchspace.testutils.RealTransactionSpringTestBase;
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@Ignore(
+    "Requires chemistry service to run. See"
+        + " https://documentation.researchspace.com/article/1jbygguzoa")
+@TestPropertySource(
+    properties = {"chemistry.service.url=http://localhost:8090", "chemistry.provider=indigo"})
+public class ChemistryDocumentCopyIT extends RealTransactionSpringTestBase {
+
+  @Autowired RecordManager recordManager;
+
+  @Autowired RSChemElementManager chemElementManager;
+
+  @Test
+  public void testCopiedDocumentsAreChemistrySearchable() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    RSForm form = createAnyForm(user);
+
+    // create doc with chemical structure
+    StructuredDocument doc = createDocumentInFolder(user.getRootFolder(), form, user);
+    RSChemElement chem = addChemStructureToField(doc.getFields().get(0), user);
+
+    // confirm 1 search result when searching for the chemical structure
+    List<ChemSearchedItem> searchHits =
+        chemElementManager.search(chem.getSmilesString(), "EXACT", 1000, user);
+    assertEquals(1, searchHits.size());
+
+    // copy the doc
+    recordManager.copy(doc.getId(), "copy", user, user.getRootFolder().getId());
+
+    // confirm 2 search results
+    List<ChemSearchedItem> searchHitsAfterCopy =
+        chemElementManager.search(chem.getSmilesString(), "EXACT", 1000, user);
+    assertEquals(2, searchHitsAfterCopy.size());
+  }
+}


### PR DESCRIPTION
## Description ##
When a document is copied, the chemical element was saved via the dao layer rather than manager layer, which meant the call to save the chemical to rspace document pair to the chemistry service was bypassed. 

This meant the copied document wouldn't be returned as a search hit when searching for the chemical element. 

The fix is to save the copied document via the manager rather than the dao layer.

## Design decisions
As the test requires an instance of the chemistry service, it's been ignored in the open-source build, which is the case for other chemistry-dependent tests. 

I've created https://researchspace.atlassian.net/browse/RSDEV-673 with some ideas on how to handle these tests in a nicer way. 

I'll enable this test in the closed-source repo once it's been synced.

## Testing notes
Passing Jenkins build here: https://jenkins.researchspace.com/job/rspace-web/job/rsdev-633-save-copied-chems/2/ (shows there are no regressions, though the new test will be ignored in this build.)
