### PR TITLE
Fix bug where TinyMCE had only one toolbar

### DIFF
--- a/src/main/webapp/scripts/externalTinymcePlugins/toolbar/scripts/index.js
+++ b/src/main/webapp/scripts/externalTinymcePlugins/toolbar/scripts/index.js
@@ -86,6 +86,10 @@ var custom_toolbar = {
 
   saveSettings: function() {
     this.exportSettings();
+    if (Object.keys(current_config).length < 2) {
+      alert("Toolbar must contain at least two rows");
+      throw new Error("Toolbar must contain at least two rows");
+    }
     localStorage.setItem('custom_toolbar', JSON.stringify(current_config));
     this.closeDialog();
   },

--- a/src/main/webapp/scripts/externalTinymcePlugins/toolbar/scripts/index.js
+++ b/src/main/webapp/scripts/externalTinymcePlugins/toolbar/scripts/index.js
@@ -87,7 +87,7 @@ var custom_toolbar = {
   saveSettings: function() {
     this.exportSettings();
     if (Object.keys(current_config).length < 2) {
-      alert("Toolbar must contain at least two rows");
+      parent.apprise("Toolbar must contain at least two rows");
       throw new Error("Toolbar must contain at least two rows");
     }
     localStorage.setItem('custom_toolbar', JSON.stringify(current_config));

--- a/src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js
+++ b/src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js
@@ -610,6 +610,7 @@ function runAfterTinymceActiveEditorInitialized(afterInitCallback) {
 }
 
 function addToToolbarIfNotPresent(localTinymcesetup, toolBarName) {
+  while (localTinymcesetup.toolbar.length < 2) localTinymcesetup.toolbar.push('');
 	if (localTinymcesetup.toolbar[1].indexOf(toolBarName) === -1) {
 		localTinymcesetup.toolbar[1] = localTinymcesetup.toolbar[1] + toolBarName;
 	}


### PR DESCRIPTION
## Description ##
This change fixes #475 wherein it was possible for the user to remove the second TinyMCE toolbar, which the code that adds toolbar buttons for the various integrations assumes will always be there. This PR makes two changes
1. When the user is customising the toolbar, they are prevented from removing the second toolbar
2. When registering toolbar buttons for the various integrations, we now create additional toolbars to ensure that we can add the new toolbar buttons to the second toolbar. This catches cases where users have already broken their toolbars or where the second toolbar may be removed through any other mechanism.
