### PR TITLE
RSDEV-710: Show "create from 3rd party" everywhere

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
@@ -137,9 +137,7 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
         parentFolder.isNotebook()
             && permissionUtils.isPermitted(parentFolder, PermissionType.CREATE, usr);
     model.addAttribute("allowCreateNewEntryInNotebook", canCreateEntry);
-
     model.addAttribute("createPermission", dto);
-    model.addAttribute("allowThirdPartyImport", !parentFolder.isSharedFolder());
     model.addAttribute("allowCreateForm", !parentFolder.isSharedFolder());
 
     return dto;

--- a/src/main/webapp/WEB-INF/pages/workspace_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/workspace_ajax.jsp
@@ -28,7 +28,6 @@
 <div style="position: relative;" class="optionsPopup">
     <input id="currFolderId" type="hidden" value="${recordId}" />
     <input id="authzCreateRecord" type="hidden" value="${createPermission.createRecord}" />
-    <input id="authzCreateThirdPartyRecord" type="hidden" value="${allowThirdPartyImport}" />
     <input id="authzCreateFormRecord" type="hidden" value="${allowCreateForm}" />
     <input id="authzCreateFolder" type="hidden" value="${createPermission.createFolder}" />
     <input id="movetargetRoot" type="hidden" value="${movetargetRoot}" />

--- a/src/main/webapp/scripts/pages/workspace.js
+++ b/src/main/webapp/scripts/pages/workspace.js
@@ -143,7 +143,6 @@ function init() {
 
 function configurePermittedActions() {
   var canCreateRecord = $('#authzCreateRecord').val() === 'true';
-  var canCreateThirdPartyRecord = $('#authzCreateThirdPartyRecord').val() === 'true';
   var canCreateFormRecord = $('#authzCreateFormRecord').val() === 'true';
   var isNotebook = $('#isNotebook').val() === 'true';
   var allowCreateNewEntryInNotebook = $('#allowCreateNewEntryInNotebook').val() === 'true';
@@ -157,11 +156,9 @@ function configurePermittedActions() {
   var canCreateFolder = $('#authzCreateFolder').val() === 'true';
   $("#createFolder").toggle(canCreateFolder);
   $("#create").toggle(canCreateFolder || canCreateRecord);
-  $('#createFromWord').toggle(canCreateRecord && canCreateThirdPartyRecord);
-  $('#createFromEvernote').toggle(canCreateRecord && canCreateThirdPartyRecord);
-
-  $('#createFromProtocolsIo').toggle(
-      canCreateRecord && canCreateThirdPartyRecord);
+  $('#createFromWord').toggle(canCreateRecord);
+  $('#createFromEvernote').toggle(canCreateRecord);
+  $('#createFromProtocolsIo').toggle(canCreateRecord);
   $('#createNewForm').toggle(canCreateRecord && canCreateFormRecord);
   // if permitted to create a record, there will be at least one option in the 2nd and 3rd menu sections therefore show the dividers
   $('.createMenuItemDivider').toggle(canCreateRecord);


### PR DESCRIPTION
## Description ##
This PR allows to see the following 3 create menu entries everywhere the user has the createMenu permission:
  - "From Word"
  - "From protocol.io"
  - "From Evernote"

## Testing notes
 - Be sure to be in a shared folder (or a shared notebook) where you have permission to create itmes 
 - - WHEN Push the "CREATE" button
 - - THEN you should be able to see the 3 entries that have been unlocked
