### PR TITLE
remove 'liquibase-update-test' liquibase context

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -400,7 +400,7 @@ pipeline {
                   -Djava-vendor=${params.MAVEN_TOOLCHAIN_JAVA_VENDOR} \
                   -Dlog4j2.configurationFile=log4j2-dev.xml \
                   -Djdbc.url=jdbc:mysql://localhost:3306/testLiquibaseUpdate \
-                  -Dliquibase.context=liquibase-update-test,run \
+                  -Dliquibase.context=run \
                   -Dmaven.test.failure.ignore=false   -Denvironment=keepdbintact  \
                   -DRS.devlogLevel=INFO -DRS_FILE_BASE=/var/lib/jenkins/userContent/RS_FileRepoLiquibase"
             }

--- a/src/main/resources/sqlUpdates/changeLog-0.15.xml
+++ b/src/main/resources/sqlUpdates/changeLog-0.15.xml
@@ -55,7 +55,7 @@
 			  <column name="role_id" type="NUMERIC"/>
 </loadData>
 </changeSet>
-<changeSet id="4" author="radams" context="dev-test,liquibase-update-test">
+<changeSet id="4" author="radams" context="dev-test">
 <validCheckSum>7:86de01ed1524537224d0aee871372ec3</validCheckSum>
 <comment> Load data into DB for when running unit/ IT tests</comment>
 <loadData tableName="User"  file="sqlUpdates/data/users.csv">
@@ -81,7 +81,7 @@
 			  <column name="role_id" type="NUMERIC"/>
 </loadData>
 </changeSet>
-<changeSet id="8_4-3-2014" author="radams" context="dev-test,liquibase-update-test">
+<changeSet id="8_4-3-2014" author="radams" context="dev-test">
 <validCheckSum>7:342153c696e26acc480a2a88bdfb75da</validCheckSum>
 <validCheckSum>8:6892fc5d3be61363eae670a7196fdb1f</validCheckSum>
 <comment> Load  developer users data into DB for when running unit/ IT tests/ localhost runs</comment>

--- a/src/main/resources/sqlUpdates/changeLog-0.16.xml
+++ b/src/main/resources/sqlUpdates/changeLog-0.16.xml
@@ -22,7 +22,7 @@ insert into user_role select distinct user_id, roles.id  from UserGroup,roles wh
 </sql>
 </changeSet>
 
-<changeSet id="7-3-2014-1" author="radams" context="dev-test,liquibase-update-test">
+<changeSet id="7-3-2014-1" author="radams" context="dev-test">
 <comment>Set some test users to have PI role</comment>
 <sql>
  insert into user_role select User.id, roles.id from User,roles where username='user1a' and name='ROLE_PI';
@@ -177,14 +177,6 @@ insert into user_role select distinct user_id, roles.id  from UserGroup,roles wh
 <rollback>
     <sql>delete from community_admin where community_id=-1</sql>
 </rollback>
-</changeSet>
-<changeSet id="08-04-14d" author="radams" context="dev-test,liquibase-update-test,sso-ed">
- <comment>Alter username of developer test account</comment>
- <update tableName="User">
-     <column name="username" >v1gyang</column>
-     <where>username='sunny';</where>
- </update>
-    
 </changeSet>
 <changeSet author="radams (generated)" id="1396998485977-1" context="run">
     <comment>Add profile text to community table</comment>

--- a/src/main/resources/sqlUpdates/changeLog-1.37.xml
+++ b/src/main/resources/sqlUpdates/changeLog-1.37.xml
@@ -281,20 +281,8 @@
 	</loadData>
 	
 	</changeSet>
-	
-		
-	<changeSet id="16-7-18g-pre-TestData" author="richard" context="liquibase-update-test">
-	<!-- required for liquibase update to 3.5 -->
-	<validCheckSum>7:4b1a6a97be9d038bd4fd8f63f28f4b10</validCheckSum>	
-	<comment>Need to reset all property values for liquibase tests</comment>
-	<delete tableName="SystemPropertyValue"></delete>
-	<loadData file="sqlUpdates/data/SystemPropertyTestData_1-37/SystemPropertyValues.csv" tableName="SystemPropertyValue">
-	        <column name="value" type="STRING"/>
-			<column name="property_id" type="NUMERIC"/>
-	</loadData>
-	</changeSet>
-	
-	<changeSet id="16-7-18g-pre-TestData2" author="richard" context="liquibase-update-test,run">
+
+	<changeSet id="16-7-18g-pre-TestData2" author="richard" context="run">
 	<comment>Need to reset all property descriptor values for liquibase tests and production</comment>
 	<update tableName="SystemProperty">
 	     <column name="descriptor_id" valueComputed="id"/>

--- a/src/main/resources/sqlUpdates/changeLog-1.49.xml
+++ b/src/main/resources/sqlUpdates/changeLog-1.49.xml
@@ -66,7 +66,7 @@
             select null, pd.id, app.id from PropertyDescriptor pd, App app where app.name="app.onboarding" and pd.name='SEEN_TOOLTIPS';</sql>
     </changeSet>
 
