### PR TITLE
RSDEV-652: api usage log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /emailErrors.txt
 /error.log*
 /httpRequests.log
+/ApiRequests.txt
 /FTsearchIndices/
 /LuceneFTsearchIndices/
 /Users/

--- a/pom.xml
+++ b/pom.xml
@@ -2963,6 +2963,7 @@
     <!-- Location of security log -->
     <RSSecurityEvent.log.file>SecurityEvents.txt</RSSecurityEvent.log.file>
     <RSfailedEmails.log.file>emailErrors.txt</RSfailedEmails.log.file>
+    <ApiRequests.log.file>ApiRequests.txt</ApiRequests.log.file>
     <!-- choice of deployment.properties file - must be name of subfolder in 'deployments' -->
     <deployment>dev</deployment>
     <!-- default location of external properties file is actually the classpath one! -->

--- a/src/main/java/com/researchspace/api/v1/service/impl/ApiRequestLogger.java
+++ b/src/main/java/com/researchspace/api/v1/service/impl/ApiRequestLogger.java
@@ -1,0 +1,13 @@
+package com.researchspace.api.v1.service.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Does nothing except define a logger that can be used to write to an API requests event log. This
+ * logger is configured in log4j2.xml
+ */
+public class ApiRequestLogger {
+
+  public static Logger apiRequestLog = LoggerFactory.getLogger(ApiRequestLogger.class);
+}

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
@@ -86,7 +86,8 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
       String state, Boolean isAssociated, String identifier, User owner)
       throws InvalidNameException {
     String finalIdentifier;
-    if (isNotBlank(identifier) && (isValidURL(identifier) || isValidURL("https://" + identifier))
+    if (isNotBlank(identifier)
+        && (isValidURL(identifier) || isValidURL("https://" + identifier))
         && isValidIdentifier(identifier)) {
       finalIdentifier = getIdentifierSuffix(identifier);
     } else {

--- a/src/main/resources/log4j2-dev.xml
+++ b/src/main/resources/log4j2-dev.xml
@@ -37,6 +37,18 @@
       </Policies>
       <DefaultRolloverStrategy max="100000"/>
     </RollingFile>
+
+    <RollingFile name="ApiRequestLogAppender" fileName="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}" filePattern="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}.%i">
+      <PatternLayout>
+        <Pattern>%d{DATE} - %m%n</Pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="${RSRequest.log.maxFileSize}"/>
+      </Policies>
+      <DefaultRolloverStrategy max="100000"/>
+    </RollingFile>
+
+
   </Appenders>
 
   <Loggers>
@@ -64,6 +76,10 @@
 
     <Logger name="com.researchspace.webapp.controller.LoggingInterceptor" level="INFO">
       <AppenderRef ref="HttpRequestLogger"/>
+    </Logger>
+
+    <Logger name="com.researchspace.api.v1.service.impl.ApiRequestLogger" level="INFO">
+      <AppenderRef ref="ApiRequestLogAppender"/>
     </Logger>
 
     <Logger name="com.researchspace.webapp.controller.PerformanceLoggingInterceptor" level="INFO">

--- a/src/main/resources/log4j2-dev.xml
+++ b/src/main/resources/log4j2-dev.xml
@@ -18,6 +18,16 @@
       <DefaultRolloverStrategy max="100000"/>
     </RollingFile>
 
+    <RollingFile name="ApiRequestLogAppender" fileName="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}" filePattern="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}.%i">
+      <PatternLayout>
+        <Pattern>%d{DATE} - %m%n</Pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="${RSRequest.log.maxFileSize}"/>
+      </Policies>
+      <DefaultRolloverStrategy max="100000"/>
+    </RollingFile>
+
     <RollingFile name="SecurityEventLogAppender" fileName="${sys:loggingDirectory:-.}${sys:file.separator}${RSSecurityEvent.log.file}" filePattern="${sys:loggingDirectory:-.}${sys:file.separator}${RSSecurityEvent.log.file}.%i">
       <PatternLayout>
         <Pattern>%d{DATE} - %m%n</Pattern>
@@ -37,17 +47,6 @@
       </Policies>
       <DefaultRolloverStrategy max="100000"/>
     </RollingFile>
-
-    <RollingFile name="ApiRequestLogAppender" fileName="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}" filePattern="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}.%i">
-      <PatternLayout>
-        <Pattern>%d{DATE} - %m%n</Pattern>
-      </PatternLayout>
-      <Policies>
-        <SizeBasedTriggeringPolicy size="${RSRequest.log.maxFileSize}"/>
-      </Policies>
-      <DefaultRolloverStrategy max="100000"/>
-    </RollingFile>
-
 
   </Appenders>
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
       <DefaultRolloverStrategy max="100000"/>
     </RollingFile>
 
-    <RollingFile name="ApiRequestLogger" fileName="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}" filePattern="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}.%i">
+    <RollingFile name="ApiRequestLogAppender" fileName="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}" filePattern="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}.%i">
       <PatternLayout>
         <Pattern>%d{DATE} - %m%n</Pattern>
       </PatternLayout>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -13,6 +13,17 @@
       <DefaultRolloverStrategy max="100000"/>
     </RollingFile>
 
+    <RollingFile name="ApiRequestLogger" fileName="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}" filePattern="${sys:loggingDirectory:-.}${sys:file.separator}${ApiRequests.log.file}.%i">
+      <PatternLayout>
+        <Pattern>%d{DATE} - %m%n</Pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="${RSRequest.log.maxFileSize}"/>
+      </Policies>
+      <!--      keep 100_000 files so that logs aren't removed by default-->
+      <DefaultRolloverStrategy max="100000"/>
+    </RollingFile>
+
     <RollingFile name="auditTrailLogger" fileName="${sys:loggingDirectory:-.}${sys:file.separator}${RSRequest.log.file}" filePattern="${sys:loggingDirectory:-.}${sys:file.separator}${RSRequest.log.file}.%i">
       <PatternLayout>
         <Pattern>%d{DATE} - %m%n</Pattern>
@@ -109,6 +120,10 @@
     <Logger additivity="false" name="com.researchspace.model.permissions.SecurityLogger"
       level="INFO">
       <AppenderRef ref="SecurityEventLogAppender"/>
+    </Logger>
+
+    <Logger name="com.researchspace.api.v1.service.impl.ApiRequestLogger" level="INFO">
+      <AppenderRef ref="ApiRequestLogAppender"/>
     </Logger>
 
     <Logger name="com.researchspace.model.audittrail.AuditTrailService" level="INFO">


### PR DESCRIPTION
The PR adds new server log `ApiRequests.txt` that adds an entry anytime the external API client makes a request to the public API.

Example content of the new log file:
```
03 Jun 2025 08:05:21,360 - POST [/app/api/v1/sysadmin/groups] from 3.10.136.135, for user [sysadmin1] (API_KEY)
03 Jun 2025 09:12:28,959 - GET [/app/api/v1/documents] from 3.11.69.118, for user [matthias] (API_OAUTH_TOKEN)
03 Jun 2025 09:15:10,753 - GET [/app/api/v1/documents/297] from 3.11.69.118, for user [matthias] (API_OAUTH_TOKEN)
```

Additionally, the PR fixes the issue with external API call trying to reuse active Shiro session, which was happening when the user was logged into UI at the same time as making API call. The session reusage was causing such calls to not be recognized as external API calls, and therefore not logged nor sent to analytics.
