### PR TITLE
Use fast-check to assert properties in playwright tests

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/index.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/index.spec.tsx
@@ -53,9 +53,11 @@ type ArbType = "string" | "integer" | "natural number" | "one of";
 function property(name: string) {
   return {
     let: function <T>(
-      setupFn: (
-        IsAny: (desc: ArbType, ...args: Array<unknown>) => unknown,
-      ) => T,
+      setupFn: ({
+        IsAny,
+      }: {
+        IsAny: (desc: ArbType, ...args: Array<unknown>) => unknown;
+      }) => T,
     ) {
       return {
         checkThat: (
@@ -90,9 +92,11 @@ function property(name: string) {
              * properties are used in the setup function.
              */
             const usedProperties = new Map<string, Array<unknown>>();
-            setupFn((description: ArbType, ...args: Array<unknown>) => {
-              usedProperties.set(description, args);
-              return "some string";
+            setupFn({
+              IsAny: (description: ArbType, ...args: Array<unknown>) => {
+                usedProperties.set(description, args);
+                return "some string";
+              },
             });
 
             /*
@@ -134,7 +138,7 @@ function property(name: string) {
                   return generated[description];
                 };
 
-                const actualValues = setupFn(isAny);
+                const actualValues = setupFn({ IsAny: isAny });
 
                 try {
                   await testFn(actualValues, {
@@ -318,7 +322,7 @@ test.describe("Gallery", () => {
     property(
       "On '?mediaType={section}', the title should be '{section} | RSpace Gallery'",
     )
-      .let((IsAny) => ({
+      .let(({ IsAny }) => ({
         section: IsAny(
           "one of",
           "Images",
@@ -350,7 +354,7 @@ test.describe("Gallery", () => {
       });
 
     property("On '/{id}', the title should be '{folder name} | RSpace Gallery'")
-      .let((IsAny) => ({
+      .let(({ IsAny }) => ({
         id: IsAny("natural number"),
         folderName: IsAny("string"),
       }))
@@ -409,7 +413,7 @@ test.describe("Gallery", () => {
     property(
       "On '/item/{id}', the title should be '{filename} | RSpace Gallery'",
     )
-      .let((IsAny) => ({
+      .let(({ IsAny }) => ({
         id: IsAny("integer"),
         filename: IsAny("string"),
       }))

--- a/src/main/webapp/ui/src/eln/gallery/index.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/index.spec.tsx
@@ -3,16 +3,9 @@ import React from "react";
 import { GalleryStory } from "./index.story";
 import * as Jwt from "jsonwebtoken";
 import fc from "fast-check";
+import { type RouterFixture } from "@playwright/experimental-ct-core";
 
 const feature = test.extend<{
-  Let: {
-    "the id be an integer": (
-      cb: (id: number) => Promise<void>,
-    ) => Promise<void>;
-  };
-  Let2: {
-    "the id be an integer": () => AsyncGenerator<void, void, unknown>;
-  };
   Given: {
     "the Gallery is mounted": ({
       url,
@@ -27,30 +20,6 @@ const feature = test.extend<{
   };
   networkRequests: Array<URL>;
 }>({
-  Let: async ({}, use) => {
-    await use({
-      "the id be an integer": async (cb: (id: number) => Promise<void>) => {
-        await fc.assert(
-          fc.asyncProperty(fc.integer({ min: 1 }), async (id) => {
-            await cb(id);
-          }),
-          { numRuns: 5 },
-        );
-      },
-    });
-  },
-  // Let2: async ({}, use) => {
-  //   await use({
-  //     "the id be an integer": async function* () {
-  //       await fc.assert(
-  //         fc.asyncProperty(fc.integer({ min: 1 }), async (id) => {
-  //           yield id;
-  //         }),
-  //         { numRuns: 5 },
-  //       );
-  //     },
-  //   });
-  // },
   Given: async ({ mount }, use) => {
     await use({
       "the Gallery is mounted": async ({
@@ -79,6 +48,107 @@ const feature = test.extend<{
     await use([]);
   },
 });
+
+type ArbType = "string" | "integer" | "natural number";
+function property(name: string) {
+  return {
+    let: function <T>(
+      setupFn: (IsAny: (desc: ArbType) => string | number) => T,
+    ) {
+      return {
+        checkThat: (
+          testFn: (
+            values: T,
+            helpers: { Given: any; Then: any; router: RouterFixture },
+          ) => Promise<void>,
+        ) => {
+          return feature(name, async ({ Given, Then, router }) => {
+            /*
+             * With each iteration of the test, we need to make sure that
+             * react has a clean state so we wrap the Given steps that mount
+             * components to keep track of the mounted components, so that
+             * after the test is done, we can unmount them.
+             */
+            let mountedComponent: MountResult | null = null;
+            const wrappedGiven = {
+              ...Given,
+              "the Gallery is mounted": async (
+                args: {
+                  url?: React.ComponentProps<typeof GalleryStory>["urlSuffix"];
+                } = {},
+              ) => {
+                const component = await Given["the Gallery is mounted"](args);
+                mountedComponent = component;
+                return component;
+              },
+            };
+
+            /*
+             * We take a first pass over the IsAny calls to determine which
+             * properties are used in the setup function.
+             */
+            const usedProperties = new Set<string>();
+            setupFn((description: ArbType) => {
+              usedProperties.add(description);
+              return "some string";
+            });
+
+            /*
+             * Next we create the arbitraries for the properties that were
+             * used in the setup function.
+             */
+            const propertyValues: {
+              integer: fc.Arbitrary<number>;
+              string: fc.Arbitrary<string>;
+              "natural number": fc.Arbitrary<number>;
+            } = Object.fromEntries(
+              Array.from(usedProperties).map((key) => {
+                switch (key) {
+                  case "integer":
+                    return [key, fc.integer({ min: 1 })];
+                  case "string":
+                    return [key, fc.string()];
+                  case "natural number":
+                    return [key, fc.nat()];
+                  default:
+                    throw new Error(`Unknown property: ${key}`);
+                }
+              }),
+            );
+
+            /*
+             * Finally we run the test function with the generated values.
+             */
+            await fc.assert(
+              fc.asyncProperty(fc.record(propertyValues), async (generated) => {
+                const isAny = (description: ArbType) => {
+                  if (!(description in generated)) {
+                    throw new Error(`Unknown property: ${description}`);
+                  }
+                  return generated[description];
+                };
+
+                const actualValues = setupFn(isAny);
+
+                await testFn(actualValues, {
+                  Given: wrappedGiven,
+                  Then,
+                  router,
+                });
+
+                if (mountedComponent) {
+                  await mountedComponent.unmount();
+                  mountedComponent = null;
+                }
+              }),
+              { numRuns: 5 },
+            );
+          });
+        },
+      };
+    },
+  };
+}
 
 feature.beforeEach(async ({ router }) => {
   await router.route("/userform/ajax/inventoryOauthToken", (route) => {
@@ -222,233 +292,73 @@ feature.beforeEach(async ({ router }) => {
       }),
     });
   });
-  await router.route("/api/v1/files/*", (route) => {
-    return route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        id: 456,
-        globalId: "GL456",
-        name: "Picture1.png",
-        caption: null,
-        contentType: "image/x-png",
-        created: "2025-07-07T11:09:18.312Z",
-        size: 40721,
-        version: 1,
-        parentFolderId: 123,
-        _links: [
-          {
-            link: "http://localhost:8080/api/v1/files/149",
-            rel: "self",
-          },
-          {
-            link: "http://localhost:8080/api/v1/files/149/file",
-            rel: "enclosure",
-          },
-        ],
-      }),
-    });
-  });
 });
 
