### PR TITLE
PRT-951: Fix CSV import suggesting "identifier" field also when all the values are empty

### DIFF
--- a/src/main/java/com/researchspace/service/inventory/csvimport/InventoryImportSampleFieldCreator.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/InventoryImportSampleFieldCreator.java
@@ -97,7 +97,7 @@ public class InventoryImportSampleFieldCreator {
   }
 
   private boolean isSuggestedFieldForValues(Set<String> values, SampleField field) {
-    return values.stream().allMatch(v -> field.isSuggestedFieldForData(v));
+    return !values.isEmpty() && values.stream().allMatch(v -> field.isSuggestedFieldForData(v));
   }
 
   private boolean shouldRadioTypeBeSuggested(

--- a/src/test/java/com/researchspace/service/inventory/csvimport/InventoryImportSampleFieldCreatorTest.java
+++ b/src/test/java/com/researchspace/service/inventory/csvimport/InventoryImportSampleFieldCreatorTest.java
@@ -2,6 +2,7 @@ package com.researchspace.service.inventory.csvimport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.field.InventoryRadioField;
@@ -176,5 +177,16 @@ public class InventoryImportSampleFieldCreatorTest {
     values.add(null);
     fieldMappings = helper.getFieldMappingForIdentifier("testIgsn", values);
     assertNull(fieldMappings.get("testIgsn"));
+
+  // all empty values
+    values.clear();
+    values.add("");
+    values.add("");
+    values.add("");
+    values.add("");
+    values.add("");
+    values.add(null);
+    fieldMappings = helper.getFieldMappingForIdentifier("testIgsn", values);
+    assertTrue(fieldMappings.isEmpty());
   }
 }


### PR DESCRIPTION
## Description ##
 - The CSV import was suggesting that a field could be mapped to an identifier in case all the values were empty


## Testing notes
***OPTIONAL***
- WHEN import a CSV with a coulmn that has all values empty
- THEN the repsonse MUST NOT suggest the column as identifier