### PR TITLE
RSDEV-957: Fix Permission issue when creating from Word (or creating from protocols.io) in a shared folder/notebook

### DIFF
--- a/src/main/java/com/researchspace/linkedelements/TextFieldEmbedIframeHandler.java
+++ b/src/main/java/com/researchspace/linkedelements/TextFieldEmbedIframeHandler.java
@@ -32,7 +32,7 @@ public class TextFieldEmbedIframeHandler {
   private static final String JOVE_SRC_SUFFIX_PATTERN =
       "\\?id=\\d+((&\\w+=1)|(&language=\\w+)|(&access=\\w+)|(&utm_source=\\w+))*";
 
-   // TIB AV-Portal src url last fragment
+  // TIB AV-Portal src url last fragment
   private static final String AVPORTAL_SRC_SUFFIX_PATTERN = "\\d+";
 
   private static final String[] knownIframeSrcPatterns = {

--- a/src/main/java/com/researchspace/service/RecordManager.java
+++ b/src/main/java/com/researchspace/service/RecordManager.java
@@ -646,5 +646,5 @@ public interface RecordManager {
    */
   boolean forceMoveDocumentToOwnerWorkspace(StructuredDocument userDoc);
 
-  boolean isSharedFolderOrSharedNotebookWithoutCreatePermssison(User user, Folder parentFolder);
+  boolean isSharedFolderOrSharedNotebookWithoutCreatePermssion(User user, Folder parentFolder);
 }

--- a/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
@@ -331,7 +331,7 @@ public class RecordManagerImpl implements RecordManager {
       parentFolder = folderDao.get(parentId);
     }
 
-    if (this.isSharedFolderOrSharedNotebookWithoutCreatePermssison(user, parentFolder)) {
+    if (this.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parentFolder)) {
       log.warn(
           "The record will be created inside the root folder since the"
               + " specified one [{}] is a shared folder",
@@ -929,8 +929,10 @@ public class RecordManagerImpl implements RecordManager {
   }
 
   private void assertCreatePermission(User user, Folder parentFolder) {
-    if (!permissnUtils.isPermitted(parentFolder, PermissionType.CREATE, user)) {
-      throw new AuthorizationException();
+    if (!permissnUtils.isPermitted(parentFolder, PermissionType.CREATE, user)
+        && !isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parentFolder)) {
+      throw new AuthorizationException(
+          "User is not authorized to created in this folder or notebook");
     }
   }
 
@@ -1364,7 +1366,7 @@ public class RecordManagerImpl implements RecordManager {
   }
 
   @Override
-  public boolean isSharedFolderOrSharedNotebookWithoutCreatePermssison(
+  public boolean isSharedFolderOrSharedNotebookWithoutCreatePermssion(
       User user, Folder folderOrNotebook) {
     return folderOrNotebook.isSharedFolder()
         || (folderOrNotebook.isNotebook()

--- a/src/main/java/com/researchspace/service/impl/SharingHandlerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SharingHandlerImpl.java
@@ -97,7 +97,7 @@ public class SharingHandlerImpl implements SharingHandler {
 
   public List<RecordGroupSharing> shareIntoSharedFolderOrNotebook(
       User user, Folder sharedFolderOrNotebook, Long recordId) {
-    if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssison(
+    if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(
         user, sharedFolderOrNotebook)) {
       ServiceOperationResultCollection<RecordGroupSharing, RecordGroupSharing> sharingResult;
       if (sharedFolderOrNotebook.isNotebook()) {

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -99,7 +99,9 @@ public class NotebookEditorController extends BaseController {
     }
 
     ActionPermissionsDTO permDTO = new ActionPermissionsDTO();
-    permDTO.setCreateRecord(permissionUtils.isPermitted(notebook, PermissionType.CREATE, user));
+    permDTO.setCreateRecord(
+        permissionUtils.isPermitted(notebook, PermissionType.CREATE, user)
+            || recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, notebook));
     // this is a quick fix, we need to hook into permissions system so that
     // shared notebook entries can't be deleted by PI/admin in the way that other shared content
     // can be deleted from shared folders
@@ -151,6 +153,8 @@ public class NotebookEditorController extends BaseController {
         "clientUISettingsPref", getUserPreferenceValue(user, Preference.UI_CLIENT_SETTINGS));
     model.addAttribute("workspaceFolderId", bcrumb.getParentFolderId());
     model.addAttribute("pioEnabled", isProtocolsIOEnabled(user));
+    model.addAttribute("evernoteEnabled", isEvernoteEnabled(user));
+    model.addAttribute("asposeEnabled", isAsposeEnabled());
     model.addAttribute("isPublished", notebook.isPublished());
     model.addAttribute("enforce_ontologies", anyGroupEnforcesOntologies(user));
     model.addAttribute("allow_bioOntologies", allGroupsAllowBioOntologies(user));

--- a/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOToDocumentConverter.java
+++ b/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOToDocumentConverter.java
@@ -6,5 +6,5 @@ import com.researchspace.protocolsio.Protocol;
 
 public interface ProtocolsIOToDocumentConverter {
 
-  StructuredDocument generateFromProtocol(Protocol toImport, User subject);
+  StructuredDocument generateFromProtocol(Protocol toImport, User subject, Long parentFolderId);
 }

--- a/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOToDocumentConverterImpl.java
+++ b/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOToDocumentConverterImpl.java
@@ -67,27 +67,31 @@ public class ProtocolsIOToDocumentConverterImpl extends AbstractExternalDocImpor
   }
 
   @Override
-  public StructuredDocument generateFromProtocol(Protocol toImport, User subject) {
+  public StructuredDocument generateFromProtocol(
+      Protocol toImport, User subject, Long parentFolderId) {
     String html = generateHtml(toImport);
 
-    return saveDocument(toImport, html, subject);
+    return saveDocument(toImport, html, subject, parentFolderId);
   }
 
-  private StructuredDocument saveDocument(Protocol toImport, String html, User subject) {
-    StructuredDocument newDocument = createAPioDocument(toImport, subject);
+  private StructuredDocument saveDocument(
+      Protocol toImport, String html, User subject, Long parentFolderId) {
+    StructuredDocument newDocument = createAPioDocument(toImport, subject, parentFolderId);
     newDocument = processHtml(html, newDocument, subject);
 
     publisher.publishEvent(new GenericEvent(subject, newDocument, AuditAction.CREATE));
     return newDocument;
   }
 
-  private StructuredDocument createAPioDocument(Protocol toImport, User subject) {
+  private StructuredDocument createAPioDocument(
+      Protocol toImport, User subject, Long parentFolderId) {
     RSForm form =
         formMgr.getCurrentSystemForm("ProtocolsIO").orElseGet(() -> createProtocolsIOForm(subject));
 
-    Folder importFolder = folderMgr.getImportsFolder(subject);
+    Long importFolderId =
+        parentFolderId != null ? parentFolderId : folderMgr.getImportsFolder(subject).getId();
     return recordMgr.createNewStructuredDocument(
-        importFolder.getId(),
+        importFolderId,
         form.getId(),
         toImport.getTitle(),
         subject,

--- a/src/main/webapp/WEB-INF/pages/notebookEditor/notebookMainPanel.jsp
+++ b/src/main/webapp/WEB-INF/pages/notebookEditor/notebookMainPanel.jsp
@@ -3,7 +3,7 @@
     <div id="createDocForm">
         <axt:importFromWord isNotebook="${isNotebook}" parentId="${selectedNotebookId}"/>
     </div>
-        <axt:importFromProtocolsIo />
+        <axt:importFromProtocolsIo parentId="${selectedNotebookId}" />
     </c:if>
     <c:url var="createFromTemplateURL" value="/workspace/editor/structuredDocument/create/${selectedNotebookId}"></c:url>
     <script src="<c:url value='/scripts/bower_components/file-saverjs/FileSaver.js'/>"></script>

--- a/src/main/webapp/WEB-INF/pages/workspace.jsp
+++ b/src/main/webapp/WEB-INF/pages/workspace.jsp
@@ -16,16 +16,16 @@
 </script>
 
 <title>
-  <spring:message code="workspace.title" /> 
+  <spring:message code="workspace.title" />
 </title>
 
 <head>
   <meta name="heading" content="Workspace" />
   <link rel="stylesheet" href="<c:url value='/styles/pages/workspace/workspace.css'/>" />
-  
+
   <!-- moved to default.jsp -->
   <!-- <link rel="stylesheet" href="<c:url value='/styles/bootstrap-custom-flat.css'/>" /> -->
-  
+
   <link rel="stylesheet" href="<c:url value='/styles/dropbox.css'/>" />
   <link rel="stylesheet" href="<c:url value='/styles/journal.css'/>" />
   <link rel="stylesheet" href="<c:url value='/scripts/jqueryFileTree/jqueryFileTree.css'/>" />
@@ -63,9 +63,9 @@
   <!-- <script src="<c:url value='/scripts/bower_components/bootstrap/dist/js/bootstrap.js'/>"></script> -->
 </head>
 
-<div 
+<div
   id="toolbar2"
-  data-pio-enabled="${pioEnabled}" 
+  data-pio-enabled="${pioEnabled}"
   data-evernote-enabled="${evernoteEnabled}"
   data-aspose-enabled="${asposeEnabled}"
   data-labgroups-folder-id="${labgroupsFolderId}">
@@ -74,7 +74,7 @@
 <div id="createDocForm">
   <!-- Importing script for word files manipulation -->
   <axt:importFromWord isNotebook="${isNotebook}" parentId="${recordId}"/>
-  <axt:importFromProtocolsIo />
+  <axt:importFromProtocolsIo parentId="${recordId}"/>
 
   <%--
        And also some strange stuff happens here.
@@ -139,7 +139,7 @@ $(document).ready(function() {
   //to activate bootstrap.js dropdown component without conflicts with jquery ui.
   //It is located in the end because otherwise jquery ui components overrides it
   $('.dropdown-toggle').dropdown();
-  
+
 });
 </script>
 

--- a/src/main/webapp/WEB-INF/tags/importFromProtocolsIo.tag
+++ b/src/main/webapp/WEB-INF/tags/importFromProtocolsIo.tag
@@ -1,6 +1,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="axt" tagdir="/WEB-INF/tags"%>
 
+<%@ attribute name="parentId" required="true" type="java.lang.Long"%>
+
 <script src="<c:url value='/scripts/tags/importFromProtocolsIo.js'/>"></script>
 
 <style>
@@ -11,5 +13,5 @@
 </style>
 
 <div id="protocolsIoChooserDlg" style="display: none">
-	<iframe id="protocolsIoChooserDlgIframe" style="width:100%;height:1400px;" class="seamless" scrolling="no" frameborder="0"></iframe>
+	<iframe id="protocolsIoChooserDlgIframe" data-parentid="${parentId}" style="width:100%;height:1400px;" class="seamless" scrolling="no" frameborder="0"></iframe>
 </div>

--- a/src/main/webapp/scripts/externalTinymcePlugins/protocols_io/js/main.js
+++ b/src/main/webapp/scripts/externalTinymcePlugins/protocols_io/js/main.js
@@ -47,8 +47,9 @@ $(document).ready(function () {
 			//wait for all pio_Requests to come back
 			$.when.apply($, pio_requests).done(function (resp) {
 				// submit all protocols
+        const targetFolderId = window.parent.document.querySelector("#protocolsIoChooserDlgIframe").dataset.parentid;
 				$.ajax({
-					url: '/importer/generic/protocols_io', dataType: 'json',
+					url: `/importer/generic/protocols_io/${targetFolderId}`, dataType: 'json',
 					"data": JSON.stringify(pio_results), type: "POST", contentType: "application/json;"
 				})
 					.done(function (response) {

--- a/src/main/webapp/scripts/pages/workspace.js
+++ b/src/main/webapp/scripts/pages/workspace.js
@@ -138,6 +138,7 @@ function init() {
     $(this).attr("action", newurl);
   });
   $("form#wordImportForm").data("parentid", workspaceSettings.parentFolderId);
+  document.getElementById("protocolsIoChooserDlgIframe").setAttribute("data-parentid", workspaceSettings.parentFolderId);
   displayOrderIcon();
 }
 

--- a/src/test/java/com/researchspace/linkedelements/TextFieldEmbedIframeHandlerTest.java
+++ b/src/test/java/com/researchspace/linkedelements/TextFieldEmbedIframeHandlerTest.java
@@ -302,7 +302,8 @@ public class TextFieldEmbedIframeHandlerTest extends SpringTransactionalTest {
 
     String htmlFragmentFormat = "<p>start</p>\n%s <img src=\"123\" />\n<p>end</p>";
     String htmlFragment = String.format(htmlFragmentFormat, avportalEmbed);
-    String expectedConvertedHtml = String.format(htmlFragmentFormat, expectedConvertedAvportalEmbed);
+    String expectedConvertedHtml =
+        String.format(htmlFragmentFormat, expectedConvertedAvportalEmbed);
 
     String convertedHtml = iframeHandler.encodeKnownIframesAsParagraphs(htmlFragment);
     assertEquals(expectedConvertedHtml, convertedHtml);

--- a/src/test/java/com/researchspace/service/RecordManagerTest.java
+++ b/src/test/java/com/researchspace/service/RecordManagerTest.java
@@ -1740,12 +1740,12 @@ public class RecordManagerTest extends SpringTransactionalTest {
   @Test
   public void testIsSharedFolderOrSharedNotebookWithoutCreatePermssison_whenSharedFolder() {
     // when is NOT shared folder && NOT shared notebook
-    assertFalse(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssison(user, parent));
+    assertFalse(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parent));
 
     // when is shared folder and NOT shared notebook
     parent.addType(RecordType.SHARED_FOLDER);
     Assertions.assertTrue(parent.isSharedFolder());
-    assertTrue(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssison(user, parent));
+    assertTrue(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parent));
   }
 
   @Test
@@ -1765,11 +1765,11 @@ public class RecordManagerTest extends SpringTransactionalTest {
     Assertions.assertTrue(notebook.isShared());
 
     // when is shared Notebook with CREATE permission
-    assertFalse(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssison(user, notebook));
+    assertFalse(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, notebook));
 
     logoutAndLoginAs(anotherUser);
     // when is shared Notebook and NO CREATE permission
     assertTrue(
-        recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssison(anotherUser, notebook));
+        recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(anotherUser, notebook));
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/RecordManagerStub.java
+++ b/src/test/java/com/researchspace/webapp/controller/RecordManagerStub.java
@@ -412,7 +412,7 @@ public class RecordManagerStub implements RecordManager {
   }
 
   @Override
-  public boolean isSharedFolderOrSharedNotebookWithoutCreatePermssison(
+  public boolean isSharedFolderOrSharedNotebookWithoutCreatePermssion(
       User user, Folder parentFolder) {
     return true;
   }

--- a/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOControllerMVCIT.java
@@ -98,13 +98,14 @@ public class ProtocolsIOControllerMVCIT extends MVCTestBase {
   public void testStandardUpload() throws Exception {
     User anyUser = createInitAndLoginAnyUser();
     File testFile = RSpaceTestUtils.getResource("p_io_8163.json");
+    Folder rootFolderWorkspace = folderMgr.getRootFolderForUser(anyUser);
     String p1 = readFileToString(testFile, "UTF-8");
     String p2 = readFileToString(testFile, "UTF-8");
     String protocolList = "[" + p1 + "," + p2 + "]";
     MvcResult result =
         mockMvc
             .perform(
-                post("/importer/generic/protocols_io")
+                post("/importer/generic/protocols_io/" + rootFolderWorkspace.getId())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(protocolList))
             .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())

--- a/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOConverterTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOConverterTest.java
@@ -124,7 +124,7 @@ public class ProtocolsIOConverterTest {
 
     setupmocks(protocol, aform);
     impl.document = doc;
-    assertEquals(doc, impl.generateFromProtocol(protocol, any));
+    assertEquals(doc, impl.generateFromProtocol(protocol, any, null));
     verify(publisher).publishEvent(Mockito.any(GenericEvent.class));
   }
 
@@ -145,7 +145,7 @@ public class ProtocolsIOConverterTest {
 
     setupmocks(protocol, aform);
     impl.document = doc;
-    assertEquals(doc, impl.generateFromProtocol(protocol, any));
+    assertEquals(doc, impl.generateFromProtocol(protocol, any, null));
     assertTrue(impl.updateFieldContentInvoked);
   }
 


### PR DESCRIPTION
## Description ##
When creatng from Word/Evernote (or protocols.io) the process was failing for a ermisisons issue
In this PR we have extended the `create` permissions in those cases to allow the user to create also if is a SharedFolder or a SharedNotebook

## Testing notes
To test you can create from Word/Evernote or protocols.io from inside a shared notebook made by another user of the same group
- AWS instance: https://prt-957-create-from-word-16.researchspace.com
-  - you need to configure `protocolsio.client.id` and `protocolsio.secret` in the deployment.properties 

