### PR TITLE
RSDEV-694: Fix Tags were not created when import Container from CSV into Inventory

### DIFF
--- a/src/main/java/com/axiope/service/cfg/ProductionConfig.java
+++ b/src/main/java/com/axiope/service/cfg/ProductionConfig.java
@@ -49,7 +49,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.context.WebApplicationContext;

--- a/src/main/java/com/axiope/service/cfg/TestAppConfig.java
+++ b/src/main/java/com/axiope/service/cfg/TestAppConfig.java
@@ -44,7 +44,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Scope;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
 

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryImportManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryImportManagerImpl.java
@@ -592,6 +592,9 @@ public class InventoryImportManagerImpl implements InventoryImportManager {
         ApiContainer moveRequest = new ApiContainer();
         moveRequest.setId(importedRecord.getId());
         moveRequest.setParentContainer(targetParent);
+        /* needed for backward compatibility as explained on the method
+        ApiInventoryRecordInfo.applyChangesToDatabaseInventoryRecord(...) */
+        moveRequest.setTags(null);
         ApiContainer updatedContainer =
             containerManager.updateApiContainer(moveRequest, importResult.getCurrentUser());
         importedRecordResult.setRecord(updatedContainer);

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryImportManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryImportManagerTest.java
@@ -1127,17 +1127,18 @@ public class InventoryImportManagerTest extends SpringTransactionalTest {
     String workbenchGlobalId = getWorkbenchForUser(testUser).getGlobalId();
 
     List<String[]> csvContainerLines = new ArrayList<>();
-    csvContainerLines.add(new String[] {"testContent1", "testContainer1", "1", "", ""});
-    csvContainerLines.add(new String[] {"testContent2", "testContainer2", "", "1", ""});
-    csvContainerLines.add(new String[] {"testContent3", "testContainer3", "", "4", ""});
-    csvContainerLines.add(new String[] {"testContent4", "testContainer4", "4", "1", ""});
+    csvContainerLines.add(new String[] {"testContent1", "testContainer1", "1", "", "", "tag1"});
+    csvContainerLines.add(new String[] {"testContent2", "testContainer2", "", "1", "", ""});
+    csvContainerLines.add(new String[] {"testContent3", "testContainer3", "", "4", "", ""});
+    csvContainerLines.add(new String[] {"testContent4", "testContainer4", "4", "1", "", ""});
     csvContainerLines.add(
-        new String[] {"testContent4", "testContainer5", "", "", workbenchGlobalId});
+        new String[] {"testContent4", "testContainer5", "", "", workbenchGlobalId, ""});
     Map<Integer, String> colIndexToDefaultFieldMapping = new HashMap<>();
     colIndexToDefaultFieldMapping.put(1, "name");
     colIndexToDefaultFieldMapping.put(2, "import identifier");
     colIndexToDefaultFieldMapping.put(3, "parent container import id");
     colIndexToDefaultFieldMapping.put(4, "parent container global id");
+    colIndexToDefaultFieldMapping.put(5, "tags");
 
     // test lines conversion
     ApiInventoryImportPartialResult processingResult = new ApiInventoryImportSampleImportResult();
@@ -1178,6 +1179,11 @@ public class InventoryImportManagerTest extends SpringTransactionalTest {
     assertEquals("testContainer1", containerImportResult.getResults().get(0).getRecord().getName());
     assertNotNull(
         containerImportResult.getResults().get(0).getRecord().getId()); // should be set now
+    assertFalse(
+        containerImportResult.getResults().get(0).getRecord().getTags().isEmpty(),
+        "Tags have not being correctly set");
+    assertEquals(
+        "tag1", containerImportResult.getResults().get(0).getRecord().getTags().get(0).getValue());
     assertEquals(
         defaultImportContainerName,
         containerImportResult.getResults().get(0).getRecord().getParentContainer().getName());


### PR DESCRIPTION
## Description ##
- Fix Tags were not set when importing containers from CSV into Inventory. 
- Some import cleaning by from the maven plugin

## Testing notes
- To test in AWS https://rsdev-694-fix-tags-container-csv-5.researchspace.com/ you can submit the CSV that is attached to the JIRA ticket RSDEV-694
