### PR TITLE
RSDEV-758 Use ValidatingSubmitButton when creating new notes

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/NewNote.tsx
+++ b/src/main/webapp/ui/src/Inventory/Subsample/Fields/Notes/NewNote.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { observer } from "mobx-react-lite";
-import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import TextField from "../../../../components/Inputs/TextField";
 import SubSampleModel from "../../../../stores/models/SubSampleModel";
 import FormField from "../../../../components/Inputs/FormField";
 import Stack from "@mui/material/Stack";
+import ValidatingSubmitButton, {
+  IsInvalid,
+  IsValid,
+} from "@/components/ValidatingSubmitButton";
 
 const emptyNote = {
   content: "",
@@ -17,20 +20,14 @@ type NewNoteArgs = {
 };
 
 function NewNote({ record, onErrorStateChange }: NewNoteArgs): React.ReactNode {
-  const [note, setNote] = useState(emptyNote);
-  const [initial, setInitial] = useState(true);
-  const [error, setError] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [note, setNote] = useState("");
 
   const handleChange = ({
     target: { value },
   }: {
     target: { name: string; value: string };
   }) => {
-    setNote({
-      ...note,
-      content: value,
-    });
+    setNote(value);
     if (value === "") {
       // when editing, unsetting the dirty flag could result in other changes
       // being not savable
@@ -38,47 +35,37 @@ function NewNote({ record, onErrorStateChange }: NewNoteArgs): React.ReactNode {
     } else {
       record.setDirtyFlag();
     }
+    onErrorStateChange(validate().isError);
   };
 
   const createNote = () => {
-    void record.createNote(note);
-    setNote(emptyNote);
-    setInitial(true);
+    void record.createNote({ content: note });
+    setNote("");
   };
 
   useEffect(() => {
-    if (initial) {
-      setInitial(false);
-    } else if (note.content === "") {
-      setError(true);
-      setErrorMessage("Content should not be empty.");
-      onErrorStateChange(true);
-    } else if (note.content.length > 2000) {
-      setError(true);
-      setErrorMessage("Content should not exceed 2000 characters.");
-      onErrorStateChange(true);
-    } else {
-      setError(false);
-      setErrorMessage(null);
-      onErrorStateChange(false);
-    }
-  }, [note.content, initial, onErrorStateChange]);
-
-  useEffect(() => {
-    setError(false);
-    setInitial(true);
-    setErrorMessage(null);
-    setNote(emptyNote);
+    setNote("");
   }, [record]);
+
+  function validate() {
+    if (!record.isFieldEditable("notes")) {
+      return IsInvalid("Notes are not editable");
+    }
+    if (note === "") {
+      return IsInvalid("Note cannot be empty.");
+    }
+    if (note.length > 2000) {
+      return IsInvalid("Note cannot exceed 2000 characters.");
+    }
+    return IsValid();
+  }
 
   return (
     <>
       <FormField
         label="New note"
         maxLength={2000}
-        helperText={errorMessage}
-        error={error}
-        value={note.content}
+        value={note}
         renderInput={({ error: _error, ...props }) => (
           <TextField onChange={handleChange} name="content" {...props} />
         )}
@@ -93,21 +80,13 @@ function NewNote({ record, onErrorStateChange }: NewNoteArgs): React.ReactNode {
           Please note that once created, notes can be neither edited nor
           deleted.
         </Typography>
-        <Button
-          style={{ minWidth: "unset", whiteSpace: "nowrap" }}
-          disableElevation
-          disabled={
-            !record.isFieldEditable("notes") || error || note.content === ""
-          }
-          variant="contained"
-          id="add-note"
-          data-test-id="add-note-button"
-          aria-label="Add new note"
+        <ValidatingSubmitButton
+          validationResult={validate()}
           onClick={createNote}
-          color="primary"
+          loading={false}
         >
           Create note
-        </Button>
+        </ValidatingSubmitButton>
       </Stack>
     </>
   );

--- a/src/main/webapp/ui/src/components/Inputs/FormField.tsx
+++ b/src/main/webapp/ui/src/components/Inputs/FormField.tsx
@@ -294,7 +294,12 @@ export default function FormField<T>({
       role="group"
       className={className}
       fullWidth
-      error={error}
+      error={
+        error ||
+        (typeof value === "string" &&
+          typeof maxLength === "number" &&
+          value.length > maxLength)
+      }
       aria-labelledby={labelId}
       required={required}
       id={id}


### PR DESCRIPTION
## Description ##
Improve new note validation, replacing stateful logic that didn't get correctly reset with the ValidatingSubmitButton