### PR TITLE
PRT-962: ensure that filetree browser doesn't scroll up&down when switching entries in notebook view 

### DIFF
--- a/src/main/webapp/scripts/pages/journal.js
+++ b/src/main/webapp/scripts/pages/journal.js
@@ -401,7 +401,6 @@ function journal($, extensions = default_extensions) {
       }
 
       methods._readjustJournalPageAfterImagesLoaded();
-      extensions.selectFileTreeBrowserRecordById(journalPrivateVars.selectedRecordId);
     },
 
     _readjustJournalPageAfterImagesLoaded: function() {
@@ -412,6 +411,7 @@ function journal($, extensions = default_extensions) {
 
         methods._updateTopHeaderWithEntryData();
         updateEntryNameInBreadcrumbs(journalPrivateVars.selectedRecordId, journalPrivateVars.pageName);
+        extensions.selectFileTreeBrowserRecordById(journalPrivateVars.selectedRecordId);
 
         // updating top scrollbar
         var journalPageElement = $(".journalPageContent")[0];

--- a/src/main/webapp/scripts/tags/fileTreeBrowser.js
+++ b/src/main/webapp/scripts/tags/fileTreeBrowser.js
@@ -312,7 +312,7 @@ function _selectFileTreeBrowserNode(node) {
 
   var $tree = $('#fancyTree');
   var topMargin = -($tree.height() / 3); // so selected record is about the middle
-  $('#fancyTree').scrollTo(node.li, 300, { axis : 'y', offset: { top: topMargin } });
+  $('#fancyTree').scrollTo(node.li, 300, {axis: 'y', offset: {top: topMargin}});
 }
 
 function _selectRecordInFileTreeBrowserBranch(node) {
@@ -325,15 +325,42 @@ function _selectRecordInFileTreeBrowserBranch(node) {
       });
     } else if (!node.isLoading()) {
       node.load();
-    };
-  } 
-  if (node.key == fileTreeBrowserRecordId) {
-    if (!fileTreeBrowserCurrentBreadcrumbIds.includes(node.key)) {
-      fileTreeBrowserCurrentBreadcrumbIds.push(node.key);
     }
-    // in timeout, as maybe the tree is just being expanded
-    setTimeout(function() {
-      _selectFileTreeBrowserNode(node);
-    }, 0);
   }
+
+  if (node.key === fileTreeBrowserRecordId.toString()) {
+    if (_isNodeAncestorMatchingBreadcrumbs(node)) {
+      // in timeout, as maybe the tree is just being expanded
+      setTimeout(function () {
+        _selectFileTreeBrowserNode(node);
+      }, 0);
+    }
+  }
+}
+
+/* prt-962, the node with given key may be in a few places of the filetree,
+   e.g. in Workspace and in Shared folder. The method checks if the node parents
+    are matching the nodes shown by breadcrumbs */
+function _isNodeAncestorMatchingBreadcrumbs(node) {
+  const breadcrumbsLength = fileTreeBrowserCurrentBreadcrumbIds.length;
+  if (node === null || node.parent === null || breadcrumbsLength < 1) {
+    return false; // unexpected
+  }
+  if (breadcrumbsLength === 2 && node.parent.parent === null) {
+    return true; // top level workspace
+  }
+  if (breadcrumbsLength === 3) {
+    if (node.parent.key === fileTreeBrowserCurrentBreadcrumbIds.slice(-2)[0]
+        && node.parent.parent.parent === null) {
+      return true; // workspace subfolder/notebook
+    }
+  }
+  if (breadcrumbsLength > 3) {
+    if (node.parent.key === fileTreeBrowserCurrentBreadcrumbIds.slice(-2)[0]
+        && node.parent.parent.key
+        === fileTreeBrowserCurrentBreadcrumbIds.slice(-3)[0]) {
+      return true; // both parent and grandparent ids are matching
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
## Description ##
The problem with filetree browser scrolling up&down could happen if selected record was visible in multiple places of the filetree, e.g. if it was in user's Workspace, but also in Shared notebook. The root cause is that filetree uses record ids as node keys, which are not unique. The (quick) fix for this PR is that when finding a node that should be marked as selected/active, the code doesn't just check if node's key matches record id, but also verifies that node's parents are matching breadcrumb trail.  

Additionally, the PR fixes the problem with filetree selection starting before the journal entry was fully loaded, that could happen if notebook had multiple images to load. 