### PR TITLE
RSDEV-754: use default cursor when hovering over unclickable part of workspace listing

### DIFF
--- a/src/main/webapp/styles/rs-global.css
+++ b/src/main/webapp/styles/rs-global.css
@@ -791,6 +791,11 @@ div .searchButton {
     .newTabularView .mainTable.noCheckboxes td:first-child {
       padding-left: 20px; }
 
+/* rsdev-754 */
+#file_table {
+  cursor: default;
+}
+
 .linkedRecordInfoAction {
   position: relative;
   left: 4px;


### PR DESCRIPTION
## Description ##
The PR changes the default on-hover cursor shown over Workspace listing, so the user has better chance of clicking on the active part of the row.