### PR TITLE
PRT-950 Fix incorrect import samples warning

### DIFF
--- a/src/main/webapp/ui/src/stores/models/ImportModel.ts
+++ b/src/main/webapp/ui/src/stores/models/ImportModel.ts
@@ -1171,7 +1171,7 @@ export default class Import {
       return { matches: false, reason: "Template has not been selected" };
     const template = this.template;
 
-    const customFields = this.mappingsByRecordType.filter(
+    const customFields = this.samplesMappings.filter(
       ({ field, selected }) => field === Fields.custom && selected
     );
     if (customFields.length !== template.fields.length)


### PR DESCRIPTION
When on the subsamples import page, we were comparing the template definition to the custom fields of the parsed subsamples CSV file (which will always be empty). A warning would then say that there was a problem with the samples import, but there wasn't.
