### PR TITLE
RSDEV-826 Lazy load KetcherDialog

### DIFF
--- a/src/main/webapp/ui/package.json
+++ b/src/main/webapp/ui/package.json
@@ -9,7 +9,7 @@
     "clustermarket-test": "node_modules/.bin/jest --runInBand   --roots ./src/tinyMCE/clustermarket",
     "omero-test": "node_modules/.bin/jest --runInBand   --roots ./src/tinyMCE/omero",
     "build": "webpack --mode production",
-    "serve": "webpack --watch --mode development --devtool eval-cheap-module-source-map",
+    "serve": "NODE_OPTIONS='--max-old-space-size=8192' webpack --watch --mode development --devtool eval-cheap-module-source-map",
     "depcruise": "npx depcruise src",
     "tsc": "tsc --noEmit",
     "test-ct": "playwright test -c playwright-ct.config.ts",

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Attachments/AttachmentTableRow.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Attachments/AttachmentTableRow.tsx
@@ -21,7 +21,11 @@ import { mkAlert } from "../../../../stores/contexts/Alert";
 import { type HasEditableFields } from "../../../../stores/definitions/Editable";
 import { type BlobUrl } from "../../../../util/types";
 import { doNotAwait } from "../../../../util/Util";
-import KetcherDialog from "../../../../components/Ketcher/KetcherDialog";
+import Backdrop from "@mui/material/Backdrop";
+import CircularProgress from "@mui/material/CircularProgress";
+const KetcherDialog = React.lazy(
+  () => import("../../../../components/Ketcher/KetcherDialog"),
+);
 
 const ChemicalPreview = observer(
   ({ attachment }: { attachment: Attachment }) => {
@@ -50,12 +54,12 @@ const ChemicalPreview = observer(
             chemicalString
               ? ""
               : loadingString
-              ? "Loading file"
-              : chemistrySupported
-              ? "Preview file as 3D structure"
-              : isChemicalFile && !attachment.id
-              ? "Save first to enable 3D preview"
-              : "3D Preview is not supported for this file type"
+                ? "Loading file"
+                : chemistrySupported
+                  ? "Preview file as 3D structure"
+                  : isChemicalFile && !attachment.id
+                    ? "Save first to enable 3D preview"
+                    : "3D Preview is not supported for this file type"
           }
           size="small"
           color="primary"
@@ -69,19 +73,35 @@ const ChemicalPreview = observer(
             )
           }
         />
-        <KetcherDialog
-          isOpen={!loadingString && Boolean(chemicalString) && showPreview}
-          handleInsert={() => {}}
-          title={"View Chemical (Read-only)"}
-          existingChem={attachment.chemicalString}
-          handleClose={() => {
-            setShowPreview(false);
-          }}
-          readOnly={true}
-        />
+        {!loadingString && Boolean(chemicalString) && showPreview && (
+          <React.Suspense
+            fallback={
+              <Backdrop
+                open
+                sx={{
+                  color: "#fff",
+                  zIndex: (theme) => theme.zIndex.drawer + 1,
+                }}
+              >
+                <CircularProgress color="inherit" />
+              </Backdrop>
+            }
+          >
+            <KetcherDialog
+              isOpen
+              handleInsert={() => {}}
+              title={"View Chemical (Read-only)"}
+              existingChem={attachment.chemicalString}
+              handleClose={() => {
+                setShowPreview(false);
+              }}
+              readOnly={true}
+            />
+          </React.Suspense>
+        )}
       </>
     );
-  }
+  },
 );
 
 const Download = ({ attachment }: { attachment: Attachment }) => (
@@ -101,7 +121,7 @@ const SetAsPreviewImage = <
     image: BlobUrl | null;
     newBase64Image: string | null;
   },
