### PR TITLE
Rsdev 611 fix ketcher preview inventory

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/InventoryFilesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InventoryFilesApiController.java
@@ -216,12 +216,10 @@ public class InventoryFilesApiController extends BaseApiInventoryController
       @PathVariable Long id, @RequestAttribute(name = "user") User user) throws IOException {
     InventoryFile invFile = doGetInventoryFile(id, user);
     File file = fileStore.findFile(invFile.getFileProperty());
-    String chemString = chemistryProvider.convert(file);
-    String extension = FilenameUtils.getExtension(file.getName());
 
     RSChemElement chem =
         RSChemElement.builder()
-            .chemElements(chemistryProvider.convertToDefaultFormat(chemString, extension))
+            .chemElements(chemistryProvider.convert(file))
             .chemElementsFormat(chemistryProvider.defaultFormat())
             .build();
 

--- a/src/main/java/com/researchspace/api/v1/controller/InventoryFilesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InventoryFilesApiController.java
@@ -6,7 +6,6 @@ import com.researchspace.api.v1.InventoryFilesApi;
 import com.researchspace.api.v1.model.ApiInventoryFile;
 import com.researchspace.files.service.FileStore;
 import com.researchspace.model.FileProperty;
-import com.researchspace.model.RSChemElement;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.dtos.chemistry.ChemicalExportFormat;
@@ -217,15 +216,9 @@ public class InventoryFilesApiController extends BaseApiInventoryController
     InventoryFile invFile = doGetInventoryFile(id, user);
     File file = fileStore.findFile(invFile.getFileProperty());
 
-    RSChemElement chem =
-        RSChemElement.builder()
-            .chemElements(chemistryProvider.convert(file))
-            .chemElementsFormat(chemistryProvider.defaultFormat())
-            .build();
-
     return new AjaxReturnObject<>(
         new ChemEditorInputDto(
-            null, chem.getChemElements(), chem.getChemElementsFormat(), chem.getEcatChemFileId()),
+            null, chemistryProvider.convert(file), chemistryProvider.defaultFormat(), null),
         null);
   }
 

--- a/src/main/java/com/researchspace/service/impl/DocumentCopyManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/DocumentCopyManagerImpl.java
@@ -155,10 +155,7 @@ public class DocumentCopyManagerImpl implements DocumentCopyManager {
         try {
           rsChemElementManager.save(copyChem, user);
         } catch (IOException e) {
-          log.error(
-              "Problem saving chemical in document with id {}.",
-              destRecord.getId(),
-              e);
+          log.error("Problem saving chemical in document with id {}.", destRecord.getId(), e);
         }
 
         chemOldKey2NewKey.put(origChem.getId(), copyChem.getId());

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryFilesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryFilesApiControllerTest.java
@@ -182,11 +182,10 @@ public class InventoryFilesApiControllerTest extends SpringTransactionalTest {
         uploadedFile.getId(), new ApiInventoryFileImageRequest(1, 1, 1.0), user, resp);
     assertArrayEquals(new byte[] {1, 2, 3}, resp.getContentAsByteArray());
 
-    resp = new MockHttpServletResponse();
     AjaxReturnObject<ChemEditorInputDto> chemDto =
         invFilesApi.getChemFileDto(uploadedFile.getId(), user);
     assertTrue(chemDto.isSuccess());
-    assertEquals("123chemStringConverted", chemDto.getData().getChemElements());
+    assertEquals("123chemString", chemDto.getData().getChemElements());
   }
 
   @Test()
@@ -234,7 +233,5 @@ public class InventoryFilesApiControllerTest extends SpringTransactionalTest {
     when(chemistryProvider.exportToImage(anyString(), anyString(), any(ChemicalExportFormat.class)))
         .thenReturn(new byte[] {1, 2, 3});
     when(chemistryProvider.convert(any(File.class))).thenReturn("123chemString");
-    when(chemistryProvider.convertToDefaultFormat("123chemString", "mol"))
-        .thenReturn("123chemStringConverted");
   }
 }


### PR DESCRIPTION
## Description ##
When a chemistry file attachment to an Inventory item was opened in Ketcher, the contents of the file were first being converted to the "default" format before being read by Ketcher. This causes some information to be lost, and is needless. 

The fix is to load the file in it's original format, using `ChemistryProvider.convert(File)` which reads the file contents, handling conversion to base64 if the file is a `.cdx`. This same fix was applied in other cases where files are loaded into Ketcher.

before:
<img width="1305" alt="Screenshot 2025-05-14 at 14 39 00" src="https://github.com/user-attachments/assets/1b3f9c32-2b2c-465d-b9e9-861641e83125" />


after:
<img width="1308" alt="Screenshot 2025-05-14 at 14 39 24" src="https://github.com/user-attachments/assets/10e67c4f-e4e9-4e1e-a5aa-2d79f7ed80b4" />

