### PR TITLE
revert call order so notification pagination is calculated last

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/DashboardController.java
+++ b/src/main/java/com/researchspace/webapp/controller/DashboardController.java
@@ -51,8 +51,8 @@ public class DashboardController extends BaseController {
   public String dashboard(Model model, Principal principal) {
     PaginationCriteria<CommunicationTarget> pgCrit =
         PaginationCriteria.createDefaultForClass(CommunicationTarget.class);
-    doNotificationListingAndPrepareView(model, principal, pgCrit);
     doMessageListingAndPrepareView(model, principal, pgCrit);
+    doNotificationListingAndPrepareView(model, principal, pgCrit);
     User user = getUserByUsername(principal.getName());
     setPublicationAllowed(model, user);
     return "dashboard/dashboard";


### PR DESCRIPTION
## Description ##
It's the notifications listing that is shown by default, and so the `/dashboard` endpoint should call notifications preparation after messages preparation, so the common elements (e.g. pagingation) are not overridden.