-  FieldOwner extends HasEditableFields<Fields>
+  FieldOwner extends HasEditableFields<Fields>,
 >({
   attachment,
   disabled,
@@ -117,7 +137,7 @@ const SetAsPreviewImage = <
   const storeImage = async (dataURL: string | null, file: Blob | null) => {
     if (!fieldOwner)
       throw new Error(
-        "The preview image cannot be set as the item is not available."
+        "The preview image cannot be set as the item is not available.",
       );
     if (!dataURL || !file)
       throw new Error("Unable to set attachment as preview image.");
@@ -131,7 +151,7 @@ const SetAsPreviewImage = <
         message: `Setting ${attachment.name} as preview image. Please Save the item to confirm.`,
         variant: "notice",
         isInfinite: false,
-      })
+      }),
     );
   };
 
@@ -145,7 +165,7 @@ const SetAsPreviewImage = <
           title: "Could not fetch image",
           message: (e as Error).message,
           variant: "error",
-        })
+        }),
       );
     }
   };
@@ -156,8 +176,8 @@ const SetAsPreviewImage = <
           disabled && !attachment.previewSupported
             ? "Save first to enable setting this file as the item's Preview Image."
             : disabled
-            ? "First press Edit to set as Preview Image."
-            : "Set as Preview Image"
+              ? "First press Edit to set as Preview Image."
+              : "Set as Preview Image"
         }
         size="small"
         color="primary"
@@ -175,7 +195,7 @@ function AttachmentTableRow<
     image: BlobUrl | null;
     newBase64Image: string | null;
   },
-  FieldOwner extends HasEditableFields<Fields>
+  FieldOwner extends HasEditableFields<Fields>,
 >({
   attachment,
   fieldOwner,

--- a/src/main/webapp/ui/src/tinyMCE/ketcher/KetcherTinyMce.js
+++ b/src/main/webapp/ui/src/tinyMCE/ketcher/KetcherTinyMce.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 
-import KetcherDialog from "../../components/Ketcher/KetcherDialog";
 import { createRoot } from "react-dom/client";
 import { blobToBase64 } from "../../util/files";
 import axios from "@/common/axios";
@@ -11,6 +10,11 @@ import theme from "../../theme";
 import useChemicalImport from "../../hooks/api/useChemicalImport";
 import Alerts from "../../components/Alerts/Alerts";
 import { IsInvalid, IsValid } from "@/components/ValidatingSubmitButton";
+import CircularProgress from "@mui/material/CircularProgress";
+import Backdrop from "@mui/material/Backdrop";
+const KetcherDialog = React.lazy(
+  () => import("../../components/Ketcher/KetcherDialog"),
+);
 
 export const KetcherTinyMce = () => {
   const { trackEvent } = React.useContext(AnalyticsContext);
@@ -39,7 +43,7 @@ export const KetcherTinyMce = () => {
         })
         .catch(() => {
           tinymceDialogUtils.showErrorAlert(
-            "Loading chemical elements failed."
+            "Loading chemical elements failed.",
           );
         });
     }
@@ -117,7 +121,7 @@ export const KetcherTinyMce = () => {
         setExistingChemical("");
         void window.ketcher.setMolecule("");
       },
-      () => {}
+      () => {},
     );
   };
 
@@ -133,13 +137,13 @@ export const KetcherTinyMce = () => {
     }
     ketcher.getKet().then((ketData) => {
       const molecules = Object.keys(JSON.parse(ketData)).filter((key) =>
-        key.startsWith("mol")
+        key.startsWith("mol"),
       );
       if (molecules.length === 0) {
         setIsValid(
           IsInvalid(
-            "Please draw, paste, or open a molecule to insert into the document"
-          )
+            "Please draw, paste, or open a molecule to insert into the document",
+          ),
         );
         return;
       }
@@ -149,18 +153,32 @@ export const KetcherTinyMce = () => {
 
   return $(tinymce.activeEditor.selection.getNode()).hasClass("chem") &&
     existingChemical === "" ? null : (
-    <KetcherDialog
-      isOpen={dialogIsOpen}
-      handleInsert={handleInsert}
-      title={"Ketcher Insert Chemical"}
-      existingChem={existingChemical}
-      handleClose={handleClose}
-      actionBtnText={"Insert"}
-      validationResult={isValid}
-      onChange={() => {
-        validate(window.ketcher);
-      }}
-    />
+    <React.Suspense
+      fallback={
+        <Backdrop
+          open
+          sx={{
+            color: "#fff",
+            zIndex: 2, // higher than the TinyMCE form field editor
+          }}
+        >
+          <CircularProgress color="inherit" />
+        </Backdrop>
+      }
+    >
+      <KetcherDialog
+        isOpen={dialogIsOpen}
+        handleInsert={handleInsert}
+        title={"Ketcher Insert Chemical"}
+        existingChem={existingChemical}
+        handleClose={handleClose}
+        actionBtnText={"Insert"}
+        validationResult={isValid}
+        onChange={() => {
+          validate(window.ketcher);
+        }}
+      />
+    </React.Suspense>
   );
 };
 
@@ -178,7 +196,7 @@ document.addEventListener("DOMContentLoaded", () => {
               <KetcherTinyMce />
             </Alerts>
           </Analytics>
-        </ThemeProvider>
+        </ThemeProvider>,
       );
     }
   });

