### PR TITLE
RSDEV-520: Extend Fieldmark import with IGSN ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1861,7 +1861,13 @@
     <dependency>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>fieldmark-java-client</artifactId>
-        <version>1.1.0</version>
+        <version>RSDEV-520-client-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-validator</groupId>
+          <artifactId>commons-validator</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
         <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1861,7 +1861,7 @@
     <dependency>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>fieldmark-java-client</artifactId>
-        <version>RSDEV-520-client-SNAPSHOT</version>
+        <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-validator</groupId>

--- a/src/main/java/com/researchspace/api/v1/FieldmarkApi.java
+++ b/src/main/java/com/researchspace/api/v1/FieldmarkApi.java
@@ -13,10 +13,10 @@ import org.springframework.http.MediaType;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @RequestMapping("/api/inventory/v1")
@@ -47,10 +47,11 @@ public interface FieldmarkApi {
    * @throws MalformedURLException
    * @throws URISyntaxException
    */
-  @GetMapping(value = "/fieldmark/notebooks/igsn/{notebookId}")
+  @GetMapping(value = "/fieldmark/notebooks/igsnCandidateFields")
   @ResponseStatus(HttpStatus.OK)
   List<String> getIgsnCandidateFields(
-      @PathVariable("notebookId") String notebookId, @RequestAttribute(name = "user") User user)
+      @RequestParam(name = "notebookId") String notebookId,
+      @RequestAttribute(name = "user") User user)
       throws BindException;
 
   /***

--- a/src/main/java/com/researchspace/api/v1/FieldmarkApi.java
+++ b/src/main/java/com/researchspace/api/v1/FieldmarkApi.java
@@ -7,12 +7,15 @@ import com.researchspace.webapp.integrations.fieldmark.FieldmarkApiImportResult;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.List;
+import javax.naming.InvalidNameException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -34,6 +37,22 @@ public interface FieldmarkApi {
   List<FieldmarkNotebook> getNotebooks(User user)
       throws BindException, MalformedURLException, URISyntaxException;
 
+  /**
+   * End point that gives the list of fields of the notebook that can be imported as identifiers
+   *
+   * @param notebookId
+   * @param user
+   * @return a list of fields that can be imported as Igsn
+   * @throws BindException
+   * @throws MalformedURLException
+   * @throws URISyntaxException
+   */
+  @GetMapping(value = "/fieldmark/notebooks/igsn/{notebookId}")
+  @ResponseStatus(HttpStatus.OK)
+  List<String> getIgsnCandidateFields(
+      @PathVariable("notebookId") String notebookId, @RequestAttribute(name = "user") User user)
+      throws BindException;
+
   /***
    *
    * Imports the notebook identified by notebookId into RSpace by creating:
@@ -49,5 +68,5 @@ public interface FieldmarkApi {
   @ResponseStatus(HttpStatus.CREATED)
   FieldmarkApiImportResult importNotebook(
       FieldmarkApiImportRequest importRequest, BindingResult errors, User user)
-      throws BindException;
+      throws BindException, InvalidNameException;
 }

--- a/src/main/java/com/researchspace/model/dtos/fieldmark/FieldmarkNotebookDTO.java
+++ b/src/main/java/com/researchspace/model/dtos/fieldmark/FieldmarkNotebookDTO.java
@@ -23,14 +23,16 @@ public class FieldmarkNotebookDTO {
   private String id;
   private String timestamp;
   private Map<String, FieldmarkRecordDTO> records;
+  private String doiIdentifierFieldName;
 
   private FieldmarkNotebookMetadata metadata;
 
-  public FieldmarkNotebookDTO(String notebookId, String name) {
+  public FieldmarkNotebookDTO(String notebookId, String name, String doiIdentifierFieldName) {
     this.id = notebookId;
     this.name = name;
     this.records = new LinkedHashMap<>();
     this.timestamp = dateFormat.format(LocalDateTime.now(Clock.systemDefaultZone()));
+    this.doiIdentifierFieldName = doiIdentifierFieldName;
   }
 
   public FieldmarkRecordDTO addRecord(FieldmarkRecordDTO record) {

--- a/src/main/java/com/researchspace/service/fieldmark/FieldmarkServiceClientAdapter.java
+++ b/src/main/java/com/researchspace/service/fieldmark/FieldmarkServiceClientAdapter.java
@@ -14,6 +14,10 @@ public interface FieldmarkServiceClientAdapter {
   List<FieldmarkNotebook> getFieldmarkNotebookList(User user)
       throws HttpServerErrorException, MalformedURLException, URISyntaxException;
 
-  FieldmarkNotebookDTO getFieldmarkNotebook(User user, String notebookId)
+  List<String> getIgsnCandidateFields(User user, String notebookId)
+      throws IOException, HttpServerErrorException;
+
+  FieldmarkNotebookDTO getFieldmarkNotebook(
+      User user, String notebookId, String identifierFieldName)
       throws IOException, HttpServerErrorException;
 }

--- a/src/main/java/com/researchspace/service/fieldmark/FieldmarkServiceManager.java
+++ b/src/main/java/com/researchspace/service/fieldmark/FieldmarkServiceManager.java
@@ -1,0 +1,16 @@
+package com.researchspace.service.fieldmark;
+
+import com.researchspace.fieldmark.model.FieldmarkNotebook;
+import com.researchspace.model.User;
+import com.researchspace.webapp.integrations.fieldmark.FieldmarkApiImportRequest;
+import com.researchspace.webapp.integrations.fieldmark.FieldmarkApiImportResult;
+import java.util.List;
+
+public interface FieldmarkServiceManager {
+
+  FieldmarkApiImportResult importNotebook(FieldmarkApiImportRequest importRequest, User user);
+
+  List<FieldmarkNotebook> getFieldmarkNotebookList(User user);
+
+  List<String> getIgsnCandidateFields(User user, String notebookId);
+}

--- a/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
@@ -1,0 +1,329 @@
+package com.researchspace.service.fieldmark.impl;
+
+import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverter.createContainerRequest;
+import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverter.createSampleRequest;
+import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverter.createSampleTemplateRequest;
+
+import com.researchspace.api.v1.controller.ContainerApiPostValidator;
+import com.researchspace.api.v1.controller.InventoryFilePostValidator;
+import com.researchspace.api.v1.controller.InventoryFilesApiController.ApiInventoryFilePost;
+import com.researchspace.api.v1.controller.SampleApiPostFullValidator;
+import com.researchspace.api.v1.controller.SampleApiPostValidator;
+import com.researchspace.api.v1.controller.SampleTemplatePostValidator;
+import com.researchspace.api.v1.controller.SamplesApiController.ApiSampleFullPost;
+import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiContainerInfo;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryDOI;
+import com.researchspace.api.v1.model.ApiQuantityInfo;
+import com.researchspace.api.v1.model.ApiSampleField;
+import com.researchspace.api.v1.model.ApiSampleInfo;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.api.v1.model.ApiSubSample;
+import com.researchspace.fieldmark.model.FieldmarkMultipartFile;
+import com.researchspace.fieldmark.model.FieldmarkNotebook;
+import com.researchspace.fieldmark.model.exception.FieldmarkImportException;
+import com.researchspace.fieldmark.model.utils.FieldmarkDoiIdentifierExtractor;
+import com.researchspace.fieldmark.model.utils.FieldmarkFileExtractor;
+import com.researchspace.fieldmark.model.utils.FieldmarkTypeExtractor;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.dtos.IControllerInputValidator;
+import com.researchspace.model.dtos.fieldmark.FieldmarkNotebookDTO;
+import com.researchspace.model.dtos.fieldmark.FieldmarkRecordDTO;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.service.ApiAvailabilityHandler;
+import com.researchspace.service.fieldmark.FieldmarkServiceClientAdapter;
+import com.researchspace.service.fieldmark.FieldmarkServiceManager;
+import com.researchspace.service.inventory.ContainerApiManager;
+import com.researchspace.service.inventory.InventoryFileApiManager;
+import com.researchspace.service.inventory.InventoryIdentifierApiManager;
+import com.researchspace.service.inventory.SampleApiManager;
+import com.researchspace.webapp.integrations.fieldmark.FieldmarkApiImportRequest;
+import com.researchspace.webapp.integrations.fieldmark.FieldmarkApiImportResult;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.naming.InvalidNameException;
+import javax.ws.rs.NotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+public class FieldmarkServiceManagerImpl implements FieldmarkServiceManager {
+
+  private @Autowired FieldmarkServiceClientAdapter fieldmarkServiceClientAdapter;
+
+  private @Autowired ApiAvailabilityHandler apiHandler;
+
+  private @Autowired SampleTemplatePostValidator sampleTemplatePostValidator;
+  private @Autowired ContainerApiPostValidator apiContainerPostValidator;
+  private @Autowired IControllerInputValidator inputValidator;
+  private @Autowired SampleApiPostValidator sampleApiPostValidator;
+  private @Autowired SampleApiPostFullValidator sampleApiPostFullValidator;
+  private @Autowired InventoryFilePostValidator invFilePostValidator;
+
+  private @Autowired InventoryIdentifierApiManager inventoryIdentifierApiManager;
+  private @Autowired InventoryFileApiManager inventoryFileManager;
+  private @Autowired ContainerApiManager containerApiMgr;
+  private @Autowired SampleApiManager sampleApiMgr;
+
+  @Override
+  public List<FieldmarkNotebook> getFieldmarkNotebookList(User user) {
+    try {
+      return fieldmarkServiceClientAdapter.getFieldmarkNotebookList(user);
+    } catch (Exception ex) {
+      throw new FieldmarkImportException(ex);
+    }
+  }
+
+  @Override
+  public List<String> getIgsnCandidateFields(User user, String notebookId) {
+    try {
+      return fieldmarkServiceClientAdapter.getIgsnCandidateFields(user, notebookId);
+    } catch (Exception ex) {
+      throw new FieldmarkImportException(ex);
+    }
+  }
+
+  @Override
+  public FieldmarkApiImportResult importNotebook(
+      FieldmarkApiImportRequest importRequest, User user) {
+    FieldmarkApiImportResult importResult = null;
+    try {
+      FieldmarkNotebookDTO notebookDTO = getFieldmarkNotebookDTO(importRequest, user);
+
+      // create sample template
+      ApiSampleTemplatePost sampleTemplatePost = createSampleTemplateRequest(notebookDTO);
+      BindingResult bindingResult =
+          new BeanPropertyBindingResult(sampleTemplatePost, "templatePost");
+      validatePostBody(sampleTemplatePost, bindingResult);
+      ApiSampleTemplate createdSampleTemplate =
+          sampleApiMgr.createSampleTemplate(sampleTemplatePost, user);
+
+      // create container
+      ApiContainer containerPost = createContainerRequest(notebookDTO, user);
+      bindingResult = new BeanPropertyBindingResult(containerPost, "containerPost");
+      validateCreateContainerInput(containerPost, bindingResult);
+      ApiContainer createdContainer = containerApiMgr.createNewApiContainer(containerPost, user);
+
+      // create samples and associate identifiers (if it is the case)
+      importResult = new FieldmarkApiImportResult(createdContainer, createdSampleTemplate);
+      for (FieldmarkRecordDTO currentRecordDTO : notebookDTO.getRecords().values()) {
+
+        ApiSampleWithFullSubSamples samplePost =
+            createSampleRequest(currentRecordDTO, createdSampleTemplate, createdContainer.getId());
+
+        bindingResult = new BeanPropertyBindingResult(samplePost, "apiSample");
+        validateCreateSampleInput(samplePost, bindingResult, user);
+        associateSubSamplesAndContainer(samplePost);
+        ApiSampleWithFullSubSamples createdSample =
+            sampleApiMgr.createNewApiSample(samplePost, user);
+        importResult.addSample(createdSample);
+
+        if (StringUtils.isNotBlank(notebookDTO.getDoiIdentifierFieldName())) {
+          apiHandler.assertInventoryAndDataciteEnabled(user);
+          assignIdentifierToSample(user, currentRecordDTO, createdSample);
+        }
+        // for each ATTACHMENT field get "globalID" and "content" (having file identifier) and
+        // then upload the right file
+        for (ApiSampleField currentField : createdSample.getFields()) {
+          if (ApiFieldType.ATTACHMENT.equals(currentField.getType())) {
+            String sampleFieldGlobalId = currentField.getGlobalId();
+
+            FieldmarkFileExtractor fileExtractor =
+                (FieldmarkFileExtractor) currentRecordDTO.getField(currentField.getName());
+
+            if (StringUtils.isNotBlank(fileExtractor.getFileName())) {
+              uploadAttachmentToSample(user, sampleFieldGlobalId, fileExtractor, createdSample);
+            } else {
+              log.warn(
+                  "The Fieldmark attachment has not been uploaded since the filename is empty");
+            }
+          }
+        }
+      }
+    } catch (FieldmarkImportException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new FieldmarkImportException(ex);
+    }
+    return importResult;
+  }
+
+  private static void associateSubSamplesAndContainer(ApiSampleWithFullSubSamples samplePost) {
+    List<ApiSubSample> newSubSamples =
+        Stream.generate(ApiSubSample::new)
+            .limit(samplePost.getNewSampleSubSamplesCount())
+            .collect(Collectors.toList());
+    BigDecimal newQuantityValue =
+        samplePost
+            .getQuantity()
+            .getNumericValue()
+            .divide(
+                BigDecimal.valueOf(samplePost.getNewSampleSubSamplesCount()),
+                MathContext.DECIMAL32);
+    ApiQuantityInfo subSampleQuantity =
+        new ApiQuantityInfo(newQuantityValue, samplePost.getQuantity().getUnitId());
+    newSubSamples.stream().forEach(ss -> ss.setQuantity(subSampleQuantity));
+    for (int i = 0; i < newSubSamples.size(); i++) {
+      ApiContainerInfo parentContainer = new ApiContainerInfo();
+      parentContainer.setId(
+          samplePost.getNewSampleSubSampleTargetLocations().get(i).getContainerId());
+      newSubSamples.get(i).setParentContainer(parentContainer);
+      newSubSamples
+          .get(i)
+          .setParentLocation(
+              samplePost.getNewSampleSubSampleTargetLocations().get(i).getContainerLocation());
+    }
+    samplePost.setSubSamples(newSubSamples);
+  }
+
+  private void uploadAttachmentToSample(
+      User user,
+      String globalId,
+      FieldmarkFileExtractor fileExtractor,
+      ApiSampleWithFullSubSamples samplePost)
+      throws BindException, FieldmarkImportException {
+    BindingResult bindingResult;
+    ApiInventoryFilePost uploadPost =
+        new ApiInventoryFilePost(globalId, fileExtractor.getFileName());
+
+    bindingResult = new BeanPropertyBindingResult(samplePost, "fileSettings");
+    inputValidator.validate(uploadPost, invFilePostValidator, bindingResult);
+    throwBindExceptionIfErrors(bindingResult);
+    String fileName = uploadPost.getFileName();
+    GlobalIdentifier parentFieldGlobalId = new GlobalIdentifier(uploadPost.getParentGlobalId());
+    sampleApiMgr.assertUserCanEditSampleField(parentFieldGlobalId.getDbId(), user);
+
+    MultipartFile file = new FieldmarkMultipartFile(fileExtractor.getFieldValue(), fileName);
+    try (InputStream is = file.getInputStream()) {
+      inventoryFileManager.attachNewInventoryFileToInventoryRecord(
+          parentFieldGlobalId, fileName, is, user);
+    } catch (IOException ioe) {
+      throw new FieldmarkImportException("Impossible to upload attachment to RSpace: " + ioe);
+    }
+  }
+
+  private void assignIdentifierToSample(
+      User user, FieldmarkRecordDTO currentRecordDTO, ApiSampleWithFullSubSamples samplePost)
+      throws InvalidNameException {
+    FieldmarkDoiIdentifierExtractor doiExtractor =
+        (FieldmarkDoiIdentifierExtractor)
+            currentRecordDTO.getFields().values().stream()
+                .filter(FieldmarkTypeExtractor::isDoiIdentifier)
+                .findFirst()
+                .get();
+    String identifierValue = doiExtractor.getFieldValue().getDoiIdentifier();
+    if (StringUtils.isNotBlank(identifierValue)) {
+      List<ApiInventoryDOI> identifierList =
+          inventoryIdentifierApiManager.findIdentifiers(
+              "draft", false, identifierValue, false, user);
+      if (identifierList.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Unable to find an existing assignable identifier: " + identifierValue);
+      } else if (identifierList.size() > 1) {
+        throw new IllegalArgumentException(
+            "Found more than one identifier to assign for the value: " + identifierValue);
+      } else {
+        inventoryIdentifierApiManager.assignIdentifier(
+            samplePost.getOid(), identifierList.get(0).getId(), user);
+      }
+    }
+  }
+
+  public void validateCreateSampleInput(
+      ApiSampleWithFullSubSamples apiSample, BindingResult errors, User user) throws BindException {
+
+    Sample template = verifyTemplateIsCompatible(apiSample, errors, user);
+    inputValidator.validate(apiSample, sampleApiPostValidator, errors);
+    ApiSampleFullPost allData = new ApiSampleFullPost(apiSample, user, template);
+    inputValidator.validate(allData, sampleApiPostFullValidator, errors);
+    throwBindExceptionIfErrors(errors);
+  }
+
+  private Sample verifyTemplateIsCompatible(
+      ApiSampleInfo apiSample, BindingResult errors, User user) throws BindException {
+    if (apiSample.getTemplateId() != null) {
+      try {
+        return sampleApiMgr.getSampleTemplateByIdWithPopulatedFields(
+            apiSample.getTemplateId(), user);
+      } catch (NotFoundException e) {
+        errors.rejectValue("templateId", "", e.getMessage());
+        throwBindExceptionIfErrors(errors);
+      }
+    }
+    return null;
+  }
+
+  private void validateCreateContainerInput(ApiContainer container, BindingResult errors)
+      throws BindException {
+    apiContainerPostValidator.validate(container, errors);
+    throwBindExceptionIfErrors(errors);
+  }
+
+  private void validatePostBody(ApiSampleTemplatePost templatePost, BindingResult errors)
+      throws BindException {
+    sampleTemplatePostValidator.validate(templatePost, errors);
+    throwBindExceptionIfErrors(errors);
+  }
+
+  private void throwBindExceptionIfErrors(BindingResult errors) throws BindException {
+    if (errors != null && errors.hasErrors()) {
+      throw new BindException(errors);
+    }
+  }
+
+  private FieldmarkNotebookDTO getFieldmarkNotebookDTO(
+      FieldmarkApiImportRequest importRequest, User user) throws FieldmarkImportException {
+    FieldmarkNotebookDTO fieldmarkNotebookDTO;
+    try {
+      fieldmarkNotebookDTO =
+          fieldmarkServiceClientAdapter.getFieldmarkNotebook(
+              user, importRequest.getNotebookId(), importRequest.getIdentifier());
+    } catch (IOException ioEx) {
+      log.error(
+          "The notebookID \""
+              + importRequest.getNotebookId()
+              + "\" has not being imported from Fieldmark "
+              + "cause to the following error: "
+              + ioEx.getMessage());
+      throw new FieldmarkImportException(
+          "The notebookID \""
+              + importRequest.getNotebookId()
+              + "\" has not being imported from Fieldmark "
+              + "cause to the following error: "
+              + ioEx.getMessage());
+    } catch (HttpServerErrorException serverEx) {
+      log.error(
+          "The notebook cannot be fetched because of an error on the Fieldmark server: "
+              + serverEx.getMessage());
+      throw new FieldmarkImportException(
+          "The notebook cannot be fetched because of an error on the Fieldmark server: "
+              + serverEx.getMessage());
+    } catch (HttpClientErrorException clientEx) {
+      log.error(
+          "The notebook cannot be fetched because of the following error: "
+              + clientEx.getMessage());
+      throw new FieldmarkImportException(
+          "The notebook cannot be fetched because of the following error: "
+              + clientEx.getMessage());
+    }
+    return fieldmarkNotebookDTO;
+  }
+}

--- a/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
@@ -295,37 +295,31 @@ public class FieldmarkServiceManagerImpl implements FieldmarkServiceManager {
   private FieldmarkNotebookDTO getFieldmarkNotebookDTO(
       FieldmarkApiImportRequest importRequest, User user) throws FieldmarkImportException {
     FieldmarkNotebookDTO fieldmarkNotebookDTO;
+    String errorMsg = null;
     try {
       fieldmarkNotebookDTO =
           fieldmarkServiceClientAdapter.getFieldmarkNotebook(
               user, importRequest.getNotebookId(), importRequest.getIdentifier());
     } catch (IOException ioEx) {
-      log.error(
+      errorMsg =
           "The notebookID \""
               + importRequest.getNotebookId()
-              + "\" has not being imported from Fieldmark "
-              + "cause to the following error: "
-              + ioEx.getMessage());
-      throw new FieldmarkImportException(
-          "The notebookID \""
-              + importRequest.getNotebookId()
-              + "\" has not being imported from Fieldmark "
-              + "cause to the following error: "
-              + ioEx.getMessage());
+              + "\" has not being imported "
+              + "from Fieldmark cause to the following error: "
+              + ioEx.getMessage();
+      log.error(errorMsg);
+      throw new FieldmarkImportException(errorMsg);
     } catch (HttpServerErrorException serverEx) {
-      log.error(
+      errorMsg =
           "The notebook cannot be fetched because of an error on the Fieldmark server: "
-              + serverEx.getMessage());
-      throw new FieldmarkImportException(
-          "The notebook cannot be fetched because of an error on the Fieldmark server: "
-              + serverEx.getMessage());
+              + serverEx.getMessage();
+      log.error(errorMsg);
+      throw new FieldmarkImportException(errorMsg);
     } catch (HttpClientErrorException clientEx) {
-      log.error(
-          "The notebook cannot be fetched because of the following error: "
-              + clientEx.getMessage());
-      throw new FieldmarkImportException(
-          "The notebook cannot be fetched because of the following error: "
-              + clientEx.getMessage());
+      errorMsg =
+          "The notebook cannot be fetched because of the following error: " + clientEx.getMessage();
+      log.error(errorMsg);
+      throw new FieldmarkImportException(errorMsg);
     }
     return fieldmarkNotebookDTO;
   }

--- a/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
@@ -106,6 +106,9 @@ public class FieldmarkServiceManagerImpl implements FieldmarkServiceManager {
       FieldmarkApiImportRequest importRequest, User user) {
     FieldmarkApiImportResult importResult = null;
     try {
+      if (StringUtils.isNotBlank(importRequest.getIdentifier())) {
+        apiHandler.assertInventoryAndDataciteEnabled(user);
+      }
       FieldmarkNotebookDTO notebookDTO = getFieldmarkNotebookDTO(importRequest, user);
 
       // create sample template
@@ -161,7 +164,7 @@ public class FieldmarkServiceManagerImpl implements FieldmarkServiceManager {
     } catch (FieldmarkImportException ex) {
       throw ex;
     } catch (Exception ex) {
-      throw new FieldmarkImportException(ex);
+      throw new FieldmarkImportException(ex.getMessage());
     }
     return importResult;
   }

--- a/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkToRSpaceApiConverter.java
+++ b/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkToRSpaceApiConverter.java
@@ -57,8 +57,11 @@ public class FieldmarkToRSpaceApiConverter {
       int columnIndex = 1;
       for (Entry<String, FieldmarkTypeExtractor> fieldDTO :
           currentRecordDTO.getFields().entrySet()) {
-        columnIndex =
-            createSampleTemplateFieldFromDTO(fieldDTO, columnIndex, sampleTemplatePost.getFields());
+        if (!fieldDTO.getValue().isDoiIdentifier()) {
+          columnIndex =
+              createSampleTemplateFieldFromDTO(
+                  fieldDTO, columnIndex, sampleTemplatePost.getFields());
+        }
       }
     }
     sampleTemplatePost.setDefaultUnitId(RSUnitDef.DIMENSIONLESS.getId());
@@ -177,8 +180,11 @@ public class FieldmarkToRSpaceApiConverter {
     List<ApiSampleField> currentFieldList = new LinkedList<>();
     int columnIndex = 1;
     for (Entry<String, FieldmarkTypeExtractor> currentFieldDTO : recordDTO.getFields().entrySet()) {
-      columnIndex =
-          createSampleFieldFromDTO(currentFieldDTO, currentFieldList, idsByFieldName, columnIndex);
+      if (!currentFieldDTO.getValue().isDoiIdentifier()) {
+        columnIndex =
+            createSampleFieldFromDTO(
+                currentFieldDTO, currentFieldList, idsByFieldName, columnIndex);
+      }
     }
     samplePost.setFields(currentFieldList);
 

--- a/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiController.java
@@ -51,10 +51,10 @@ public class FieldmarkApiController extends BaseApiInventoryController implement
   public List<String> getIgsnCandidateFields(
       @PathVariable("notebookId") String notebookId, @RequestAttribute(name = "user") User user)
       throws BindException {
-    apiHandler.assertInventoryAndDataciteEnabled(user);
     BindingResult errors = new BeanPropertyBindingResult("notebookId", "notebookId");
     List<String> candidateFields = new LinkedList<>();
     try {
+      apiHandler.assertInventoryAndDataciteEnabled(user);
       candidateFields = fieldmarkServiceManagerImpl.getIgsnCandidateFields(user, notebookId);
     } catch (FieldmarkImportException serverEx) {
       log.error("Error creating IGSN candidate fields: " + serverEx.getMessage());
@@ -63,7 +63,17 @@ public class FieldmarkApiController extends BaseApiInventoryController implement
           "errors.fieldmark.import",
           new Object[] {},
           "Error creating IGSN candidate fields for notebook \"" + notebookId + "\"");
-      throwBindExceptionIfErrors(errors);
+    } catch (UnsupportedOperationException dataciteEx) {
+      log.error("Error creating IGSN candidate fields: " + dataciteEx.getMessage());
+      errors.rejectValue(
+          "",
+          "errors.fieldmark.import",
+          new Object[] {},
+          "Not possible to create IGSN candidate fields for notebook \""
+              + notebookId
+              + "\" because "
+              + dataciteEx.getMessage());
+
     } finally {
       throwBindExceptionIfErrors(errors);
     }

--- a/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiController.java
@@ -16,9 +16,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Slf4j
 @ApiController
@@ -49,7 +49,8 @@ public class FieldmarkApiController extends BaseApiInventoryController implement
 
   @Override
   public List<String> getIgsnCandidateFields(
-      @PathVariable("notebookId") String notebookId, @RequestAttribute(name = "user") User user)
+      @RequestParam(name = "notebookId") String notebookId,
+      @RequestAttribute(name = "user") User user)
       throws BindException {
     BindingResult errors = new BeanPropertyBindingResult("notebookId", "notebookId");
     List<String> candidateFields = new LinkedList<>();

--- a/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiController.java
@@ -1,33 +1,14 @@
 package com.researchspace.webapp.integrations.fieldmark;
 
-import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverter.createContainerRequest;
-import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverter.createSampleRequest;
-import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverter.createSampleTemplateRequest;
-
 import com.researchspace.api.v1.FieldmarkApi;
 import com.researchspace.api.v1.controller.ApiController;
-import com.researchspace.api.v1.controller.BaseApiController;
-import com.researchspace.api.v1.controller.ContainersApiController;
-import com.researchspace.api.v1.controller.InventoryFilesApiController;
-import com.researchspace.api.v1.controller.InventoryFilesApiController.ApiInventoryFilePost;
-import com.researchspace.api.v1.controller.SampleTemplatesApiController;
-import com.researchspace.api.v1.controller.SamplesApiController;
-import com.researchspace.api.v1.model.ApiContainer;
-import com.researchspace.api.v1.model.ApiField.ApiFieldType;
-import com.researchspace.api.v1.model.ApiSampleField;
-import com.researchspace.api.v1.model.ApiSampleTemplate;
-import com.researchspace.api.v1.model.ApiSampleTemplatePost;
-import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
-import com.researchspace.fieldmark.model.FieldmarkMultipartFile;
+import com.researchspace.api.v1.controller.BaseApiInventoryController;
 import com.researchspace.fieldmark.model.FieldmarkNotebook;
-import com.researchspace.fieldmark.model.utils.FieldmarkFileExtractor;
+import com.researchspace.fieldmark.model.exception.FieldmarkImportException;
 import com.researchspace.model.User;
-import com.researchspace.model.dtos.fieldmark.FieldmarkNotebookDTO;
-import com.researchspace.model.dtos.fieldmark.FieldmarkRecordDTO;
-import com.researchspace.service.fieldmark.FieldmarkServiceClientAdapter;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
+import com.researchspace.service.ApiAvailabilityHandler;
+import com.researchspace.service.fieldmark.FieldmarkServiceManager;
+import java.util.LinkedList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -35,30 +16,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
 
 @Slf4j
 @ApiController
-public class FieldmarkApiController extends BaseApiController implements FieldmarkApi {
+public class FieldmarkApiController extends BaseApiInventoryController implements FieldmarkApi {
 
-  private @Autowired SampleTemplatesApiController sampleTemplatesApiController;
-  private @Autowired InventoryFilesApiController inventoryFilesApiController;
-  private @Autowired SamplesApiController samplesApiController;
-  private @Autowired ContainersApiController containersApiController;
-
-  private @Autowired FieldmarkServiceClientAdapter fieldmarkServiceClientAdapter;
+  private @Autowired ApiAvailabilityHandler apiHandler;
+  private @Autowired FieldmarkServiceManager fieldmarkServiceManagerImpl;
 
   @Override
   public List<FieldmarkNotebook> getNotebooks(@RequestAttribute(name = "user") User user)
-      throws MalformedURLException, URISyntaxException, BindException {
+      throws BindException {
     try {
-      return fieldmarkServiceClientAdapter.getFieldmarkNotebookList(user);
-    } catch (HttpServerErrorException serverEx) {
+      return fieldmarkServiceManagerImpl.getFieldmarkNotebookList(user);
+    } catch (FieldmarkImportException serverEx) {
       log.error(
-          "The list of notebooks cannot be fetched because of an error on the Fieldmark server: "
+          "The list of notebooks cannot be fetched because of the following error: "
               + serverEx.getMessage());
       BindingResult errors = new BeanPropertyBindingResult(null, "fieldmarkServer");
       errors.rejectValue(
@@ -72,6 +48,29 @@ public class FieldmarkApiController extends BaseApiController implements Fieldma
   }
 
   @Override
+  public List<String> getIgsnCandidateFields(
+      @PathVariable("notebookId") String notebookId, @RequestAttribute(name = "user") User user)
+      throws BindException {
+    apiHandler.assertInventoryAndDataciteEnabled(user);
+    BindingResult errors = new BeanPropertyBindingResult("notebookId", "notebookId");
+    List<String> candidateFields = new LinkedList<>();
+    try {
+      candidateFields = fieldmarkServiceManagerImpl.getIgsnCandidateFields(user, notebookId);
+    } catch (FieldmarkImportException serverEx) {
+      log.error("Error creating IGSN candidate fields: " + serverEx.getMessage());
+      errors.rejectValue(
+          "",
+          "errors.fieldmark.import",
+          new Object[] {},
+          "Error creating IGSN candidate fields for notebook \"" + notebookId + "\"");
+      throwBindExceptionIfErrors(errors);
+    } finally {
+      throwBindExceptionIfErrors(errors);
+    }
+    return candidateFields;
+  }
+
+  @Override
   public FieldmarkApiImportResult importNotebook(
       @RequestBody FieldmarkApiImportRequest importRequest,
       BindingResult errors,
@@ -79,109 +78,28 @@ public class FieldmarkApiController extends BaseApiController implements Fieldma
       throws BindException {
     validateInput(importRequest, errors);
     throwBindExceptionIfErrors(errors);
-
-    FieldmarkNotebookDTO fieldmarkNotebookDTO = null;
+    FieldmarkApiImportResult importResult = null;
     try {
-      fieldmarkNotebookDTO =
-          fieldmarkServiceClientAdapter.getFieldmarkNotebook(user, importRequest.getNotebookId());
-    } catch (IOException ioEx) {
-      log.error(
-          "The notebookID \""
-              + importRequest.getNotebookId()
-              + "\" has not being imported from Fieldmark "
-              + "cause to the following error:"
-              + ioEx.getMessage());
+      importResult = fieldmarkServiceManagerImpl.importNotebook(importRequest, user);
+    } catch (FieldmarkImportException e) {
+      log.error("Error importing notebook from Fieldmark: " + e.getMessage());
       errors.rejectValue(
           "",
           "errors.fieldmark.import",
           new Object[] {},
           "Error importing notebook \""
               + importRequest.getNotebookId()
-              + "\" from fieldmark due to the following error: "
-              + ioEx.getMessage());
-
-    } catch (HttpServerErrorException serverEx) {
-      log.error(
-          "The notebook cannot be fetched because of an error on the Fieldmark server: "
-              + serverEx.getMessage());
-      errors.rejectValue(
-          "",
-          "errors.fieldmark.import",
-          new Object[] {},
-          "Error importing notebook \""
-              + importRequest.getNotebookId()
-              + "\" due to Fieldmark server "
-              + "unavailable: "
-              + serverEx.getMessage());
-    } catch (HttpClientErrorException clientEx) {
-      log.error(
-          "The notebook cannot be fetched because of the following error: "
-              + clientEx.getMessage());
-      errors.rejectValue(
-          "",
-          "errors.fieldmark.import",
-          new Object[] {},
-          "Error importing notebook \""
-              + importRequest.getNotebookId()
-              + "\" due to the following error: "
-              + clientEx.getMessage());
+              + "\" from Fieldmark: "
+              + e.getMessage());
     } finally {
       throwBindExceptionIfErrors(errors);
     }
-
-    // call the controller to create 1 sample template
-    ApiSampleTemplatePost sampleTemplatePost = createSampleTemplateRequest(fieldmarkNotebookDTO);
-    BindingResult bindingResult = new BeanPropertyBindingResult(sampleTemplatePost, "templatePost");
-    ApiSampleTemplate sampleTemplateRSpace =
-        sampleTemplatesApiController.createNewSampleTemplate(
-            sampleTemplatePost, bindingResult, user);
-
-    // call the Controllers to create 1 container
-    ApiContainer containerToPost = createContainerRequest(fieldmarkNotebookDTO, user);
-    bindingResult = new BeanPropertyBindingResult(containerToPost, "containerPost");
-    ApiContainer containerRSpace =
-        containersApiController.createNewContainer(containerToPost, bindingResult, user);
-
-    FieldmarkApiImportResult result =
-        new FieldmarkApiImportResult(
-            containerRSpace.getGlobalId(),
-            containerRSpace.getName(),
-            sampleTemplateRSpace.getGlobalId());
-    // call the Controllers to create 1 sample (with 1 subSample) placed into the container
-    for (FieldmarkRecordDTO currentRecordDTO : fieldmarkNotebookDTO.getRecords().values()) {
-
-      ApiSampleWithFullSubSamples samplePost =
-          createSampleRequest(currentRecordDTO, sampleTemplateRSpace, containerRSpace.getId());
-
-      bindingResult = new BeanPropertyBindingResult(samplePost, "samplePost");
-      samplePost = samplesApiController.createNewSample(samplePost, bindingResult, user);
-      result.addSampleGlobalId(samplePost.getGlobalId());
-
-      // for each ATTACHMENT field get "globalID" and "content" (having file identifier) and
-      // then upload the right file
-      for (ApiSampleField currentField : samplePost.getFields()) {
-        if (ApiFieldType.ATTACHMENT.equals(currentField.getType())) {
-          String globalId = currentField.getGlobalId();
-
-          FieldmarkFileExtractor fileExtractor =
-              (FieldmarkFileExtractor) currentRecordDTO.getField(currentField.getName());
-
-          if (StringUtils.isNotBlank(fileExtractor.getFileName())) {
-            inventoryFilesApiController.uploadFile(
-                new FieldmarkMultipartFile(
-                    fileExtractor.getFieldValue(), fileExtractor.getFileName()),
-                new ApiInventoryFilePost(globalId, fileExtractor.getFileName()),
-                user);
-          }
-        }
-      }
-    }
-    return result;
+    return importResult;
   }
 
   private void validateInput(FieldmarkApiImportRequest importRequest, BindingResult errors) {
     if (importRequest == null || StringUtils.isBlank(importRequest.getNotebookId())) {
-      log.error("Cannot import from Fieldmark casue the \"notebookId\" is empty");
+      log.error("Cannot import from Fieldmark cause the \"notebookId\" is empty");
       errors.rejectValue(
           "notebookId",
           "errors.fieldmark.import",

--- a/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiImportRequest.java
+++ b/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiImportRequest.java
@@ -1,5 +1,6 @@
 package com.researchspace.webapp.integrations.fieldmark;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,18 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 public class FieldmarkApiImportRequest {
+
+  @JsonProperty(required = true)
   private String notebookId;
+
+  private String identifier;
+
+  public FieldmarkApiImportRequest(FieldmarkApiImportRequest fieldmarkImportRequest) {
+    this.notebookId = fieldmarkImportRequest.getNotebookId();
+    this.identifier = fieldmarkImportRequest.getIdentifier();
+  }
+
+  public FieldmarkApiImportRequest(String notebookId) {
+    this.notebookId = notebookId;
+  }
 }

--- a/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiImportResult.java
+++ b/src/main/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiImportResult.java
@@ -1,36 +1,50 @@
 package com.researchspace.webapp.integrations.fieldmark;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @EqualsAndHashCode
 @JsonPropertyOrder(
     value = {"containerGlobalId", "containerName", "sampleTemplateGlobalId", "sampleGlobalIds"})
+@NoArgsConstructor
 public class FieldmarkApiImportResult {
 
-  private final String containerGlobalId;
-  private final String containerName;
-  private final String sampleTemplateGlobalId;
-  private final Set<String> sampleGlobalIds;
+  private String containerGlobalId;
+  private Long containerId;
+  private String containerName;
+  private String sampleTemplateGlobalId;
+  private Long sampleTemplateId;
+  private Set<String> sampleGlobalIds;
+  private Set<Long> sampleIds;
 
-  public FieldmarkApiImportResult(
-      String containerGlobalId, String containerName, String sampleTemplateGlobalId) {
-    this.containerGlobalId = containerGlobalId;
-    this.containerName = containerName;
-    this.sampleTemplateGlobalId = sampleTemplateGlobalId;
+  public FieldmarkApiImportResult(ApiContainer container, ApiSampleTemplate sampleTemplate) {
+    this.containerGlobalId = container.getGlobalId();
+    this.containerId = container.getId();
+    this.containerName = container.getName();
+    this.sampleTemplateGlobalId = sampleTemplate.getGlobalId();
+    this.sampleTemplateId = sampleTemplate.getId();
     this.sampleGlobalIds = new HashSet<>();
+    this.sampleIds = new HashSet<>();
   }
 
-  public boolean addSampleGlobalId(String sampleGlobalId) {
-    return this.sampleGlobalIds.add(sampleGlobalId);
+  public boolean addSample(ApiSampleWithFullSubSamples sample) {
+    return this.sampleIds.add(sample.getId()) && this.sampleGlobalIds.add(sample.getGlobalId());
   }
 
   public Set<String> getSampleGlobalIds() {
     return Collections.unmodifiableSet(sampleGlobalIds);
+  }
+
+  public Set<Long> getSampleIds() {
+    return Collections.unmodifiableSet(sampleIds);
   }
 }

--- a/src/main/resources/applicationContext-service.xml
+++ b/src/main/resources/applicationContext-service.xml
@@ -27,6 +27,7 @@
         <aop:advisor id="managerTx" advice-ref="txAdvice" pointcut="execution(* *..service.*Manager.*(..))" order="2"/>
         <aop:advisor id="archiveManagerTx" advice-ref="txAdvice" pointcut="execution(* *..service.archive.*Manager.*(..))" order="2"/>
         <aop:advisor id="inventoryManagerTx" advice-ref="txAdvice" pointcut="execution(* *..service.inventory.*Manager.*(..))" order="2"/>
+        <aop:advisor id="inventoryFieldmarkManagerTx" advice-ref="txAdvice" pointcut="execution(* *..service.fieldmark.*Manager.*(..))" order="2"/>
         <aop:advisor id="searchManagerTx" advice-ref="txAdvice" pointcut="execution(* *..search.SearchManager.*(..))" order="2"/>
         <aop:advisor id="validatorTx" advice-ref="txAdvice" pointcut="execution(* *..service.*Validator.*(..))" order="2"/>
         <aop:advisor id="recordAdapterTx" advice-ref="txAdvice" pointcut="execution(* *..BaseRecordAdapter.*(..))" order="2"/>

--- a/src/main/webapp/WEB-INF/pages/public/apiDocs.jsp
+++ b/src/main/webapp/WEB-INF/pages/public/apiDocs.jsp
@@ -28,7 +28,7 @@
       const baseUrl = window.location.href.substring(0, window.location.href.indexOf("/public/apiDocs"));
        var urls = [
                   { url: baseUrl + "/resources/rspace_api_specs_1_112_0.yaml", name: "RSpace ELN"},
-                  { url: baseUrl + "/resources/rspace_api_inventory_specs_1_111_0.yaml", name: "RSpace Inventory"}
+                  { url: baseUrl + "/resources/rspace_api_inventory_specs_1_113_0.yaml", name: "RSpace Inventory"}
                 ];
        var urlPrimaryName = "RSpace ELN";
 

--- a/src/main/webapp/resources/rspace_api_inventory_specs_1_113_0.yaml
+++ b/src/main/webapp/resources/rspace_api_inventory_specs_1_113_0.yaml
@@ -1859,7 +1859,7 @@ paths:
           description: >-
             Returns a list of notebook Ids for the given user
 
-  /fieldmark/notebooks/igsn/{notebookId}:
+  /fieldmark/notebooks/igsnCandidateFields:
     get:
       summary: List Fieldmark fields (of a given notebook) that could be imported as IGSN
       description: >-
@@ -1872,9 +1872,9 @@ paths:
         - Import
       parameters:
         - name: notebookId
+          in: query
           description: The notebookId to check
           type: string
-          in: path
           required: true
       responses:
         '200':

--- a/src/main/webapp/resources/rspace_api_inventory_specs_1_113_0.yaml
+++ b/src/main/webapp/resources/rspace_api_inventory_specs_1_113_0.yaml
@@ -5,7 +5,7 @@ info:
   description: >
     Welcome to the RSpace Inventory API.
 
-  version: "1.111"
+  version: "1.113"
   termsOfService: >-
     Currently unrestricted, subject to usage limits returned in X-Rate-Limit headers.
   license:
@@ -1859,6 +1859,28 @@ paths:
           description: >-
             Returns a list of notebook Ids for the given user
 
+  /fieldmark/notebooks/igsn/{notebookId}:
+    get:
+      summary: List Fieldmark fields (of a given notebook) that could be imported as IGSN
+      description: >-
+        Return the list Fieldmark fields (of a given notebook) that could be imported as IGSN
+        
+        The pre-requisite is that user enables Fieldmark App on RSpace Apps page, and saves their Fieldmark API token.
+      produces:
+        - application/json
+      tags:
+        - Import
+      parameters:
+        - name: notebookId
+          description: The notebookId to check
+          type: string
+          in: path
+          required: true
+      responses:
+        '200':
+          description: >-
+            Returns a list of fields that can be imported as Igsn
+
   /import/fieldmark/notebook:
     post:
       summary: >-
@@ -1880,12 +1902,15 @@ paths:
       tags:
         - Import
       parameters:
-        - name: notebookId
+        - name: FieldmarkApiImportRequest
           in: body
           description: >-
-                        The ID for the Fieldmark notebook. 
-                        The notebook ID is returned in `project_id` property 
-                        of the `/fieldmark/notebooks` response.
+            The ID for the Fieldmark notebook. 
+            The notebook ID is returned in `project_id` property 
+            of the `/fieldmark/notebooks` response (*required*)
+            
+            The name of the field you want to be imported as DOI identifier (*optional*).
+            DataCite and Inventory MUST be enabled by the admin in order to map to DOi Identifiers
           required: true
           schema:
             $ref: '#/definitions/FieldmarkApiImportRequest'
@@ -2956,6 +2981,10 @@ definitions:
         type: string
         description: Unique identifier Fieldmark notebook
         example: "1726126204618-rspace-igsn-demo"
+      identifier:
+        type: string
+        description: Name of the field you want to be the Doi Identifier
+        example: "FieldName"
   FieldmarkApiImportResult:
     description: Representation of Fieldmark Api import result
     properties:

--- a/src/test/java/com/researchspace/service/FieldmarkServiceClientAdapterRealConnectionTest.java
+++ b/src/test/java/com/researchspace/service/FieldmarkServiceClientAdapterRealConnectionTest.java
@@ -54,7 +54,7 @@ public class FieldmarkServiceClientAdapterRealConnectionTest extends SpringTrans
   @Test
   public void testImportNotebook() throws IOException {
     FieldmarkNotebookDTO notebookList =
-        fieldmarkServiceClientAdapter.getFieldmarkNotebook(user, NOTEBOOK_ID);
+        fieldmarkServiceClientAdapter.getFieldmarkNotebook(user, NOTEBOOK_ID, null);
 
     assertNotNull(notebookList);
   }

--- a/src/test/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerTest.java
+++ b/src/test/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -254,7 +255,7 @@ public class FieldmarkServiceManagerTest extends SpringTransactionalTest {
     verify(sampleApiMgr).createNewApiSample(any(), any());
     verify(sampleApiMgr).assertUserCanEditSampleField(any(), any());
 
-    verify(apiHandler).assertInventoryAndDataciteEnabled(goodUser);
+    verify(apiHandler, times(2)).assertInventoryAndDataciteEnabled(goodUser);
     verify(inventoryIdentifierApiManager)
         .findIdentifiers("draft", false, IDENTIFIER_VALUE, false, goodUser);
     verify(inventoryFileManager)

--- a/src/test/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerTest.java
+++ b/src/test/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerTest.java
@@ -1,0 +1,270 @@
+package com.researchspace.service.fieldmark.impl;
+
+import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverterTest.getPreBuiltSample;
+import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverterTest.getPreBuiltSampleTemplate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.researchspace.api.v1.controller.ContainerApiPostValidator;
+import com.researchspace.api.v1.controller.InventoryFilePostValidator;
+import com.researchspace.api.v1.controller.SampleApiPostFullValidator;
+import com.researchspace.api.v1.controller.SampleApiPostValidator;
+import com.researchspace.api.v1.controller.SampleTemplatePostValidator;
+import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiInventoryDOI;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.fieldmark.model.FieldmarkNotebook;
+import com.researchspace.fieldmark.model.exception.FieldmarkImportException;
+import com.researchspace.fieldmark.model.utils.FieldmarkDoiIdentifierExtractor;
+import com.researchspace.model.User;
+import com.researchspace.model.dtos.IControllerInputValidator;
+import com.researchspace.model.dtos.fieldmark.FieldmarkNotebookDTO;
+import com.researchspace.service.ApiAvailabilityHandler;
+import com.researchspace.service.fieldmark.FieldmarkServiceClientAdapter;
+import com.researchspace.service.inventory.ContainerApiManager;
+import com.researchspace.service.inventory.InventoryFileApiManager;
+import com.researchspace.service.inventory.InventoryIdentifierApiManager;
+import com.researchspace.service.inventory.SampleApiManager;
+import com.researchspace.testutils.SpringTransactionalTest;
+import com.researchspace.webapp.integrations.fieldmark.FieldmarkApiImportRequest;
+import com.researchspace.webapp.integrations.fieldmark.FieldmarkApiImportResult;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.naming.InvalidNameException;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.client.HttpServerErrorException;
+
+public class FieldmarkServiceManagerTest extends SpringTransactionalTest {
+
+  private static final String NOTEBOOK_ID = "notebookId";
+  private static final String GOOD_IDENTIFIER_FIELD_NAME = "IGSN-QR-Code";
+  private static final String WRONG_IDENTIFIER_FIELD_NAME = "IdenfifierFieldName_wrong";
+  private static String IDENTIFIER_VALUE;
+  private static final FieldmarkApiImportRequest GOOD_NOTEBOOK_REQ =
+      new FieldmarkApiImportRequest(NOTEBOOK_ID, GOOD_IDENTIFIER_FIELD_NAME);
+  private static final FieldmarkApiImportRequest WRONG_NOTEBOOK_REQ =
+      new FieldmarkApiImportRequest("wrong_notebookId", WRONG_IDENTIFIER_FIELD_NAME);
+  private static final String FIELD_GLOBAL_IDENTIFIER = "SA98307";
+  private static final String RECORD_ID = "rec-ae48f602-c9c4-4e9e-ae3b-6ecf65706e87";
+
+  private @InjectMocks FieldmarkServiceManagerImpl fieldmarkServiceManagerImpl;
+  private @Mock FieldmarkServiceClientAdapter fieldmarkServiceClientAdapter;
+  private @Mock ApiAvailabilityHandler apiHandler;
+  private @Mock SampleTemplatePostValidator sampleTemplatePostValidator;
+  private @Mock ContainerApiPostValidator apiContainerPostValidator;
+  private @Mock IControllerInputValidator inputValidator;
+  private @Mock SampleApiPostValidator sampleApiPostValidator;
+  private @Mock SampleApiPostFullValidator sampleApiPostFullValidator;
+  private @Mock InventoryFilePostValidator invFilePostValidator;
+
+  private @Mock InventoryIdentifierApiManager inventoryIdentifierApiManager;
+  private @Mock InventoryFileApiManager inventoryFileManager;
+  private @Mock ContainerApiManager containerApiMgr;
+  private @Mock SampleApiManager sampleApiMgr;
+  private @Mock User goodUser;
+  private @Mock User wrongUser;
+  private BindingResult bindingResult;
+
+  private List<FieldmarkNotebook> notebookList;
+  private FieldmarkNotebookDTO notebookDTO;
+  private ApiSampleTemplate sampleTemplateRSpace;
+  private ApiContainer containerRSpace;
+  private ApiSampleWithFullSubSamples sampleRSpace10;
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final String DOI_1 = "10.12345/nico-test1";
+  private final String DOI_2 = "10.12345/nico-test2";
+  private final ApiInventoryDOI DOI_TEST_1 = new ApiInventoryDOI();
+  private final ApiInventoryDOI DOI_TEST_2 = new ApiInventoryDOI();
+
+  @Before
+  public void setUp() throws IOException, URISyntaxException, BindException, InvalidNameException {
+    MockitoAnnotations.openMocks(this);
+    bindingResult = new BeanPropertyBindingResult(null, "fieldmark");
+    DOI_TEST_1.setId(1L);
+    DOI_TEST_1.setDoi(DOI_1);
+    DOI_TEST_2.setId(2L);
+    DOI_TEST_2.setDoi(DOI_2);
+    String json =
+        IOUtils.resourceToString(
+            "/TestResources/fieldmark/notebooks.json", Charset.defaultCharset());
+    notebookList = Arrays.asList(mapper.readValue(json, FieldmarkNotebook[].class));
+
+    when(fieldmarkServiceClientAdapter.getFieldmarkNotebookList(goodUser)).thenReturn(notebookList);
+    when(fieldmarkServiceClientAdapter.getFieldmarkNotebookList(wrongUser))
+        .thenThrow(
+            new FieldmarkImportException(
+                new HttpServerErrorException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error")));
+
+    json =
+        IOUtils.resourceToString(
+            "/TestResources/fieldmark/notebookDTO-singleRecord.json", Charset.defaultCharset());
+    notebookDTO = mapper.readValue(json, FieldmarkNotebookDTO.class);
+    notebookDTO.setDoiIdentifierFieldName(GOOD_IDENTIFIER_FIELD_NAME);
+    IDENTIFIER_VALUE =
+        (String)
+            notebookDTO
+                .getRecord(RECORD_ID)
+                .getFields()
+                .get(GOOD_IDENTIFIER_FIELD_NAME)
+                .getFieldValue();
+    notebookDTO
+        .getRecord(RECORD_ID)
+        .getFields()
+        .put(GOOD_IDENTIFIER_FIELD_NAME, new FieldmarkDoiIdentifierExtractor(IDENTIFIER_VALUE));
+
+    when(fieldmarkServiceClientAdapter.getFieldmarkNotebook(
+            goodUser, GOOD_NOTEBOOK_REQ.getNotebookId(), GOOD_IDENTIFIER_FIELD_NAME))
+        .thenReturn(notebookDTO);
+    when(fieldmarkServiceClientAdapter.getFieldmarkNotebook(
+            wrongUser, GOOD_NOTEBOOK_REQ.getNotebookId(), GOOD_IDENTIFIER_FIELD_NAME))
+        .thenThrow(new IOException("No disk space left"));
+    when(fieldmarkServiceClientAdapter.getFieldmarkNotebook(
+            goodUser, WRONG_NOTEBOOK_REQ.getNotebookId(), WRONG_IDENTIFIER_FIELD_NAME))
+        .thenThrow(new HttpServerErrorException(HttpStatus.UNAUTHORIZED, "Unauthorized"));
+
+    sampleTemplateRSpace = getPreBuiltSampleTemplate(notebookDTO);
+
+    when(sampleApiMgr.createSampleTemplate(any(), any())).thenReturn(sampleTemplateRSpace);
+
+    json =
+        IOUtils.resourceToString(
+            "/TestResources/fieldmark/api-container-response.json", Charset.defaultCharset());
+    containerRSpace = mapper.readValue(json, ApiContainer.class);
+
+    when(containerApiMgr.createNewApiContainer(any(), any())).thenReturn(containerRSpace);
+
+    sampleRSpace10 = getPreBuiltSample(notebookDTO);
+
+    when(sampleApiMgr.createNewApiSample(any(), any())).thenReturn(sampleRSpace10);
+
+    when(inventoryIdentifierApiManager.findIdentifiers(
+            "draft", false, IDENTIFIER_VALUE, false, goodUser))
+        .thenReturn(List.of(DOI_TEST_1));
+    when(inventoryIdentifierApiManager.findIdentifiers(
+            "draft", false, WRONG_IDENTIFIER_FIELD_NAME, false, goodUser))
+        .thenReturn(Collections.EMPTY_LIST);
+    when(inventoryIdentifierApiManager.findIdentifiers(
+            "draft", false, IDENTIFIER_VALUE, false, wrongUser))
+        .thenThrow(new HttpServerErrorException(HttpStatus.UNAUTHORIZED));
+    when(inventoryIdentifierApiManager.findIdentifiers(
+            "draft", false, WRONG_IDENTIFIER_FIELD_NAME, false, wrongUser))
+        .thenReturn(List.of(DOI_TEST_2));
+  }
+
+  @Test
+  public void testGetNotebooksSuccessful() {
+    List<FieldmarkNotebook> result = fieldmarkServiceManagerImpl.getFieldmarkNotebookList(goodUser);
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertEquals("1726126204618-rspace-igsn-demo", result.get(0).getNonUniqueProjectId());
+  }
+
+  @Test
+  public void testGetNotebookListRaisesException() {
+    FieldmarkImportException thrown =
+        assertThrows(
+            FieldmarkImportException.class,
+            () -> fieldmarkServiceManagerImpl.getFieldmarkNotebookList(wrongUser),
+            "FieldmarkServiceManager did not throw the exception, but it was needed");
+    assertTrue(thrown.getMessage().contains("Internal Server Error"));
+  }
+
+  @Test
+  public void testImportNotebookRaisesIoException() {
+    FieldmarkImportException thrown =
+        assertThrows(
+            FieldmarkImportException.class,
+            () -> fieldmarkServiceManagerImpl.importNotebook(GOOD_NOTEBOOK_REQ, wrongUser),
+            "FieldmarkServiceManager did not throw the exception, but it was needed");
+    assertTrue(
+        thrown
+            .getMessage()
+            .contains(
+                "The notebookID \""
+                    + GOOD_NOTEBOOK_REQ.getNotebookId()
+                    + "\" has not being imported"));
+    assertTrue(thrown.getMessage().contains("No disk space left"));
+  }
+
+  @Test
+  public void testImportNotebookRaisesServerHttpException() throws IOException {
+    when(fieldmarkServiceClientAdapter.getFieldmarkNotebook(
+            goodUser, GOOD_NOTEBOOK_REQ.getNotebookId(), GOOD_IDENTIFIER_FIELD_NAME))
+        .thenThrow(
+            new HttpServerErrorException(
+                HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"));
+    FieldmarkImportException thrown =
+        assertThrows(
+            FieldmarkImportException.class,
+            () -> fieldmarkServiceManagerImpl.importNotebook(GOOD_NOTEBOOK_REQ, goodUser),
+            "FieldmarkServiceManager did not throw the exception, but it was needed");
+
+    assertTrue(thrown.getMessage().contains("The notebook cannot be fetched"));
+    assertTrue(thrown.getMessage().contains("Internal Server Error"));
+  }
+
+  public void testImportNotebookRaisesClientHttpException() {
+    BindException thrown =
+        assertThrows(
+            BindException.class,
+            () -> fieldmarkServiceManagerImpl.importNotebook(WRONG_NOTEBOOK_REQ, goodUser),
+            "FieldmarkServiceManager did not throw the exception, but it was needed");
+    assertTrue(thrown.getMessage().contains("Unauthorized"));
+  }
+
+  @Test
+  public void testImportNotebookSuccessful() throws IOException, InvalidNameException {
+    FieldmarkApiImportResult result =
+        fieldmarkServiceManagerImpl.importNotebook(GOOD_NOTEBOOK_REQ, goodUser);
+
+    verify(fieldmarkServiceClientAdapter)
+        .getFieldmarkNotebook(
+            goodUser, GOOD_NOTEBOOK_REQ.getNotebookId(), GOOD_IDENTIFIER_FIELD_NAME);
+
+    verify(sampleTemplatePostValidator).validate(any(), any());
+    verify(sampleApiMgr).createSampleTemplate(any(), any());
+
+    verify(apiContainerPostValidator).validate(any(), any());
+    verify(containerApiMgr).createNewApiContainer(any(), any());
+
+    verify(inputValidator).validate(any(), any(SampleApiPostValidator.class), any());
+    verify(inputValidator).validate(any(), any(SampleApiPostFullValidator.class), any());
+    verify(inputValidator).validate(any(), any(InventoryFilePostValidator.class), any());
+    verify(sampleApiMgr).createNewApiSample(any(), any());
+    verify(sampleApiMgr).assertUserCanEditSampleField(any(), any());
+
+    verify(apiHandler).assertInventoryAndDataciteEnabled(goodUser);
+    verify(inventoryIdentifierApiManager)
+        .findIdentifiers("draft", false, IDENTIFIER_VALUE, false, goodUser);
+    verify(inventoryFileManager)
+        .attachNewInventoryFileToInventoryRecord(any(), any(), any(), any());
+
+    assertNotNull(result);
+    assertEquals("IC98304", result.getContainerGlobalId());
+    assertEquals("IT98304", result.getSampleTemplateGlobalId());
+    assertEquals("Container RSpace IGSN Demo - 2024-11-20 18:24:03", result.getContainerName());
+    assertEquals(1, result.getSampleGlobalIds().size());
+    assertEquals(FIELD_GLOBAL_IDENTIFIER, result.getSampleGlobalIds().stream().findFirst().get());
+  }
+}

--- a/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiControllerRealConnectionTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiControllerRealConnectionTest.java
@@ -15,6 +15,7 @@ import com.researchspace.testutils.SpringTransactionalTest;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
+import javax.naming.InvalidNameException;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class FieldmarkApiControllerRealConnectionTest extends SpringTransactiona
     assertNotNull(result);
   }
 
-  public void testImportNotebook() throws BindException {
+  public void testImportNotebook() throws BindException, InvalidNameException {
     FieldmarkApiImportResult result =
         fieldmarkApiController.importNotebook(IMPORT_REQ, mockBindingResult, user);
     assertNotNull(result);

--- a/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiControllerRealConnectionTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiControllerRealConnectionTest.java
@@ -12,10 +12,7 @@ import com.researchspace.model.oauth.UserConnection;
 import com.researchspace.model.oauth.UserConnectionId;
 import com.researchspace.service.UserConnectionManager;
 import com.researchspace.testutils.SpringTransactionalTest;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
-import javax.naming.InvalidNameException;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -53,12 +50,13 @@ public class FieldmarkApiControllerRealConnectionTest extends SpringTransactiona
   }
 
   @Test
-  public void testGetNotebooks() throws BindException, IOException, URISyntaxException {
+  public void testGetNotebooks() throws BindException {
     List<FieldmarkNotebook> result = fieldmarkApiController.getNotebooks(user);
     assertNotNull(result);
   }
 
-  public void testImportNotebook() throws BindException, InvalidNameException {
+  @Test
+  public void testImportNotebook() throws BindException {
     FieldmarkApiImportResult result =
         fieldmarkApiController.importNotebook(IMPORT_REQ, mockBindingResult, user);
     assertNotNull(result);

--- a/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkApiControllerTest.java
@@ -1,29 +1,20 @@
 package com.researchspace.webapp.integrations.fieldmark;
 
-import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverterTest.getPreBuiltSample;
-import static com.researchspace.service.fieldmark.impl.FieldmarkToRSpaceApiConverterTest.getPreBuiltSampleTemplate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.researchspace.api.v1.controller.ContainersApiController;
-import com.researchspace.api.v1.controller.InventoryFilesApiController;
-import com.researchspace.api.v1.controller.SampleTemplatesApiController;
-import com.researchspace.api.v1.controller.SamplesApiController;
 import com.researchspace.api.v1.model.ApiContainer;
-import com.researchspace.api.v1.model.ApiInventoryFile;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
-import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.fieldmark.model.FieldmarkNotebook;
+import com.researchspace.fieldmark.model.exception.FieldmarkImportException;
 import com.researchspace.model.User;
-import com.researchspace.model.dtos.fieldmark.FieldmarkNotebookDTO;
-import com.researchspace.service.fieldmark.FieldmarkServiceClientAdapter;
+import com.researchspace.service.ApiAvailabilityHandler;
+import com.researchspace.service.fieldmark.FieldmarkServiceManager;
 import com.researchspace.testutils.SpringTransactionalTest;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -43,26 +34,22 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.client.HttpServerErrorException;
 
 public class FieldmarkApiControllerTest extends SpringTransactionalTest {
+
+  private static final String NOTEBOOK_ID = "notebookId";
   private static final FieldmarkApiImportRequest GOOD_NOTEBOOK_REQ =
-      new FieldmarkApiImportRequest("notebookId");
+      new FieldmarkApiImportRequest(NOTEBOOK_ID, "IgsnFieldName");
   private static final FieldmarkApiImportRequest WRONG_NOTEBOOK_REQ =
       new FieldmarkApiImportRequest("wrong_notebookId");
 
   private @InjectMocks FieldmarkApiController fieldmarkApiController;
-  private @Mock SampleTemplatesApiController sampleTemplatesApiController;
-  private @Mock InventoryFilesApiController inventoryFilesApiController;
-  private @Mock SamplesApiController samplesApiController;
-  private @Mock ContainersApiController containersApiController;
-  private @Mock FieldmarkServiceClientAdapter fieldmarkServiceClientAdapter;
+  private @Mock FieldmarkServiceManager fieldmarkServiceManagerImpl;
+  private @Mock ApiAvailabilityHandler apiHandler;
   private @Mock User goodUser;
   private @Mock User wrongUser;
   private BindingResult bindingResult;
-
   private List<FieldmarkNotebook> notebookList;
-  private FieldmarkNotebookDTO notebookDTO;
-  private ApiSampleTemplate sampleTemplateRSpace;
-  private ApiContainer containerRSpace;
-  private ApiSampleWithFullSubSamples sampleRSpace10;
+
+  FieldmarkApiImportResult importResult;
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Before
@@ -70,55 +57,48 @@ public class FieldmarkApiControllerTest extends SpringTransactionalTest {
     MockitoAnnotations.openMocks(this);
     bindingResult = new BeanPropertyBindingResult(null, "fieldmark");
 
+    ApiContainer container = new ApiContainer();
+    container.setId(1L);
+    container.setGlobalId("CC1");
+    container.setName("container");
+
+    ApiSampleTemplate sampleTemplate = new ApiSampleTemplate();
+    sampleTemplate.setId(1L);
+    sampleTemplate.setGlobalId("ST1");
+    sampleTemplate.setName("sampleTemplate");
+    importResult = new FieldmarkApiImportResult(container, sampleTemplate);
+
     String json =
         IOUtils.resourceToString(
             "/TestResources/fieldmark/notebooks.json", Charset.defaultCharset());
     notebookList = Arrays.asList(mapper.readValue(json, FieldmarkNotebook[].class));
 
-    when(fieldmarkServiceClientAdapter.getFieldmarkNotebookList(goodUser)).thenReturn(notebookList);
-    when(fieldmarkServiceClientAdapter.getFieldmarkNotebookList(wrongUser))
+    when(fieldmarkServiceManagerImpl.getFieldmarkNotebookList(goodUser)).thenReturn(notebookList);
+    when(fieldmarkServiceManagerImpl.getFieldmarkNotebookList(wrongUser))
         .thenThrow(
-            new HttpServerErrorException(
-                HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"));
+            new FieldmarkImportException(
+                new HttpServerErrorException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error")));
 
-    json =
-        IOUtils.resourceToString(
-            "/TestResources/fieldmark/notebookDTO-singleRecord.json", Charset.defaultCharset());
-    notebookDTO = mapper.readValue(json, FieldmarkNotebookDTO.class);
+    when(fieldmarkServiceManagerImpl.importNotebook(GOOD_NOTEBOOK_REQ, goodUser))
+        .thenReturn(importResult);
+    when(fieldmarkServiceManagerImpl.importNotebook(GOOD_NOTEBOOK_REQ, wrongUser))
+        .thenThrow(
+            new FieldmarkImportException(
+                new HttpServerErrorException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error")));
 
-    when(fieldmarkServiceClientAdapter.getFieldmarkNotebook(
-            goodUser, GOOD_NOTEBOOK_REQ.getNotebookId()))
-        .thenReturn(notebookDTO);
-    when(fieldmarkServiceClientAdapter.getFieldmarkNotebook(
-            wrongUser, GOOD_NOTEBOOK_REQ.getNotebookId()))
-        .thenThrow(new IOException("No disk space left"));
-    when(fieldmarkServiceClientAdapter.getFieldmarkNotebook(
-            goodUser, WRONG_NOTEBOOK_REQ.getNotebookId()))
-        .thenThrow(new HttpServerErrorException(HttpStatus.UNAUTHORIZED, "Unauthorized"));
-
-    sampleTemplateRSpace = getPreBuiltSampleTemplate(notebookDTO);
-
-    when(sampleTemplatesApiController.createNewSampleTemplate(any(), any(), any()))
-        .thenReturn(sampleTemplateRSpace);
-
-    json =
-        IOUtils.resourceToString(
-            "/TestResources/fieldmark/api-container-response.json", Charset.defaultCharset());
-    containerRSpace = mapper.readValue(json, ApiContainer.class);
-
-    when(containersApiController.createNewContainer(any(), any(), any()))
-        .thenReturn(containerRSpace);
-
-    sampleRSpace10 = getPreBuiltSample(notebookDTO);
-
-    when(samplesApiController.createNewSample(any(), any(), any())).thenReturn(sampleRSpace10);
-
-    when(inventoryFilesApiController.uploadFile(any(), any(), any()))
-        .thenReturn(new ApiInventoryFile());
+    when(fieldmarkServiceManagerImpl.getIgsnCandidateFields(goodUser, NOTEBOOK_ID))
+        .thenReturn(List.of("fieldName1", "fieldName2"));
+    when(fieldmarkServiceManagerImpl.getIgsnCandidateFields(wrongUser, NOTEBOOK_ID))
+        .thenThrow(
+            new FieldmarkImportException(
+                new HttpServerErrorException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error")));
   }
 
   @Test
-  public void testGetNotebooksSuccessful() throws BindException, IOException, URISyntaxException {
+  public void testGetNotebooksSuccessful() throws BindException {
     List<FieldmarkNotebook> result = fieldmarkApiController.getNotebooks(goodUser);
     assertNotNull(result);
     assertEquals(1, result.size());
@@ -150,16 +130,16 @@ public class FieldmarkApiControllerTest extends SpringTransactionalTest {
             .contains(
                 "Error importing notebook \""
                     + GOOD_NOTEBOOK_REQ.getNotebookId()
-                    + "\" from fieldmark"));
+                    + "\" from Fieldmark"));
   }
 
   @Test
-  public void testImportNotebookRaisesServerHttpException() throws IOException {
-    when(fieldmarkServiceClientAdapter.getFieldmarkNotebook(
-            goodUser, GOOD_NOTEBOOK_REQ.getNotebookId()))
+  public void testImportNotebookRaisesServerHttpException() {
+    when(fieldmarkServiceManagerImpl.importNotebook(GOOD_NOTEBOOK_REQ, goodUser))
         .thenThrow(
-            new HttpServerErrorException(
-                HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"));
+            new FieldmarkImportException(
+                new HttpServerErrorException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error")));
     BindException thrown =
         assertThrows(
             BindException.class,
@@ -171,7 +151,7 @@ public class FieldmarkApiControllerTest extends SpringTransactionalTest {
             .contains(
                 "Error importing notebook \""
                     + GOOD_NOTEBOOK_REQ.getNotebookId()
-                    + "\" due to Fieldmark server unavailable"));
+                    + "\" from Fieldmark"));
   }
 
   public void testImportNotebookRaisesClientHttpException() {
@@ -185,26 +165,34 @@ public class FieldmarkApiControllerTest extends SpringTransactionalTest {
   }
 
   @Test
-  public void testImportNotebookSuccessful() throws BindException, IOException {
+  public void testImportNotebookSucceed() throws BindException {
     FieldmarkApiImportResult result =
         fieldmarkApiController.importNotebook(GOOD_NOTEBOOK_REQ, bindingResult, goodUser);
 
-    verify(fieldmarkServiceClientAdapter)
-        .getFieldmarkNotebook(goodUser, GOOD_NOTEBOOK_REQ.getNotebookId());
-    verifyNoMoreInteractions(fieldmarkServiceClientAdapter);
-    verify(sampleTemplatesApiController).createNewSampleTemplate(any(), any(), any());
-    verifyNoMoreInteractions(sampleTemplatesApiController);
-    verify(containersApiController).createNewContainer(any(), any(), any());
-    verifyNoMoreInteractions(containersApiController);
-    verify(samplesApiController).createNewSample(any(), any(), any());
-    verifyNoMoreInteractions(samplesApiController);
-    verify(inventoryFilesApiController).uploadFile(any(), any(), any());
-    verifyNoMoreInteractions(inventoryFilesApiController);
+    verify(fieldmarkServiceManagerImpl).importNotebook(GOOD_NOTEBOOK_REQ, goodUser);
     assertNotNull(result);
-    assertEquals("IC98304", result.getContainerGlobalId());
-    assertEquals("IT98304", result.getSampleTemplateGlobalId());
-    assertEquals("Container RSpace IGSN Demo - 2024-11-20 18:24:03", result.getContainerName());
-    assertEquals(1, result.getSampleGlobalIds().size());
-    assertEquals("SA98307", result.getSampleGlobalIds().stream().findFirst().get());
+  }
+
+  @Test
+  public void testGetIgsnCandidateFieldsSucceed() throws BindException {
+    List<String> result = fieldmarkApiController.getIgsnCandidateFields(NOTEBOOK_ID, goodUser);
+
+    verify(fieldmarkServiceManagerImpl).getIgsnCandidateFields(goodUser, NOTEBOOK_ID);
+    assertNotNull(result);
+  }
+
+  @Test
+  public void testGetIgsnCandidateFieldsRaisesException() {
+    BindException thrown =
+        assertThrows(
+            BindException.class,
+            () -> fieldmarkApiController.getIgsnCandidateFields(NOTEBOOK_ID, wrongUser),
+            "FieldmarkApiController did not throw the exception, but it was needed");
+    assertTrue(
+        thrown
+            .getMessage()
+            .contains(
+                "Error creating IGSN candidate fields for notebook \""
+                    + GOOD_NOTEBOOK_REQ.getNotebookId()));
   }
 }

--- a/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkRealConnectionMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkRealConnectionMVCIT.java
@@ -4,8 +4,12 @@ import static com.researchspace.service.IntegrationsHandler.FIELDMARK_APP_NAME;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.researchspace.api.v1.controller.API_MVC_TestBase;
 import com.researchspace.api.v1.controller.API_VERSION;
+import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiSample;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.model.User;
 import com.researchspace.model.oauth.UserConnection;
 import com.researchspace.model.oauth.UserConnectionId;
@@ -64,6 +68,36 @@ public class FieldmarkRealConnectionMVCIT extends API_MVC_TestBase {
                 createBuilderForInventoryPostWithJSONBody(
                     apiKey, "/import/fieldmark/notebook", user, IMPORT_REQUEST))
             .andExpect(status().isCreated())
+            .andReturn();
+    assertNotNull(result.getResponse());
+    ObjectMapper objectMapper = new ObjectMapper();
+    FieldmarkApiImportResult importResult =
+        objectMapper.readValue(
+            result.getResponse().getContentAsString(), FieldmarkApiImportResult.class);
+
+    ApiContainer container =
+        containerApiMgr.getApiContainerIfExists(importResult.getContainerId(), user);
+    assertNotNull(container);
+    ApiSampleTemplate sampleTemplate =
+        sampleApiMgr.getApiSampleTemplateById(importResult.getSampleTemplateId(), user);
+    assertNotNull(sampleTemplate);
+    for (Long currentSampleId : importResult.getSampleIds()) {
+      ApiSample currentSample = sampleApiMgr.getApiSampleById(currentSampleId, user);
+      assertNotNull(currentSample);
+    }
+  }
+
+  @Test
+  public void testGetIgsnCandidateFields() throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForInventoryGet(
+                    API_VERSION.ONE,
+                    apiKey,
+                    "fieldmark/notebooks/igsn/" + IMPORT_REQUEST.getNotebookId(),
+                    user))
+            .andExpect(status().isOk())
             .andReturn();
     assertNotNull(result.getResponse());
   }

--- a/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkRealConnectionMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/fieldmark/FieldmarkRealConnectionMVCIT.java
@@ -95,7 +95,8 @@ public class FieldmarkRealConnectionMVCIT extends API_MVC_TestBase {
                 createBuilderForInventoryGet(
                     API_VERSION.ONE,
                     apiKey,
-                    "fieldmark/notebooks/igsn/" + IMPORT_REQUEST.getNotebookId(),
+                    "fieldmark/notebooks/igsnCandidateFields?notebookId="
+                        + IMPORT_REQUEST.getNotebookId(),
                     user))
             .andExpect(status().isOk())
             .andReturn();

--- a/src/test/resources/TestResources/fieldmark/notebookDTO-singleRecord.json
+++ b/src/test/resources/TestResources/fieldmark/notebookDTO-singleRecord.json
@@ -24,7 +24,7 @@
           "simpleTypeName": "Integer"
         },
         "IGSN-QR-Code": {
-          "fieldValue": "1",
+          "fieldValue": "10.82316/zkrr-as98",
           "fieldType": "java.lang.String",
           "simpleTypeName": "String"
         },

--- a/src/test/resources/TestResources/fieldmark/records.json
+++ b/src/test/resources/TestResources/fieldmark/records.json
@@ -9,7 +9,7 @@
         "Field-ID": "00010",
         "hridPrimary-Next-Section": "Sample-45-00010",
         "Survey-Number": 45,
-        "IGSN-QR-Code": "1",
+        "IGSN-QR-Code": "",
         "Sample-Location": {
           "type": "Feature",
           "properties": {
@@ -117,7 +117,7 @@
         "Field-ID": "00008",
         "hridPrimary-Next-Section": "Sample-1-00008",
         "Survey-Number": 1,
-        "IGSN-QR-Code": "1",
+        "IGSN-QR-Code": "10.12345/asdf-good",
         "Sample-Location": null,
         "New-Text-Field": "glasgow",
         "Description": "rock hard",
@@ -207,7 +207,7 @@
         "Field-ID": "00009",
         "hridPrimary-Next-Section": "Sample-12-00009",
         "Survey-Number": 12,
-        "IGSN-QR-Code": "1",
+        "IGSN-QR-Code": "",
         "Sample-Location": null,
         "New-Text-Field": "Rome",
         "Description": "Arcdheological interest area",


### PR DESCRIPTION
## Description ##
- This PR extends the functionality "Import from Fieldmark"
- - From now when importing from fieldmark the system will analyse all the rows and returns a list of candidate fields that can be used as DOI identifiers. Finally the user will be able select one of the candidate fields to be treated as IGSN DOI Identifier. Finally, when importing the fieldmark notebook into the inventory, the Samples will already have the DOI linked as specified on the Fieldmark UI.

## Pre requisites to merge ##
 - merge the fieldmark repo PR: https://github.com/rspace-os/fieldmark-java-client/pull/4

## Testing notes
- I have alreadsy prefilled the "`Description`" field into Fieldmark UI to have DOIs.
- If you want to test on an instance you need to be sure that those DOIs are already generated on the RSpace instance and are not assigned to any inventory object already.
- This PR is **ONLY BACKEND** so in order to test it you need to go to the swagger page of the Inventory: https://your_instance/public/apiDocs?urls.primaryName=RSpace%20Inventory
- - **The UI for this feature** will be implemented on another PR referencing the folliowing JIRA: https://researchspace.atlassian.net/browse/RSDEV-746
- **AWS instance** spinned: https://rsdev-520-backend-25.researchspace.com 

## How to test ##

### List Fieldmark fields (of a given notebook) that could be imported as IGSN ###
**WHEN**
1.  Enable fieldmark, auth access from the configuration
2. Add Fieldmark bearer token and enable Fieldmark banner from the App page
3. Enable DataCite from the Inventory setting section
4. Create a bunch of new IGSN to allocate (5 would be more than enough)
5. Go to Fieldmark UI and fill the "`Description`" field of all the 3 observations with the IGSNs created on fieldmark
6. go to the swagger UI and login
7. Run the end point `GET /fieldmark/notebooks/igsn/{notebookId}` giving your notebookId as parameter

**THEN** 
 - You need to have as result a list of fieldName (in this case should only be "`Description`"):
```
[ "Description" ]
```

### Import a notebook from Fieldmark into the RSpace Inventory (including IGSN DOIs)  ###
**WHEN**
1. go to the swagger UI and login
2. Run the end point `POST /import​/fieldmark​/notebook` giving your notebookId and the IGSN identifier field as parameters in the JSON body:
```
{
  "notebookId": "1726126204618-rspace-igsn-demo",
  "identifier": "Description"
}
```
**THEN** 
 - You need to have as result the importResult JSON with the IDs of the container, sample template and samples global IDs
 - On the inventory UI you can see all the samples just created, and each one of them has already the Identifier DOI corectly linked
