### PR TITLE
PRT-935 IGSN place description field loses focus

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/GeoLocationField.js
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/GeoLocationField.js
@@ -218,7 +218,12 @@ const GeoLocationField = ({
               disabled={false}
               value={geoLocationPlace}
               onChange={({ target: { value } }) => {
-                handleUpdateValue(i, "geoLocationPlace", value);
+                runInAction(() => {
+                  geoLocation.geoLocationPlace = value;
+                });
+              }}
+              onBlur={() => {
+                doUpdateIdentifiers();
               }}
               error={false}
               helperText={""}


### PR DESCRIPTION
## Description ##
Whenever the text of the IGSN place text description field is changed, it loses focus thanks to a react re-rendering. This change fixes this by only causes the re-rendering when the user moves focus away from the textfield. This is a little hacky but the whole IGSN UI code is a mess and I don't fancy refactoring it all