-    <changeSet id="25-01-17" author="matthias" context="dev-test,liquibase-update-test">
+    <changeSet id="25-01-17" author="matthias" context="dev-test">
         <comment>RSPAC-1416 on test servers onboarding should be disabled by default</comment>
         <update tableName="SystemPropertyValue">
           <column name="value" value="DENIED"></column>

--- a/src/main/resources/sqlUpdates/changeLog-1.91.xml
+++ b/src/main/resources/sqlUpdates/changeLog-1.91.xml
@@ -17,7 +17,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="2023-08-07" author="matthias" context="dev-test,liquibase-update-test">
+    <changeSet id="2023-08-07" author="matthias" context="dev-test">
         <comment>RSOPS-506: keep 'admin' account enabled on test servers and in liquibase test run</comment>
         <sql>
             update User set account_enabled = true where username = 'admin'

--- a/src/main/resources/sqlUpdates/data-changeLog.xml
+++ b/src/main/resources/sqlUpdates/data-changeLog.xml
@@ -31,25 +31,7 @@
 		</addColumn>
 	</changeSet>
 
-
-	<changeSet id="2-2-15b" author="radams" runAlways="true"
-		context="liquibase-update-test">
-		<comment>Removes checksum for password hint for liquibase test</comment>
-		<update tableName="DATABASECHANGELOG">
-			<column name="MD5SUM" value="NULL"></column>
-			<where>ID="3" and author='radams'</where>
-		</update>
-		<update tableName="DATABASECHANGELOG">
-			<column name="MD5SUM" value="NULL"></column>
-			<where>ID="4" and author='radams'</where>
-		</update>
-		<update tableName="DATABASECHANGELOG">
-			<column name="MD5SUM" value="NULL"></column>
-			<where>ID="8_4-3-2014" and author='radams'</where>
-		</update>
-	</changeSet>
-
-	<changeSet id="3" author="radams" context="dev-test,liquibase-update-test">
+	<changeSet id="3" author="radams" context="dev-test">
 		<validCheckSum>7:0bdaedb4be732e5ad5ce275acf2b5dc1</validCheckSum>
 		<validCheckSum>7:e0ae39271657d50ecda9415eecf80225</validCheckSum>
 		<!-- only add if roles table is empty, implies this is a new, empty DB 
@@ -98,14 +80,7 @@
 			<where>ID="25-08-14a" and AUTHOR='radams'</where>
 		</update>
 	</changeSet>
-	<changeSet id="16-09-15d" author="radams" runAlways="true" context="liquibase-update-test">
-		<comment>Removes checksum for problematic SQL statement</comment>
-		<update tableName="DATABASECHANGELOG">
-			<column name="MD5SUM" value="NULL"></column>
-			<where>ID="2016-07-08" and AUTHOR='richard'</where>
-		</update>
-	</changeSet>
-	
+
     <!-- this is 1.44 change but is added to this file rather than changeLog-1.44.xml
          so the liquibase java updates operating on Group entity can pass. -->
     <changeSet id="17-05-17-rspac-1232" author="matthias" context="run">

--- a/src/test/java/com/researchspace/api/v1/auth/CombinedApiAuthenticatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/auth/CombinedApiAuthenticatorTest.java
@@ -13,6 +13,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.UserAuthenticationMethod;
 import com.researchspace.model.record.TestFactory;
 import com.researchspace.service.ApiAvailabilityHandler;
+import org.apache.shiro.authz.AuthorizationException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -51,8 +52,7 @@ public class CombinedApiAuthenticatorTest {
      * also with system setting not allowing external oauth connections  */
     user.setAuthenticatedBy(UserAuthenticationMethod.API_OAUTH_TOKEN);
     when(apiAvailabilityHandler.isOAuthAccessAllowed(user)).thenReturn(false);
-    assertThrows(
-        ApiAuthenticationException.class, () -> combinedApiAuthenticator.authenticate(mockRequest));
+    assertThrows(ApiAuthenticationException.class, () -> combinedApiAuthenticator.authenticate(mockRequest));
     verifyNoInteractions(apiKeyAuthenticator);
     verifyNoInteractions(analyticsManager);
 

--- a/src/test/java/com/researchspace/api/v1/auth/CombinedApiAuthenticatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/auth/CombinedApiAuthenticatorTest.java
@@ -13,7 +13,6 @@ import com.researchspace.model.User;
 import com.researchspace.model.UserAuthenticationMethod;
 import com.researchspace.model.record.TestFactory;
 import com.researchspace.service.ApiAvailabilityHandler;
-import org.apache.shiro.authz.AuthorizationException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -52,7 +51,8 @@ public class CombinedApiAuthenticatorTest {
      * also with system setting not allowing external oauth connections  */
     user.setAuthenticatedBy(UserAuthenticationMethod.API_OAUTH_TOKEN);
     when(apiAvailabilityHandler.isOAuthAccessAllowed(user)).thenReturn(false);
-    assertThrows(ApiAuthenticationException.class, () -> combinedApiAuthenticator.authenticate(mockRequest));
+    assertThrows(
+        ApiAuthenticationException.class, () -> combinedApiAuthenticator.authenticate(mockRequest));
     verifyNoInteractions(apiKeyAuthenticator);
     verifyNoInteractions(analyticsManager);
 


### PR DESCRIPTION
I believe that context is no longer needed, and it is likely reason for recent problems with jenkins nightly test run.