### PR TITLE
RSDEV-760: optional logging of request processing time on web filter level

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/PerformanceLoggingInterceptor.java
+++ b/src/main/java/com/researchspace/webapp/controller/PerformanceLoggingInterceptor.java
@@ -11,7 +11,7 @@ import org.springframework.web.servlet.ModelAndView;
 /**
  * Writes details of slow requests to a log file. This is set in log4j2.xml to be 'SlowRequests.txt'
  *
- * <p>Note: If rennaming or moving to another package, log4j configuration files should also be
+ * <p>Note: If renaming or moving to another package, log4j2 configuration files should also be
  * updated.
  */
 public class PerformanceLoggingInterceptor implements HandlerInterceptor {

--- a/src/main/java/com/researchspace/webapp/filter/LocaleFilter.java
+++ b/src/main/java/com/researchspace/webapp/filter/LocaleFilter.java
@@ -10,10 +10,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.servlet.jsp.jstl.core.Config;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /** Filter to wrap request with a request including user preferred locale. */
+@Slf4j
 public class LocaleFilter extends OncePerRequestFilter {
 
   /**
@@ -31,6 +33,7 @@ public class LocaleFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain chain)
       throws IOException, ServletException {
 
+    long tStart = System.currentTimeMillis();
     String locale = request.getParameter("locale");
     Locale preferredLocale = null;
 
@@ -71,5 +74,17 @@ public class LocaleFilter extends OncePerRequestFilter {
 
     // Reset thread-bound LocaleContext.
     LocaleContextHolder.setLocaleContext(null);
+
+    /* RSDEV-760: LocaleFilter is the first of RSpace filters configured in web.xml, and measuring
+    the request processing time here, rather than e.g. in PerformanceLoggingInterceptor, may
+    sometimes give a better picture. To enable logging just uncomment the line in log4j2.xml */
+    if (log.isDebugEnabled()) {
+      long tEnd = System.currentTimeMillis();
+      String requestUrl = request.getRequestURI();
+      log.debug(
+          "It took [{}] ms to complete request to {} (as measured by LocaleFilter)",
+          tEnd - tStart,
+          requestUrl);
+    }
   }
 }

--- a/src/main/resources/log4j2-dev.xml
+++ b/src/main/resources/log4j2-dev.xml
@@ -85,6 +85,9 @@
       <AppenderRef ref="SlowRequestsLogAppender"/>
     </Logger>
 
+    <!-- for debugging some performance issues, will log request time on filter level (RSDEV-760) -->
+    <!--<Logger name="com.researchspace.webapp.filter.LocaleFilter" level="DEBUG"/>-->
+
     <Logger name="com.researchspace.service.impl.FailedEmailLogger" level="INFO">
       <AppenderRef ref="FailedEmailLogAppender"/>
     </Logger>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -138,6 +138,10 @@
       <AppenderRef ref="SlowRequestsLogAppender"/>
     </Logger>
 
+    <!-- for debugging some performance issues, will log request time on filter level (RSDEV-760) -->
+    <!--<Logger name="com.researchspace.webapp.filter.LocaleFilter" level="DEBUG"/>-->
+
+
     <!-- all appenders need to be registered here so that they can get the root logging
      folder set in at application startup -->
     <Logger name="com.researchspace.service.impl.LoggingInitializer" level="INFO">


### PR DESCRIPTION
## Description ##
RSpace by default logs slow requests into `SlowRequests.txt` log by using `PerformanceLoggingInterceptor`, but that interceptor really measures the time taken by the MVC Controller class. It seem that in some cases the total time taken by the RSpace webapp is significantly longer longer than value reported by the interceptor.

This PR adds a few additional lines that'd log time required for processing request on web filter level. To enable that additional log entries uncomment the line in `log4j2.xml`.