### PR TITLE
Remove unimplemented ReferenceField

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/Fields.js
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/Fields.js
@@ -11,7 +11,6 @@ import DateField from "../../../../components/Inputs/DateField";
 import { truncateIsoTimestamp } from "../../../../stores/definitions/Units";
 import NumberField from "../../../../components/Inputs/NumberField";
 import RadioField from "../../../../components/Inputs/RadioField";
-import ReferenceField from "../../../../components/Inputs/ReferenceField";
 import StringField from "../../../../components/Inputs/StringField";
 import TextField from "../../../../components/Inputs/TextField";
 import TimeField from "../../../../components/Inputs/TimeField";
@@ -201,17 +200,6 @@ function Fields({ onErrorStateChange, sample }: FieldsArgs): Node {
               }}
             />
           )}
-        />
-      );
-    }
-
-    if (field.type === "reference") {
-      return (
-        <FormField
-          {...commonProps}
-          key={field.name}
-          value={void 0}
-          renderInput={() => <ReferenceField />}
         />
       );
     }

--- a/src/main/webapp/ui/src/Inventory/components/Inputs/CustomField.js
+++ b/src/main/webapp/ui/src/Inventory/components/Inputs/CustomField.js
@@ -24,9 +24,6 @@ import NumberField, {
 import RadioField, {
   type RadioFieldArgs,
 } from "../../../components/Inputs/RadioField";
-import ReferenceField, {
-  type ReferenceFieldArgs,
-} from "../../../components/Inputs/ReferenceField";
 import StringField, {
   type StringFieldArgs,
 } from "../../../components/Inputs/StringField";
@@ -57,7 +54,6 @@ type FieldArgs<T: string> =
   | {| type: "File", ...FileFieldArgs |}
   | {| type: "Number", ...NumberFieldArgs |}
   | {| type: "Radio", ...RadioFieldArgs<T> |}
-  | {| type: "Reference", ...ReferenceFieldArgs |}
   | {| type: "String", ...StringFieldArgs |}
   | {| type: "Text", ...TextFieldArgs |}
   | {| type: "Time", ...TimeFieldArgs |}
@@ -145,8 +141,6 @@ function CustomField<T: string>(props: CustomFieldArgs<T>): Node {
     field = <NumberField {...fieldProps} />;
   } else if (props.type === "Radio") {
     field = <RadioField {...fieldProps} />;
-  } else if (props.type === "Reference") {
-    field = <ReferenceField {...fieldProps} />;
   } else if (props.type === "String") {
     field = <StringField {...fieldProps} />;
   } else if (props.type === "Text") {

--- a/src/main/webapp/ui/src/components/Inputs/ReferenceField.js
+++ b/src/main/webapp/ui/src/components/Inputs/ReferenceField.js
@@ -1,8 +1,0 @@
-//@flow
-import React, { type Node } from "react";
-
-export type ReferenceFieldArgs = {||};
-
-export default function ReferenceField(): Node {
-  return <i>Not yet supported.</i>;
-}


### PR DESCRIPTION
## Description ##
This ReferenceField was a placeholder component that we never implemented. It doesn't add anything to the codebase, except for making it slightly more confusing for someone who doesn't have the whole context of the history of the Inventory product.