-// feature.afterEach(({}) => {});
+feature.afterEach(({}) => {});
 
 test.describe("Gallery", () => {
   test.describe("Should have a title that describes the current page", () => {
-    //     /*
-    //      * This an a11y requirement, under WCAG 2.2 criteria 2.4.2 Page Titled (A),
-    //      * see https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html
-    //      */
-    //     feature(
-    //       "On `/gallery', the title should be 'Images | RSpace Gallery'",
-    //       async ({ Given, Then }) => {
-    //         await Given["the Gallery is mounted"]();
-    //         await Then["the page title should be"]("Images | RSpace Gallery");
-    //         /*
-    //          * The images is the default gallery section.
-    //          */
-    //       },
-    //     );
-    //     feature(
-    //       "On '/gallery?mediaType=Videos', the title should be 'Videos | RSpace Gallery'",
-    //       async ({ Given, Then }) => {
-    //         await Given["the Gallery is mounted"]({ url: "?mediaType=Videos" });
-    //         await Then["the page title should be"]("Videos | RSpace Gallery");
-    //       },
-    //     );
-    //     feature(
-    //       "On '/123', the title should be 'Examples | RSpace Gallery'",
-    //       async ({ Given, Then }) => {
-    //         await Given["the Gallery is mounted"]({ url: "/123" });
-    //         await Then["the page title should be"]("Examples | RSpace Gallery");
-    //       },
-    //     );
-    //     feature(
-    //       "On '/item/456', the title should be 'Picture1.png | RSpace Gallery'",
-    //       async ({ Given, Then }) => {
-    //         return fc.assert(
-    //           fc.asyncProperty(fc.integer({ min: 1 }), async (id) => {
-    //             const component = await Given["the Gallery is mounted"]({
-    //               url: "/item/456",
-    //             });
-    //             await Then["the page title should be"](
-    //               "Picture1.png | RSpace Gallery",
-    //             );
-    //             component.unmount();
-    //           }),
-    //         );
-    //       },
-    //     );
+    /*
+     * This an a11y requirement, under WCAG 2.2 criteria 2.4.2 Page Titled (A),
+     * see https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html
+     */
+    feature(
+      "On `/gallery', the title should be 'Images | RSpace Gallery'",
+      async ({ Given, Then }) => {
+        await Given["the Gallery is mounted"]();
+        await Then["the page title should be"]("Images | RSpace Gallery");
+        /*
+         * The images is the default gallery section.
+         */
+      },
+    );
+    feature(
+      "On '/gallery?mediaType=Videos', the title should be 'Videos | RSpace Gallery'",
+      async ({ Given, Then }) => {
+        await Given["the Gallery is mounted"]({ url: "?mediaType=Videos" });
+        await Then["the page title should be"]("Videos | RSpace Gallery");
+      },
+    );
+    feature(
+      "On '/123', the title should be 'Examples | RSpace Gallery'",
+      async ({ Given, Then }) => {
+        await Given["the Gallery is mounted"]({ url: "/123" });
+        await Then["the page title should be"]("Examples | RSpace Gallery");
+      },
+    );
 
-    feature("fast-check test", async ({ mount, Then }) => {
-      await fc.assert(
-        fc.asyncProperty(fc.integer({ min: 1 }), async (id) => {
-          const component = await mount(
-            <GalleryStory urlSuffix={`/item/${id}`} />,
-          );
-          await Then["the page title should be"](
-            "Picture1.png | RSpace Gallery",
-          );
-          await component.unmount();
-        }),
-        { numRuns: 5 },
-      );
-    });
+    property(
+      "On '/item/{id}', the title should be '{filename} | RSpace Gallery'",
+    )
+      .let((IsAny) => ({
+        id: IsAny("natural number"),
+        filename: IsAny("string"),
+      }))
+      .checkThat(async ({ id, filename }, { Given, Then, router }) => {
+        await router.route(`/api/v1/files/${id}`, (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              id,
+              globalId: `GL${id}`,
+              name: `${filename}.jpg`,
+              caption: null,
+              contentType: "image/jpeg",
+              created: "2025-07-07T11:09:18.312Z",
+              size: 40721,
+              version: 1,
+              parentFolderId: 123,
+            }),
+          }),
+        );
 
-    feature("fast-check test 2", async ({ Let, Given, Then }) => {
-      await Let["the id be an integer"](async (id) => {
         await Given["the Gallery is mounted"]({
           url: `/item/${id}`,
         });
-        await Then["the page title should be"]("Picture1.png | RSpace Gallery");
+        await Then["the page title should be"](
+          `${filename}.jpg | RSpace Gallery`,
+        );
       });
-    });
   });
-
-  // feature("fast-check test 3", async ({ Let2, Given, Then }) => {
-  //   async function* test() {
-  //     const id: number = yield Let2["the id be an integer"]();
-  //     await Given["the Gallery is mounted"]({
-  //       url: `/item/${id}`,
-  //     });
-  //     await Then["the page title should be"]("Picture1.png | RSpace Gallery");
-  //   }
-  //   test();
-  // });
 });