--- a/src/main/webapp/ui/src/tinyMCE/ketcher/KetcherViewer.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/ketcher/KetcherViewer.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useState } from "react";
 
-import KetcherDialog from "../../components/Ketcher/KetcherDialog";
 import { createRoot } from "react-dom/client";
 import axios from "@/common/axios";
 import Analytics from "../../components/Analytics";
+import CircularProgress from "@mui/material/CircularProgress";
+import Backdrop from "@mui/material/Backdrop";
+const KetcherDialog = React.lazy(
+  () => import("../../components/Ketcher/KetcherDialog"),
+);
 
 /**
  * This component retrieves the selected chemical element in the global tinymce
@@ -35,7 +39,7 @@ export const KetcherViewer = (): React.ReactNode => {
         if (!response.data) {
           // @ts-expect-error global
           tinymceDialogUtils.showErrorAlert(
-            "Problem loading chemical element."
+            "Problem loading chemical element.",
           );
           return;
         }
@@ -67,14 +71,28 @@ export const KetcherViewer = (): React.ReactNode => {
   // @ts-expect-error global
   return $(tinymce.activeEditor.selection.getNode()).hasClass("chem") &&
     existingChemical === "" ? null : (
-    <KetcherDialog
-      isOpen={dialogIsOpen}
-      handleInsert={() => {}}
-      title={"Ketcher Chemical Viewer (Read-Only)"}
-      existingChem={existingChemical}
-      handleClose={handleClose}
-      readOnly={true}
-    />
+    <React.Suspense
+      fallback={
+        <Backdrop
+          open
+          sx={{
+            color: "#fff",
+            zIndex: 1301, // more than the menu bar that opens the ketcher viewer
+          }}
+        >
+          <CircularProgress color="inherit" />
+        </Backdrop>
+      }
+    >
+      <KetcherDialog
+        isOpen={dialogIsOpen}
+        handleInsert={() => {}}
+        title={"Ketcher Chemical Viewer (Read-Only)"}
+        existingChem={existingChemical}
+        handleClose={handleClose}
+        readOnly={true}
+      />
+    </React.Suspense>
   );
 };
 
@@ -87,7 +105,7 @@ document.addEventListener("DOMContentLoaded", () => {
       root.render(
         <Analytics>
           <KetcherViewer />
-        </Analytics>
+        </Analytics>,
       );
     }
   });


### PR DESCRIPTION
## Description ##
Ketcher is a very big third-party library that dwarfs all of our other libraries and our own code. It is also used in several places across the codebase so was being included in several JS assets. Moreover, it is only used by a minority of users, and yet all users were paying the performance cost of downloading and parsing this library's code several times over.

This change instead lazily loads the KetcherDialog component, only downloading the JS code when the user goes to use the component. Webpack will now create a separate JS asset for it, which should be cached by the users' browser meaning that they will only need to download the code once across our entire product.

The only downside being that there will be a brief spinner the first time that the user goes to use the component, but this is certainly preferable to adding the same loading to the initial page load for everyone. If this is intolerable, we could look at pre-emptively loading the JS asset if the user has the chemistry integration enabled (although this would mean gating the Inventory chemistry previewer behind the chemistry integration which currently it is not).