### PR TITLE
Allow embedding AV portal videos into RSpace documents 

### DIFF
--- a/src/main/java/com/researchspace/linkedelements/TextFieldEmbedIframeHandler.java
+++ b/src/main/java/com/researchspace/linkedelements/TextFieldEmbedIframeHandler.java
@@ -30,13 +30,18 @@ public class TextFieldEmbedIframeHandler {
   // jove src url last fragment, e.g. 'id=54239&t=1&s=1&fpv=1'
   private static final String JOVE_SRC_SUFFIX_PATTERN =
       "\\?id=\\d+((&\\w+=1)|(&language=\\w+)|(&access=\\w+)|(&utm_source=\\w+))*";
+   // AV Portal patterns, in the same style:Add commentMore actions
+  private static final String AVPORTAL_SRC_BASE = 
+      "https://av.tib.eu/player/";
+  private static final String AVPORTAL_SRC_SUFFIX_PATTERN = 
+      "\\d+";
 
   private static final String[] knownIframeSrcPatterns = {
     "https://www.youtube.com/embed/" + YOUTUBE_SRC_SUFFIX_PATTERN,
     "https://www.youtube-nocookie.com/embed/" + YOUTUBE_SRC_SUFFIX_PATTERN,
     "https://www.jove.com/embed/player" + JOVE_SRC_SUFFIX_PATTERN,
     "https://app.jove.com/embed/player" + JOVE_SRC_SUFFIX_PATTERN,
-    "https://richard-dev2.jove.com/embed/player" + JOVE_SRC_SUFFIX_PATTERN
+    AVPORTAL_SRC_BASE + AVPORTAL_SRC_SUFFIX_PATTERN
   };
 
   private static final Map<String, String> knownIframeAttrsAndPatterns;


### PR DESCRIPTION
## Description ##
***REQUIRED***
- ***brief description of the change***
- Updated TextFieldEmbedIframeHandler.java to recognise embed code from TIB's AV-portal as allowed content in RSpace documents
- removed an apparently obsolete white-listed URL

## Design decisions
***OPTIONAL***
- ***if there were any particular design decisions made, list them here***

## Testing notes
***OPTIONAL***
- ***if there are any particular pre-requisites or instructions for manual testing, list them here***
