### PR TITLE
Rsdev 684 limit search input to a single molecule

### DIFF
--- a/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
+++ b/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
@@ -182,7 +182,7 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
         handleClose={closeAndReset}
         existingChem={searchSmiles}
         validationResult={isValid}
-        instructionText="Draw a single molecule above to search"
+        instructionText="Draw a single molecule below to search"
         onChange={() => {
           validate(window.ketcher);
         }}

--- a/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
+++ b/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
@@ -84,18 +84,23 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
     setErrorMessage(null);
   };
 
+  const [isValid, setIsValid] = useState(IsValid());
   const validate = (ketcher) => {
-    if(!ketcher){
-      return IsValid();
+    if (!ketcher) {
+      setIsValid(IsValid());
+      return;
     }
     ketcher.getKet().then((ketData) => {
-      const molecules = Object.keys(JSON.parse(ketData)).filter(key => key.startsWith('mol'));
-      console.log("molecules: " + molecules.length)
-      if(molecules.length > 1){
-        return IsInvalid("Please select only 1 molecule")
+      const molecules = Object.keys(JSON.parse(ketData)).filter((key) =>
+        key.startsWith("mol")
+      );
+      if (molecules.length > 1) {
+        setIsValid(IsInvalid("Please select only 1 molecule"));
+        return;
       }
-      return IsValid();
-  })};
+      setIsValid(IsValid());
+    });
+  };
 
   const handleInsert = (ketcher) => {
     setShowKetcherDialog(false);
@@ -104,7 +109,7 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
       fetchData(0, smiles);
       void window.ketcher.setMolecule("");
     });
