### PR TITLE
RSDEV-775: allow direct move of docs into owned shared notebook 

### DIFF
--- a/src/main/java/com/researchspace/service/RecordManager.java
+++ b/src/main/java/com/researchspace/service/RecordManager.java
@@ -646,5 +646,7 @@ public interface RecordManager {
    */
   boolean forceMoveDocumentToOwnerWorkspace(StructuredDocument userDoc);
 
-  boolean isSharedFolderOrSharedNotebookWithoutCreatePermssion(User user, Folder parentFolder);
+  boolean isSharedNotebookWithoutCreatePermission(User user, Folder folder);
+
+  boolean isSharedFolderOrSharedNotebookWithoutCreatePermission(User user, Folder folder);
 }

--- a/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
@@ -331,7 +331,7 @@ public class RecordManagerImpl implements RecordManager {
       parentFolder = folderDao.get(parentId);
     }
 
-    if (this.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parentFolder)) {
+    if (this.isSharedFolderOrSharedNotebookWithoutCreatePermission(user, parentFolder)) {
       log.warn(
           "The record will be created inside the root folder since the"
               + " specified one [{}] is a shared folder",
@@ -930,7 +930,7 @@ public class RecordManagerImpl implements RecordManager {
 
   private void assertCreatePermission(User user, Folder parentFolder) {
     if (!permissnUtils.isPermitted(parentFolder, PermissionType.CREATE, user)
-        && !isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parentFolder)) {
+        && !isSharedFolderOrSharedNotebookWithoutCreatePermission(user, parentFolder)) {
       throw new AuthorizationException(
           "User is not authorized to created in this folder or notebook");
     }
@@ -1366,11 +1366,16 @@ public class RecordManagerImpl implements RecordManager {
   }
 
   @Override
-  public boolean isSharedFolderOrSharedNotebookWithoutCreatePermssion(
+  public boolean isSharedNotebookWithoutCreatePermission(User user, Folder folderOrNotebook) {
+    return folderOrNotebook.isNotebook()
+        && folderOrNotebook.isShared()
+        && !permissnUtils.isPermitted(folderOrNotebook, PermissionType.CREATE, user);
+  }
+
+  @Override
+  public boolean isSharedFolderOrSharedNotebookWithoutCreatePermission(
       User user, Folder folderOrNotebook) {
     return folderOrNotebook.isSharedFolder()
-        || (folderOrNotebook.isNotebook()
-            && folderOrNotebook.isShared()
-            && !permissnUtils.isPermitted(folderOrNotebook, PermissionType.CREATE, user));
+        || isSharedNotebookWithoutCreatePermission(user, folderOrNotebook);
   }
 }

--- a/src/main/java/com/researchspace/service/impl/SharingHandlerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SharingHandlerImpl.java
@@ -97,7 +97,7 @@ public class SharingHandlerImpl implements SharingHandler {
 
   public List<RecordGroupSharing> shareIntoSharedFolderOrNotebook(
       User user, Folder sharedFolderOrNotebook, Long recordId) {
-    if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(
+    if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
         user, sharedFolderOrNotebook)) {
       ServiceOperationResultCollection<RecordGroupSharing, RecordGroupSharing> sharingResult;
       if (sharedFolderOrNotebook.isNotebook()) {

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -101,7 +101,7 @@ public class NotebookEditorController extends BaseController {
     ActionPermissionsDTO permDTO = new ActionPermissionsDTO();
     permDTO.setCreateRecord(
         permissionUtils.isPermitted(notebook, PermissionType.CREATE, user)
-            || recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, notebook));
+            || recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(user, notebook));
     // this is a quick fix, we need to hook into permissions system so that
     // shared notebook entries can't be deleted by PI/admin in the way that other shared content
     // can be deleted from shared folders

--- a/src/main/java/com/researchspace/webapp/controller/StructuredDocumentController.java
+++ b/src/main/java/com/researchspace/webapp/controller/StructuredDocumentController.java
@@ -251,7 +251,7 @@ public class StructuredDocumentController extends BaseController {
         }
         if (createdOrUpdated != null) {
           rc.add(createdOrUpdated.toRecordInfo());
-          if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(
+          if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
               user, originalParentFolder)) {
             recordShareHandler.shareIntoSharedFolderOrNotebook(
                 user, originalParentFolder, createdOrUpdated.getId());
@@ -322,7 +322,7 @@ public class StructuredDocumentController extends BaseController {
         throw new RecordAccessDeniedException(getResourceNotFoundMessage("Form", formid));
       }
       Folder originalParentFolder = folderManager.getFolder(parentRecordId, user);
-      if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(
+      if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
           user, originalParentFolder)) {
         sharedWithGroup =
             recordShareHandler.shareIntoSharedFolderOrNotebook(

--- a/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
@@ -609,7 +609,7 @@ public class WorkspaceController extends BaseController {
         moveResult = folderManager.move(recordIdToMove, target.getId(), sourceFolder.getId(), user);
       } else {
         BaseRecord baseRecordToMove = recordManager.get(recordIdToMove);
-        if (target.isNotebook() && target.isShared()) {
+        if (recordManager.isSharedNotebookWithoutCreatePermission(user, target)) {
           try {
             Group group = groupManager.getGroupFromAnyLevelOfSharedFolder(user, sourceFolder);
             SharingResult sharingResult =

--- a/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOController.java
@@ -60,7 +60,7 @@ public class ProtocolsIOController extends BaseController {
       StructuredDocument converted =
           converter.generateFromProtocol(protocol, subject, finalParentFolderId);
       results.add(converted.toRecordInfo());
-      if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(
+      if (recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
           subject, originalParentFolder)) {
         recordShareHandler.shareIntoSharedFolderOrNotebook(
             subject, originalParentFolder, converted.getId());

--- a/src/test/java/com/researchspace/service/RecordManagerTest.java
+++ b/src/test/java/com/researchspace/service/RecordManagerTest.java
@@ -1740,12 +1740,12 @@ public class RecordManagerTest extends SpringTransactionalTest {
   @Test
   public void testIsSharedFolderOrSharedNotebookWithoutCreatePermssison_whenSharedFolder() {
     // when is NOT shared folder && NOT shared notebook
-    assertFalse(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parent));
+    assertFalse(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermission(user, parent));
 
     // when is shared folder and NOT shared notebook
     parent.addType(RecordType.SHARED_FOLDER);
     Assertions.assertTrue(parent.isSharedFolder());
-    assertTrue(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parent));
+    assertTrue(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermission(user, parent));
   }
 
   @Test
@@ -1765,11 +1765,11 @@ public class RecordManagerTest extends SpringTransactionalTest {
     Assertions.assertTrue(notebook.isShared());
 
     // when is shared Notebook with CREATE permission
-    assertFalse(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, notebook));
+    assertFalse(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermission(user, notebook));
 
     logoutAndLoginAs(anotherUser);
     // when is shared Notebook and NO CREATE permission
     assertTrue(
-        recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(anotherUser, notebook));
+        recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermission(anotherUser, notebook));
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/RecordManagerStub.java
+++ b/src/test/java/com/researchspace/webapp/controller/RecordManagerStub.java
@@ -412,8 +412,12 @@ public class RecordManagerStub implements RecordManager {
   }
 
   @Override
-  public boolean isSharedFolderOrSharedNotebookWithoutCreatePermssion(
-      User user, Folder parentFolder) {
+  public boolean isSharedNotebookWithoutCreatePermission(User user, Folder folder) {
+    return true;
+  }
+
+  @Override
+  public boolean isSharedFolderOrSharedNotebookWithoutCreatePermission(User user, Folder folder) {
     return true;
   }
 

--- a/src/test/java/com/researchspace/webapp/controller/StructuredDocumentControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/StructuredDocumentControllerTest.java
@@ -594,7 +594,7 @@ public class StructuredDocumentControllerTest {
     when(permissionUtils.isRecordAccessPermitted(user, parentFolder, PermissionType.READ))
         .thenReturn(TRUE);
     whenCreatingDoc(multipart).thenReturn(created);
-    when(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parentFolder))
+    when(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermission(user, parentFolder))
         .thenReturn(false);
 
     AjaxReturnObject<List<RecordInformation>> res =
@@ -636,7 +636,7 @@ public class StructuredDocumentControllerTest {
     when(permissionUtils.isRecordAccessPermitted(user, parentFolder, PermissionType.READ))
         .thenReturn(TRUE);
     whenCreatingDoc(multipart).thenReturn(created);
-    when(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermssion(user, parentFolder))
+    when(recordMgr.isSharedFolderOrSharedNotebookWithoutCreatePermission(user, parentFolder))
         .thenReturn(true);
 
     AjaxReturnObject<List<RecordInformation>> res =

--- a/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOControllerTest.java
@@ -71,10 +71,11 @@ public class ProtocolsIOControllerTest {
 
   @Test
   public void importExternalDataOK() {
-    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(
+    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
             subject, workspaceRootFolder))
         .thenReturn(false);
-    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(subject, importsFolder))
+    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
+            subject, importsFolder))
         .thenReturn(false);
     AjaxReturnObject<ProtocolsIOController.PIOResponse> rc =
         ctrller.importExternalData(workspaceRootFolder.getId(), TransformerUtils.toList(protocol));
@@ -85,7 +86,7 @@ public class ProtocolsIOControllerTest {
 
   @Test
   public void importExternalDataIntoASharedFolder() {
-    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(subject, sharedFolder))
+    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(subject, sharedFolder))
         .thenReturn(true);
     AjaxReturnObject<ProtocolsIOController.PIOResponse> rc =
         ctrller.importExternalData(sharedFolder.getId(), TransformerUtils.toList(protocol));
@@ -97,7 +98,7 @@ public class ProtocolsIOControllerTest {
 
   @Test
   public void importExternalData_INTO_OWNED_SharedNotebook() {
-    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(
+    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
             subject, sharedNotebook))
         .thenReturn(false);
     when(permissionUtils.isPermitted(sharedNotebook, PermissionType.CREATE, subject))
@@ -112,7 +113,7 @@ public class ProtocolsIOControllerTest {
 
   @Test
   public void importExternalData_INTO_NOT_OWNED_SharedNotebook() {
-    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermssion(
+    when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
             subject, sharedNotebook))
         .thenReturn(true);
     when(permissionUtils.isPermitted(sharedNotebook, PermissionType.CREATE, subject))


### PR DESCRIPTION
Previously the check in code was assuming that if notebook is shared, the move action should try sharing into notebook. But that's not true if user has permission to directly add things into notebook (e.g. they are a notebook owner), in that case we should do normal move.

The actual code fix is just one line in `WorkspaceController` (well, plus a new method in `RecordManager` and a unit test). The rest of changeset for this PR comes from fixed typo in adjacent method name.
