### PR TITLE
clear playwright cache before running

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,6 +242,7 @@ pipeline {
                 echo 'Running Playwright tests'
                 dir('src/main/webapp/ui') {
                     sh 'npx playwright install'
+                    sh 'rm -r playwright/.cache'
                     sh 'npm run test-ct -- --only-changed=main'
                 }
             }
@@ -261,6 +262,7 @@ pipeline {
                 echo 'Running Playwright tests'
                 dir('src/main/webapp/ui') {
                     sh 'npx playwright install'
+                    sh 'rm -r playwright/.cache'
                     sh 'npm run test-ct'
                 }
             }


### PR DESCRIPTION
## Description ##
Clear the playwright cache before each run on Jenkins. This may have some performance hit, but it is better than the build randomly failing because the cache needs flushing
