### PR TITLE
RSDEV-669: allow signup of SSO users with known suffix with RSpace usernames having replacement suffix

### DIFF
--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -250,8 +250,8 @@ following to your mvn launch command:
 
 Enterprise Standalone: this is the default, no extra configuration is needed.
 
-Enterprise Institutional SSO: `-Ddeployment.sso.type=TEST -Dmock.remote.username=user -Ddeployment.standalone=false`
-(where the username is for a user already in the database)
+Enterprise Institutional SSO: `-Ddeployment.sso.type=TEST -Dmock.remote.username=<existing_username> -Ddeployment.standalone=false`
+(where `existing_username` is for a user already in the database)
 
 Community: `-Ddeployment.cloud=true`
 

--- a/DevDocs/public/RSpaceConfiguration.md
+++ b/DevDocs/public/RSpaceConfiguration.md
@@ -404,13 +404,13 @@ These optional settings will enable you to import user data from LDAP, or enable
 ### SSO configuration
 Set these properties to configure RSpace to run in SSO mode e.g. for Shibboleth integration. There may be further integration work needed with Apache headers/redirects etc. to get this working.
 * **deployment.standalone** true /false. Set to false to enable SSO integration. Default is true.
-* **deployment.sso.type** if single sign-on is configured (if deployment.standalone=false), this property must switch authentication filter to 'SAML' (default) or 'openid'.
+* **deployment.sso.type** if single sign-on is configured (if deployment.standalone=false), this property must switch authentication filter to 'SAML' or 'openid'.
 * **deployment.sso.logout.url** the URL to redirect to after logout from RSpace. Default is 'You're logged out' page.
 * **deployment.sso.idp.logout.url** the URL presented to the user on 'You're logged out' page, which should point to a link that ends the global SSO session with IDP. No default. 
-* **user.signup.acceptedDomains**  restricts self sign-up for users in SSO environments.
+* **user.signup.acceptedDomains** restricts self sign-up for users in SSO environments. Only users with a username ending with the accepted domain will be allowed to sign up, and other users will be redirected to an information page. There is no default. E.g., @uni.ac.uk.
+* **deployment.sso.signup.usernameSuffixReplacement** optional, comma-separated string pair defining SSO username suffix that should be replaced with other suffix when signing up a new RSpace user; the original SSO username will be saved as username alias
 * **deployment.sso.ssoInfoVariant** Sets a custom "RSpace doesn't know you " page when self-signup is disabled. Default is unset. Requires custom page for RSpace.
 * **deployment.sso.adminEmail** Sets the support email address for matters relating to accounts managed by SSO.
-* Only users with a username ending with the accepted domain will be allowed to sign up, and other users will be redirected to an information page. There is no default. E.g., @uni.ac.uk.
 
 #### SSO configuration - backdoor admin login functionality
 The following two properties can be enabled to allow creation and use of special System Admin backdoor account(s), i.e. accounts that work independently from SSO identity.

--- a/src/main/java/com/researchspace/webapp/controller/SignupController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SignupController.java
@@ -235,7 +235,15 @@ public class SignupController extends BaseController {
       if (!isSsoSignupAllowed(remoteUser)) {
         return returnToSignupPage(user);
       }
+
       setUsernameAndAliasFromRemoteUserInSsoMode(user, remoteUser);
+      if (user.getUsernameAlias() != null) {
+        log.info(
+            "Signing up SSO remote user '{}' with username '{}' and usernameAlias '{}'",
+            remoteUser,
+            user.getUsername(),
+            user.getUsernameAlias());
+      }
       user.setPassword(pwd);
       user.setConfirmPassword(pwd);
     }

