### PR TITLE
RSDEV-755: correctly index doc-type gallery attachment when uploading new version

### DIFF
--- a/src/main/java/com/researchspace/service/impl/GroupManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/GroupManagerImpl.java
@@ -491,7 +491,8 @@ public class GroupManagerImpl implements GroupManager {
 
     Folder snippetFolder = recordManager.getGallerySubFolderForUser(Folder.SNIPPETS_FOLDER, u);
     Folder snippetSharedFolder;
-    if (snippetFolder.getSystemSubFolderByName(SHARED_SNIPPETS_FOLDER_PREFIX + Folder.SHARED_FOLDER_NAME)
+    if (snippetFolder.getSystemSubFolderByName(
+            SHARED_SNIPPETS_FOLDER_PREFIX + Folder.SHARED_FOLDER_NAME)
         == null) {
       snippetSharedFolder =
           recordFactory.createSystemCreatedFolder(

--- a/src/main/java/com/researchspace/service/impl/MediaManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/MediaManagerImpl.java
@@ -490,9 +490,8 @@ public class MediaManagerImpl implements MediaManager {
           fileStore.createAndSaveFileProperty(fileType, user, updatedFileName, inputStream);
     }
 
+    // reset doc-type attachment thumbnail to force re-generation on next request
     if (media.isEcatDocument()) {
-      indexFile(media);
-      // reset the thumbnail to force re-generation on next request
       ((EcatDocumentFile) media).setThumbNail(null);
     }
 
@@ -512,6 +511,9 @@ public class MediaManagerImpl implements MediaManager {
     media.setVersion(media.getVersion() + 1);
     recordDao.save(media);
 
+    if (media.isEcatDocument()) {
+      indexFile(media);
+    }
     updateRevisionOfLinkedDocuments(media, user);
 
     return media;

--- a/src/main/java/com/researchspace/service/impl/UserContentUpdaterImpl.java
+++ b/src/main/java/com/researchspace/service/impl/UserContentUpdaterImpl.java
@@ -30,7 +30,8 @@ public class UserContentUpdaterImpl implements UserContentUpdater {
   private void createSharedSnippetFolder(User subject) {
     Folder snippetFolder =
         recordManager.getGallerySubFolderForUser(Folder.SNIPPETS_FOLDER, subject);
-    if (snippetFolder.getSystemSubFolderByName(SHARED_SNIPPETS_FOLDER_PREFIX + Folder.SHARED_FOLDER_NAME)
+    if (snippetFolder.getSystemSubFolderByName(
+            SHARED_SNIPPETS_FOLDER_PREFIX + Folder.SHARED_FOLDER_NAME)
         == null) {
       userFolderCreator.createSharedSnippetFolder(subject, snippetFolder);
     }

--- a/src/main/java/com/researchspace/webapp/controller/FolderToDisplayInMoveDialogFilter.java
+++ b/src/main/java/com/researchspace/webapp/controller/FolderToDisplayInMoveDialogFilter.java
@@ -5,7 +5,6 @@ import com.researchspace.model.core.RecordType;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.RSPath;
-import java.util.Iterator;
 
 /**
  * Filter that does not return any record that is
@@ -38,7 +37,8 @@ public class FolderToDisplayInMoveDialogFilter implements CollectionFilter<BaseR
   private boolean isSharedFolder(BaseRecord br) {
     RSPath ownerParentHierarchy = br.getParentHierarchyForUser(br.getOwner());
     for (BaseRecord rec : ownerParentHierarchy) {
-      if (rec.isFolder() && ((Folder) rec).isTopLevelSharedFolder()
+      if (rec.isFolder()
+          && ((Folder) rec).isTopLevelSharedFolder()
           && rec.getOwner().equals(br.getOwner())) {
         return true;
       }

--- a/src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java
+++ b/src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java
@@ -90,7 +90,8 @@ public class FolderOrganisationAndApiInboxFolderTest {
         snippet.getSystemSubFolderByName(SHARED_SNIPPETS_FOLDER_PREFIX + Folder.SHARED_FOLDER_NAME);
     assertTrue(shared.isSystemFolder());
     Folder labGroup =
-        shared.getSystemSubFolderByName(SHARED_SNIPPETS_FOLDER_PREFIX + Folder.LAB_GROUPS_FOLDER_NAME);
+        shared.getSystemSubFolderByName(
+            SHARED_SNIPPETS_FOLDER_PREFIX + Folder.LAB_GROUPS_FOLDER_NAME);
     assertNotNull(labGroup);
     Folder collabGrp =
         shared.getSystemSubFolderByName(

--- a/src/test/java/com/researchspace/service/GroupManagerTest.java
+++ b/src/test/java/com/researchspace/service/GroupManagerTest.java
@@ -475,7 +475,8 @@ public class GroupManagerTest extends SpringTransactionalTest {
       User aUser, String expectedName, boolean shouldFolderExist) {
     Folder snippetFolder = recordMgr.getGallerySubFolderForUser(Folder.SNIPPETS_FOLDER, aUser);
     Folder snippetSharedFolder =
-        snippetFolder.getSystemSubFolderByName(SHARED_SNIPPETS_FOLDER_PREFIX + Folder.SHARED_FOLDER_NAME);
+        snippetFolder.getSystemSubFolderByName(
+            SHARED_SNIPPETS_FOLDER_PREFIX + Folder.SHARED_FOLDER_NAME);
     Folder snippetLabGroups =
         snippetSharedFolder.getSystemSubFolderByName(
             SHARED_SNIPPETS_FOLDER_PREFIX + Folder.LAB_GROUPS_FOLDER_NAME);


### PR DESCRIPTION
The PR moves call of `indexFile(media);` few lines down, so when method is called, the `media.fileProperty` is updated to the new property. Previously, the indexing was run with the old `fileProperty`, so subsequent search couldn't find the connected record.

The real changes are just in two classes: `MediaManagerImpl.java` and `AttachmentSearchTest.java`, other files in the PR are just a spotless formatting missing from previous merges.

