### PR TITLE
RSDEV-733: remove unnecessary round-trip call when loading notebook entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3019,7 +3019,7 @@
     <jstl.version>1.1.2</jstl.version>
     <lucene.version>5.5.5</lucene.version>
     <netty.version>4.1.63.Final</netty.version>
-    <rspace-core-model.version>2.12.0</rspace-core-model.version>
+    <rspace-core-model.version>2.12.1</rspace-core-model.version>
     <servlet.version>3.1.0</servlet.version>
     <sitemesh.version>2.4.2</sitemesh.version>
     <urlrewrite.version>4.0.3</urlrewrite.version>

--- a/src/main/java/com/researchspace/webapp/controller/JournalController.java
+++ b/src/main/java/com/researchspace/webapp/controller/JournalController.java
@@ -74,7 +74,7 @@ public class JournalController extends BaseController {
     this.signingManager = signingManager;
   }
 
-  /** Load notebook entry by id notebook id */
+  /** Load notebook entry by record id (and notebook id) */
   @GetMapping("/ajax/retrieveEntryById/{notebookId}/{recordId}")
   @ResponseBody
   public JournalEntry retrieveEntry(

--- a/src/main/java/com/researchspace/webapp/controller/JournalController.java
+++ b/src/main/java/com/researchspace/webapp/controller/JournalController.java
@@ -74,17 +74,36 @@ public class JournalController extends BaseController {
     this.signingManager = signingManager;
   }
 
-  /** Load notebook entry after opening the notebook or using previuos/next entry arrows */
-  @GetMapping("/ajax/retrieveEntry/{notebookid}/{position}/{positionmodifier}")
+  /** Load notebook entry by id notebook id */
+  @GetMapping("/ajax/retrieveEntryById/{notebookId}/{recordId}")
   @ResponseBody
   public JournalEntry retrieveEntry(
-      @PathVariable("notebookid") Long notebookId,
+      @PathVariable("notebookId") Long notebookId,
+      @PathVariable("recordId") Long recordId,
+      Principal principal) {
+
+    User user = userManager.getUserByUsername(principal.getName());
+    return retrieveEntryByRecordIdOrPosition(notebookId, recordId, null, null, user);
+  }
+
+  /** Load notebook entry after opening the notebook or using previuos/next entry arrows */
+  @GetMapping("/ajax/retrieveEntry/{notebookId}/{position}/{positionmodifier}")
+  @ResponseBody
+  public JournalEntry retrieveEntry(
+      @PathVariable("notebookId") Long notebookId,
       @PathVariable("position") Integer position,
       @PathVariable("positionmodifier")
           Integer positionModifier, // used when clicking on arrow tags
       Principal principal) {
 
     User user = userManager.getUserByUsername(principal.getName());
+
+    // this is the index of entry that front end wants to be opened
+    return retrieveEntryByRecordIdOrPosition(notebookId, null, position, positionModifier, user);
+  }
+
+  private JournalEntry retrieveEntryByRecordIdOrPosition(
+      Long notebookId, Long recordId, Integer position, Integer positionModifier, User user) {
 
     // this only retrieves structured documents
     List<Long> allRecordIds = recordManager.getDescendantRecordIdsExcludeFolders(notebookId);
@@ -96,24 +115,32 @@ public class JournalController extends BaseController {
       return new JournalEntry("EMPTY", "");
     }
 
-    // this is the index of entry that front end wants to be opened
-    int requestedEntryPosition = position + positionModifier;
+    // this is the count of requested position, or null if retrieving by id
+    Integer requestedEntryPosition = null;
+    if (position != null && positionModifier != null) {
+      requestedEntryPosition = position + positionModifier;
+    }
 
     // this is the counter of readable documents that were processed
     int readableRecordPosition = 0;
 
     // need to iterate from the beginning, to skip entries that user can't access
     for (int allRecordPosition = 0; allRecordPosition < allRecordIds.size(); allRecordPosition++) {
-      // omit unreadable records
+      // iterate over unreadable records
       if (!ObjectUtils.equals(
           allRecordIds.get(allRecordPosition),
           readableRecords.get(readableRecordPosition).getId())) {
         continue;
       }
+
       Record currentRecord = readableRecords.get(readableRecordPosition);
-      if (readableRecordPosition == requestedEntryPosition) {
+      boolean recordFound =
+          requestedEntryPosition != null && requestedEntryPosition.equals(readableRecordPosition)
+              || recordId != null && recordId.equals(currentRecord.getId());
+      if (recordFound) {
         return retrieveJournalEntry(currentRecord, user, allRecordPosition);
       }
+
       readableRecordPosition++;
     }
 
@@ -125,32 +152,6 @@ public class JournalController extends BaseController {
       noResultEntry.setPosition(-1);
     }
     return noResultEntry;
-  }
-
-  /**
-   * Get the chronological position of an entry in a notebook, or -1 if the entry id does not exist
-   * or if no permission. Called when opening journal from workspace by clicking on particular
-   * entry, or when privateVars.searchModeOn is true. - authorisation OK May15
-   */
-  @GetMapping("/ajax/entryIndex/{notebookId}/{entryId}")
-  @ResponseBody
-  public String entryIndex(
-      @PathVariable("notebookId") Long notebookId,
-      @PathVariable("entryId") Long entryId,
-      Principal principal) {
-
-    User u = userManager.getUserByUsername(principal.getName());
-    List<Record> readableRecords = recordManager.getLoadableNotebookEntries(u, notebookId);
-
-    int index = -1;
-    for (int i = 0; i < readableRecords.size(); i++) {
-      Record record = readableRecords.get(i);
-      if (record.getId().equals(entryId)) {
-        index = i;
-        break;
-      }
-    }
-    return Integer.toString(index);
   }
 
   /* Creates a journal entry based on the type of record */

--- a/src/main/java/com/researchspace/webapp/controller/JournalController.java
+++ b/src/main/java/com/researchspace/webapp/controller/JournalController.java
@@ -97,8 +97,6 @@ public class JournalController extends BaseController {
       Principal principal) {
 
     User user = userManager.getUserByUsername(principal.getName());
-
-    // this is the index of entry that front end wants to be opened
     return retrieveEntryByRecordIdOrPosition(notebookId, null, position, positionModifier, user);
   }
 
@@ -115,7 +113,7 @@ public class JournalController extends BaseController {
       return new JournalEntry("EMPTY", "");
     }
 
-    // this is the count of requested position, or null if retrieving by id
+    // this is the index of requested position, or null if retrieving by id
     Integer requestedEntryPosition = null;
     if (position != null && positionModifier != null) {
       requestedEntryPosition = position + positionModifier;

--- a/src/main/webapp/scripts/pages/journal.js
+++ b/src/main/webapp/scripts/pages/journal.js
@@ -215,10 +215,6 @@ function journal($, extensions = default_extensions) {
 
             $("#cachedData").text(data.html);
 
-            //var position = parseInt(data);
-            //journalPrivateVars.recordPosition = position;
-            //journalPrivateVars.selectedRecordId = recordId;
-
             //rspac-1396
             document.title = data.name;
             // this works in history list but not in back button

--- a/src/main/webapp/scripts/pages/journal.js
+++ b/src/main/webapp/scripts/pages/journal.js
@@ -173,10 +173,9 @@ function journal($, extensions = default_extensions) {
       $("#prevEntryButton, #nextEntryButton, #prevEntryButton_mobile, #nextEntryButton_mobile").hide();
       RS.addBreadcrumbAndRefresh("editorBcrumb", "" + notebookId, notebookName);
 
-      var url = extensions.springMVCUrlReroutePrefix;
-
       /* retrieve entry either by record id, or by using current position and
          pagePositionModifier (for next/prev page navigation) */
+      var url = extensions.springMVCUrlReroutePrefix;
       if (recordId !== undefined) {
         url += "/journal/ajax/retrieveEntryById/" + journalSettings.parentRecordId + "/" + recordId;
       } else {

--- a/src/main/webapp/scripts/pages/journal.js
+++ b/src/main/webapp/scripts/pages/journal.js
@@ -169,14 +169,21 @@ function journal($, extensions = default_extensions) {
       }
     },
 
-    loadEntry: function(pagePositionModifier) {
+    loadEntry: function(pagePositionModifier, recordId) {
       $("#prevEntryButton, #nextEntryButton, #prevEntryButton_mobile, #nextEntryButton_mobile").hide();
       RS.addBreadcrumbAndRefresh("editorBcrumb", "" + notebookId, notebookName);
 
-      const url =extensions.springMVCUrlReroutePrefix + "/journal/ajax/retrieveEntry/";
-      /* loads an entry in a page uses page modifier to determine if it should show a new document
-       * or another page of an existing record */
-      $.get(url + journalSettings.parentRecordId + "/" + journalPrivateVars.recordPosition + "/" + pagePositionModifier,
+      var url = extensions.springMVCUrlReroutePrefix;
+
+      /* retrieve entry either by record id, or by using current position and
+         pagePositionModifier (for next/prev page navigation) */
+      if (recordId !== undefined) {
+        url += "/journal/ajax/retrieveEntryById/" + journalSettings.parentRecordId + "/" + recordId;
+      } else {
+        url += "/journal/ajax/retrieveEntry/" + journalSettings.parentRecordId + "/"
+            + journalPrivateVars.recordPosition + "/" + pagePositionModifier;
+      }
+      $.get(url,
         function(data) {
             tagMetaData = data.tagMetaData ? data.tagMetaData: "";
           if (data.name == "EMPTY") {
@@ -199,6 +206,7 @@ function journal($, extensions = default_extensions) {
               }});
               RS.checkToolbarDividers(".toolbar-divider");
               journalPrivateVars.selectedRecordId = null;
+              journalPrivateVars.recordPosition = 0;
               methods._statusMessage("There are no entries to display.");
               displayStatus(editable);
             });
@@ -207,6 +215,10 @@ function journal($, extensions = default_extensions) {
             $("#journalSearch").show();
 
             $("#cachedData").text(data.html);
+
+            //var position = parseInt(data);
+            //journalPrivateVars.recordPosition = position;
+            //journalPrivateVars.selectedRecordId = recordId;
 
             //rspac-1396
             document.title = data.name;
@@ -489,22 +501,12 @@ function journal($, extensions = default_extensions) {
     },
 
     /*
-     * Loads an entry based on ID - delegates to loadEntry once an index is found.
+     * Loads an entry based on record ID.
      * Passed numeric record id must be prefixed with 'journalEntry'.
      */
-    loadEntryById: function(recordId) {
-      var prefixLength = 'journalEntry'.length;
-      const url =extensions.springMVCUrlReroutePrefix + "/journal/ajax/entryIndex/";
-      var jqxhr = $.get(url + journalSettings.parentRecordId + "/" + recordId.substring(prefixLength) + "/");
-      jqxhr.done(function(data) {
-          var position = parseInt(data);
-          journalPrivateVars.recordPosition = position;
-          journalPrivateVars.selectedRecordId = recordId;
-          methods.loadEntry(0);
-      });
-      jqxhr.fail(function(xhr, status, error) {
-          alert(error);
-      });
+    loadEntryById: function(journalEntryRecordId) {
+        var recordId = journalEntryRecordId.substring('journalEntry'.length);
+        methods.loadEntry(null, recordId);
     },
 
     /* =========================

--- a/src/main/webapp/scripts/pages/journal.js
+++ b/src/main/webapp/scripts/pages/journal.js
@@ -171,6 +171,8 @@ function journal($, extensions = default_extensions) {
 
     loadEntry: function(pagePositionModifier) {
       $("#prevEntryButton, #nextEntryButton, #prevEntryButton_mobile, #nextEntryButton_mobile").hide();
+      RS.addBreadcrumbAndRefresh("editorBcrumb", "" + notebookId, notebookName);
+
       const url =extensions.springMVCUrlReroutePrefix + "/journal/ajax/retrieveEntry/";
       /* loads an entry in a page uses page modifier to determine if it should show a new document
        * or another page of an existing record */

--- a/src/main/webapp/scripts/tags/fileTreeBrowser.js
+++ b/src/main/webapp/scripts/tags/fileTreeBrowser.js
@@ -274,7 +274,7 @@ function _defaultRecordClickHandler(node) {
   var breadcrumbsLength = fileTreeBrowserCurrentBreadcrumbIds.length;
   if (breadcrumbsLength > 1) {
     var currentParentId = fileTreeBrowserCurrentBreadcrumbIds[breadcrumbsLength - 2];
-    if (parentNotebookId === currentParentId && !isDocumentEditor) {
+    if (!isDocumentEditor && parentNotebookId === currentParentId) {
       console.log('clicked node ' + node.key + ' is an entry within the same notebook, switching');
       $("#notebook").journal("loadEntryById", "journalEntry" + node.key);
       clickHandled = true; // notebook entry is reloading on the right

--- a/src/test/java/com/axiope/service/cfg/ProdProfileTestConfig.java
+++ b/src/test/java/com/axiope/service/cfg/ProdProfileTestConfig.java
@@ -32,5 +32,4 @@ public class ProdProfileTestConfig {
   public SimpMessagingTemplate simpMessagingTemplate() {
     return Mockito.mock(SimpMessagingTemplate.class);
   }
-
 }


### PR DESCRIPTION
## Description ##
This PR removes `/journal/ajax/entryIndex` endpoint that front-end was using during opening of notebook view, if it didn't know the position of the entry within the notebook (as the server-side was only supporting retrieving notebook entry by its position). Now the entry data can be retrieved either by position of the entry within notebook (old way), or just with id of the entry (new way) - with new `/journal/ajax/retrieveEntryById` endpoint. As a result, front-end code method `loadEntryById` may now start loading entry details immediately after page is rendered, rather than waiting for response with the position of the entry.
