### PR TITLE
RSDEV-653: oauth authentication enabled by system setting

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/OAuthClientController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/OAuthClientController.java
@@ -11,6 +11,8 @@ import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.service.ApiAvailabilityHandler;
 import com.researchspace.service.IReauthenticator;
 import com.researchspace.service.OAuthTokenManager;
+import com.researchspace.service.SystemPropertyName;
+import com.researchspace.service.SystemPropertyPermissionManager;
 import com.researchspace.service.UserManager;
 import com.researchspace.webapp.controller.IgnoreInLoggingInterceptor;
 import javax.servlet.http.HttpServletRequest;
@@ -44,6 +46,8 @@ public class OAuthClientController {
 
   @Autowired private AnalyticsManager analyticsMgr;
 
+  private @Autowired SystemPropertyPermissionManager systemPropertyMgr;
+
   /** Main endpoint for token grants. New or refreshed. */
   @PostMapping("/token")
   @IgnoreInLoggingInterceptor(ignoreRequestParams = {"client_secret", "password"})
@@ -66,6 +70,14 @@ public class OAuthClientController {
     if (!apiHandler.isApiAvailableForUser(null)) {
       throw new ApiAuthenticationException(
           "Access to API has been disabled by RSpace administrator.");
+    }
+
+    boolean oauthAuthEnabled =
+        systemPropertyMgr.isPropertyAllowed(
+            (User) null, SystemPropertyName.API_OAUTH_AUTHENTICATION);
+    if (!oauthAuthEnabled) {
+      throw new ApiAuthenticationException(
+          "OAuth authentication has been disabled by RSpace administrator.");
     }
 
     NewOAuthTokenResponse response;

--- a/src/main/java/com/researchspace/api/v1/controller/OAuthClientController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/OAuthClientController.java
@@ -72,10 +72,10 @@ public class OAuthClientController {
           "Access to API has been disabled by RSpace administrator.");
     }
 
-    boolean oauthAuthEnabled =
+    boolean oauthAuthenticationEnabled =
         systemPropertyMgr.isPropertyAllowed(
             (User) null, SystemPropertyName.API_OAUTH_AUTHENTICATION);
-    if (!oauthAuthEnabled) {
+    if (!oauthAuthenticationEnabled) {
       throw new ApiAuthenticationException(
           "OAuth authentication has been disabled by RSpace administrator.");
     }

--- a/src/main/java/com/researchspace/service/SystemPropertyName.java
+++ b/src/main/java/com/researchspace/service/SystemPropertyName.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum SystemPropertyName {
   API_AVAILABLE("api.available"),
+  API_OAUTH_AUTHENTICATION("api.oauth.authentication"),
   BOX_AVAILABLE("box.available"),
   CHEMISTRY_AVAILABLE("chemistry.available"),
   DATACITE_ENABLED("datacite.enabled"),

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -326,6 +326,8 @@ system.property.description.chemistry.available=Makes chemistry integration avai
   users can create and edit chemical sketches, and search for chemical structures in the Workspace
 system.property.description.slack.available=Makes Slack integration available to the users. After enabling the integration, \
   user can connect to their Slack channels to send messages or forward notifications
+system.property.description.msteams.available=Makes MS Teams integration available to the users. After enabling the integration, \
+  user can connect to their MS Teams channels to send messages or forward notifications
 system.property.description.orcid.available=Enables ORCID integration. After enabling the integration, \
   users can set up their ORCID ID on 'My Profile' page.
 system.property.description.repo.available=Makes {0} repository integration available. After enabling, \
@@ -334,12 +336,8 @@ system.property.description.pyrat.available=Makes PyRAT integration available. A
   users can link to animals in the PyRAT database.
 system.property.description.clustermarket.available=Makes Clustermarket integration available. After enabling the integration, \
   users can link to data regarding laboratory equipment.
-system.property.description.clustermarket.enabled=Enables linking to Clustermarket in text field editor. \
-  Relevant only if 'clustermarket.available' is 'true'.
 system.property.description.omero.available=Makes Omero integration available. After enabling the integration, \
   users can link to Omero image data.
-system.property.description.omero.enabled=Enables linking to Omero in text field editor. \
-  Relevant only if 'omero.available' is 'true'.
 system.property.description.jove.available=Makes JoVE integration available. User can search for and insert videos/articles from JoVE.
 system.property.description.dryad.available=Makes Dryad integration available. User can create new dryad submission\
   and attach RSpace exports or documents to that submission.
@@ -350,18 +348,22 @@ system.property.description.argos.available=Makes Argos integration available.
 system.property.description.zenodo.available=Makes Zenodo integration available.
 system.property.description.fieldmark.available=Makes Fieldmark integration available.
 system.property.description.galaxy.available=Makes Galaxy integration available.
-system.property.description.digital_commons_data.available=Makes Digital Commons Data integration available.
 system.property.description.github.available=Makes Github integration available. After enabling, user can add links \
   to files in Github repositories.
+system.property.description.protocols_io.available=Makes Protocols.io integration available, allowing users to create documents from \
+  the protocols available through that service.
 system.property.description.api.available=Enables API access for users
+system.property.description.api.oauth.authentication=Enables accessing public API with OAuth authentication flow
 system.property.description.onboarding.available=Enables onboarding announcements across RSpace.
 system.property.description.snapgene.available=Enables Snapgene viewer for DNA sequence files. This must only be enabled if the deployment property\
  'snapgene.web.url' is configured to point at an RSpace-Snapgene web-service.
-system.property.description.group_autosharing.available=Enables the management of group-wide autosharing.\
+system.property.description.group_autosharing.available=Enables the management of group-wide autosharing. \
  Enables PIs and lab admins with the 'View All' permission to manage the autoshare status for non-PI lab members.
-system.property.description.self_service_labgroups=When true, a user with permissions (eg a PI) can create a LabGroup
-system.property.description.allow_project_groups=When true, a user can create a group without a PI
+system.property.description.self_service_labgroups=When true, a user with permissions (e.g. a PI) can create a LabGroup.
+system.property.description.allow_project_groups=When true, users can create Project Groups (which don't have a PI)
 system.property.description.publicLastLogin.available=If enabled, a user's last login time is publicly viewable on their profile page.
-system.property.description.inventory.available=Enables Inventory module
-system.property.description.public_sharing=Enables Publication of Documents
-system.property.description.publicdocs_allow_seo=Enables search engine indexing of published documents
+system.property.description.inventory.available=Enables Inventory module.
+system.property.description.public_sharing=Enables Publication of Documents.
+system.property.description.publicdocs_allow_seo=Enables search engine indexing of published documents.
+system.property.description.pi_can_edit_all_work_in_labgroup=Gives PI edit access to all data in their LabGroup.
+

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-365.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-365.xml
@@ -1,0 +1,31 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <changeSet id="2025-05-21" author="matthias">
+        <comment>Create a new system property to toggle OAuth authentication for public API</comment>
+        <insert tableName="PropertyDescriptor">
+            <column name="id" type="NUMERIC" value="NULL"/>
+            <column name="defaultValue" type="STRING" value="DENIED"/>
+            <column name="name" type="STRING" value="api.oauth.authentication"/>
+            <column name="type" type="NUMERIC" value="3"/>
+        </insert>
+        <insert tableName="SystemProperty">
+            <column name="id" type="NUMERIC" value="NULL"/>
+            <column name="dependent_id" type="NUMERIC" value="NULL"/>
+            <column name="descriptor_id"
+                    type="NUMERIC"
+                    valueComputed="(select id from PropertyDescriptor where name ='api.oauth.authentication')"/>
+        </insert>
+        <insert tableName="SystemPropertyValue">
+            <column name="id" type="NUMERIC" value="NULL"/>
+            <column name="value" type="String" value="DENIED"/>
+            <column name="property_id"
+                    type="NUMERIC"
+                    valueComputed="(select sp.id from SystemProperty sp inner join PropertyDescriptor pd on sp.descriptor_id=pd.id where pd.name='api.oauth.authentication')"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -143,7 +143,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-435.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-607.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-638.xml"/>
-
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-365.xml"/>
 
   <!--  ensure that customUpdates-changeLog.xml always runs LAST! -->
     <include relativeToChangelogFile="true" file="customUpdates-changeLog.xml"/>

--- a/src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp
@@ -79,15 +79,19 @@
         <div id="fieldmark.available.description"><spring:message code="system.property.description.fieldmark.available" /></div>
         <div id="github.available.description"><spring:message code="system.property.description.github.available" /></div>
         <div id="api.available.description"><spring:message code="system.property.description.api.available" /></div>
+        <div id="api.oauth.authentication.description"><spring:message code="system.property.description.api.oauth.authentication" /></div>
         <div id="onboarding.available.description"><spring:message code="system.property.description.onboarding.available" /></div>
         <div id="snapgene.available.description"><spring:message code="system.property.description.snapgene.available" /></div>
         <div id="group_autosharing.available.description"><spring:message code="system.property.description.group_autosharing.available" /></div>
-        <div id="self_service_labgroups.available.description"><spring:message code="system.property.description.self_service_labgroups" /></div>
+        <div id="self_service_labgroups.description"><spring:message code="system.property.description.self_service_labgroups" /></div>
         <div id="publicLastLogin.available.description"><spring:message code="system.property.description.publicLastLogin.available" /></div>
         <div id="inventory.available.description"><spring:message code="system.property.description.inventory.available" /></div>
         <div id="public_sharing.description"><spring:message code="system.property.description.public_sharing" /></div>
         <div id="publicdocs_allow_seo.description"><spring:message code="system.property.description.publicdocs_allow_seo" /></div>
         <div id="allow_project_groups.description"><spring:message code="system.property.description.allow_project_groups" /></div>
+        <div id="pi_can_edit_all_work_in_labgroup.description"><spring:message code="system.property.description.pi_can_edit_all_work_in_labgroup" /></div>
+        <div id="msteams.available.description"><spring:message code="system.property.description.msteams.available" /></div>
+        <div id="protocols_io.available.description"><spring:message code="system.property.description.protocols_io.available" /></div>
     </div>
 
 </div>

--- a/src/main/webapp/scripts/pages/system/settings_mod.js
+++ b/src/main/webapp/scripts/pages/system/settings_mod.js
@@ -33,6 +33,7 @@ define(function() {
 
         _printSubCategory('RSpace API');
         _printSettings([ 'api.available' ]);
+        _printSettings([ 'api.oauth.authentication' ]);
 
         _printSubCategory('Lab Group Settings');
         _printSettings([ 'pi_can_edit_all_work_in_labgroup' ]);

--- a/src/test/java/com/researchspace/webapp/controller/MVCTestBase.java
+++ b/src/test/java/com/researchspace/webapp/controller/MVCTestBase.java
@@ -69,6 +69,20 @@ public abstract class MVCTestBase extends RealTransactionSpringTestBase {
         SystemPropertyName.API_AVAILABLE, HierarchicalPermission.ALLOWED, getSysAdminUser());
   }
 
+  public void disableApiOauthAuthentication() {
+    sysPropMgr.save(
+        SystemPropertyName.API_OAUTH_AUTHENTICATION,
+        HierarchicalPermission.DENIED,
+        getSysAdminUser());
+  }
+
+  public void enableApiOauthAuthentication() {
+    sysPropMgr.save(
+        SystemPropertyName.API_OAUTH_AUTHENTICATION,
+        HierarchicalPermission.ALLOWED,
+        getSysAdminUser());
+  }
+
   /**
    * Mimics edit lock request, autosave and save, and unlock behaviour from editor via MVC
    * /controller test.

--- a/src/test/java/com/researchspace/webapp/controller/MVCTestBase.java
+++ b/src/test/java/com/researchspace/webapp/controller/MVCTestBase.java
@@ -69,14 +69,14 @@ public abstract class MVCTestBase extends RealTransactionSpringTestBase {
         SystemPropertyName.API_AVAILABLE, HierarchicalPermission.ALLOWED, getSysAdminUser());
   }
 
-  public void disableApiOauthAuthentication() {
+  public void disableApiOAuthAuthentication() {
     sysPropMgr.save(
         SystemPropertyName.API_OAUTH_AUTHENTICATION,
         HierarchicalPermission.DENIED,
         getSysAdminUser());
   }
 
-  public void enableApiOauthAuthentication() {
+  public void enableApiOAuthAuthentication() {
     sysPropMgr.save(
         SystemPropertyName.API_OAUTH_AUTHENTICATION,
         HierarchicalPermission.ALLOWED,

--- a/src/test/java/com/researchspace/webapp/controller/OAuthAPIAccessMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/OAuthAPIAccessMVCIT.java
@@ -21,7 +21,7 @@ public class OAuthAPIAccessMVCIT extends API_MVC_TestBase {
   @Test
   public void createAccessTokenAndAccessApi() throws Exception {
     enableGlobalApiAccess();
-    enableApiOauthAuthentication();
+    enableApiOAuthAuthentication();
 
     User user = createInitAndLoginAnyUser();
     RSpaceTestUtils.logout();
@@ -53,7 +53,7 @@ public class OAuthAPIAccessMVCIT extends API_MVC_TestBase {
     assertTrue(folders.getTotalHits() > 0);
 
     // confirm that access token request doesn't succeed if oauth authentication is disabled
-    disableApiOauthAuthentication();
+    disableApiOAuthAuthentication();
     mockMvc.perform(accessTokenRequest).andExpect(status().isUnauthorized());
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/OAuthClientCommunityControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/OAuthClientCommunityControllerMVCIT.java
@@ -40,6 +40,9 @@ public class OAuthClientCommunityControllerMVCIT extends MVCTestBase {
 
     // verification password succeeds
     verificationPasswordHandler.encryptAndSavePassword(user, "abcdefghi");
+
+    // confirm oauth authentication accepts verification password
+    enableApiOauthAuthentication();
     postOauthAccessTokenRequest(username, password, app).andExpect(status().isOk()).andReturn();
   }
 

--- a/src/test/java/com/researchspace/webapp/controller/OAuthClientCommunityControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/OAuthClientCommunityControllerMVCIT.java
@@ -42,7 +42,7 @@ public class OAuthClientCommunityControllerMVCIT extends MVCTestBase {
     verificationPasswordHandler.encryptAndSavePassword(user, "abcdefghi");
 
     // confirm oauth authentication accepts verification password
-    enableApiOauthAuthentication();
+    enableApiOAuthAuthentication();
     postOauthAccessTokenRequest(username, password, app).andExpect(status().isOk()).andReturn();
   }
 

--- a/src/test/java/com/researchspace/webapp/controller/OAuthClientControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/OAuthClientControllerMVCIT.java
@@ -33,7 +33,7 @@ public class OAuthClientControllerMVCIT extends MVCTestBase {
 
     // let's disable API on the server
     disableGlobalApiAccess();
-    disableApiOauthAuthentication();
+    disableApiOAuthAuthentication();
 
     // missing parameters (grant_type) are reported first
     mockMvc
@@ -79,7 +79,7 @@ public class OAuthClientControllerMVCIT extends MVCTestBase {
                     result.getResolvedException().getMessage()));
 
     // re-enable OAuth authentication
-    enableApiOauthAuthentication();
+    enableApiOAuthAuthentication();
 
     // next, report invalid value for parameter grant_type
     mockMvc
@@ -208,7 +208,7 @@ public class OAuthClientControllerMVCIT extends MVCTestBase {
 
     OAuthAppInfo app = oAuthAppManager.addApp(user, "newApp").getEntity();
     enableGlobalApiAccess();
-    enableApiOauthAuthentication();
+    enableApiOAuthAuthentication();
 
     MvcResult result =
         mockMvc
@@ -246,7 +246,7 @@ public class OAuthClientControllerMVCIT extends MVCTestBase {
     assertNotEquals(oldRefreshToken, response.getRefreshToken());
 
     // confirm that refresh token request won't work after disabling oauth authentication
-    disableApiOauthAuthentication();
+    disableApiOAuthAuthentication();
     mockMvc
         .perform(
             post("/oauth/token")

--- a/src/test/java/com/researchspace/webapp/controller/OAuthClientControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/OAuthClientControllerMVCIT.java
@@ -33,6 +33,7 @@ public class OAuthClientControllerMVCIT extends MVCTestBase {
 
     // let's disable API on the server
     disableGlobalApiAccess();
+    disableApiOauthAuthentication();
 
     // missing parameters (grant_type) are reported first
     mockMvc
@@ -60,8 +61,27 @@ public class OAuthClientControllerMVCIT extends MVCTestBase {
                     "Access to API has been disabled by RSpace administrator.",
                     result.getResolvedException().getMessage()));
 
-    // next, report invalid value for parameter grant_type
+    // re-enable global API access
     enableGlobalApiAccess();
+
+    // disabled OAuth authentication is reported next
+    mockMvc
+        .perform(
+            post("/oauth/token")
+                .param("client_id", clientId)
+                .param("client_secret", clientSecret)
+                .param("grant_type", "invalid"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(
+            result ->
+                assertEquals(
+                    "OAuth authentication has been disabled by RSpace administrator.",
+                    result.getResolvedException().getMessage()));
+
+    // re-enable OAuth authentication
+    enableApiOauthAuthentication();
+
+    // next, report invalid value for parameter grant_type
     mockMvc
         .perform(
             post("/oauth/token")
@@ -188,6 +208,7 @@ public class OAuthClientControllerMVCIT extends MVCTestBase {
 
     OAuthAppInfo app = oAuthAppManager.addApp(user, "newApp").getEntity();
     enableGlobalApiAccess();
+    enableApiOauthAuthentication();
 
     MvcResult result =
         mockMvc
@@ -221,8 +242,23 @@ public class OAuthClientControllerMVCIT extends MVCTestBase {
             .andReturn();
     jsonResponse = result.getResponse().getContentAsString();
     response = parseOAuthTokenResponse(jsonResponse);
-
     assertNotEquals(oldAccessToken, response.getAccessToken());
     assertNotEquals(oldRefreshToken, response.getRefreshToken());
+
+    // confirm that refresh token request won't work after disabling oauth authentication
+    disableApiOauthAuthentication();
+    mockMvc
+        .perform(
+            post("/oauth/token")
+                .param("client_id", app.getClientId())
+                .param("client_secret", app.getUnhashedClientSecret())
+                .param("grant_type", "refresh_token")
+                .param("refresh_token", response.getRefreshToken()))
+        .andExpect(status().isUnauthorized())
+        .andExpect(
+            res ->
+                assertEquals(
+                    "OAuth authentication has been disabled by RSpace administrator.",
+                    res.getResolvedException().getMessage()));
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/OAuthClientSSOControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/OAuthClientSSOControllerMVCIT.java
@@ -33,6 +33,7 @@ public class OAuthClientSSOControllerMVCIT extends MVCTestBase {
 
     // if API access is globally disabled, the SSO verification password shouldn't work either
     disableGlobalApiAccess();
+    disableApiOauthAuthentication();
     OAuthAppInfo app = oAuthAppManager.addApp(user, "newApp").getEntity();
     postOauthAccessTokenRequest(username, password, app)
         .andExpect(status().isUnauthorized())
@@ -44,6 +45,7 @@ public class OAuthClientSSOControllerMVCIT extends MVCTestBase {
 
     // user1234 now fails
     enableGlobalApiAccess();
+    enableApiOauthAuthentication();
     app = oAuthAppManager.addApp(user, "newApp").getEntity();
     postOauthAccessTokenRequest(username, password, app)
         .andExpect(status().isUnauthorized())
@@ -57,7 +59,11 @@ public class OAuthClientSSOControllerMVCIT extends MVCTestBase {
     verificationPasswordhandler.encryptAndSavePassword(user, "abcdefghi");
 
     // verification password succeeds
-    postOauthAccessTokenRequest(username, password, app).andExpect(status().isOk()).andReturn();
+    postOauthAccessTokenRequest(username, password, app).andExpect(status().isOk());
+
+    // disabling just oauth authentication also stops generation of access tokens
+    disableApiOauthAuthentication();
+    postOauthAccessTokenRequest(username, password, app).andExpect(status().isUnauthorized());
   }
 
   private ResultActions postOauthAccessTokenRequest(

--- a/src/test/java/com/researchspace/webapp/controller/OAuthClientSSOControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/OAuthClientSSOControllerMVCIT.java
@@ -33,7 +33,7 @@ public class OAuthClientSSOControllerMVCIT extends MVCTestBase {
 
     // if API access is globally disabled, the SSO verification password shouldn't work either
     disableGlobalApiAccess();
-    disableApiOauthAuthentication();
+    disableApiOAuthAuthentication();
     OAuthAppInfo app = oAuthAppManager.addApp(user, "newApp").getEntity();
     postOauthAccessTokenRequest(username, password, app)
         .andExpect(status().isUnauthorized())
@@ -45,7 +45,7 @@ public class OAuthClientSSOControllerMVCIT extends MVCTestBase {
 
     // user1234 now fails
     enableGlobalApiAccess();
-    enableApiOauthAuthentication();
+    enableApiOAuthAuthentication();
     app = oAuthAppManager.addApp(user, "newApp").getEntity();
     postOauthAccessTokenRequest(username, password, app)
         .andExpect(status().isUnauthorized())
@@ -62,7 +62,7 @@ public class OAuthClientSSOControllerMVCIT extends MVCTestBase {
     postOauthAccessTokenRequest(username, password, app).andExpect(status().isOk());
 
     // disabling just oauth authentication also stops generation of access tokens
-    disableApiOauthAuthentication();
+    disableApiOAuthAuthentication();
     postOauthAccessTokenRequest(username, password, app).andExpect(status().isUnauthorized());
   }
 


### PR DESCRIPTION
## Description ##
The PR adds new system setting `api.oauth.authentication`, which is set to DENIED by default. That stops oauth authentication endpoint from generating tokens, unless Sysadmin explicitly allows it.

The setting is available just for System Admins (not on Community level), on System -> Configuration -> System Settings page;
![image](https://github.com/user-attachments/assets/a3cf1928-4d43-46ab-8979-5152f5a60da3)

## Testing notes
Can be tested by trying OAuth login option in swagger docs (at `/public/apiDocs`).