### PR TITLE
RSDEV-617: Adding the facility to search DOI without the URL protocol (i.e.: https)

### DIFF
--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
@@ -86,7 +86,8 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
       String state, Boolean isAssociated, String identifier, User owner)
       throws InvalidNameException {
     String finalIdentifier;
-    if (isNotBlank(identifier) && isValidURL(identifier) && isValidIdentifier(identifier)) {
+    if (isNotBlank(identifier) && (isValidURL(identifier) || isValidURL("https://" + identifier))
+        && isValidIdentifier(identifier)) {
       finalIdentifier = getIdentifierSuffix(identifier);
     } else {
       finalIdentifier = identifier;

--- a/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerTest.java
@@ -34,7 +34,8 @@ public class InventoryIdentifierApiManagerTest extends SpringTransactionalTest {
 
   private User user;
 
-  @Autowired private DigitalObjectIdentifierDao doiDao;
+  @Autowired
+  private DigitalObjectIdentifierDao doiDao;
 
   @Before
   public void setUp() throws Exception {
@@ -165,11 +166,9 @@ public class InventoryIdentifierApiManagerTest extends SpringTransactionalTest {
         inventoryIdentifierApiMgr.findIdentifiers(null, true, null, user);
     List<ApiInventoryDOI> userAssociatedAndDraft =
         inventoryIdentifierApiMgr.findIdentifiers("draft", true, null, user);
-    List<ApiInventoryDOI> userExistingDoiAssociatedAndDraft =
-        inventoryIdentifierApiMgr.findIdentifiers("draft", true, DUMMY_VALID_DOI, user);
+
     List<ApiInventoryDOI> userNotExistingDoiAssociatedAndDraft =
         inventoryIdentifierApiMgr.findIdentifiers("draft", true, "NOT_" + DUMMY_VALID_DOI, user);
-
     List<ApiInventoryDOI> userAssociatedAndRegistered =
         inventoryIdentifierApiMgr.findIdentifiers("registered", true, null, user);
     List<ApiInventoryDOI> userNotAssociated =
@@ -186,12 +185,35 @@ public class InventoryIdentifierApiManagerTest extends SpringTransactionalTest {
     List<ApiInventoryDOI> anotherUserNotAssociated =
         inventoryIdentifierApiMgr.findIdentifiers(null, false, null, anotherUser);
 
+    List<ApiInventoryDOI> userExistingDoiAssociatedAndDraft =
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true, DUMMY_VALID_DOI, user);
+    assertEquals(1, userExistingDoiAssociatedAndDraft.size());
+    userExistingDoiAssociatedAndDraft =
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true,
+            "https://doi.org/" + DUMMY_VALID_DOI, user);
+    assertEquals(1, userExistingDoiAssociatedAndDraft.size());
+    userExistingDoiAssociatedAndDraft =
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true, "doi.org/" + DUMMY_VALID_DOI,
+            user);
+    assertEquals(1, userExistingDoiAssociatedAndDraft.size());
+    userExistingDoiAssociatedAndDraft =
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true,
+            DUMMY_VALID_DOI.substring(0, DUMMY_VALID_DOI.length() - 3), user);
+    assertEquals(1, userExistingDoiAssociatedAndDraft.size());
+    userExistingDoiAssociatedAndDraft =
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true,
+            "https://doi.org/" + DUMMY_VALID_DOI.substring(0, DUMMY_VALID_DOI.length() - 3), user);
+    assertEquals(1, userExistingDoiAssociatedAndDraft.size());
+    userExistingDoiAssociatedAndDraft =
+        inventoryIdentifierApiMgr.findIdentifiers("draft", true,
+            "doi.org/" + DUMMY_VALID_DOI.substring(0, DUMMY_VALID_DOI.length() - 3), user);
+    assertEquals(1, userExistingDoiAssociatedAndDraft.size());
+
     // THEN
     assertEquals(3, userAll.size());
     assertEquals(1, userAssociated.size());
     assertEquals(user, userAssociated.get(0).getOwner());
     assertEquals(1, userAssociatedAndDraft.size());
-    assertEquals(1, userExistingDoiAssociatedAndDraft.size());
     assertTrue(userNotExistingDoiAssociatedAndDraft.isEmpty());
     assertTrue(userAssociatedAndRegistered.isEmpty());
 


### PR DESCRIPTION
User can now search a DOI inserting the url without protocol i.e.: `doi.org/10.86724/n1c0-t35t`
