### PR TITLE
RSDEV-729: store temporary notebook data on page as text, rather than html

### DIFF
--- a/src/main/webapp/scripts/pages/journal.js
+++ b/src/main/webapp/scripts/pages/journal.js
@@ -204,7 +204,7 @@ function journal($, extensions = default_extensions) {
             $("#journalToolbar>button").show();
             $("#journalSearch").show();
 
-            $("#cachedData").html(data.html);
+            $("#cachedData").text(data.html);
 
             //rspac-1396
             document.title = data.name;
@@ -359,7 +359,7 @@ function journal($, extensions = default_extensions) {
 
     _loadPage: function() {
 
-      $(".journalPageContent").html($("#cachedData").html());
+      $(".journalPageContent").html($("#cachedData").text());
 
       $(".commentIcon").click(function() {
         showCommentDialog(this, true);


### PR DESCRIPTION
## Description ##
The PR changes the way how temporary notebook data is stored on a page during loading of the notebook view. Previously this data was stored within `<div>` element as html, and as a consequence various js/react code selectors were matching the temporary data fragment. That was causing front-end to make duplicated calls e.g. to `/listOfMaterials/forField/` and `/chemical/ajax/getInfo` endpoints.

Now that temporary notebook data is stored as text, it no longer triggers any js/react code.

