### PR TITLE
PRT-979 Fix callToAction colour in high contrast mode

### DIFF
--- a/src/main/webapp/ui/src/accentedTheme.ts
+++ b/src/main/webapp/ui/src/accentedTheme.ts
@@ -539,28 +539,19 @@ export default function createAccentedTheme(accent: AccentColor): Theme {
               },
             },
             containedCallToAction: {
-              border: `2px solid ${
-                prefersMoreContrast
-                  ? "black"
-                  : (
-                      baseTheme.palette
-                        .callToAction as SimplePaletteColorOptions
-                    ).main
-              }`,
+              border: "none",
+              paddingTop: baseTheme.spacing(0.5),
+              paddingBottom: baseTheme.spacing(0.5),
               backgroundColor: prefersMoreContrast
                 ? "black"
                 : (baseTheme.palette.callToAction as SimplePaletteColorOptions)
                     .main,
-              color: (
-                baseTheme.palette.callToAction as SimplePaletteColorOptions
-              ).contrastText,
+              color: prefersMoreContrast
+                ? "white"
+                : (baseTheme.palette.callToAction as SimplePaletteColorOptions)
+                    .contrastText,
               "&:hover": {
-                borderColor: (
-                  baseTheme.palette.callToAction as SimplePaletteColorOptions
-                ).main,
-              },
-              [`&.${buttonClasses.disabled}`]: {
-                borderColor: darken(disabledColor, 0.1),
+                backgroundColor: prefersMoreContrast ? "black" : null,
               },
             },
             containedPrimary: {

--- a/src/main/webapp/ui/src/components/SubmitSpinnerButton.tsx
+++ b/src/main/webapp/ui/src/components/SubmitSpinnerButton.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles<{ progress: Progress }>()(
       position: "relative",
       overflow: "hidden",
     },
-  })
+  }),
 );
 
 type SubmitSpinnerButtonArgs = {

--- a/src/main/webapp/ui/src/components/ValidatingSubmitButton.story.tsx
+++ b/src/main/webapp/ui/src/components/ValidatingSubmitButton.story.tsx
@@ -6,6 +6,8 @@ import ValidatingSubmitButton, {
 } from "./ValidatingSubmitButton";
 import { ThemeProvider } from "@mui/material/styles";
 import theme from "../theme";
+import createAccentedTheme from "../accentedTheme";
+import { ACCENT_COLOR } from "../assets/branding/rspace/other";
 
 /**
  * A simple example of how to use ValidatingSubmitButton
@@ -15,9 +17,8 @@ export const SimpleExample = ({
 }: {
   onClick: () => void;
 }) => {
-  const [validationResult, setValidationResult] = useState<ValidationResult>(
-    IsValid()
-  );
+  const [validationResult, setValidationResult] =
+    useState<ValidationResult>(IsValid());
   const [loading, setLoading] = useState(false);
 
   const handleClick = () => {
@@ -61,9 +62,8 @@ export const ProgressExample = ({
 }: {
   onClick: () => void;
 }) => {
-  const [validationResult, setValidationResult] = useState<ValidationResult>(
-    IsValid()
-  );
+  const [validationResult, setValidationResult] =
+    useState<ValidationResult>(IsValid());
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState<number | undefined>(undefined);
 
@@ -102,6 +102,71 @@ export const ProgressExample = ({
           validationResult={validationResult}
           loading={loading}
           progress={progress}
+          onClick={handleClick}
+        >
+          Submit
+        </ValidatingSubmitButton>
+      </div>
+    </ThemeProvider>
+  );
+};
+
+export const HighContrastExample = ({
+  onClick = () => {},
+}: {
+  onClick: () => void;
+}) => {
+  const [validationResult, setValidationResult] =
+    useState<ValidationResult>(IsValid());
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = () => {
+    onClick();
+  };
+
+  React.useEffect(() => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = function (query) {
+      if (query === "(prefers-contrast: more)") {
+        return {
+          matches: true,
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => true,
+        };
+      }
+      return originalMatchMedia.call(this, query);
+    };
+
+    return () => {
+      window.matchMedia = originalMatchMedia;
+    };
+  }, []);
+
+  return (
+    <ThemeProvider theme={createAccentedTheme(ACCENT_COLOR)}>
+      <div style={{ padding: "20px" }}>
+        <h3>Validating Submit Button (High Contrast)</h3>
+        <div style={{ marginBottom: "10px" }}>
+          <button onClick={() => setValidationResult(IsValid())}>
+            Set Valid
+          </button>
+          <button
+            onClick={() => setValidationResult(IsInvalid("Validation failed."))}
+          >
+            Set Invalid
+          </button>
+          <button onClick={() => setLoading(!loading)}>
+            Toggle Loading ({loading ? "Off" : "On"})
+          </button>
+        </div>
+        <ValidatingSubmitButton
+          validationResult={validationResult}
+          loading={loading}
           onClick={handleClick}
         >
           Submit


### PR DESCRIPTION
## Description ##
This changes fix the issue where the buttons with the `callToAction` colour would not have sufficient contrast when the user has enabled a high contrast mode in their browser. 

In addition to fixing the issue, this change also adds a test for ValidatingSubmitButton, one of the main use cases for the `callToAction` colour that asserts that the button has sufficient contrast to meet the AAA threshold of the WCAG 2.2 standard when the browser is requesting additional contrast. This is not simple to do because the MUI Button's ripple effect normally prevents automated accessibility testing tools like axe from being able to assert the foreground and background colours as they cannot be certain what text is actually visible. As such, we remove the ripple to be able to assert the colours. 