-
-function propertyTest(name: string) {
-  return {
-    using: function <T>(
-      setupFn: (IsAny: (desc: "string" | "integer") => string | number) => T,
-    ) {
-      return {
-        run: (
-          testFn: (
-            values: T,
-            helpers: { Given: any; Then: any },
-          ) => Promise<void>,
-        ) => {
-          return feature(
-            name,
-            async ({ Given, Then /* other existing fixtures */ }) => {
-              /*
-               * With each iteration of the test, we need to make sure that
-               * react has a clean state so we wrap the Given steps that mount
-               * components to keep track of the mounted components, so that
-               * after the test is done, we can unmount them.
-               */
-              let mountedComponent: MountResult | null = null;
-              const wrappedGiven = {
-                ...Given,
-                "the Gallery is mounted": async (
-                  args: {
-                    url?: React.ComponentProps<
-                      typeof GalleryStory
-                    >["urlSuffix"];
-                  } = {},
-                ) => {
-                  const component = await Given["the Gallery is mounted"](args);
-                  mountedComponent = component;
-                  return component;
-                },
-              };
-
-              /*
-               * We take a first pass over the IsAny calls to determine which
-               * properties are used in the setup function.
-               */
-              const usedProperties = new Set<string>();
-              setupFn((description: "string" | "integer") => {
-                usedProperties.add(description);
-                return "some string";
-              });
-
-              /*
-               * Next we create the arbitraries for the properties that were
-               * used in the setup function.
-               */
-              const propertyValues: {
-                integer: fc.Arbitrary<number>;
-                string: fc.Arbitrary<string>;
-              } = Object.fromEntries(
-                Array.from(usedProperties).map((key) => {
-                  switch (key) {
-                    case "integer":
-                      return [key, fc.integer({ min: 1 })];
-                    case "string":
-                      return [key, fc.string()];
-                    default:
-                      throw new Error(`Unknown property: ${key}`);
-                  }
-                }),
-              );
-
-              /*
-               * Finally we run the test function with the generated values.
-               */
-              await fc.assert(
-                fc.asyncProperty(
-                  fc.record(propertyValues),
-                  async (generated) => {
-                    const isAny = (description: "string" | "integer") => {
-                      if (!(description in generated)) {
-                        throw new Error(`Unknown property: ${description}`);
-                      }
-                      return generated[description];
-                    };
-
-                    const actualValues = setupFn(isAny);
-
-                    await testFn(actualValues, {
-                      Given: wrappedGiven,
-                      Then /* pass other fixtures */,
-                    });
-
-                    // Unmount all components after the test
-                    if (mountedComponent) {
-                      await mountedComponent.unmount();
-                      mountedComponent = null;
-                    }
-                  },
-                ),
-                { numRuns: 5 },
-              );
-            },
-          );
-        },
-      };
-    },
-  };
-}
-
-propertyTest("fast-check test 3")
-  .using((IsAny) => ({
-    id: IsAny("integer"),
-  }))
-  .run(async ({ id }, { Given, Then }) => {
-    await Given["the Gallery is mounted"]({
-      url: `/item/${id}`,
-    });
-    await Then["the page title should be"](`Picture1.png | RSpace Gallery`);
-  });

