### PR TITLE
[RSDEV-819][RSDEV-823]: Fix `CREATE` button that was shown when it should have not

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3040,7 +3040,7 @@
     <jstl.version>1.1.2</jstl.version>
     <lucene.version>5.5.5</lucene.version>
     <netty.version>4.1.63.Final</netty.version>
-    <rspace-core-model.version>2.15.2</rspace-core-model.version>
+    <rspace-core-model.version>2.15.4</rspace-core-model.version>
     <servlet.version>3.1.0</servlet.version>
     <sitemesh.version>2.4.2</sitemesh.version>
     <urlrewrite.version>4.0.3</urlrewrite.version>

--- a/src/main/java/com/researchspace/api/v1/model/ApiDocumentInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiDocumentInfo.java
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
       "created",
       "lastModified",
       "parentFolderId",
-      "grandParentFolderId",
+      "grandParentId",
       "signed",
       "tags",
       "tagMetaData",
@@ -49,8 +49,8 @@ public class ApiDocumentInfo extends IdentifiableNameableApiObject {
   @JsonProperty("parentFolderId")
   private Long parentFolderId;
 
-  @JsonProperty("grandParentFolderId")
-  private Long grandParentFolderId;
+  @JsonProperty("grandParentId")
+  private Long grandParentId;
 
   @JsonProperty("signed")
   private Boolean signed = null;
@@ -76,7 +76,7 @@ public class ApiDocumentInfo extends IdentifiableNameableApiObject {
     if (authorisedSubject.equals(record.getOwner()) && record.hasParents()) {
       setParentFolderId(record.getOwnerParent().get().getId());
       if (record.getOwnerParent().get().hasParents()) {
-        setGrandParentFolderId(record.getOwnerParent().get().getOwnerParent().get().getId());
+        setGrandParentId(record.getOwnerParent().get().getOwnerParent().get().getId());
       }
     }
 

--- a/src/main/java/com/researchspace/api/v1/service/impl/RecordApiManagerImpl.java
+++ b/src/main/java/com/researchspace/api/v1/service/impl/RecordApiManagerImpl.java
@@ -66,7 +66,7 @@ public class RecordApiManagerImpl implements RecordApiManager {
     if (apiDocument.getParentFolderId() != null) {
       Folder originalParentFolder = folderManager.getFolder(apiDocument.getParentFolderId(), user);
       recordShareHandler.shareIntoSharedFolderOrNotebook(
-          user, originalParentFolder, newDocument.getId(), apiDocument.getGrandParentFolderId());
+          user, originalParentFolder, newDocument.getId(), apiDocument.getGrandParentId());
     }
     try {
       saveApiDocumentChangesToStructuredDocument(apiDocument, user, newDocument);

--- a/src/main/java/com/researchspace/model/dtos/WorkspaceListingConfig.java
+++ b/src/main/java/com/researchspace/model/dtos/WorkspaceListingConfig.java
@@ -40,7 +40,7 @@ public class WorkspaceListingConfig implements Serializable {
 
   @Getter @Setter private Long parentFolderId;
 
-  @Getter @Setter private Long grandparentFolderId;
+  @Getter @Setter private Long grandParentId;
 
   @Getter @Setter private boolean advancedSearch = false;
 

--- a/src/main/java/com/researchspace/model/dtos/WorkspaceSettings.java
+++ b/src/main/java/com/researchspace/model/dtos/WorkspaceSettings.java
@@ -68,7 +68,7 @@ public class WorkspaceSettings implements Serializable {
    * actual deletion, or an unshare. Pretty backwards way of solving that problem, would be better
    * if delete button always deleted, and maybe we added a "unshare" button to crudops menu.
    */
-  private Long grandparentFolderId;
+  private Long grandParentId;
 
   private boolean advancedSearch;
   private SearchOperator operator = SearchOperator.AND;
@@ -98,7 +98,7 @@ public class WorkspaceSettings implements Serializable {
     ontologiesFilter = workspaceListingConfig.getFilters().isOntologiesFilter();
     // search
     parentFolderId = workspaceListingConfig.getParentFolderId();
-    grandparentFolderId = workspaceListingConfig.getParentFolderId();
+    grandParentId = workspaceListingConfig.getParentFolderId();
     advancedSearch = workspaceListingConfig.isAdvancedSearch();
     operator = workspaceListingConfig.getOperator();
     notebookFilter = workspaceListingConfig.isNotebookFilter();

--- a/src/main/java/com/researchspace/service/FolderManager.java
+++ b/src/main/java/com/researchspace/service/FolderManager.java
@@ -227,24 +227,24 @@ public interface FolderManager {
    * hierarchy.
    * <p>
    * If the {@code parentSharedFolderId} is a shared Notebook, the method needs to know also the
-   * {@code grandParentFolderId} in order to locate the specific group/individual root folder,
+   * {@code grandParentId} in order to locate the specific group/individual root folder,
    * otherwise it raises a NotebookInvalidLocationException
    *
    * @param parentSharedFolderOrNotebookId is the ID of the folder/notebook where the record is
    *                                       located
-   * @param grandParentFolderId            is the ID of the parent folder where the main folder
+   * @param grandParentId            is the ID of the parent folder where the main folder
    *                                       {@code parentSharedFolderId} is located. This parameter
    *                                       is mandatory when
    *                                       {@code parentSharedFolderOrNotebookId) is a shared
    *                                       Notebook
    * @param user                           The authenticated user
    * @return The ROOT shared group folder, or <code>Optional.empty</code> if this couldn't be found.
-   * @throws NotebookInvalidLocationException if the {@code grandParentFolderId} id is not passed
+   * @throws NotebookInvalidLocationException if the {@code grandParentId} id is not passed
    *                                          when the {@code parentSharedFolderOrNotebookId} is a
    *                                          Notebook
    */
   Optional<Folder> getGroupOrIndividualShrdFolderRootFromSharedSubfolder(
-      Long parentSharedFolderOrNotebookId, Long grandParentFolderId, User user);
+      Long parentSharedFolderOrNotebookId, Long grandParentId, User user);
 
   boolean isFolderInSharedTree(Folder folderOrNotebook, Long parentId, User usr);
 

--- a/src/main/java/com/researchspace/service/FolderManager.java
+++ b/src/main/java/com/researchspace/service/FolderManager.java
@@ -246,6 +246,8 @@ public interface FolderManager {
   Optional<Folder> getGroupOrIndividualShrdFolderRootFromSharedSubfolder(
       Long parentSharedFolderOrNotebookId, Long grandParentFolderId, User user);
 
+  boolean isParentFolderInSharedTree(Folder parentFolder, Long grandParentId, User usr);
+
   /**
    * Ease of use method returns the root record always
    *

--- a/src/main/java/com/researchspace/service/FolderManager.java
+++ b/src/main/java/com/researchspace/service/FolderManager.java
@@ -246,7 +246,7 @@ public interface FolderManager {
   Optional<Folder> getGroupOrIndividualShrdFolderRootFromSharedSubfolder(
       Long parentSharedFolderOrNotebookId, Long grandParentFolderId, User user);
 
-  boolean isParentFolderInSharedTree(Folder parentFolder, Long grandParentId, User usr);
+  boolean isFolderInSharedTree(Folder folderOrNotebook, Long parentId, User usr);
 
   /**
    * Ease of use method returns the root record always

--- a/src/main/java/com/researchspace/service/impl/FolderManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/FolderManagerImpl.java
@@ -199,6 +199,19 @@ public class FolderManagerImpl implements FolderManager {
         || br.hasType(RecordType.INDIVIDUAL_SHARED_FOLDER_ROOT);
   }
 
+  @Override
+  public boolean isParentFolderInSharedTree(Folder parentFolder, Long grandParentId, User usr) {
+    boolean isParentFolderInSharedTree = false;
+    if (parentFolder.isNotebook()) {
+      Folder grandParentFolder = this.getFolder(grandParentId, usr);
+      isParentFolderInSharedTree = grandParentFolder.isSharedFolder();
+    } else {
+      isParentFolderInSharedTree = parentFolder.isSharedFolder();
+    }
+    return isParentFolderInSharedTree;
+  }
+
+  @Override
   public Notebook getNotebook(Long notebookid) {
     Notebook notebook = (Notebook) folderDao.get(notebookid);
     long count =

--- a/src/main/java/com/researchspace/service/impl/FolderManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/FolderManagerImpl.java
@@ -200,13 +200,13 @@ public class FolderManagerImpl implements FolderManager {
   }
 
   @Override
-  public boolean isParentFolderInSharedTree(Folder parentFolder, Long grandParentId, User usr) {
+  public boolean isFolderInSharedTree(Folder folderOrNotebook, Long parentId, User usr) {
     boolean isParentFolderInSharedTree = false;
-    if (parentFolder.isNotebook()) {
-      Folder grandParentFolder = this.getFolder(grandParentId, usr);
+    if (folderOrNotebook.isNotebook()) {
+      Folder grandParentFolder = this.getFolder(parentId, usr);
       isParentFolderInSharedTree = grandParentFolder.isSharedFolder();
     } else {
-      isParentFolderInSharedTree = parentFolder.isSharedFolder();
+      isParentFolderInSharedTree = folderOrNotebook.isSharedFolder();
     }
     return isParentFolderInSharedTree;
   }

--- a/src/main/java/com/researchspace/service/impl/FolderManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/FolderManagerImpl.java
@@ -171,16 +171,16 @@ public class FolderManagerImpl implements FolderManager {
 
   @Override
   public Optional<Folder> getGroupOrIndividualShrdFolderRootFromSharedSubfolder(
-      Long parentId, Long grandParentFolderId, User user) {
+      Long parentId, Long grandParentId, User user) {
     Folder src = folderDao.get(parentId);
     if (src.isNotebook() && src.isShared()) {
-      if (grandParentFolderId == null) {
+      if (grandParentId == null) {
         throw new IllegalStateException(
             "Cannot infer shared context for Notebook with ID=["
                 + parentId
-                + "], as \"grandParentFolderId\" param is not set");
+                + "], as \"grandParentId\" param is not set");
       }
-      src = folderDao.get(grandParentFolderId);
+      src = folderDao.get(grandParentId);
     }
     Folder target = folderDao.getUserSharedFolder(user);
     RSPath path =

--- a/src/main/java/com/researchspace/service/impl/RecordDeletionManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordDeletionManagerImpl.java
@@ -94,7 +94,7 @@ public class RecordDeletionManagerImpl implements RecordDeletionManager {
   @Builder
   public static class DeletionSettings {
 
-    private Long grandParentFolderId;
+    private Long grandParentId;
     private boolean notebookEntryDeletion;
     private Folder parent;
     private UserSessionTracker currentUsers;
@@ -128,7 +128,7 @@ public class RecordDeletionManagerImpl implements RecordDeletionManager {
             if (context.isNotebookEntryDeletion()) {
               log.info("deleting notebook entry");
               recordDeletionResult =
-                  deleteEntry(context.getGrandParentFolderId(), parentFolderId, id, user);
+                  deleteEntry(context.getGrandParentId(), parentFolderId, id, user);
             } else {
               recordDeletionResult = deleteRecord(parentFolderId, id, user);
             }

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -1,5 +1,7 @@
 package com.researchspace.webapp.controller;
 
+import static com.researchspace.model.core.RecordType.INDIVIDUAL_SHARED_FOLDER_ROOT;
+import static com.researchspace.model.core.RecordType.SHARED_GROUP_FOLDER_ROOT;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.allGroupsAllowBioOntologies;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.anyGroupEnforcesOntologies;
 
@@ -98,10 +100,14 @@ public class NotebookEditorController extends BaseController {
       }
     }
 
+    boolean isNotebookInSharedTree =
+        notebook.hasAncestorOfType(INDIVIDUAL_SHARED_FOLDER_ROOT, true)
+            || notebook.hasAncestorOfType(SHARED_GROUP_FOLDER_ROOT, true);
+
     ActionPermissionsDTO permDTO = new ActionPermissionsDTO();
     permDTO.setCreateRecord(
-        permissionUtils.isPermitted(notebook, PermissionType.CREATE, user)
-            || recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(user, notebook));
+        isNotebookInSharedTree
+            && permissionUtils.isPermitted(notebook, PermissionType.CREATE, user));
     // this is a quick fix, we need to hook into permissions system so that
     // shared notebook entries can't be deleted by PI/admin in the way that other shared content
     // can be deleted from shared folders

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -107,7 +107,7 @@ public class NotebookEditorController extends BaseController {
 
     ActionPermissionsDTO permDTO = new ActionPermissionsDTO();
     permDTO.setCreateRecord(
-        folderManager.isParentFolderInSharedTree(notebook, grandParentId, user)
+        folderManager.isFolderInSharedTree(notebook, grandParentId, user)
             && permissionUtils.isPermitted(notebook, PermissionType.WRITE, user));
     // this is a quick fix, we need to hook into permissions system so that
     // shared notebook entries can't be deleted by PI/admin in the way that other shared content

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -99,13 +99,11 @@ public class NotebookEditorController extends BaseController {
       }
     }
 
-    //    Long grandParentId =
-    //        ((Breadcrumb) model.getAttribute("bcrumb"))
-    //            .getElements()
-    //            .get(((Breadcrumb) model.getAttribute("bcrumb")).getElements().size() - 2)
-    //            .getId();
 
     ActionPermissionsDTO permDTO = new ActionPermissionsDTO();
+    if(grandParentId == null){
+      grandParentId = notebook.getParent().getId();
+    }
     permDTO.setCreateRecord(
         folderManager.isFolderInSharedTree(notebook, grandParentId, user)
             && permissionUtils.isPermitted(notebook, PermissionType.WRITE, user));

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -69,7 +69,7 @@ public class NotebookEditorController extends BaseController {
       @PathVariable("notebookId") Long notebookId,
       @RequestParam(value = "initialRecordToDisplay", required = false) Long entryId,
       @RequestParam(value = "settingsKey", required = false) String settingsKey,
-      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
+      @RequestParam(value = "grandParentId") Long grandParentId,
       Model model,
       HttpSession session,
       Principal principal)
@@ -147,14 +147,9 @@ public class NotebookEditorController extends BaseController {
             (showWholeNotebook ? notebook : entryToShow), PermissionType.WRITE, user));
 
     Folder rootRecord = folderManager.getRootFolderForUser(user);
-    WorkspaceListingConfig cfg = null;
     Folder notebookparent = null;
-    if (isValidSettingsKey(settingsKey)
-        && (cfg = (WorkspaceListingConfig) session.getAttribute(settingsKey)) != null) {
-      Long grandparentId = cfg.getGrandparentFolderId();
-      if (grandparentId != null) {
-        notebookparent = folderManager.getFolder(grandparentId, user);
-      }
+    if (isValidSettingsKey(settingsKey)) {
+      notebookparent = folderManager.getFolder(grandParentId, user);
     }
     Breadcrumb bcrumb =
         breadcrumbGenerator.generateBreadcrumbToHome(

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -9,7 +9,6 @@ import com.researchspace.model.User;
 import com.researchspace.model.audittrail.AuditAction;
 import com.researchspace.model.audittrail.GenericEvent;
 import com.researchspace.model.dtos.FormMenu;
-import com.researchspace.model.dtos.WorkspaceListingConfig;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.preference.Preference;
 import com.researchspace.model.record.Breadcrumb;
@@ -107,7 +106,7 @@ public class NotebookEditorController extends BaseController {
         throw new IllegalStateException(
             "Cannot infer shared context for Notebook with ID=["
                 + notebook.getId()
-                + "], as \"grandParentFolderId\" param is not set");
+                + "], as \"grandParentId\" param is not set");
       }
     }
     permDTO.setCreateRecord(

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -68,7 +68,7 @@ public class NotebookEditorController extends BaseController {
       @PathVariable("notebookId") Long notebookId,
       @RequestParam(value = "initialRecordToDisplay", required = false) Long entryId,
       @RequestParam(value = "settingsKey", required = false) String settingsKey,
-      @RequestParam(value = "grandParentId") Long grandParentId,
+      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
       Model model,
       HttpSession session,
       Principal principal)
@@ -100,8 +100,8 @@ public class NotebookEditorController extends BaseController {
 
     ActionPermissionsDTO permDTO = new ActionPermissionsDTO();
     if (grandParentId == null) {
-      if (notebook.getParent() != null) {
-        grandParentId = notebook.getParent().getId();
+      if (notebook.getOwnerOrSharedParentForUser(user).isPresent()) {
+        grandParentId = notebook.getOwnerOrSharedParentForUser(user).get().getId();
       } else {
         throw new IllegalStateException(
             "Cannot infer shared context for Notebook with ID=["

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -99,10 +99,16 @@ public class NotebookEditorController extends BaseController {
       }
     }
 
-
     ActionPermissionsDTO permDTO = new ActionPermissionsDTO();
-    if(grandParentId == null){
-      grandParentId = notebook.getParent().getId();
+    if (grandParentId == null) {
+      if (notebook.getParent() != null) {
+        grandParentId = notebook.getParent().getId();
+      } else {
+        throw new IllegalStateException(
+            "Cannot infer shared context for Notebook with ID=["
+                + notebook.getId()
+                + "], as \"grandParentFolderId\" param is not set");
+      }
     }
     permDTO.setCreateRecord(
         folderManager.isFolderInSharedTree(notebook, grandParentId, user)

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -1,7 +1,5 @@
 package com.researchspace.webapp.controller;
 
-import static com.researchspace.model.core.RecordType.INDIVIDUAL_SHARED_FOLDER_ROOT;
-import static com.researchspace.model.core.RecordType.SHARED_GROUP_FOLDER_ROOT;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.allGroupsAllowBioOntologies;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.anyGroupEnforcesOntologies;
 
@@ -71,6 +69,7 @@ public class NotebookEditorController extends BaseController {
       @PathVariable("notebookId") Long notebookId,
       @RequestParam(value = "initialRecordToDisplay", required = false) Long entryId,
       @RequestParam(value = "settingsKey", required = false) String settingsKey,
+      @RequestParam(value = "grandParentId") Long grandParentId,
       Model model,
       HttpSession session,
       Principal principal)
@@ -100,14 +99,16 @@ public class NotebookEditorController extends BaseController {
       }
     }
 
-    boolean isNotebookInSharedTree =
-        notebook.hasAncestorOfType(INDIVIDUAL_SHARED_FOLDER_ROOT, true)
-            || notebook.hasAncestorOfType(SHARED_GROUP_FOLDER_ROOT, true);
+    //    Long grandParentId =
+    //        ((Breadcrumb) model.getAttribute("bcrumb"))
+    //            .getElements()
+    //            .get(((Breadcrumb) model.getAttribute("bcrumb")).getElements().size() - 2)
+    //            .getId();
 
     ActionPermissionsDTO permDTO = new ActionPermissionsDTO();
     permDTO.setCreateRecord(
-        isNotebookInSharedTree
-            && permissionUtils.isPermitted(notebook, PermissionType.CREATE, user));
+        folderManager.isParentFolderInSharedTree(notebook, grandParentId, user)
+            && permissionUtils.isPermitted(notebook, PermissionType.WRITE, user));
     // this is a quick fix, we need to hook into permissions system so that
     // shared notebook entries can't be deleted by PI/admin in the way that other shared content
     // can be deleted from shared folders

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -111,8 +111,9 @@ public class NotebookEditorController extends BaseController {
       }
     }
     permDTO.setCreateRecord(
-        folderManager.isFolderInSharedTree(notebook, grandParentId, user)
-            && permissionUtils.isPermitted(notebook, PermissionType.WRITE, user));
+        user.equals(notebook.getOwner())
+            || (folderManager.isFolderInSharedTree(notebook, grandParentId, user)
+                && permissionUtils.isPermitted(notebook, PermissionType.WRITE, user)));
     // this is a quick fix, we need to hook into permissions system so that
     // shared notebook entries can't be deleted by PI/admin in the way that other shared content
     // can be deleted from shared folders

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -69,7 +69,7 @@ public class NotebookEditorController extends BaseController {
       @PathVariable("notebookId") Long notebookId,
       @RequestParam(value = "initialRecordToDisplay", required = false) Long entryId,
       @RequestParam(value = "settingsKey", required = false) String settingsKey,
-      @RequestParam(value = "grandParentId") Long grandParentId,
+      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
       Model model,
       HttpSession session,
       Principal principal)

--- a/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
@@ -420,12 +420,12 @@ public class WorkspaceController extends BaseController {
               user, originalParentFolder, newNotebookId, grandParentId);
     }
 
-    return getNotebookRedirectUrl(newNotebookId, sharedWithGroup);
+    return getNotebookRedirectUrl(newNotebookId, grandParentId, sharedWithGroup);
   }
 
   @NotNull
   private static String getNotebookRedirectUrl(
-      Long newNotebookId, List<RecordGroupSharing> sharedWithGroup) {
+      Long newNotebookId, Long grandParentId, List<RecordGroupSharing> sharedWithGroup) {
     String redirectUrl = "redirect:/notebookEditor/" + newNotebookId;
     if (!(sharedWithGroup == null || sharedWithGroup.isEmpty())) {
       redirectUrl +=
@@ -433,7 +433,7 @@ public class WorkspaceController extends BaseController {
               + URLEncoder.encode(
                   sharedWithGroup.get(0).getSharee().getDisplayName(), StandardCharsets.UTF_8);
     }
-    return redirectUrl;
+    return redirectUrl + "?grandParentId=" + grandParentId;
   }
 
   @PostMapping("/ajax/createNotebook")

--- a/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
@@ -295,7 +295,7 @@ public class WorkspaceController extends BaseController {
       throws IOException {
 
     WorkspaceListingConfig cfg = null;
-    Long grandparentFolderId = workspaceSettings.getParentFolderId();
+    Long grandParentId = workspaceSettings.getParentFolderId();
 
     // if we have a settings key, then we use that to configure workspace reload
     if (isValidSettingsKey(settingsKey)
@@ -312,7 +312,7 @@ public class WorkspaceController extends BaseController {
                 cfg.getPgCrit(),
                 cfg.getCurrentViewMode(),
                 user,
-                grandparentFolderId));
+                grandParentId));
       }
 
       model.addAttribute("settingsKey", settingsKey);
@@ -329,11 +329,11 @@ public class WorkspaceController extends BaseController {
               workspaceSettings.createPaginationCriteria(),
               workspaceSettings.getCurrentViewMode(),
               user,
-              grandparentFolderId));
+              grandParentId));
 
       workspaceSettings.setParentFolderId(folder.getId());
       cfg = new WorkspaceListingConfig(workspaceSettings);
-      cfg.setGrandparentFolderId(grandparentFolderId);
+      cfg.setGrandParentId(grandParentId);
       addWorkspaceConfigToSessionAndKeyModel(cfg, model, session);
       model.addAttribute("workspaceConfigJson", workspaceSettings.toJson());
     }
@@ -618,7 +618,7 @@ public class WorkspaceController extends BaseController {
           try {
             Group group =
                 groupManager.getGroupFromAnyLevelOfSharedFolder(
-                    user, sourceFolder, settings.getGrandparentFolderId());
+                    user, sourceFolder, settings.getGrandParentId());
             SharingResult sharingResult =
                 recordShareHandler.moveIntoSharedNotebook(
                     group, baseRecordToMove, (Notebook) target);
@@ -703,7 +703,7 @@ public class WorkspaceController extends BaseController {
             RS_DELETE_RECORD_PROGRESS, toDelete.length * 10, "Deleting records", session);
     DeletionSettings delContext =
         DeletionSettings.builder()
-            .grandParentFolderId(settings.getGrandparentFolderId())
+            .grandParentId(settings.getGrandParentId())
             .notebookEntryDeletion(isNotebookEntryDeletion)
             .parent(parent)
             .currentUsers(users)
@@ -715,7 +715,7 @@ public class WorkspaceController extends BaseController {
 
     if (isNotebookEntryDeletion) {
       /* let's set up proper grandparent for listFilesInFolder (RSPAC-991) */
-      settings.setParentFolderId(settings.getGrandparentFolderId());
+      settings.setParentFolderId(settings.getGrandParentId());
     }
     if (parent == null) {
       parent =
@@ -952,10 +952,10 @@ public class WorkspaceController extends BaseController {
           user,
           settings.getParentFolderId());
 
-      Long grandparentFolderId = settings.getParentFolderId();
+      Long grandParentId = settings.getParentFolderId();
       settings.setParentFolderId(parentFolder.getId()); // update with new parent id
       WorkspaceListingConfig config = new WorkspaceListingConfig(settings);
-      config.setGrandparentFolderId(grandparentFolderId);
+      config.setGrandParentId(grandParentId);
       addWorkspaceConfigToSessionAndKeyModel(config, model, session);
 
     } else {

--- a/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
@@ -418,6 +418,9 @@ public class WorkspaceController extends BaseController {
       sharedWithGroup =
           recordShareHandler.shareIntoSharedFolderOrNotebook(
               user, originalParentFolder, newNotebookId, grandParentId);
+      grandParentId = grandParentId != null ? grandParentId : originalParentFolder.getId();
+    } else {
+      grandParentId = grandParentId != null ? grandParentId : targetFolderId;
     }
 
     return getNotebookRedirectUrl(newNotebookId, grandParentId, sharedWithGroup);
@@ -432,6 +435,7 @@ public class WorkspaceController extends BaseController {
           "?sharedWithGroup="
               + URLEncoder.encode(
                   sharedWithGroup.get(0).getSharee().getDisplayName(), StandardCharsets.UTF_8);
+      return redirectUrl + "&grandParentId=" + grandParentId;
     }
     return redirectUrl + "?grandParentId=" + grandParentId;
   }

--- a/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
@@ -60,7 +60,7 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
     boolean isParentFolderInSharedTree = false;
     if (parentFolder.isNotebook()) {
       if (model.getAttribute("bcrumb") != null
-          && !((Breadcrumb) model.getAttribute("bcrumb")).getElements().isEmpty()) {
+          && ((Breadcrumb) model.getAttribute("bcrumb")).getElements().size() > 1) {
         Long grandParentId =
             ((Breadcrumb) model.getAttribute("bcrumb"))
                 .getElements()

--- a/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
@@ -31,9 +31,7 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
   private FolderManager fMger;
   private RecordManager recMgr;
 
-  @Getter
-  @Setter
-  private @Autowired IPermissionUtils permissionUtils;
+  @Getter @Setter private @Autowired IPermissionUtils permissionUtils;
 
   @Autowired
   public void setRecMgr(RecordManager recMgr) {
@@ -61,18 +59,18 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
 
     boolean isParentFolderInSharedTree = false;
     if (parentFolder.isNotebook()) {
-      if (model.getAttribute("bcrumb") != null &&
-          !((Breadcrumb) model.getAttribute("bcrumb")).getElements().isEmpty()) {
+      if (model.getAttribute("bcrumb") != null
+          && !((Breadcrumb) model.getAttribute("bcrumb")).getElements().isEmpty()) {
         Long grandParentId =
             ((Breadcrumb) model.getAttribute("bcrumb"))
                 .getElements()
                 .get(((Breadcrumb) model.getAttribute("bcrumb")).getElements().size() - 2)
                 .getId();
-        isParentFolderInSharedTree =
-            fMger.isFolderInSharedTree(parentFolder, grandParentId, usr);
+        isParentFolderInSharedTree = fMger.isFolderInSharedTree(parentFolder, grandParentId, usr);
       } else {
-        log.warn("it was not possible to get Breadcumbs from the model for notebookID="
-            + parentFolder.getId());
+        log.warn(
+            "it was not possible to get Breadcumbs from the model for notebookID="
+                + parentFolder.getId());
       }
     }
 
@@ -92,7 +90,7 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
             !br.isMediaRecord()
                 && !br.isSnippet()
                 && recMgr.canMove(
-                br, parentFolder, usr); // manager transaction as may need to query db
+                    br, parentFolder, usr); // manager transaction as may need to query db
         if (isSearch) {
           move = move && usr.isOwnerOfRecord(br);
         }
@@ -121,7 +119,7 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
       createRecord =
           createRecord
               || (isParentFolderInSharedTree
-              && permissionUtils.isPermitted(parentFolder, PermissionType.WRITE, usr));
+                  && permissionUtils.isPermitted(parentFolder, PermissionType.WRITE, usr));
       dto.setCreateRecord(createRecord);
       dto.setCreateFolder(false);
     }

--- a/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
@@ -9,6 +9,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.record.BaseRecord;
+import com.researchspace.model.record.Breadcrumb;
 import com.researchspace.model.record.Folder;
 import com.researchspace.service.FolderManager;
 import com.researchspace.service.RecordManager;
@@ -54,9 +55,20 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
     boolean createFolder =
         parentFolder.getSharingACL().isPermitted(usr, PermissionType.CREATE_FOLDER);
 
-    boolean isParentFolderInSharedTree =
-        parentFolder.hasAncestorOfType(INDIVIDUAL_SHARED_FOLDER_ROOT, true)
-            || parentFolder.hasAncestorOfType(SHARED_GROUP_FOLDER_ROOT, true);
+    boolean isParentFolderInSharedTree = false;
+    if (parentFolder.isNotebook()) {
+      Folder grandParentFolder =
+          fMger.getFolder(
+              ((Breadcrumb) model.getAttribute("bcrumb"))
+                  .getElements()
+                  .get(((Breadcrumb) model.getAttribute("bcrumb")).getElements().size() - 2)
+                  .getId(),
+              usr);
+      isParentFolderInSharedTree = grandParentFolder.isSharedFolder();
+    } else {
+      isParentFolderInSharedTree = parentFolder.isSharedFolder();
+    }
+
     ActionPermissionsDTO dto = new ActionPermissionsDTO();
     if (records != null) {
       // allowed options per record in page.

--- a/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
@@ -4,7 +4,6 @@ import static com.researchspace.model.core.RecordType.INDIVIDUAL_SHARED_FOLDER_R
 import static com.researchspace.model.core.RecordType.SHARED_FOLDER;
 import static com.researchspace.model.core.RecordType.SHARED_GROUP_FOLDER_ROOT;
 import static com.researchspace.model.core.RecordType.TEMPLATE;
-import static com.researchspace.model.core.RecordType.isNotebook;
 
 import com.researchspace.model.User;
 import com.researchspace.model.permissions.IPermissionUtils;
@@ -70,7 +69,7 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
                 .get(((Breadcrumb) model.getAttribute("bcrumb")).getElements().size() - 2)
                 .getId();
         isParentFolderInSharedTree =
-            fMger.isParentFolderInSharedTree(parentFolder, grandParentId, usr);
+            fMger.isFolderInSharedTree(parentFolder, grandParentId, usr);
       } else {
         log.warn("it was not possible to get Breadcumbs from the model for notebookID="
             + parentFolder.getId());

--- a/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilder.java
@@ -57,16 +57,13 @@ public class WorkspacePermissionsDTOBuilder implements IWorkspacePermissionsDTOB
 
     boolean isParentFolderInSharedTree = false;
     if (parentFolder.isNotebook()) {
-      Folder grandParentFolder =
-          fMger.getFolder(
-              ((Breadcrumb) model.getAttribute("bcrumb"))
-                  .getElements()
-                  .get(((Breadcrumb) model.getAttribute("bcrumb")).getElements().size() - 2)
-                  .getId(),
-              usr);
-      isParentFolderInSharedTree = grandParentFolder.isSharedFolder();
-    } else {
-      isParentFolderInSharedTree = parentFolder.isSharedFolder();
+      Long grandParentId =
+          ((Breadcrumb) model.getAttribute("bcrumb"))
+              .getElements()
+              .get(((Breadcrumb) model.getAttribute("bcrumb")).getElements().size() - 2)
+              .getId();
+      isParentFolderInSharedTree =
+          fMger.isParentFolderInSharedTree(parentFolder, grandParentId, usr);
     }
 
     ActionPermissionsDTO dto = new ActionPermissionsDTO();

--- a/src/main/webapp/WEB-INF/tags/record_editor_link.tag
+++ b/src/main/webapp/WEB-INF/tags/record_editor_link.tag
@@ -27,8 +27,8 @@
 	<c:when test="${record.structuredDocument}">
 		<c:choose>
 			<c:when test="${record.notebookEntry and not empty parentType and parentType eq 'NOTEBOOK'}">
-				<c:url value='/notebookEditor/${recordId}?initialRecordToDisplay=${record.id}&settingsKey=${settingsKey}'
-					var="notebookentryLink" />
+				<c:url value='/notebookEditor/${recordId}?initialRecordToDisplay=${record.id}&settingsKey=${settingsKey}&grandParentId=${bcrumb.getFolderId()}'
+					var="notebookentryLink"/>
 
 				<a id="structuredDocument_${record.id}" class="structuredDocument recordNameCell"
 					href="${notebookentryLink}" title="${record.name}">${visibleRecordName}</a>

--- a/src/main/webapp/WEB-INF/tags/record_icon.tag
+++ b/src/main/webapp/WEB-INF/tags/record_icon.tag
@@ -118,7 +118,7 @@
 <c:choose>
     <c:when test="${record.notebook}">
   	    <%-- This opens the notebook directly in Notebook view --%>
-		<a data-id="${record.id}" class="notebook" href="<c:url value='/notebookEditor/${record.id}?settingsKey=${settingsKey}'/>">
+		<a data-id="${record.id}" class="notebook" href="<c:url value='/notebookEditor/${record.id}?settingsKey=${settingsKey}&grandParentId=${bcrumb.getFolderId()}'/>">
 			 <img src="<c:url value='${src}'/>" alt="${alt}" title="${alt}" height="${imgHeight}" width="${imgWidth}" data-type="${type}"/>
 		</a>
     </c:when>

--- a/src/main/webapp/resources/rspace_api_specs_1_115_0.yaml
+++ b/src/main/webapp/resources/rspace_api_specs_1_115_0.yaml
@@ -254,7 +254,7 @@ paths:
         ## Rules for parsing POST request body
 
         Provided request body must match #definitions/Document model (see the
-        bottom of the page). Only `name`, `tags`, `form`, `parentFolderId`, `grandParentFolderId` and
+        bottom of the page). Only `name`, `tags`, `form`, `parentFolderId`, `grandParentId` and
         `fields` properties are processed, other properties are skipped.
 
         ### When parsing `name` and `tags` properties:
@@ -274,10 +274,10 @@ paths:
           * The folder ID must be the id of a folder in the Workspace, *not* a Gallery folder or a subfolder of the 'Shared' folder.
           * If no folderID is provided, document will be created in 'ApiInbox' folder.
 
-        ### When parsing `grandParentFolderId` property (only needed for shared Notebooks):
+        ### When parsing `grandParentId` property (only needed for shared Notebooks):
 
           * The grand parent folder ID must be the id of the parent of the shared notebook you want to create the document into.
-          * If no `grandParentFolderId` is provided when creating a document into a shared notebook, the creation fails.
+          * If no `grandParentId` is provided when creating a document into a shared notebook, the creation fails.
 
         ### When parsing `fields` array:
           * `fields` array may be omitted - that will create document without any content.

--- a/src/main/webapp/scripts/global.js
+++ b/src/main/webapp/scripts/global.js
@@ -2542,11 +2542,12 @@ RS.getVersionIdFromGlobalId = function (globalId) {
 }
 
 /* Returns URL to view a document */
-function getDocumentViewUrl(notebookId, recordId, withSettingsKey) {
+function getDocumentViewUrl(notebookId, recordId, grandParentId, withSettingsKey) {
   if (notebookId) {
     return "/notebookEditor/" + notebookId +
-      (recordId ? "?initialRecordToDisplay=" + recordId : "") +
-      (withSettingsKey ? "&settingsKey=" + settingsKey : "");
+        (grandParentId ? "?grandParentId=" + grandParentId : "") +
+        (recordId ? "&initialRecordToDisplay=" + recordId : "") +
+        (withSettingsKey ? "&settingsKey=" + settingsKey : "");
   } else {
     return "/workspace/editor/structuredDocument/" + recordId +
       (withSettingsKey ? "?settingsKey=" + settingsKey : "");

--- a/src/main/webapp/scripts/pages/notebookEditor.js
+++ b/src/main/webapp/scripts/pages/notebookEditor.js
@@ -48,10 +48,7 @@ function editEntryHandler(e) {
 }
 
 function updateEntryNameInBreadcrumbs(entryId, entryName) {
-  /* FIXME: this is too simplistic, in case of shared entries the parent notebook is not visible at all.
-    * also particular entries may be shared into various locations of a Shared folder */
-
-  // reset breadcrumbs to notebook level 
+  // reset breadcrumbs to notebook level
   RS.addBreadcrumbAndRefresh("editorBcrumb", "" + notebookId, notebookName);
   // add breadcrumb for notebook entry
   RS.addBreadcrumbAndRefresh("editorBcrumb", "" + entryId, RS.escapeHtml(entryName));

--- a/src/main/webapp/scripts/pages/workspace/editor/documentView.js
+++ b/src/main/webapp/scripts/pages/workspace/editor/documentView.js
@@ -240,6 +240,15 @@ function _scanAllTextFieldsForAttachments() {
   }
 }
 
+function getGrandParentFolderId() {
+  const breadcrumbs = [...document.getElementsByClassName("breadcrumbLink")];
+  const grandParent = breadcrumbs[breadcrumbs.length - 2]
+  if(grandParent === undefined){
+    return null;
+  }
+  return grandParent.getAttribute("id").split("_")[1];
+}
+
 function initTopBarButtonsForEditableDoc() {
   $('#close').click(function (e) {
     if (editable === 'EDIT_MODE') {
@@ -248,7 +257,7 @@ function initTopBarButtonsForEditableDoc() {
     }
   });
   if (fromNotebook) {
-    $('#close').attr('href', getDocumentViewUrl(fromNotebook, recordId, true));
+    $('#close').attr('href', getDocumentViewUrl(fromNotebook, recordId, getGrandParentFolderId(),true));
   }
 
   $('#save').click(function (e) {

--- a/src/main/webapp/scripts/tags/fileTreeBrowser.js
+++ b/src/main/webapp/scripts/tags/fileTreeBrowser.js
@@ -284,7 +284,7 @@ function _defaultRecordClickHandler(node) {
   // clicks on docs/entries outside of current notebook
   if (!clickHandled) {
     // get url without settings key, as workspaceSettings may not be valid for new selection
-    var urlToOpen = getDocumentViewUrl(parentNotebookId, node.key, false);
+    var urlToOpen = getDocumentViewUrl(parentNotebookId, node.key, node.parent?.parent?.key,false);
     navigateToDocument(urlToOpen, node);
   }
 }
@@ -294,7 +294,7 @@ function _defaultFolderClickHandler(node) {
   var isNotebook = node.extraClasses.includes('notebook');
   // if empty notebook, then click will open it
   if (isExpanded && isNotebook && !node.children.length) {
-    var urlToOpen = getDocumentViewUrl(node.key, null, false);
+    var urlToOpen = getDocumentViewUrl(node.key, null, node.parent?.parent?.key, false);
     navigateToDocument(urlToOpen, node);
     return;
   }

--- a/src/test/java/com/researchspace/service/FolderManagerSpringTest.java
+++ b/src/test/java/com/researchspace/service/FolderManagerSpringTest.java
@@ -16,7 +16,6 @@ import com.researchspace.model.record.IllegalAddChildOperation;
 import com.researchspace.model.record.Notebook;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.testutils.SpringTransactionalTest;
-import com.researchspace.testutils.TestGroup;
 import com.researchspace.webapp.controller.ServiceLoggerAspct;
 import org.junit.After;
 import org.junit.Before;
@@ -127,15 +126,20 @@ public class FolderManagerSpringTest extends SpringTransactionalTest {
     Folder grpFolderShared = folderMgr.getFolder(group.getCommunalGroupFolderId(), piUser);
 
     Notebook notebookShared = recordFactory.createNotebook("notebookShared", user);
-    sharingHandler.shareIntoSharedFolderOrNotebook(user, grpFolderShared, notebookShared.getId(),
+    sharingHandler.shareIntoSharedFolderOrNotebook(
+        user,
+        grpFolderShared,
+        notebookShared.getId(),
         grpFolderShared.getParents().stream()
             .filter(recToParent -> recToParent.getFolder().getOwner().equals(user))
-            .findFirst().get().getFolder().getId());
+            .findFirst()
+            .get()
+            .getFolder()
+            .getId());
 
     assertTrue(folderMgr.isFolderInSharedTree(notebookShared, grpFolderShared.getId(), user));
     assertTrue(folderMgr.isFolderInSharedTree(notebookShared, grpFolderShared.getId(), piUser));
   }
-
 
   @Test
   public void getGroupFolderRootFromSharedSubfolderTest() throws IllegalAddChildOperation {

--- a/src/test/java/com/researchspace/service/FolderManagerSpringTest.java
+++ b/src/test/java/com/researchspace/service/FolderManagerSpringTest.java
@@ -8,12 +8,15 @@ import static org.junit.Assert.assertTrue;
 
 import com.researchspace.license.InactiveLicenseTestService;
 import com.researchspace.licensews.LicenseExpiredException;
+import com.researchspace.model.Group;
 import com.researchspace.model.User;
 import com.researchspace.model.core.RecordType;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.IllegalAddChildOperation;
+import com.researchspace.model.record.Notebook;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.testutils.SpringTransactionalTest;
+import com.researchspace.testutils.TestGroup;
 import com.researchspace.webapp.controller.ServiceLoggerAspct;
 import org.junit.After;
 import org.junit.Before;
@@ -21,10 +24,12 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class FolderManagerSpringTest extends SpringTransactionalTest {
+
   User user;
 
   private @Autowired RecordManager recordManager;
   private @Autowired ServiceLoggerAspct aspect;
+  private @Autowired SharingHandler sharingHandler;
 
   @Before
   public void setUp() throws Exception {
@@ -109,6 +114,28 @@ public class FolderManagerSpringTest extends SpringTransactionalTest {
     assertEquals(b4, numChildrenAfter);
     assertEquals(b4, fromDB);
   }
+
+  @Test
+  public void isFolderInSharedTreeTest() throws IllegalAddChildOperation {
+    User piUser = createAndSaveAPi();
+    initialiseContentWithEmptyContent(piUser);
+    assertTrue(piUser.isContentInitialized());
+    logoutAndLoginAs(piUser);
+
+    Group group = createGroup("groupName", piUser);
+    addUsersToGroup(piUser, group, user);
+    Folder grpFolderShared = folderMgr.getFolder(group.getCommunalGroupFolderId(), piUser);
+
+    Notebook notebookShared = recordFactory.createNotebook("notebookShared", user);
+    sharingHandler.shareIntoSharedFolderOrNotebook(user, grpFolderShared, notebookShared.getId(),
+        grpFolderShared.getParents().stream()
+            .filter(recToParent -> recToParent.getFolder().getOwner().equals(user))
+            .findFirst().get().getFolder().getId());
+
+    assertTrue(folderMgr.isFolderInSharedTree(notebookShared, grpFolderShared.getId(), user));
+    assertTrue(folderMgr.isFolderInSharedTree(notebookShared, grpFolderShared.getId(), piUser));
+  }
+
 
   @Test
   public void getGroupFolderRootFromSharedSubfolderTest() throws IllegalAddChildOperation {

--- a/src/test/java/com/researchspace/webapp/controller/FolderManagerStub.java
+++ b/src/test/java/com/researchspace/webapp/controller/FolderManagerStub.java
@@ -132,6 +132,11 @@ public class FolderManagerStub implements FolderManager {
   }
 
   @Override
+  public boolean isParentFolderInSharedTree(Folder parentFolder, Long grandParentId, User usr) {
+    return false;
+  }
+
+  @Override
   public Folder getRootRecordForUser(User subject, User user) {
     return null;
   }

--- a/src/test/java/com/researchspace/webapp/controller/FolderManagerStub.java
+++ b/src/test/java/com/researchspace/webapp/controller/FolderManagerStub.java
@@ -132,7 +132,7 @@ public class FolderManagerStub implements FolderManager {
   }
 
   @Override
-  public boolean isParentFolderInSharedTree(Folder parentFolder, Long grandParentId, User usr) {
+  public boolean isFolderInSharedTree(Folder folderOrNotebook, Long parentId, User usr) {
     return false;
   }
 

--- a/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
@@ -108,7 +108,15 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     when(permissionUtils.isPermitted(
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(false);
-    notebookEditorController.openNotebook(1l, null, "", null, model, mockSession, mockPrincipal);
+    notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void handleRequestNoGrandParentId() throws AuthorizationException {
+    when(permissionUtils.isPermitted(
+            any(BaseRecord.class), any(PermissionType.class), any(User.class)))
+        .thenReturn(true);
+    notebookEditorController.openNotebook(1L, null, "", null, model, mockSession, mockPrincipal);
   }
 
   @Test
@@ -118,8 +126,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView results =
-        notebookEditorController.openNotebook(
-            1l, null, "", null, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
     assertNotNull(results);
   }
 
@@ -130,8 +137,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView result =
-        notebookEditorController.openNotebook(
-            1l, null, "", null, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("enforce_ontologies"));
     User aPI = createAndSaveAPi();
     Group g = createGroup("aGroup", aPI);
@@ -139,8 +145,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     grpMgr.addUserToGroup(user.getUsername(), g.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(g, user);
     result =
-        notebookEditorController.openNotebook(
-            1l, null, "", null, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
     assertTrue((Boolean) result.getModelMap().getAttribute("enforce_ontologies"));
   }
 
@@ -151,8 +156,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView result =
-        notebookEditorController.openNotebook(
-            1l, null, "", null, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
     User aPI = createAndSaveAPi();
     Group aProjectG = createGroup("aProjectGroup", aPI);
@@ -160,16 +164,14 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     grpMgr.addUserToGroup(user.getUsername(), aProjectG.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(aProjectG, user);
     result =
-        notebookEditorController.openNotebook(
-            1l, null, "", null, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
     Group g = createGroup("aGroup", aPI);
     g.setAllowBioOntologies(true);
     grpMgr.addUserToGroup(user.getUsername(), g.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(g, user);
     result =
-        notebookEditorController.openNotebook(
-            1l, null, "", null, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
     assertTrue((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
   }
 
@@ -182,21 +184,20 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView results =
-        notebookEditorController.openNotebook(
-            1l, null, "", null, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
     assertNotNull(results);
     assertTrue((Boolean) results.getModelMap().getAttribute("isPublished"));
   }
 
   @Test
   public void deleteEntryTest() throws Exception {
-    notebookEditorController.deleteEntry(1l, 1l, mockPrincipal);
+    notebookEditorController.deleteEntry(1L, 1L, mockPrincipal);
   }
 
   @Test(expected = RecordAccessDeniedException.class)
   public void deleteEntryTestAccessDenied() throws Exception {
     recordManagerStub.canEdit(false);
-    notebookEditorController.deleteEntry(1l, 1l, mockPrincipal);
+    notebookEditorController.deleteEntry(1L, 1L, mockPrincipal);
   }
 
   private StructuredDocument createRecordWithId(Long id) {

--- a/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
@@ -108,7 +108,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     when(permissionUtils.isPermitted(
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(false);
-    notebookEditorController.openNotebook(1l, null, "", model, mockSession, mockPrincipal);
+    notebookEditorController.openNotebook(1l, null, "", null, model, mockSession, mockPrincipal);
   }
 
   @Test
@@ -118,7 +118,8 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView results =
-        notebookEditorController.openNotebook(1l, null, "", model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(
+            1l, null, "", null, model, mockSession, mockPrincipal);
     assertNotNull(results);
   }
 
@@ -129,14 +130,17 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView result =
-        notebookEditorController.openNotebook(1l, null, "", model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(
+            1l, null, "", null, model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("enforce_ontologies"));
     User aPI = createAndSaveAPi();
     Group g = createGroup("aGroup", aPI);
     g.setEnforceOntologies(true);
     grpMgr.addUserToGroup(user.getUsername(), g.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(g, user);
-    result = notebookEditorController.openNotebook(1l, null, "", model, mockSession, mockPrincipal);
+    result =
+        notebookEditorController.openNotebook(
+            1l, null, "", null, model, mockSession, mockPrincipal);
     assertTrue((Boolean) result.getModelMap().getAttribute("enforce_ontologies"));
   }
 
@@ -147,20 +151,25 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView result =
-        notebookEditorController.openNotebook(1l, null, "", model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(
+            1l, null, "", null, model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
     User aPI = createAndSaveAPi();
     Group aProjectG = createGroup("aProjectGroup", aPI);
     aProjectG.setGroupType(GroupType.PROJECT_GROUP);
     grpMgr.addUserToGroup(user.getUsername(), aProjectG.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(aProjectG, user);
-    result = notebookEditorController.openNotebook(1l, null, "", model, mockSession, mockPrincipal);
+    result =
+        notebookEditorController.openNotebook(
+            1l, null, "", null, model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
     Group g = createGroup("aGroup", aPI);
     g.setAllowBioOntologies(true);
     grpMgr.addUserToGroup(user.getUsername(), g.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(g, user);
-    result = notebookEditorController.openNotebook(1l, null, "", model, mockSession, mockPrincipal);
+    result =
+        notebookEditorController.openNotebook(
+            1l, null, "", null, model, mockSession, mockPrincipal);
     assertTrue((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
   }
 
@@ -173,7 +182,8 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView results =
-        notebookEditorController.openNotebook(1l, null, "", model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(
+            1l, null, "", null, model, mockSession, mockPrincipal);
     assertNotNull(results);
     assertTrue((Boolean) results.getModelMap().getAttribute("isPublished"));
   }


### PR DESCRIPTION
## Description ##
- This PR fixes 2 bug scenarios:
- - [`CREATE` button is showed for PI when reaching `sharedNotebook` from another user's path](https://researchspace.atlassian.net/browse/RSDEV-823)
- - [`CREATE` button is shown on notebook editor when it should not be](https://researchspace.atlassian.net/browse/RSDEV-819)

## Testing notes
 - Please refer to the JIRA tickets in order to check the step to reproduce
 - 🔴  OLD AWS instance: https://rsdev-819-create-button-26.researchspace.com/ (bug)
 - 🟢  NEW AWS instance: https://rsdev-819-create-button-28.researchspace.com/
