### PR TITLE
Adjust Inventory page title

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Identifiers/IGSN/index.tsx
+++ b/src/main/webapp/ui/src/Inventory/Identifiers/IGSN/index.tsx
@@ -17,6 +17,11 @@ export default function IGSN(): React.ReactNode {
   const [selectedIgsns, setSelectedIgsns] = React.useState<RsSet<Identifier>>(
     new RsSet([])
   );
+
+  React.useEffect(() => {
+    document.title = "Manage IGSNs | RSpace Inventory";
+  }, []);
+
   return (
     <>
       <Header sidebarId={sidebarId} />

--- a/src/main/webapp/ui/src/Inventory/Import/ImportRouter.tsx
+++ b/src/main/webapp/ui/src/Inventory/Import/ImportRouter.tsx
@@ -25,6 +25,10 @@ export default function ImportRouter(): React.ReactNode {
     );
   }, [location.search]);
 
+  useEffect(() => {
+    document.title = "Import CSV | RSpace Inventory";
+  }, []);
+
   const sidebarId = React.useId();
 
   const recordType = importStore.importData?.recordType;

--- a/src/main/webapp/ui/src/Inventory/Search/SearchRouter.tsx
+++ b/src/main/webapp/ui/src/Inventory/Search/SearchRouter.tsx
@@ -18,6 +18,7 @@ import MainSearchNavigationContext from "./MainSearchNavigationContext";
 import { UiPreferences } from "../../util/useUiPreference";
 import LeftPanelView from "./LeftPanelView";
 import Box from "@mui/material/Box";
+import { globalId } from "@/stores/definitions/BaseRecord";
 
 type SearchRouterArgs = {
   paramsOverride?: CoreFetcherArgs;
@@ -30,6 +31,17 @@ const SearchRouter = observer(({ paramsOverride }: SearchRouterArgs) => {
   const { useNavigate, useLocation } = useContext(NavigateContext);
   const navigate = useNavigate();
   const location: UseLocation = useLocation();
+
+  useEffect(() => {
+    if (paramsOverride?.permalink) {
+      document.title = `${globalId({
+        type: paramsOverride.permalink.type,
+        id: paramsOverride.permalink.id,
+      })} | RSpace Inventory`;
+    } else {
+      document.title = "RSpace Inventory";
+    }
+  }, [paramsOverride]);
 
   useEffect(() => {
     void (async () => {

--- a/src/main/webapp/ui/src/stores/definitions/BaseRecord.ts
+++ b/src/main/webapp/ui/src/stores/definitions/BaseRecord.ts
@@ -54,6 +54,19 @@ export const globalIdPatterns: Record<string, RegExp> = {
   group: /^gp\d+$/i,
 };
 
+export const globalIdPrefixes: Record<string, GlobalIdPrefix> = {
+  sample: "SA",
+  subsample: "SS",
+  container: "IC",
+  sampleTemplate: "IT",
+  bench: "BE",
+  basket: "BA",
+  attachment: "IF",
+  field: "SF",
+  document: "SD",
+  group: "GP",
+};
+
 /*
  * The corresponding label, as should be rendered by the UI, for each Inventory
  * record.
@@ -100,6 +113,21 @@ export const globalIdToInventoryRecordTypeLabel: (
       inventoryRecordTypeLabels.basket,
     ],
   ]);
+
+/**
+ * Creates the Global ID string for a given record type and ID.
+ * This works because "type + id <-> Global ID" is an isomorphism
+ */
+export function globalId({
+  type,
+  id,
+}: {
+  type: keyof typeof globalIdPatterns;
+  id: number;
+}): GlobalId {
+  const prefix = globalIdPrefixes[type];
+  return `${prefix}${id}`;
+}
 
 /**
  * This is the canonical definition of what the frontend considers to be the


### PR DESCRIPTION
## Description ##
The page title should update as the user navigates around a SPA so that the user can use standard browser features, like tab names, bookmarking defaults, and the browser's history just as if they were using a traditional multi-page site.

This is to ensure compliance with [WCAG 2.2 Criteria 2.4.2 (A)](https://www.w3.org/TR/WCAG22/#page-titled).
