### PR TITLE
RSDEV-676 Make clear that name field is required when creating new Inventory records

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Container/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Container/NewRecordForm.js
@@ -23,7 +23,9 @@ import {
   setFormSectionError,
 } from "../components/Stepper/StepperPanelHeader";
 import { observer } from "mobx-react-lite";
-import SynchroniseFormSections from "../components/Stepper/SynchroniseFormSections";
+import SynchroniseFormSections, {
+  UnsynchroniseFormSections,
+} from "../components/Stepper/SynchroniseFormSections";
 
 const OverviewSection = observer(
   ({ activeResult }: { activeResult: ContainerModel }) => {
@@ -140,7 +142,9 @@ export default function NewRecordForm(): Node {
         titleText={`New ${inventoryRecordTypeLabels.container}`}
         resetScrollPosition={Symbol("always reset scroll")}
       >
-        <OverviewSection activeResult={activeResult} />
+        <UnsynchroniseFormSections>
+          <OverviewSection activeResult={activeResult} />
+        </UnsynchroniseFormSections>
         <DetailsSection activeResult={activeResult} />
         <StepperPanel
           title="Barcodes"

--- a/src/main/webapp/ui/src/Inventory/Container/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Container/NewRecordForm.js
@@ -32,6 +32,16 @@ const OverviewSection = observer(
       globalId: activeResult.globalId,
     });
 
+    /*
+     * Name is a required field so it effectively starts in an error state.
+     */
+    React.useEffect(() => {
+      setFormSectionError(formSectionError, "name", true);
+      /* eslint-disable-next-line react-hooks/exhaustive-deps --
+       * - formSectionError will not meaningfully change
+       */
+    }, []);
+
     return (
       <StepperPanel
         title="Overview"

--- a/src/main/webapp/ui/src/Inventory/Sample/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/NewRecordForm.js
@@ -30,7 +30,9 @@ import Tags from "../components/Fields/Tags";
 import BarcodesField from "../components/Fields/Barcodes/FormField";
 import IdentifiersField from "../components/Fields/Identifiers/Identifiers";
 import AccessPermissions from "../components/Fields/AccessPermissions";
-import SynchroniseFormSections from "../components/Stepper/SynchroniseFormSections";
+import SynchroniseFormSections, {
+  UnsynchroniseFormSections,
+} from "../components/Stepper/SynchroniseFormSections";
 
 const OverviewSection = observer(
   ({ activeResult }: { activeResult: SampleModel }) => {
@@ -223,7 +225,9 @@ function NewRecordForm(): Node {
         titleText={`New ${inventoryRecordTypeLabels.sample}`}
         resetScrollPosition={Symbol("always reset scroll")}
       >
-        <OverviewSection activeResult={activeResult} />
+        <UnsynchroniseFormSections>
+          <OverviewSection activeResult={activeResult} />
+        </UnsynchroniseFormSections>
         <DetailsSection activeResult={activeResult} />
         <StepperPanel
           icon="sample"

--- a/src/main/webapp/ui/src/Inventory/Sample/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/NewRecordForm.js
@@ -39,6 +39,16 @@ const OverviewSection = observer(
       globalId: activeResult.globalId,
     });
 
+    /*
+     * Name is a required field so it effectively starts in an error state.
+     */
+    React.useEffect(() => {
+      setFormSectionError(formSectionError, "name", true);
+      /* eslint-disable-next-line react-hooks/exhaustive-deps --
+       * - formSectionError will not meaningfully change
+       */
+    }, []);
+
     return (
       <StepperPanel
         icon="sample"

--- a/src/main/webapp/ui/src/Inventory/Template/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Template/NewRecordForm.js
@@ -33,6 +33,16 @@ const OverviewSection = observer(
       globalId: activeResult.globalId,
     });
 
+    /*
+     * Name is a required field so it effectively starts in an error state.
+     */
+    React.useEffect(() => {
+      setFormSectionError(formSectionError, "name", true);
+      /* eslint-disable-next-line react-hooks/exhaustive-deps --
+       * - formSectionError will not meaningfully change
+       */
+    }, []);
+
     return (
       <StepperPanel
         title="Overview"

--- a/src/main/webapp/ui/src/Inventory/Template/NewRecordForm.js
+++ b/src/main/webapp/ui/src/Inventory/Template/NewRecordForm.js
@@ -23,7 +23,9 @@ import {
   useFormSectionError,
   setFormSectionError,
 } from "../components/Stepper/StepperPanelHeader";
-import SynchroniseFormSections from "../components/Stepper/SynchroniseFormSections";
+import SynchroniseFormSections, {
+  UnsynchroniseFormSections,
+} from "../components/Stepper/SynchroniseFormSections";
 import AccessPermissions from "../components/Fields/AccessPermissions";
 
 const OverviewSection = observer(
@@ -153,7 +155,9 @@ export default function NewRecordForm(): Node {
         titleText={`New ${inventoryRecordTypeLabels.sampleTemplate}`}
         resetScrollPosition={Symbol("always reset scroll")}
       >
-        <OverviewSection activeResult={activeResult} />
+        <UnsynchroniseFormSections>
+          <OverviewSection activeResult={activeResult} />
+        </UnsynchroniseFormSections>
         <DetailsSection activeResult={activeResult} />
         <StepperPanel
           title="Access Permissions"

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Name.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Name.js
@@ -88,6 +88,7 @@ function Name<
       disabled={!fieldOwner.isFieldEditable("name")}
       error={Boolean(errorMessage())}
       helperText={errorMessage()}
+      required
       renderInput={(props) => (
         <StringField
           {...props}

--- a/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.js
+++ b/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.js
@@ -100,3 +100,37 @@ export default function SynchroniseFormSections({
     </FormSectionsContext.Provider>
   );
 }
+
+/**
+ * Sometimes we specifically don't want to synchronise form sections, and the
+ * default open/close state should always be how the section is initially
+ * presented. For example, when creating new records we want to always present
+ * the required name field in the overview section. The user can always toggle
+ * the state of the section, but that state change is not persisted.
+ */
+export function UnsynchroniseFormSections({
+  children,
+}: SynchroniseFormSectionsArgs): Node {
+  const [formSectionExpandedState, setFormSectionExpandedState] = React.useState(defaultFormSectionExpandedState());
+  return (
+    <FormSectionsContext.Provider value={{
+      isExpanded: (recordType, sectionName) =>
+        formSectionExpandedState[recordType][sectionName],
+      setExpanded: (recordType, sectionName, value) => {
+        const formSectionExpandedStateCopy = { ...formSectionExpandedState };
+        formSectionExpandedStateCopy[recordType][sectionName] = value;
+        setFormSectionExpandedState(formSectionExpandedStateCopy);
+      },
+      setAllExpanded: (recordType, value) => {
+        const formSectionExpandedStateCopy = { ...formSectionExpandedState };
+        formSectionExpandedStateCopy[recordType] = mapObject(
+          () => value,
+          formSectionExpandedState[recordType]
+        );
+        setFormSectionExpandedState(formSectionExpandedStateCopy);
+      },
+    }}>
+      {children}
+    </FormSectionsContext.Provider>
+  );
+}


### PR DESCRIPTION
## Description ##
* Mark the field with a red asterisk to indicate that it is required
* Always show the overview section of the new-record forms, ignoring the persisted state
* If the overview section is closed, show the red indicator that there is an error inside

## Design decisions
This is intended to making it clearer that the name field is required when creating new records.

## Testing notes
None
