### PR TITLE
PRT-934 Fix rich text field onChange handler

### DIFF
--- a/src/main/webapp/ui/src/components/Inputs/TextField.tsx
+++ b/src/main/webapp/ui/src/components/Inputs/TextField.tsx
@@ -16,7 +16,7 @@ export type TextFieldArgs = {
   id?: string;
 };
 
-export default function TextField(props: TextFieldArgs): React.ReactNode {
+export default function TextField({ onChange, ...props }: TextFieldArgs): React.ReactNode {
   const handleEditorChange = (content: string) => {
     const e = {
       target: {
@@ -24,7 +24,7 @@ export default function TextField(props: TextFieldArgs): React.ReactNode {
         value: content,
       },
     };
-    if (props.onChange) props.onChange(e);
+    if (onChange) onChange(e);
   };
 
   if (props.disabled) {


### PR DESCRIPTION
Commit c8ca95ae removed the `onChange={null}`, as I figured that it didn't do anything. Turns out it did, because `props` includes `onChange` and `Editor` accepts an `onChange` prop, even though we don't use it. We were then setting `onChange` to `null`, so that the change handler being passed in would not be called directly. I could have reverted that, but then it would be no clearer to the next person why we were setting it to null. Instead, I'm pulling `onChange` out of `props`, so its not passed to `Editor` at all.
