### PR TITLE
RSDEV-706: when moving/copying to irods, ensure the absolute path is used

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/GalleryIrodsApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GalleryIrodsApiController.java
@@ -220,11 +220,11 @@ public class GalleryIrodsApiController extends GalleryFilestoresBaseApiControlle
     String irodsHomePath =
         nfsFileStore.getFileSystem().getClientOption(NfsFileSystemOption.IRODS_HOME_DIR);
     String filestorePath = nfsFileStore.getPath();
-    if (StringUtils.isEmpty(irodsHomePath)) {
-      return filestorePath;
+    if (StringUtils.isBlank(irodsHomePath)) {
+      irodsHomePath = "";
     }
-    if (StringUtils.isEmpty(filestorePath)) {
-      return irodsHomePath;
+    if (StringUtils.isBlank(filestorePath)) {
+      filestorePath = "";
     }
     if (filestorePath.startsWith(irodsHomePath)) {
       return filestorePath;

--- a/src/main/java/com/researchspace/netfiles/NfsClient.java
+++ b/src/main/java/com/researchspace/netfiles/NfsClient.java
@@ -113,13 +113,14 @@ public interface NfsClient extends Serializable {
   /***
    * Stores a list of files into a specific path of an external storage file system.
    *
-   * @param pathToFiles the path where you want to save the files
+   * @param destinationPath the path where you want to save the files
    * @param mapRecordIdToFile the Map[recordId, File] of the files you want to upload
    * @return the map of the file descriptors of the files saved
    * @throws UnsupportedOperationException if any of the file cannot be deleted
    */
   default ApiExternalStorageOperationResult uploadFilesToNfs(
-      String pathToFiles, Map<Long, File> mapRecordIdToFile) throws UnsupportedOperationException {
+      String destinationPath, Map<Long, File> mapRecordIdToFile)
+      throws UnsupportedOperationException {
     if (!this.supportWritePermission()) {
       throw new UnsupportedOperationException(
           "The Operation is not supported by the NfsClient in use");

--- a/src/main/java/com/researchspace/netfiles/irods/IRODSClient.java
+++ b/src/main/java/com/researchspace/netfiles/irods/IRODSClient.java
@@ -198,7 +198,8 @@ public class IRODSClient extends NfsAbstractClient implements NfsClient {
 
   @Override
   public ApiExternalStorageOperationResult uploadFilesToNfs(
-      String pathToFiles, Map<Long, File> mapRecordIdToFile) throws UnsupportedOperationException {
+      String absoluteDestinationPath, Map<Long, File> mapRecordIdToFile)
+      throws UnsupportedOperationException {
     IRODSFileSystem iRodsFileSystem = null;
 
     ApiExternalStorageOperationResult result = new ApiExternalStorageOperationResult();
@@ -215,7 +216,7 @@ public class IRODSClient extends NfsAbstractClient implements NfsClient {
       for (Map.Entry<Long, File> recordFileEntry : mapRecordIdToFile.entrySet()) {
         currentRecordId = recordFileEntry.getKey();
         currentFile = recordFileEntry.getValue();
-        iRODSAbsolutePathFilename = pathToFiles + '/' + currentFile.getName();
+        iRODSAbsolutePathFilename = absoluteDestinationPath + '/' + currentFile.getName();
         try {
           iRodsFile = irodsFileFactory.instanceIRODSFile(iRODSAbsolutePathFilename);
           dtoIRODS.putOperation(currentFile, iRodsFile, null, null);
@@ -228,7 +229,7 @@ public class IRODSClient extends NfsAbstractClient implements NfsClient {
             log.info(
                 "File [{}] successfully copied into IRODS path [{}]",
                 currentFile.getName(),
-                pathToFiles);
+                absoluteDestinationPath);
           } else {
             result.add(
                 new ApiExternalStorageOperationInfo(
@@ -239,7 +240,7 @@ public class IRODSClient extends NfsAbstractClient implements NfsClient {
             log.error(
                 "File [{}] failed to be copied into IRODS path [{}]",
                 currentFile.getName(),
-                pathToFiles);
+                absoluteDestinationPath);
           }
         } catch (JargonException ex) {
           result.add(
@@ -248,7 +249,7 @@ public class IRODSClient extends NfsAbstractClient implements NfsClient {
           log.error(
               "File [{}] failed to be copied into IRODS path [{}]",
               currentFile.getName(),
-              pathToFiles,
+              absoluteDestinationPath,
               ex);
         }
       }

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryIrodsApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryIrodsApiControllerTest.java
@@ -16,6 +16,9 @@ import com.researchspace.api.v1.model.ApiExternalStorageOperationResult;
 import com.researchspace.api.v1.model.EcatAudioFileStub;
 import com.researchspace.api.v1.model.NfsClientStub;
 import com.researchspace.model.User;
+import com.researchspace.model.netfiles.NfsFileStore;
+import com.researchspace.model.netfiles.NfsFileSystem;
+import com.researchspace.model.netfiles.NfsFileSystemOption;
 import com.researchspace.model.views.CompositeRecordOperationResult;
 import com.researchspace.netfiles.ApiNfsCredentials;
 import com.researchspace.netfiles.NfsAuthentication;
@@ -389,5 +392,32 @@ class GalleryIrodsApiControllerTest {
     assertEquals(1, exception.getAllErrors().size());
     assertEquals("nfsClient", exception.getAllErrors().get(0).getObjectName());
     assertEquals("User is not logged in", exception.getAllErrors().get(0).getDefaultMessage());
+  }
+
+  @Test
+  void testGettingAbsoluteTargetFilestorePath() {
+    NfsFileSystem nfsFileSystem = new NfsFileSystem();
+    nfsFileSystem.setClientOption(NfsFileSystemOption.IRODS_HOME_DIR, "/tempZone/home/alice");
+
+    NfsFileStore testFilestore = new NfsFileStore();
+    testFilestore.setFileSystem(nfsFileSystem);
+
+    // relative path saved with filestore
+    testFilestore.setPath("/testFolder/testFolder");
+    assertEquals(
+        "/tempZone/home/alice/testFolder/testFolder",
+        galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
+
+    // absolute path saved with filestore
+    testFilestore.setPath("/tempZone/home/alice/testFolder/testFolder2");
+    assertEquals(
+        "/tempZone/home/alice/testFolder/testFolder2",
+        galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
+
+    // with trailing slash in filesystem path
+    nfsFileSystem.setClientOption(NfsFileSystemOption.IRODS_HOME_DIR, "/tempZone/home/alice");
+    assertEquals(
+        "/tempZone/home/alice/testFolder/testFolder2",
+        galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
   }
 }

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryIrodsApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryIrodsApiControllerTest.java
@@ -396,28 +396,44 @@ class GalleryIrodsApiControllerTest {
 
   @Test
   void testGettingAbsoluteTargetFilestorePath() {
-    NfsFileSystem nfsFileSystem = new NfsFileSystem();
-    nfsFileSystem.setClientOption(NfsFileSystemOption.IRODS_HOME_DIR, "/tempZone/home/alice");
+    NfsFileSystem testFilesystem = new NfsFileSystem();
+    testFilesystem.setClientOption(NfsFileSystemOption.IRODS_HOME_DIR, "/tempZone/home/alice");
 
     NfsFileStore testFilestore = new NfsFileStore();
-    testFilestore.setFileSystem(nfsFileSystem);
+    testFilestore.setFileSystem(testFilesystem);
 
-    // relative path saved with filestore
-    testFilestore.setPath("/testFolder/testFolder");
+    // absolute path saved in filestore path
+    testFilestore.setPath("/tempZone/home/alice/testFolder/testFolder");
     assertEquals(
         "/tempZone/home/alice/testFolder/testFolder",
         galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
 
-    // absolute path saved with filestore
-    testFilestore.setPath("/tempZone/home/alice/testFolder/testFolder2");
+    // relative path saved in filestore path
+    testFilestore.setPath("/testFolder/testFolder2");
     assertEquals(
         "/tempZone/home/alice/testFolder/testFolder2",
         galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
 
     // with trailing slash in filesystem path
-    nfsFileSystem.setClientOption(NfsFileSystemOption.IRODS_HOME_DIR, "/tempZone/home/alice");
+    testFilesystem.setClientOption(NfsFileSystemOption.IRODS_HOME_DIR, "/tempZone/home/alice/");
     assertEquals(
         "/tempZone/home/alice/testFolder/testFolder2",
+        galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
+
+    // filestore path blank
+    testFilestore.setPath(" ");
+    assertEquals(
+        "/tempZone/home/alice/",
+        galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
+
+    // filesystem path null
+    testFilesystem.setClientOption(NfsFileSystemOption.IRODS_HOME_DIR, null);
+    assertEquals("", galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
+
+    // filesystem path null, but filestores path not null
+    testFilestore.setPath("/testFolder/testFolder3");
+    assertEquals(
+        "/testFolder/testFolder3",
         galleryIrodsApiController.getAbsoluteFilestorePathForIrods(testFilestore));
   }
 }


### PR DESCRIPTION
## Description ##
The PR fixes problem with 'move to iRODS' action executed on filestores created through a new Gallery UI. 

The problem is that iRODS jargon library action for uploading files requires absolute file path to the destination location on target iRODS server. The other jargon library actions, e.g. ones used for browsing the content of iRODS filestore, are fine with relative file paths ('relative' here means relative to irods home directory, saved on filesystem details page). 

It turns out that iRODS filestores saved by the new Gallery UI are saving relative filestore paths (this seems like a change of the behaviour from old Gallery, which we didn't notice). The relative filestore paths should be fine though, we do use them for samba/sftp filestores, it's just that when the absolute path is needed, it needs to be calculated. The change in the PR is therefore to make sure the destination path used for 'move to iRODS' action is always an absolute path, i.e. it starts with irods home directory fragment. 