-  }
+  };
 
   const columns = [
     DataGridColumn.newColumnWithValueGetter(
@@ -172,7 +177,10 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
         actionBtnText="Search"
         handleClose={closeAndReset}
         existingChem={searchSmiles}
-        validationResult={validate(window.ketcher)}
+        validationResult={isValid}
+        onChange={() => {
+          validate(window.ketcher);
+        }}
         additionalControls={
           <FormControl>
             <FormLabel id="search-type">Search Type</FormLabel>

--- a/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
+++ b/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
@@ -95,7 +95,11 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
         key.startsWith("mol")
       );
       if (molecules.length > 1) {
-        setIsValid(IsInvalid("Please select only 1 molecule"));
+        setIsValid(
+          IsInvalid(
+            "Chemical search currently requires a single molecule. Please remove extra molecules from the canvas or create separate searches."
+          )
+        );
         return;
       }
       setIsValid(IsValid());
@@ -178,6 +182,7 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
         handleClose={closeAndReset}
         existingChem={searchSmiles}
         validationResult={isValid}
+        instructionText="Draw a single molecule above to search"
         onChange={() => {
           validate(window.ketcher);
         }}

--- a/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
+++ b/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
@@ -17,6 +17,7 @@ import { DataGrid } from "@mui/x-data-grid";
 import { DataGridColumn } from "../../../util/table";
 import Link from "@mui/material/Link";
 import AnalyticsContext from "../../../stores/contexts/Analytics";
+import { IsValid, IsInvalid } from "../../../components/ValidatingSubmitButton";
 
 const ChemicalSearcher = ({ isOpen, onClose }) => {
   const { trackEvent } = React.useContext(AnalyticsContext);
@@ -83,13 +84,24 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
     setErrorMessage(null);
   };
 
+  const validate = (ketcher) => {
+    ketcher.getKet().then((ketData) => {
+      const molecules = Object.keys(JSON.parse(ketData)).filter(key => key.startsWith('mol'));
+      console.log(molecules.length)
+      if(molecules.length > 1){
+        return IsInvalid("Please select only 1 molecule")
+      }
+      return IsValid();
+  })};
+
   const handleInsert = (ketcher) => {
     setShowKetcherDialog(false);
     ketcher.getSmiles().then((smiles) => {
       setSearchSmiles(smiles);
       fetchData(0, smiles);
+      void window.ketcher.setMolecule("");
     });
-  };
+  }
 
   const columns = [
     DataGridColumn.newColumnWithValueGetter(
@@ -157,6 +169,7 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
         actionBtnText="Search"
         handleClose={closeAndReset}
         existingChem={searchSmiles}
+        validationResult={validate}
         additionalControls={
           <FormControl>
             <FormLabel id="search-type">Search Type</FormLabel>

--- a/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
+++ b/src/main/webapp/ui/src/Toolbar/Workspace/SimpleSearch/ChemicalSearcher.js
@@ -85,9 +85,12 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
   };
 
   const validate = (ketcher) => {
+    if(!ketcher){
+      return IsValid();
+    }
     ketcher.getKet().then((ketData) => {
       const molecules = Object.keys(JSON.parse(ketData)).filter(key => key.startsWith('mol'));
-      console.log(molecules.length)
+      console.log("molecules: " + molecules.length)
       if(molecules.length > 1){
         return IsInvalid("Please select only 1 molecule")
       }
@@ -169,7 +172,7 @@ const ChemicalSearcher = ({ isOpen, onClose }) => {
         actionBtnText="Search"
         handleClose={closeAndReset}
         existingChem={searchSmiles}
-        validationResult={validate}
+        validationResult={validate(window.ketcher)}
         additionalControls={
           <FormControl>
             <FormLabel id="search-type">Search Type</FormLabel>

--- a/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
+++ b/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
@@ -12,7 +12,11 @@ import { styled } from "@mui/material/styles";
 import Stack from "@mui/material/Stack";
 import AnalyticsContext from "../../stores/contexts/Analytics";
 import { Ketcher } from "ketcher-core";
-import ValidatingSubmitButton, { IsValid, IsInvalid, ValidationResult } from "../ValidatingSubmitButton";
+import ValidatingSubmitButton, {
+  IsValid,
+  IsInvalid,
+  ValidationResult,
+} from "../ValidatingSubmitButton";
 
 declare global {
   interface Window {
@@ -32,6 +36,7 @@ type KetcherDialogArgs = {
   readOnly?: boolean;
   additionalControls?: React.ReactNode;
   validationResult?: ValidationResult;
+  onChange: () => void;
 };
 
 const StyledDialog = styled(Dialog)(() => ({
@@ -49,7 +54,8 @@ const KetcherDialog = ({
   actionBtnText = "",
   readOnly = false,
   additionalControls = null,
-  validationResult = IsValid()
+  validationResult = IsValid(),
+  onChange,
 }: KetcherDialogArgs): React.ReactNode => {
   const { trackEvent } = React.useContext(AnalyticsContext);
   const [hasError, setHasError] = useState(false);
@@ -83,6 +89,9 @@ const KetcherDialog = ({
               }}
               structServiceProvider={structServiceProvider}
               onInit={(ketcher) => {
+                ketcher.editor.subscribe("change", () => {
+                  onChange?.();
+                });
                 window.ketcher = ketcher;
                 void ketcher.setMolecule(existingChem);
                 if (readOnly) {

--- a/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
+++ b/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
@@ -82,6 +82,9 @@ const KetcherDialog = ({
         <DialogTitle>{title}</DialogTitle>
         <DialogContent style={{ minHeight: "0" }}>
           <Stack sx={{ height: "100%" }}>
+            {instructionText && (
+                <Typography variant="body2" style={{ paddingBottom: "1em"}}>{instructionText}</Typography>
+            )}
             {additionalControls}
             {/* @ts-expect-error doesn't appear that staticResourcesUrl is in fact required */}
             <Editor
@@ -113,9 +116,6 @@ const KetcherDialog = ({
             )}
           </Stack>
         </DialogContent>
-        {instructionText && (
-          <Typography sx={{ px: 4, py: 1 }}>{instructionText}</Typography>
-        )}
         <DialogActions>
           <Button onClick={closeAndReset}>Cancel</Button>
           {actionBtnText && (

--- a/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
+++ b/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
@@ -12,6 +12,7 @@ import { styled } from "@mui/material/styles";
 import Stack from "@mui/material/Stack";
 import AnalyticsContext from "../../stores/contexts/Analytics";
 import { Ketcher } from "ketcher-core";
+import ValidatingSubmitButton, { IsValid, IsInvalid, ValidationResult } from "../ValidatingSubmitButton";
 
 declare global {
   interface Window {
@@ -30,6 +31,7 @@ type KetcherDialogArgs = {
   actionBtnText?: string;
   readOnly?: boolean;
   additionalControls?: React.ReactNode;
+  validationResult?: ValidationResult;
 };
 
 const StyledDialog = styled(Dialog)(() => ({
@@ -47,6 +49,7 @@ const KetcherDialog = ({
   actionBtnText = "",
   readOnly = false,
   additionalControls = null,
+  validationResult = IsValid()
 }: KetcherDialogArgs): React.ReactNode => {
   const { trackEvent } = React.useContext(AnalyticsContext);
   const [hasError, setHasError] = useState(false);
@@ -58,7 +61,6 @@ const KetcherDialog = ({
 
   const onInsertClick = () => {
     handleInsert(window.ketcher);
-    void window.ketcher.setMolecule("");
   };
 
   const closeAndReset = () => {
@@ -103,9 +105,13 @@ const KetcherDialog = ({
         <DialogActions>
           <Button onClick={closeAndReset}>Cancel</Button>
           {actionBtnText && (
-            <Button onClick={onInsertClick} type="submit">
+            <ValidatingSubmitButton
+              loading={false}
+              validationResult={validationResult}
+              onClick={onInsertClick}
+            >
               {actionBtnText}
-            </Button>
+            </ValidatingSubmitButton>
           )}
         </DialogActions>
       </StyledDialog>

--- a/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
+++ b/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
@@ -15,7 +15,6 @@ import AnalyticsContext from "../../stores/contexts/Analytics";
 import { Ketcher } from "ketcher-core";
 import ValidatingSubmitButton, {
   IsValid,
-  IsInvalid,
   ValidationResult,
 } from "../ValidatingSubmitButton";
 

--- a/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
+++ b/src/main/webapp/ui/src/components/Ketcher/KetcherDialog.tsx
@@ -6,6 +6,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
 import { Editor, InfoModal } from "ketcher-react";
 import { StandaloneStructServiceProvider } from "ketcher-standalone";
 import { styled } from "@mui/material/styles";
@@ -37,6 +38,7 @@ type KetcherDialogArgs = {
   additionalControls?: React.ReactNode;
   validationResult?: ValidationResult;
   onChange: () => void;
+  instructionText?: string;
 };
 
 const StyledDialog = styled(Dialog)(() => ({
@@ -56,6 +58,7 @@ const KetcherDialog = ({
   additionalControls = null,
   validationResult = IsValid(),
   onChange,
+  instructionText,
 }: KetcherDialogArgs): React.ReactNode => {
   const { trackEvent } = React.useContext(AnalyticsContext);
   const [hasError, setHasError] = useState(false);
@@ -111,6 +114,9 @@ const KetcherDialog = ({
             )}
           </Stack>
         </DialogContent>
+        {instructionText && (
+          <Typography sx={{ px: 4, py: 1 }}>{instructionText}</Typography>
+        )}
         <DialogActions>
           <Button onClick={closeAndReset}>Cancel</Button>
           {actionBtnText && (

--- a/src/main/webapp/ui/src/tinyMCE/ketcher/KetcherTinyMce.js
+++ b/src/main/webapp/ui/src/tinyMCE/ketcher/KetcherTinyMce.js
@@ -113,10 +113,11 @@ export const KetcherTinyMce = () => {
   const handleInsert = (ketcher) => {
     ketcherObj = ketcher;
     ketcherObj.getKet().then(
-      (chemical) => {
+      (chemical) => { 
         saveChemicalAndInsert(chemical);
         setDialogIsOpen(false);
         setExistingChemical("");
+        void window.ketcher.setMolecule("");
       },
       () => {}
     );

--- a/src/main/webapp/ui/src/tinyMCE/ketcher/KetcherTinyMce.js
+++ b/src/main/webapp/ui/src/tinyMCE/ketcher/KetcherTinyMce.js
@@ -6,6 +6,8 @@ import { blobToBase64 } from "../../util/files";
 import axios from "@/common/axios";
 import AnalyticsContext from "../../stores/contexts/Analytics";
 import Analytics from "../../components/Analytics";
+import { ThemeProvider } from "@mui/material/styles";
+import theme from "../../theme";
 
 export const KetcherTinyMce = () => {
   const { trackEvent } = React.useContext(AnalyticsContext);
@@ -149,9 +151,11 @@ document.addEventListener("DOMContentLoaded", () => {
     if (wrapperDiv) {
       const root = createRoot(wrapperDiv);
       root.render(
-        <Analytics>
-          <KetcherTinyMce />
-        </Analytics>
+        <ThemeProvider theme={theme}>
+          <Analytics>
+            <KetcherTinyMce />
+          </Analytics>
+        </ThemeProvider>
       );
     }
   });

--- a/src/test/java/com/researchspace/api/v1/auth/CombinedApiAuthenticatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/auth/CombinedApiAuthenticatorTest.java
@@ -13,7 +13,6 @@ import com.researchspace.model.User;
 import com.researchspace.model.UserAuthenticationMethod;
 import com.researchspace.model.record.TestFactory;
 import com.researchspace.service.ApiAvailabilityHandler;
-import org.apache.shiro.authz.AuthorizationException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -52,7 +51,8 @@ public class CombinedApiAuthenticatorTest {
      * also with system setting not allowing external oauth connections  */
     user.setAuthenticatedBy(UserAuthenticationMethod.API_OAUTH_TOKEN);
     when(apiAvailabilityHandler.isOAuthAccessAllowed(user)).thenReturn(false);
-    assertThrows(ApiAuthenticationException.class, () -> combinedApiAuthenticator.authenticate(mockRequest));
+    assertThrows(
+        ApiAuthenticationException.class, () -> combinedApiAuthenticator.authenticate(mockRequest));
     verifyNoInteractions(apiKeyAuthenticator);
     verifyNoInteractions(analyticsManager);
 


### PR DESCRIPTION
## Description ##
Chemistry search currently only works with a single molecule as input, although there was nothing stopping users adding multiple elements. This change adds some helper text at the top of the search dialog, and also validates that there's only 1 chemical element on the canvas when the user submits the search.

Other minor changes to get this to work:
- Moved the code to reset the canvas `window.ketcher.setMolecule("")`, which was handled in the child Ketcher component and tied to clicking the submit button, to each of the parents, as in the case of search we don't always want to clear the canvas, as the search input might not be valid. This way the user has a chance to fix the issue without having to recreate their search input
- Wrapped `KetcherTinyMCE` in a `<ThemeProvider>` as there was an error around themes after adding the `ValidatingSubmitButton` to the child component

There's also an auto-formatting change in some unrelated java code.

After these changes, this is what the user sees when they try to search with more than 1 element:

<img width="1461" alt="Screenshot 2025-06-17 at 11 32 30" src="https://github.com/user-attachments/assets/0e7efcaf-72c2-48e1-b73a-6ed57cfd8f91" />