--- a/src/main/java/com/researchspace/webapp/controller/SignupController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SignupController.java
@@ -83,6 +83,14 @@ public class SignupController extends BaseController {
   @Setter(AccessLevel.PACKAGE) // for testing
   private Boolean deploymentSsoRecodeNamesToUft8;
 
+  @Value("${deployment.sso.signup.username.suffixToReplace}")
+  @Setter(AccessLevel.PACKAGE) // for testing
+  private String deploymentSsoSignupUsernameSuffixToReplace;
+
+  @Value("${deployment.sso.signup.username.suffixReplacement}")
+  @Setter(AccessLevel.PACKAGE) // for testing
+  private String deploymentSsoSignupUsernameSuffixReplacement;
+
   public SignupController() {
     setCancelView("redirect:login");
     setSuccessView("redirect:workspace");
@@ -114,7 +122,7 @@ public class SignupController extends BaseController {
         model.setViewName("redirect:" + SSOShiroFormAuthFilterExt.SSOINFO_URL);
         return model;
       }
-      user.setUsername(remoteUser);
+      setUsernameAndAliasFromRemoteUserInSsoMode(user, remoteUser);
       // if these aren't set remotely they will set empty string.
       // if they are set, then the signup form will be pre-populated
       user.setEmail(getEmailFromRemote(request));
@@ -127,6 +135,22 @@ public class SignupController extends BaseController {
     model.addObject(user);
     model.setViewName("signup");
     return model;
+  }
+
+  protected User setUsernameAndAliasFromRemoteUserInSsoMode(User user, String remoteUser) {
+    if (StringUtils.isNotEmpty(deploymentSsoSignupUsernameSuffixToReplace)
+        && remoteUser.endsWith(deploymentSsoSignupUsernameSuffixToReplace)) {
+      /* RSDEV-669 - replace suffix in main username, set original SSO username as alias */
+      String newUsername =
+          remoteUser.substring(
+                  0, remoteUser.length() - deploymentSsoSignupUsernameSuffixToReplace.length())
+              + deploymentSsoSignupUsernameSuffixReplacement;
+      user.setUsername(newUsername);
+      user.setUsernameAlias(remoteUser);
+    } else {
+      user.setUsername(remoteUser);
+    }
+    return user;
   }
 
   private String getEmailFromRemote(HttpServletRequest req) {
@@ -211,7 +235,7 @@ public class SignupController extends BaseController {
       if (!isSsoSignupAllowed(remoteUser)) {
         return returnToSignupPage(user);
       }
-      user.setUsername(remoteUser);
+      setUsernameAndAliasFromRemoteUserInSsoMode(user, remoteUser);
       user.setPassword(pwd);
       user.setConfirmPassword(pwd);
     }

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -339,6 +339,9 @@ deployment.sso.selfDeclarePI.enabled=false
 deployment.sso.adminEmail=support@<your_server>.com
 # enables mechanism for correcting encoding of names within SSO-SAML response. See RSPAC-2209
 deployment.sso.recodeIncomingFirstNameLastNameToUtf8=true
+# enables suffix replacement for SSO usernames when signing up a new RSpace user. See RSDEV-669
+deployment.sso.signup.username.suffixToReplace=
+deployment.sso.signup.username.suffixReplacement=
 
 # openid claims used to construct unique, stable username. See RSDEV-284
 deployment.sso.openid.usernameClaim=OIDC_CLAIM_sub

--- a/src/main/resources/deployments/dev/deployment.properties
+++ b/src/main/resources/deployments/dev/deployment.properties
@@ -25,6 +25,8 @@ ui.bannerImage.loggedOutUrl=https://www.bbc.com/
 #deployment.sso.adminLogin.enabled=true
 #deployment.sso.backdoorUserCreation.enabled=true
 #deployment.sso.selfDeclarePI.enabled=true
+#deployment.sso.signup.username.suffixToReplace=#EXT#@toRemove
+#deployment.sso.signup.username.suffixReplacement=#EXT#
 #deployment.sso.idp.logout.url=https://researchspace.com
 
 onedrive.client.id=

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -102,6 +102,8 @@
       <AppenderRef ref="HttpRequestLogger"/>
     </Logger>
 
+    <Logger name="com.researchspace.webapp.controller.SignupController" level="INFO"/>
+
     <Logger name="com.researchspace.auth" level="INFO"/>
 
     <Logger name="com.researchspace.admin.service.impl.SysAdminGroupsManagerImpl" level="INFO"/>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-669.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-669.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <changeSet id="2025-08-04" context="run" author="matthias">
+        <comment>Extend User.usernameAlias column to 255 chars</comment>
+        <modifyDataType columnName="usernameAlias" newDataType="varchar(255)" tableName="User"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -148,6 +148,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-695.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-639.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-575.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-669.xml"/>
 
 
   <!--  ensure that customUpdates-changeLog.xml always runs LAST! -->

--- a/src/main/webapp/WEB-INF/pages/signup.jsp
+++ b/src/main/webapp/WEB-INF/pages/signup.jsp
@@ -175,23 +175,27 @@
         <c:set var="signup_info">
             <spring:message code="pi.signup.info"/>
         </c:set>
-        <rst:hasDeploymentProperty name="picreateGroupOnSignupEnabled" value="true">
-          <c:set var="showPiCreateGroupOnSignup" value="true" />
 
+        <rst:hasDeploymentProperty name="picreateGroupOnSignupEnabled" value="true">
+          <c:set var="allowPiCreateGroupOnSignup" value="true" />
           <rst:hasDeploymentProperty name="SSOSelfDeclarePiEnabled" value="true">
             <c:if test="${not isAllowedPiRole}">
-              <c:set var="showPiCreateGroupOnSignup" value="false"/>
+              <c:set var="allowPiCreateGroupOnSignup" value="false"/>
             </c:if>
           </rst:hasDeploymentProperty>
 
-          <c:if test="${showPiCreateGroupOnSignup}">
-            <div class="form-group col-lg-12 rs-field rs-field--input pi-create-group-on-signup">        
-              <form:checkbox id="picreateGroupOnSignup" 
-                          path="picreateGroupOnSignup"              
-                          class="form-control rs-field__input checkbox" label="${signup_info}"/>
-              <form:errors class="rs-tooltip error" path="picreateGroupOnSignup"></form:errors>
-            </div>
-          </c:if>
+          <div class="form-group col-lg-12 rs-field rs-field--input pi-create-group-on-signup">
+            <c:if test="${allowPiCreateGroupOnSignup}">
+                <form:checkbox id="picreateGroupOnSignup"
+                            path="picreateGroupOnSignup"
+                            class="form-control rs-field__input checkbox" label="${signup_info}"/>
+                <form:errors class="rs-tooltip error" path="picreateGroupOnSignup"></form:errors>
+            </c:if>
+            <c:if test="${not allowPiCreateGroupOnSignup}">
+              Based on your status at ${applicationScope['RS_DEPLOY_PROPS']['customerNameShort']},
+              you cannot become a PI unless a system administrator manually enables this for you.
+            </c:if>
+          </div>
         </rst:hasDeploymentProperty>
         
         <rst:hasDeploymentProperty name="cloud" value="true">

--- a/src/test/java/com/researchspace/webapp/controller/SignupControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SignupControllerTest.java
@@ -114,4 +114,43 @@ public class SignupControllerTest {
     assertEquals("MÃ¦ck", signupCtrller.getFirstNameFromRemote(mockIso8859Request));
     assertEquals("SchÃ¸dt-Å»Ä\u0099bski", signupCtrller.getLastNameFromRemote(mockIso8859Request));
   }
+
+  @Test
+  public void testIncomingSsoUsernameSuffixReplacement_RSDEV_669() {
+
+    // suffix deployment props not configured
+    User user =
+        signupCtrller.setUsernameAndAliasFromRemoteUserInSsoMode(new User(), "test#EXT#something");
+    assertEquals("test#EXT#something", user.getUsername());
+    assertEquals(null, user.getUsernameAlias());
+
+    // configure deployment props
+    signupCtrller.setDeploymentSsoSignupUsernameSuffixToReplace("#EXT#toReplace");
+    signupCtrller.setDeploymentSsoSignupUsernameSuffixReplacement("#EXT#replacement");
+
+    // incoming username not matching suffix replacement prop
+    user = signupCtrller.setUsernameAndAliasFromRemoteUserInSsoMode(new User(), "test#EXT#other");
+    assertEquals("test#EXT#other", user.getUsername());
+    assertEquals(null, user.getUsernameAlias());
+
+    // incoming username containing toReplace string, but not as suffix
+    user =
+        signupCtrller.setUsernameAndAliasFromRemoteUserInSsoMode(
+            new User(), "test#EXT#toReplace#EXT#other");
+    assertEquals("test#EXT#toReplace#EXT#other", user.getUsername());
+    assertEquals(null, user.getUsernameAlias());
+
+    // incoming username matching suffix replacement prop
+    user =
+        signupCtrller.setUsernameAndAliasFromRemoteUserInSsoMode(new User(), "test#EXT#toReplace");
+    assertEquals("test#EXT#replacement", user.getUsername());
+    assertEquals("test#EXT#toReplace", user.getUsernameAlias());
+
+    // chained suffix also works fine
+    user =
+        signupCtrller.setUsernameAndAliasFromRemoteUserInSsoMode(
+            new User(), "test#EXT#toReplace#EXT#toReplace");
+    assertEquals("test#EXT#toReplace#EXT#replacement", user.getUsername());
+    assertEquals("test#EXT#toReplace#EXT#toReplace", user.getUsernameAlias());
+  }
 }


### PR DESCRIPTION
## Description ##

This PR adds two new deployment properties that allow modifying RSpace username used during signup process for SSO user. If incoming SSO username has a configured suffix, then RSpace username has that suffix replaced with other configured suffix, while original SSO username is saved as `usernameAlias`. 

That change is specifically to allow registering of RSpace users in SSO environment where SSO username adds a fixed known suffix to each username. By configuring `suffixToReplace` and `suffixReplacement` properties, RSpace allows SSO users register with shorter usernames. The original SSO usernames are saved in `usernameAlias` field, which means the login flow is still operating on SSO usernames.

The PR also extends `usernameAlias` database column from 50 -> 255 chars, long SSO usernames can be registered as aliases.

Finally, the PR slightly modifies the 'signup' page, to display an explanatory message when user who signs up in SSO mode is not allowed to register as a PI.

## Testing notes
Test steps added at the end of [RSTEST-396](https://researchspace.atlassian.net/browse/RSTEST-396) scenario.
