### PR TITLE
RSDEV-740: Fix Empty fields in Fieldmark cause import to fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1861,7 +1861,7 @@
     <dependency>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>fieldmark-java-client</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </dependency>
     <dependency>
         <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceClientAdapterImpl.java
+++ b/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceClientAdapterImpl.java
@@ -25,6 +25,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpServerErrorException;
@@ -122,9 +123,11 @@ public class FieldmarkServiceClientAdapterImpl implements FieldmarkServiceClient
       if (typeExtractor != null && byte[].class.equals(typeExtractor.getFieldType())) {
         // grab the path from CSV
         String filePath = csvRecords.getStringFieldValue(currentRecordDTO.getRecordId(), fieldName);
-        // grab the file from the ZIP and attach it to the extractor
-        typeExtractor.setFieldValue(filesInRecords.get(filePath));
-        ((FieldmarkFileExtractor) typeExtractor).setFileName(filePath);
+        if (StringUtils.isNotBlank(filePath)) {
+          // grab the file from the ZIP and attach it to the extractor
+          typeExtractor.setFieldValue(filesInRecords.get(filePath));
+          ((FieldmarkFileExtractor) typeExtractor).setFileName(filePath);
+        }
       }
       currentRecordDTO.addField(fieldName, typeExtractor);
     } catch (NoSuchElementException ex2) {

--- a/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiController.java
@@ -166,11 +166,13 @@ public class FieldmarkApiController extends BaseApiController implements Fieldma
           FieldmarkFileExtractor fileExtractor =
               (FieldmarkFileExtractor) currentRecordDTO.getField(currentField.getName());
 
-          inventoryFilesApiController.uploadFile(
-              new FieldmarkMultipartFile(
-                  fileExtractor.getFieldValue(), fileExtractor.getFileName()),
-              new ApiInventoryFilePost(globalId, fileExtractor.getFileName()),
-              user);
+          if (StringUtils.isNotBlank(fileExtractor.getFileName())) {
+            inventoryFilesApiController.uploadFile(
+                new FieldmarkMultipartFile(
+                    fileExtractor.getFieldValue(), fileExtractor.getFileName()),
+                new ApiInventoryFilePost(globalId, fileExtractor.getFileName()),
+                user);
+          }
         }
       }
     }


### PR DESCRIPTION
## Description ##
This PR fixes the import to fail when on FIeldmark there is any of the field as empty

## Testing notes
- In order to test you need to:
-  - create a new observation on FieldmarkUI with all the fields as null and THEN import from Fieldmark in RSpace
-  - amend and existing observation on FIeldmarkUI by nullifying few fields (especially location and picture) and THEN import from Fieldmark in RSpace
