### PR TITLE
Add warning text to API key password confirmation dialog

### DIFF
--- a/src/main/webapp/WEB-INF/pages/userform.jsp
+++ b/src/main/webapp/WEB-INF/pages/userform.jsp
@@ -523,12 +523,13 @@
     <p>
     This API key provides access to your account, research data, and
     intellectual property. If exposed or compromised:
+    </p>
     <ul>
       <li>Unauthorized users could access and steal your data</li>
       <li>Your intellectual property could be copied or misused</li>
       <li>Your data may be permanently deleted or altered without your consent</li>
     </ul>
-
+    <p>
       Are you sure you want to generate a new API key? Please store it securely
       and never share it with others or expose it in client-side code.
     </p>

--- a/src/main/webapp/WEB-INF/pages/userform.jsp
+++ b/src/main/webapp/WEB-INF/pages/userform.jsp
@@ -517,6 +517,21 @@
 	</div>
 
 	<div id="pwdConfirmDialog" style="display: none;">
+    <p>
+      <strong>Important: Your API Key Grants Full Access to Your RSpace Account and Data</strong>
+    </p>
+    <p>
+    This API key provides access to your account, research data, and
+    intellectual property. If exposed or compromised:
+    <ul>
+      <li>Unauthorized users could access and steal your data</li>
+      <li>Your intellectual property could be copied or misused</li>
+      <li>Your data may be permanently deleted or altered without your consent</li>
+    </ul>
+
+      Are you sure you want to generate a new API key? Please store it securely
+      and never share it with others or expose it in client-side code.
+    </p>
 		<table>
 			<tr>
 				<td><label for="pwdConfirm">Please confirm your password </label></td>


### PR DESCRIPTION
## Description ##
When generating or regenerating an API key, the user is now presented with a warning about the security implications of using API keys.

## Design decisions
N/A

## Testing notes
To test, just generate or regenerate an API key from My RSpace.
