### PR TITLE
allow opening folder with incosisten sharing status

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/FileTreeController.java
+++ b/src/main/java/com/researchspace/webapp/controller/FileTreeController.java
@@ -220,9 +220,9 @@ public class FileTreeController extends BaseController {
     User user = userManager.getUserByUsername(principal.getName());
     dir = java.net.URLDecoder.decode(dir, "UTF-8");
 
-    // if it's '/' or a group folder , we're loading for the first time and just show home folder
+    // if it's '/' or a group folder, we're loading for the first time and just show home folder
     if (initialLoad) {
-      Folder targetFolder = null;
+      Folder targetFolder;
       if ("/".equals(dir)) {
         targetFolder = folderManager.getRootFolderForUser(user);
         targetFolder.setName("Home");
@@ -230,24 +230,22 @@ public class FileTreeController extends BaseController {
         Long folderId = getFolderIdFromDir(dir);
         targetFolder = folderManager.getFolder(folderId, user);
       }
-      List<BaseRecord> rc = new ArrayList<>();
-      rc.add(targetFolder);
-      return rc;
-    } else {
-      Long targetFolderId = getFolderIdFromDir(dir);
-      RecordTypeFilter moveDialogFilter =
-          showNotebooks || showNotebooksForShare
-              ? RecordTypeFilter.MOVE_DIALOGFILTER_PLUS_NOTEBOOKS
-              : RecordTypeFilter.MOVE_DIALOGFILTER;
-      List<BaseRecord> results =
-          recordManager
-              .listFolderRecords(targetFolderId, DEFAULT_TREE_PAGINATION, moveDialogFilter)
-              .getResults();
-      if (showNotebooksForShare) {
-        filterOutNotebooksForShare(results, user);
-      }
-      return results;
+      return new ArrayList<>(List.of(targetFolder));
     }
+
+    Long targetFolderId = getFolderIdFromDir(dir);
+    RecordTypeFilter moveDialogFilter =
+        showNotebooks || showNotebooksForShare
+            ? RecordTypeFilter.MOVE_DIALOGFILTER_PLUS_NOTEBOOKS
+            : RecordTypeFilter.MOVE_DIALOGFILTER;
+    List<BaseRecord> results =
+        recordManager
+            .listFolderRecords(targetFolderId, DEFAULT_TREE_PAGINATION, moveDialogFilter)
+            .getResults();
+    if (showNotebooksForShare) {
+      filterOutNotebooksForShare(results, user);
+    }
+    return results;
   }
 
   private void filterOutNotebooksForShare(List<BaseRecord> results, User user) {

--- a/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
@@ -910,7 +910,22 @@ public class WorkspaceController extends BaseController {
     Folder parentFolder = folderManager.getFolder(parentFolderId, user);
     listFilesInFolder(settings, model, session, user, parentFolder);
     setPublicationAllowed(model, principal.getName());
+    addErrorMsgIfProblematicFolder(model, parentFolder);
     return new ModelAndView(WORKSPACE_AJAX);
+  }
+
+  private void addErrorMsgIfProblematicFolder(Model model, Folder parentFolder) {
+    // SUPPORT-526 shared folder moved outside sharing hierarchy
+    if (parentFolder.isSharedFolder() && !parentFolder.isShared()) {
+      model.addAttribute(
+          "errorMsg",
+          "The folder you're browsing seems "
+              + "to have inconsistent sharing status. Please contact your System Admin "
+              + "(citing folder ID: "
+              + parentFolder.getOid()
+              + "), or check RSpace documentation for steps to fix the folder ("
+              + "https://researchspace.helpdocs.io/article/2toicmq4iu)");
+    }
   }
 
   /** Widely used function to simply list files in a folder */

--- a/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
@@ -111,22 +111,22 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
     if (parentFolder.hasType(SHARED_GROUP_FOLDER_ROOT)) {
       movetargetRoot = parentFolder.getId() + "";
     } else if (parentFolder.hasType(SHARED_FOLDER) && !parentFolder.isNotebook()) {
-      Folder grpSharedFolder =
+      movetargetRoot =
           fMger
               .getGroupOrIndividualShrdFolderRootFromSharedSubfolder(parentFolder.getId(), usr)
-              .get();
-      movetargetRoot = grpSharedFolder.getId() + "";
+              .map(folder -> folder.getId() + "")
+              .orElse("INVALID");
     } else if (parentFolder.hasType(SHARED_FOLDER)
         && parentFolder.isNotebook()
         && previousFolderId != null) {
       // this seems redundant, we only use the ID, which we already have.
       Folder previousFolder = fMger.getFolder(previousFolderId, usr);
       // this will be a shared folder above the notebook
-      Folder grpSharedFolder =
+      movetargetRoot =
           fMger
               .getGroupOrIndividualShrdFolderRootFromSharedSubfolder(previousFolder.getId(), usr)
-              .get();
-      movetargetRoot = grpSharedFolder.getId() + "";
+              .map(folder -> folder.getId() + "")
+              .orElse("INVALID");
     } else if (parentFolder.hasAncestorOfType(TEMPLATE, true)) {
       movetargetRoot = fMger.getTemplateFolderForUser(usr).getId() + "";
     }

--- a/src/main/webapp/scripts/pages/workspace/crudops.js
+++ b/src/main/webapp/scripts/pages/workspace/crudops.js
@@ -313,6 +313,11 @@ function createMoveDialog(onmove, moveparams) {
     title: "Select target folder",
     open: function () {
       var moveTargetRoot = $("#movetargetRoot").val()
+      if (moveTargetRoot === "INVALID") {
+        apprise("Cannot calculate valid move targets for content of the current folder.");
+        $(this).dialog('close');
+        return;
+      }
       var scriptUrl = '/fileTree/ajax/directoriesInModel';
       var types = $(this).data('toMoveTypes');
       if (onlyNormalDocsOnTypesList(types)) {


### PR DESCRIPTION
This PR is a couple of minor changes around handling of shared folders that were (accidentally) moved out of Shared folder into user's Workspace:

1. changes to `WorkspacePermissionsDTOBuilder.java` / `crudops.js` mean the user can navigate into shared folder that was moved to Workspace - previously attempt to open such folder was resulting in 'no value present' exception 
2. change to `WorkspaceController.java` means the user who navigates into shared folder that was moved to Workspace get an error popup explaining they should fix that folder

Changes to `FileTreeController.java` are actually just a refactoring.