--- a/src/main/webapp/ui/src/eln/gallery/index.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/index.spec.tsx
@@ -57,7 +57,11 @@ function property(name: string) {
         IsOneOf,
       }: {
         IsAny: (
-          desc: "string" | "integer" | "natural number",
+          desc:
+            | "file id"
+            | "file name without extension"
+            | "folder id"
+            | "folder name",
           ...args: Array<unknown>
         ) => unknown;
         IsOneOf: (...options: Array<unknown>) => unknown;
@@ -87,14 +91,17 @@ function property(name: string) {
           })(name, async ({ Given, Then, router }) => {
             const letBindingsToArbitraries = letBindings({
               IsAny: (description, ...args) => {
-                if (description === "integer") {
-                  return fc.integer();
+                if (description === "file id") {
+                  return fc.integer({ min: 1, max: 10000 });
                 }
-                if (description === "string") {
-                  return fc.string();
+                if (description === "file name without extension") {
+                  return fc.string({ minLength: 1, maxLength: 20 });
                 }
-                if (description === "natural number") {
-                  return fc.nat();
+                if (description === "folder id") {
+                  return fc.nat(1000);
+                }
+                if (description === "folder name") {
+                  return fc.string({ minLength: 1, maxLength: 20 });
                 }
                 throw new Error(`Unknown type: ${description}`);
               },
@@ -319,8 +326,8 @@ test.describe("Gallery", () => {
 
     property("On '/{id}', the title should be '{folder name} | RSpace Gallery'")
       .let(({ IsAny }) => ({
-        id: IsAny("natural number"),
-        folderName: IsAny("string"),
+        id: IsAny("folder id"),
+        folderName: IsAny("folder name"),
       }))
       .checkThat(async ({ id, folderName }, { Given, Then, router }) => {
         await router.route("/api/v1/folders/*", (route) =>
@@ -378,8 +385,8 @@ test.describe("Gallery", () => {
       "On '/item/{id}', the title should be '{filename} | RSpace Gallery'",
     )
       .let(({ IsAny }) => ({
-        id: IsAny("integer"),
-        filename: IsAny("string"),
+        id: IsAny("file id"),
+        filename: IsAny("file name without extension"),
       }))
       .checkThat(async ({ id, filename }, { Given, Then, router }) => {
         await router.route(`/api/v1/files/${id}`, (route) =>


### PR DESCRIPTION
## Description ##
This is an experiment with using fast-check to assert properties in playwright component tests, rather than just asserting particular examples. In this case, we're asserting the behaviour of the dynamic title of the Gallery
