### PR TITLE
PRT-967: fix problem with switching Workspace to tree-view mode

### DIFF
--- a/src/main/webapp/scripts/tags/fileTreeBrowser.js
+++ b/src/main/webapp/scripts/tags/fileTreeBrowser.js
@@ -328,7 +328,7 @@ function _selectRecordInFileTreeBrowserBranch(node) {
     }
   }
 
-  if (node.key === fileTreeBrowserRecordId.toString()) {
+  if (fileTreeBrowserRecordId != null && node.key === fileTreeBrowserRecordId.toString()) {
     if (_isNodeAncestorMatchingBreadcrumbs(node)) {
       // in timeout, as maybe the tree is just being expanded
       setTimeout(function () {


### PR DESCRIPTION
## Description ##
Adds the null check to recently-modified fileTreeBrowser code
