### PR TITLE
RSDEV-617: Allow users to manually associate IGSN IDs to a sample in Inventory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3009,7 +3009,7 @@
     <jstl.version>1.1.2</jstl.version>
     <lucene.version>5.5.5</lucene.version>
     <netty.version>4.1.63.Final</netty.version>
-    <rspace-core-model.version>2.10.0</rspace-core-model.version>
+    <rspace-core-model.version>2.11.0</rspace-core-model.version>
     <servlet.version>3.1.0</servlet.version>
     <sitemesh.version>2.4.2</sitemesh.version>
     <urlrewrite.version>4.0.3</urlrewrite.version>

--- a/src/main/java/com/researchspace/api/v1/InventoryIdentifiersApi.java
+++ b/src/main/java/com/researchspace/api/v1/InventoryIdentifiersApi.java
@@ -8,6 +8,7 @@ import com.researchspace.api.v1.controller.InventoryIdentifiersApiController.Api
 import com.researchspace.api.v1.model.ApiInventoryDOI;
 import com.researchspace.model.User;
 import java.util.List;
+import javax.naming.InvalidNameException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +24,8 @@ public interface InventoryIdentifiersApi {
 
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
-  List<ApiInventoryDOI> getUserIdentifiers(String state, Boolean isAssociated, User user);
+  List<ApiInventoryDOI> getUserIdentifiers(
+      String state, Boolean isAssociated, String identifier, User user) throws InvalidNameException;
 
   /** Register new IGSN identifier for record with given globalId */
   @PostMapping
@@ -34,6 +36,18 @@ public interface InventoryIdentifiersApi {
   @PostMapping(value = "/bulk/{count}")
   @ResponseStatus(HttpStatus.CREATED)
   List<ApiInventoryDOI> bulkAllocateIdentifiers(Integer count, User user);
+
+  /**
+   * Assign an existing IGSN (identifierId) to a specific inventory item (parentGlobalId)
+   *
+   * @param identifierId
+   * @param parentGlobalId
+   * @param user
+   * @return
+   */
+  @PostMapping(value = "/{identifierId}/assign")
+  ApiInventoryDOI assignIdentifier(
+      Long identifierId, ApiInventoryIdentifierPost parentGlobalId, User user);
 
   @DeleteMapping(value = "/{identifierId}")
   boolean deleteIdentifier(Long identifierId, User user);

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryDOI.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryDOI.java
@@ -271,6 +271,13 @@ public class ApiInventoryDOI extends LinkableApiObject {
     return deleteIdentifierRequest;
   }
 
+  private boolean assignIdentifierRequest;
+
+  @JsonIgnore
+  public boolean isAssignIdentifierRequest() {
+    return assignIdentifierRequest;
+  }
+
   public boolean applyChangesToDatabaseDOI(DigitalObjectIdentifier dbIdentifier) {
     boolean contentChanged = false;
 

--- a/src/main/java/com/researchspace/service/inventory/ApiIdentifiersHelper.java
+++ b/src/main/java/com/researchspace/service/inventory/ApiIdentifiersHelper.java
@@ -1,6 +1,7 @@
 package com.researchspace.service.inventory;
 
 import com.researchspace.api.v1.model.ApiInventoryDOI;
+import com.researchspace.dao.DigitalObjectIdentifierDao;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.DigitalObjectIdentifier;
 import com.researchspace.model.inventory.InventoryRecord;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class ApiIdentifiersHelper {
 
   private @Autowired IPropertyHolder properties;
+  private @Autowired DigitalObjectIdentifierDao doiDao;
 
   public boolean createDeleteRequestedIdentifiers(
       List<ApiInventoryDOI> incomingIdentifiers, InventoryRecord parentInvRec, User user) {
@@ -67,6 +69,14 @@ public class ApiIdentifiersHelper {
     parentInvRec.addIdentifier(newDoi);
   }
 
+  private void addRecordIdentifierForAssignApiIdentifier(
+      ApiInventoryDOI apiIdentifier, InventoryRecord parentInvRec) {
+    DigitalObjectIdentifier existingDoi = doiDao.get(apiIdentifier.getId());
+    existingDoi.setOwner(parentInvRec.getOwner());
+    apiIdentifier.applyChangesToDatabaseDOI(existingDoi);
+    parentInvRec.addIdentifier(existingDoi);
+  }
+
   public DigitalObjectIdentifier createDoiToSave(ApiInventoryDOI apiIdentifier, User creator) {
     DigitalObjectIdentifier newDoi = new DigitalObjectIdentifier(null, null);
     newDoi.addOtherData(
@@ -75,5 +85,41 @@ public class ApiIdentifiersHelper {
     newDoi.setOwner(creator);
     apiIdentifier.applyChangesToDatabaseDOI(newDoi);
     return newDoi;
+  }
+
+  public boolean createAssignRequestedIdentifiers(
+      List<ApiInventoryDOI> incomingIdentifiers, InventoryRecord parentInvRec, User user) {
+    boolean changed = false;
+    if (!CollectionUtils.isEmpty(incomingIdentifiers)) {
+      for (ApiInventoryDOI apiIdentifier : incomingIdentifiers) {
+        if (apiIdentifier.isAssignIdentifierRequest()) {
+          addRecordIdentifierForAssignApiIdentifier(apiIdentifier, parentInvRec);
+          changed = true;
+        }
+        if (apiIdentifier.isAssignIdentifierRequest()) {
+          if (apiIdentifier.getId() == null) {
+            throw new IllegalArgumentException(
+                "'id' property not provided " + "for DOI with 'assignIdentifierRequest' flag");
+          }
+          Optional<DigitalObjectIdentifier> dbIdentifier =
+              parentInvRec.getActiveIdentifiers().stream()
+                  .filter(doi -> apiIdentifier.getId().equals(doi.getId()))
+                  .findFirst();
+          if (!dbIdentifier.isPresent()) {
+            throw new IllegalArgumentException(
+                "DOI with id: "
+                    + apiIdentifier.getDoi()
+                    + " doesn't match id of any pre-existing identifiers");
+          }
+          dbIdentifier.get().setTitle(parentInvRec.getName());
+          parentInvRec.addIdentifier(dbIdentifier.get());
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      parentInvRec.refreshActiveIdentifiers();
+    }
+    return changed;
   }
 }

--- a/src/main/java/com/researchspace/service/inventory/InventoryIdentifierApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryIdentifierApiManager.java
@@ -7,6 +7,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.webapp.integrations.datacite.DataCiteConnector;
 import java.util.List;
+import javax.naming.InvalidNameException;
 
 /** Handles API actions around inventory DOI identifiers */
 public interface InventoryIdentifierApiManager {
@@ -17,10 +18,14 @@ public interface InventoryIdentifierApiManager {
 
   ApiInventoryRecordInfo findPublishedItemVersionByPublicLink(String publicLink);
 
-  List<ApiInventoryDOI> findIdentifiersByStateAndOwner(
-      String state, User owner, Boolean isAssociated);
+  List<ApiInventoryDOI> findIdentifiers(
+      String state, Boolean isAssociated, String identifier, User owner)
+      throws InvalidNameException;
 
   ApiInventoryRecordInfo registerNewIdentifier(GlobalIdentifier invRecOid, User user);
+
+  ApiInventoryRecordInfo assignIdentifier(
+      GlobalIdentifier inventoryOid, Long identifierId, User user);
 
   List<ApiInventoryDOI> registerBulkIdentifiers(Integer igsnsToAllocate, User user);
 

--- a/src/main/java/com/researchspace/service/inventory/impl/ContainerApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/ContainerApiManagerImpl.java
@@ -296,6 +296,9 @@ public class ContainerApiManagerImpl extends InventoryApiManagerImpl
       contentChanged |=
           identifiersHelper.createDeleteRequestedIdentifiers(
               apiContainer.getIdentifiers(), dbContainer, user);
+      contentChanged |=
+          identifiersHelper.createAssignRequestedIdentifiers(
+              apiContainer.getIdentifiers(), dbContainer, user);
       contentChanged |= apiContainer.applyChangesToDatabaseContainer(dbContainer, user);
       contentChanged |= saveSharingACLForIncomingApiInvRec(dbContainer, apiContainer);
       contentChanged |= saveIncomingContainerImages(dbContainer, apiContainer, user);

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
@@ -1,6 +1,7 @@
 package com.researchspace.service.inventory.impl;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiInventoryDOI;
@@ -28,8 +29,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.naming.InvalidNameException;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.validator.routines.UrlValidator;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -78,23 +82,65 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
   }
 
   @Override
-  public List<ApiInventoryDOI> findIdentifiersByStateAndOwner(
-      String state, User owner, Boolean isAssociated) {
+  public List<ApiInventoryDOI> findIdentifiers(
+      String state, Boolean isAssociated, String identifier, User owner)
+      throws InvalidNameException {
+    String finalIdentifier;
+    if (isNotBlank(identifier) && isValidURL(identifier) && isValidIdentifier(identifier)) {
+      finalIdentifier = getIdentifierSuffix(identifier);
+    } else {
+      finalIdentifier = identifier;
+    }
     return doiDao.getActiveIdentifiersByOwner(owner).stream()
+        .filter(r -> isBlank(finalIdentifier) || r.getIdentifier().contains(finalIdentifier))
         .filter(r -> (isAssociated == null) || isAssociated.equals(r.isAssociated()))
         .filter(r -> isBlank(state) || state.equals(r.getState()))
         .map(ApiInventoryDOI::new)
         .collect(Collectors.toList());
   }
 
+  private String getIdentifierSuffix(String identifierUrl) throws InvalidNameException {
+    return "10." + identifierUrl.split("/10.")[1];
+  }
+
+  private boolean isValidIdentifier(String identifier) throws InvalidNameException {
+    // DOI always starts with "10."
+    // as per specs on https://www.doi.org/#:~:text=TRY%20RESOLVING%20A%20DOI
+    if (!identifier.contains("10.")) {
+      throw new IllegalArgumentException(
+          "Identifier [" + identifier + "] it is not recognized as valid DOI");
+    }
+    return true;
+  }
+
+  private boolean isValidURL(String url) {
+    UrlValidator validator = new UrlValidator();
+    return validator.isValid(url);
+  }
+
   @Override
   public ApiInventoryRecordInfo registerNewIdentifier(GlobalIdentifier invRecOid, User user) {
-    InventoryRecord invRec = invRecRetriever.getInvRecordByGlobalId(invRecOid);
-    if (!invRec.getActiveIdentifiers().isEmpty()) {
-      throw new IllegalArgumentException(
-          "record " + invRecOid.toString() + " already has an identifier");
-    }
+    InventoryRecord invRec = getInventoryRecordIfNotAlreadyAssociated(invRecOid);
     return updateInventoryRecordWithDoiUpdate(user, invRec, createUpdateWithNewDoi(invRec, user));
+  }
+
+  @Override
+  public ApiInventoryRecordInfo assignIdentifier(
+      GlobalIdentifier inventoryOid, Long identifierId, User user) {
+    InventoryRecord inventoryItem = getInventoryRecordIfNotAlreadyAssociated(inventoryOid);
+
+    if (!inventoryItem.getOwner().equals(user)) {
+      throw new IllegalArgumentException(
+          "You can only assign an identifier that is owned by the current logged user");
+    }
+    DigitalObjectIdentifier identifierToAssign = doiDao.get(identifierId);
+    if (!identifierToAssign.canBeAssigned()) {
+      throw new IllegalArgumentException(
+          "You can only assign an active unassigned identifier in \"draft\" state");
+    }
+
+    return updateInventoryRecordWithDoiUpdate(
+        user, inventoryItem, assignUpdateWithNewDoi(inventoryItem, identifierToAssign));
   }
 
   @Override
@@ -185,6 +231,7 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
   private ApiSample getApiSampleUpdateWithIdentifier(
       InventoryRecord invRec, ApiInventoryDOI identifier) {
     ApiSample sample = new ApiSample();
+    sample.setName(invRec.getName());
     sample.setId(invRec.getId());
     sample.getIdentifiers().add(identifier);
     sample.setTags(null); // skip tags update
@@ -194,6 +241,7 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
   private ApiSubSample getApiSubSampleUpdateWithIdentifier(
       InventoryRecord invRec, ApiInventoryDOI identifier) {
     ApiSubSample subSample = new ApiSubSample();
+    subSample.setName(invRec.getName());
     subSample.setId(invRec.getId());
     subSample.getIdentifiers().add(identifier);
     subSample.setTags(null); // skip tags update
@@ -203,6 +251,7 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
   private ApiContainer getApiContainerUpdateWithIdentifier(
       InventoryRecord invRec, ApiInventoryDOI identifier) {
     ApiContainer container = new ApiContainer();
+    container.setName(invRec.getName());
     container.setId(invRec.getId());
     container.getIdentifiers().add(identifier);
     container.setTags(null);
@@ -244,6 +293,13 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
   private ApiInventoryDOI createUpdateWithNewDoi(InventoryRecord invRec, User user) {
     ApiInventoryDOI newDoi = createNewDoi(user);
     return updateNewAssociatedDoi(invRec, newDoi);
+  }
+
+  private ApiInventoryDOI assignUpdateWithNewDoi(
+      InventoryRecord inventoryItem, DigitalObjectIdentifier identifierToAssign) {
+    ApiInventoryDOI newDoi = new ApiInventoryDOI(identifierToAssign);
+    newDoi.setAssignIdentifierRequest(true);
+    return updateNewAssociatedDoi(inventoryItem, newDoi);
   }
 
   @SneakyThrows
@@ -337,6 +393,16 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
     publishDoi.setCreatorAffiliation(rorAffiliationName);
     publishDoi.setCreatorAffiliationIdentifier(rorAffiliationID);
     return publishDoi;
+  }
+
+  @NotNull
+  private InventoryRecord getInventoryRecordIfNotAlreadyAssociated(GlobalIdentifier invRecOid) {
+    InventoryRecord invRec = invRecRetriever.getInvRecordByGlobalId(invRecOid);
+    if (!invRec.getActiveIdentifiers().isEmpty()) {
+      throw new IllegalArgumentException(
+          "Inventory Item [" + invRecOid.toString() + "] has got already an identifier");
+    }
+    return invRec;
   }
 
   /* for testing */

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -571,6 +571,9 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
     contentChanged |=
         identifiersHelper.createDeleteRequestedIdentifiers(
             apiSample.getIdentifiers(), dbSample, user);
+    contentChanged |=
+        identifiersHelper.createAssignRequestedIdentifiers(
+            apiSample.getIdentifiers(), dbSample, user);
     contentChanged |= apiSample.applyChangesToDatabaseSample(dbSample, user);
     contentChanged |= saveSharingACLForIncomingApiInvRec(dbSample, apiSample);
     contentChanged |= saveIncomingSampleImage(dbSample, apiSample, user);

--- a/src/main/java/com/researchspace/service/inventory/impl/SubSampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SubSampleApiManagerImpl.java
@@ -137,6 +137,9 @@ public class SubSampleApiManagerImpl extends InventoryApiManagerImpl
       contentChanged |=
           identifiersHelper.createDeleteRequestedIdentifiers(
               apiSubSample.getIdentifiers(), dbSubSample, user);
+      contentChanged |=
+          identifiersHelper.createAssignRequestedIdentifiers(
+              apiSubSample.getIdentifiers(), dbSubSample, user);
       contentChanged |= apiSubSample.applyChangesToDatabaseSubSample(dbSubSample, user);
       contentChanged |= saveIncomingSubSampleImage(dbSubSample, apiSubSample, user);
       boolean moveSuccessful =

--- a/src/main/webapp/WEB-INF/pages/public/apiDocs.jsp
+++ b/src/main/webapp/WEB-INF/pages/public/apiDocs.jsp
@@ -28,7 +28,7 @@
       const baseUrl = window.location.href.substring(0, window.location.href.indexOf("/public/apiDocs"));
        var urls = [
                   { url: baseUrl + "/resources/rspace_api_specs_1_107_0.yaml", name: "RSpace ELN"},
-                  { url: baseUrl + "/resources/rspace_api_inventory_specs_1_109_0.yaml", name: "RSpace Inventory"}
+                  { url: baseUrl + "/resources/rspace_api_inventory_specs_1_111_0.yaml", name: "RSpace Inventory"}
                 ];
        var urlPrimaryName = "RSpace ELN";
 

--- a/src/main/webapp/resources/rspace_api_inventory_specs_1_111_0.yaml
+++ b/src/main/webapp/resources/rspace_api_inventory_specs_1_111_0.yaml
@@ -5,7 +5,7 @@ info:
   description: >
     Welcome to the RSpace Inventory API.
 
-  version: "1.109"
+  version: "1.111"
   termsOfService: >-
     Currently unrestricted, subject to usage limits returned in X-Rate-Limit headers.
   license:
@@ -2167,7 +2167,11 @@ paths:
         and having the specific `state`. 
 
         Moreover you can specify the filter `isAssociated` in case you want ONLY the Identifiers 
-        that have already been bound to a record
+        that have already been bound to a record.
+        
+        You can specify a DOI for the parameter `identifier` in one of the supported formats:
+         * `10.47366/3bgk.v5n1a3`
+         * `https://doi.org/10.47366/3bgk.v5n1a3`
 
       produces:
         - application/json
@@ -2184,6 +2188,11 @@ paths:
           type: boolean
           required: false
           description: Filter only the Identifiers that are already associated to a record
+        - name: identifier
+          description: The identifier you want to search
+          type: string
+          in: query
+          required: false
       responses:
         '200':
           description: The list is successfully returned
@@ -2238,6 +2247,49 @@ paths:
       responses:
         '201':
           description: Identifiers are created
+
+
+  '/identifiers/{doiId}/assign':
+    post:
+      summary: Assign a DataCite IGSN identifier to any inventory item
+      description: >
+        Assign a DataCite IGSN identifier to any inventory item
+        
+        The existing identifier MUST be:
+         * Unassigned
+         * not deleted
+         * in `draft`state
+        
+        It requires object with one `parentGlobalId` property as a request body.
+
+        You must have UPDATE permission for the item to create an identifier for it.
+
+        ## Example request body
+
+        | POST request body | Explanation |
+
+        | --- | --- |
+
+        { "parentGlobalId": "SS12" } | Register new identifier for a SubSample with id=12
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      parameters:
+        - name: doiId
+          type: string
+          in: path
+          required: true
+          description: The database ID of the identifier
+        - name: body
+          in: body
+          required: true
+          schema:
+            "$ref": "#/definitions/BasicObject"
+          description: The globalId of the inventory Item (for example "SS12")
+      responses:
+        '201':
+          description: Identifier is assigned to the inventory item
 
 
   '/identifiers/{doiId}':

--- a/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerTest.java
@@ -1,6 +1,8 @@
 package com.researchspace.service.inventory;
 
+import static com.researchspace.webapp.integrations.datacite.DataCiteConnectorDummy.DUMMY_VALID_DOI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,12 +18,14 @@ import com.researchspace.dao.DigitalObjectIdentifierDao;
 import com.researchspace.datacite.model.DataCiteConnectionException;
 import com.researchspace.datacite.model.DataCiteDoi;
 import com.researchspace.model.User;
+import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.DigitalObjectIdentifier;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.testutils.SpringTransactionalTest;
 import com.researchspace.webapp.integrations.datacite.DataCiteConnectorDummy;
 import com.researchspace.webapp.integrations.datacite.DataCiteConnectorDummyError;
 import java.util.List;
+import javax.naming.InvalidNameException;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -143,7 +147,7 @@ public class InventoryIdentifierApiManagerTest extends SpringTransactionalTest {
   }
 
   @Test
-  public void testFindIdentifiersByStateAndCreator() {
+  public void testFindIdentifiersByStateAndCreator() throws InvalidNameException {
     // GIVEN
     User anotherUser = createAndSaveUserIfNotExists(getRandomAlphabeticString("api_another"));
     initialiseContentWithEmptyContent(anotherUser);
@@ -156,33 +160,39 @@ public class InventoryIdentifierApiManagerTest extends SpringTransactionalTest {
 
     // WHEN
     List<ApiInventoryDOI> userAll =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner(null, user, null);
+        inventoryIdentifierApiMgr.findIdentifiers(null, null, null, user);
     List<ApiInventoryDOI> userAssociated =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner(null, user, true);
+        inventoryIdentifierApiMgr.findIdentifiers(null, true, null, user);
     List<ApiInventoryDOI> userAssociatedAndDraft =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner("draft", user, true);
-    List<ApiInventoryDOI> userAssociatedAndRegistered =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner("registered", user, true);
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true, null, user);
+    List<ApiInventoryDOI> userExistingDoiAssociatedAndDraft =
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true, DUMMY_VALID_DOI, user);
+    List<ApiInventoryDOI> userNotExistingDoiAssociatedAndDraft =
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true, "NOT_" + DUMMY_VALID_DOI, user);
 
+    List<ApiInventoryDOI> userAssociatedAndRegistered =
+        inventoryIdentifierApiMgr.findIdentifiers("registered", true, null, user);
     List<ApiInventoryDOI> userNotAssociated =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner(null, user, false);
+        inventoryIdentifierApiMgr.findIdentifiers(null, false, null, user);
     List<ApiInventoryDOI> userNotAssociatedAndDraft =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner("draft", user, false);
+        inventoryIdentifierApiMgr.findIdentifiers("draft", false, null, user);
     List<ApiInventoryDOI> userNotAssociatedAndRegisterd =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner("registered", user, false);
+        inventoryIdentifierApiMgr.findIdentifiers("registered", false, null, user);
 
     List<ApiInventoryDOI> anotherUserAll =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner(null, anotherUser, null);
+        inventoryIdentifierApiMgr.findIdentifiers(null, null, null, anotherUser);
     List<ApiInventoryDOI> anotherUserAssociated =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner(null, anotherUser, true);
+        inventoryIdentifierApiMgr.findIdentifiers(null, true, null, anotherUser);
     List<ApiInventoryDOI> anotherUserNotAssociated =
-        inventoryIdentifierApiMgr.findIdentifiersByStateAndOwner(null, anotherUser, false);
+        inventoryIdentifierApiMgr.findIdentifiers(null, false, null, anotherUser);
 
     // THEN
     assertEquals(3, userAll.size());
     assertEquals(1, userAssociated.size());
     assertEquals(user, userAssociated.get(0).getOwner());
     assertEquals(1, userAssociatedAndDraft.size());
+    assertEquals(1, userExistingDoiAssociatedAndDraft.size());
+    assertTrue(userNotExistingDoiAssociatedAndDraft.isEmpty());
     assertTrue(userAssociatedAndRegistered.isEmpty());
 
     assertEquals(2, userNotAssociated.size());
@@ -216,6 +226,92 @@ public class InventoryIdentifierApiManagerTest extends SpringTransactionalTest {
     assertTrue(
         inventoryIdentifierApiMgr.deleteUnassociatedIdentifier(
             anotherUserNotAssociated.get(1), user));
+  }
+
+  @Test
+  public void testAssignIdentifier() {
+    List<ApiInventoryDOI> bulkCreateResult =
+        inventoryIdentifierApiMgr.registerBulkIdentifiers(1, user);
+    assertEquals(1, bulkCreateResult.size());
+    assertFalse(bulkCreateResult.get(0).isAssociated());
+    assertNull(bulkCreateResult.get(0).getAssociatedGlobalId());
+    assertNull(bulkCreateResult.get(0).getTitle());
+
+    ApiContainer createdContainer = createBasicContainerForUser(user);
+    assertEquals(0, createdContainer.getIdentifiers().size());
+
+    ApiInventoryRecordInfo assignIdentifierResult =
+        inventoryIdentifierApiMgr.assignIdentifier(
+            createdContainer.getOid(), bulkCreateResult.get(0).getId(), user);
+    assertEquals(1, assignIdentifierResult.getIdentifiers().size());
+    assertEquals(
+        createdContainer.getOid().getIdString(),
+        assignIdentifierResult.getIdentifiers().get(0).getAssociatedGlobalId());
+    assertEquals(
+        createdContainer.getName(), assignIdentifierResult.getIdentifiers().get(0).getTitle());
+
+    Container refreshedContainer = containerApiMgr.getContainerById(createdContainer.getId(), user);
+    assertEquals(1, refreshedContainer.getActiveIdentifiers().size());
+    assertEquals(
+        bulkCreateResult.get(0).getDoi(),
+        refreshedContainer.getActiveIdentifiers().get(0).getIdentifier());
+
+    // cleanup identifiers
+    ApiInventoryRecordInfo updatedContainer =
+        inventoryIdentifierApiMgr.deleteAssociatedIdentifier(refreshedContainer.getOid(), user);
+    assertEquals(0, updatedContainer.getIdentifiers().size());
+  }
+
+  @Test
+  public void testAssignIdentifierToAnInventoryItemThatGotAlreadyAnIdentifierThrowsErrors() {
+    ApiSampleWithFullSubSamples createdSample = createComplexSampleForUser(user);
+    ApiInventoryRecordInfo registeredIdentifier =
+        inventoryIdentifierApiMgr.registerNewIdentifier(createdSample.getOid(), user);
+
+    ApiInventoryDOI unassignedIdentifier =
+        inventoryIdentifierApiMgr.registerBulkIdentifiers(1, user).get(0);
+
+    boolean exceptionHappened = false;
+    try {
+      inventoryIdentifierApiMgr.assignIdentifier(
+          createdSample.getOid(), unassignedIdentifier.getId(), user);
+    } catch (IllegalArgumentException e) {
+      exceptionHappened = true;
+      assertEquals(
+          "Inventory Item ["
+              + registeredIdentifier.getOid().getIdString()
+              + "] has got already an identifier",
+          e.getMessage());
+    } finally {
+      assertTrue(exceptionHappened, "The exception didn't happen");
+      // cleanup
+      inventoryIdentifierApiMgr.deleteAssociatedIdentifier(createdSample.getOid(), user);
+      inventoryIdentifierApiMgr.deleteUnassociatedIdentifier(unassignedIdentifier, user);
+    }
+  }
+
+  @Test
+  public void testAssignIdentifierThatWasAlreadyAssociatedThrowsErrors() {
+    ApiSampleWithFullSubSamples createdSample = createComplexSampleForUser(user);
+    ApiInventoryRecordInfo registeredIdentifier =
+        inventoryIdentifierApiMgr.registerNewIdentifier(createdSample.getOid(), user);
+
+    ApiContainer createdContainer = createBasicContainerForUser(user);
+    assertEquals(0, createdContainer.getIdentifiers().size());
+
+    boolean exceptionHappened = false;
+    try {
+      inventoryIdentifierApiMgr.assignIdentifier(
+          createdContainer.getOid(), registeredIdentifier.getIdentifiers().get(0).getId(), user);
+    } catch (IllegalArgumentException e) {
+      exceptionHappened = true;
+      assertEquals(
+          "You can only assign an active unassigned identifier in \"draft\" state", e.getMessage());
+    } finally {
+      assertTrue(exceptionHappened, "The exception didn't happen");
+      // cleanup
+      inventoryIdentifierApiMgr.deleteAssociatedIdentifier(createdSample.getOid(), user);
+    }
   }
 
   private void addOptionalPropertiesToIncomingDoi(ApiInventoryDOI doiUpdate) {
@@ -294,12 +390,16 @@ public class InventoryIdentifierApiManagerTest extends SpringTransactionalTest {
     updatedSubSample = inventoryIdentifierApiMgr.publishIdentifier(createdSubSample.getOid(), user);
     assertEquals(1, updatedSubSample.getIdentifiers().size());
     assertNotNull(updatedSubSample.getIdentifiers().get(0).getUrl());
-    assertEquals("https://doi.org/null", updatedSubSample.getIdentifiers().get(0).getPublicUrl());
+    assertEquals(
+        "https://doi.org/" + DUMMY_VALID_DOI,
+        updatedSubSample.getIdentifiers().get(0).getPublicUrl());
     // retract
     updatedSubSample = inventoryIdentifierApiMgr.retractIdentifier(createdSubSample.getOid(), user);
     assertEquals(1, updatedSubSample.getIdentifiers().size());
     assertNotNull(updatedSubSample.getIdentifiers().get(0).getUrl());
-    assertEquals("https://doi.org/null", updatedSubSample.getIdentifiers().get(0).getPublicUrl());
+    assertEquals(
+        "https://doi.org/" + DUMMY_VALID_DOI,
+        updatedSubSample.getIdentifiers().get(0).getPublicUrl());
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/integrations/datacite/DataCiteConnectorDummy.java
+++ b/src/test/java/com/researchspace/webapp/integrations/datacite/DataCiteConnectorDummy.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 
 public class DataCiteConnectorDummy implements DataCiteConnector {
 
+  public static final String DUMMY_VALID_DOI = "10.82316/n1c0-t35t";
   @Getter public DataCiteDoi doiSentToDatacite;
 
   @Override
   public DataCiteDoi registerDoi(DataCiteDoi dataCiteDoi) {
     doiSentToDatacite = dataCiteDoi;
     dataCiteDoi.getAttributes().setState("draft");
+    dataCiteDoi.setId(DUMMY_VALID_DOI);
     return dataCiteDoi;
   }
 


### PR DESCRIPTION
## Pre-requisites ##
The following PR is merged and a new model version is built: https://github.com/rspace-os/rspace-core-model/pull/26

## Description ##
- Allowing the users to assign an already unassociated identifier to an inventory item
- The search has been improved so now users  can search by DOI or a substring of a DOI

