### PR TITLE
[PRT-995][PRT-997]: Fix `import from word` and errors connected to `grandParentId`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3040,7 +3040,7 @@
     <jstl.version>1.1.2</jstl.version>
     <lucene.version>5.5.5</lucene.version>
     <netty.version>4.1.63.Final</netty.version>
-    <rspace-core-model.version>2.15.4</rspace-core-model.version>
+    <rspace-core-model.version>PRT-995-2.15.5-SNAPSHOT</rspace-core-model.version>
     <servlet.version>3.1.0</servlet.version>
     <sitemesh.version>2.4.2</sitemesh.version>
     <urlrewrite.version>4.0.3</urlrewrite.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3040,7 +3040,7 @@
     <jstl.version>1.1.2</jstl.version>
     <lucene.version>5.5.5</lucene.version>
     <netty.version>4.1.63.Final</netty.version>
-    <rspace-core-model.version>PRT-995-2.15.5-SNAPSHOT</rspace-core-model.version>
+    <rspace-core-model.version>2.15.5</rspace-core-model.version>
     <servlet.version>3.1.0</servlet.version>
     <sitemesh.version>2.4.2</sitemesh.version>
     <urlrewrite.version>4.0.3</urlrewrite.version>

--- a/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NotebookEditorController.java
@@ -1,5 +1,6 @@
 package com.researchspace.webapp.controller;
 
+import static com.researchspace.model.utils.Utils.convertToLongOrNull;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.allGroupsAllowBioOntologies;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.anyGroupEnforcesOntologies;
 
@@ -68,12 +69,12 @@ public class NotebookEditorController extends BaseController {
       @PathVariable("notebookId") Long notebookId,
       @RequestParam(value = "initialRecordToDisplay", required = false) Long entryId,
       @RequestParam(value = "settingsKey", required = false) String settingsKey,
-      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
+      @RequestParam(value = "grandParentId", required = false) String grandParentFolderId,
       Model model,
       HttpSession session,
       Principal principal)
       throws AuthorizationException {
-
+    Long grandParentId = convertToLongOrNull(grandParentFolderId);
     User user = userManager.getUserByUsername(principal.getName());
     Notebook notebook = folderManager.getNotebook(notebookId);
 

--- a/src/main/java/com/researchspace/webapp/controller/StructuredDocumentController.java
+++ b/src/main/java/com/researchspace/webapp/controller/StructuredDocumentController.java
@@ -1,6 +1,7 @@
 package com.researchspace.webapp.controller;
 
 import static com.researchspace.model.record.StructuredDocument.MAX_TAG_LENGTH;
+import static com.researchspace.model.utils.Utils.convertToLongOrNull;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.RSPACTAGS_FORSL__;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.allGroupsAllowBioOntologies;
 import static com.researchspace.service.impl.DocumentTagManagerImpl.anyGroupEnforcesOntologies;
@@ -178,10 +179,10 @@ public class StructuredDocumentController extends BaseController {
       @PathVariable("parentId") Long parentFolderId,
       @RequestParam("wordXfile") List<MultipartFile> mswordOrEvernoteFile,
       @RequestParam(value = "recordToReplaceId", required = false) Long recordToReplaceId,
-      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
+      @RequestParam(value = "grandParentId", required = false) String grandParentFolderId,
       HttpSession session)
       throws IOException {
-
+    Long grandParentId = convertToLongOrNull(grandParentFolderId);
     User user = userManager.getAuthenticatedUserInSession();
     log.info("Creating RSpace docs from {} submitted files", mswordOrEvernoteFile.size());
 
@@ -311,10 +312,10 @@ public class StructuredDocumentController extends BaseController {
   public String createSD(
       @PathVariable("recordid") Long parentRecordId,
       @RequestParam(value = "template") long formid,
-      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
+      @RequestParam(value = "grandParentId", required = false) String grandParentFolderId,
       Principal principal)
       throws RecordAccessDeniedException {
-
+    Long grandParentId = convertToLongOrNull(grandParentFolderId);
     User user = getUserByUsername(principal.getName());
     StructuredDocument newRecord = null;
     List<RecordGroupSharing> sharedWithGroup = null;
@@ -382,9 +383,10 @@ public class StructuredDocumentController extends BaseController {
       @PathVariable("recordid") Long parentRecordId,
       @RequestParam(value = "template") long templateid,
       @RequestParam(value = "newname", required = false) String newname,
-      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
+      @RequestParam(value = "grandParentId", required = false) String grandParentFolderId,
       Principal principal)
       throws RecordAccessDeniedException {
+    Long grandParentId = convertToLongOrNull(grandParentFolderId);
     User user = getUserByUsername(principal.getName());
     Long targetFolderId = parentRecordId;
     StructuredDocument rc = null;

--- a/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
@@ -2,6 +2,7 @@ package com.researchspace.webapp.controller;
 
 import static com.researchspace.core.util.MediaUtils.getContentTypeForFileExtension;
 import static com.researchspace.core.util.MediaUtils.getExtension;
+import static com.researchspace.model.utils.Utils.convertToLongOrNull;
 import static com.researchspace.session.SessionAttributeUtils.RS_DELETE_RECORD_PROGRESS;
 
 import com.axiope.search.SearchManager;
@@ -401,8 +402,9 @@ public class WorkspaceController extends BaseController {
   public String createNotebookAndRedirect(
       @PathVariable("recordid") long parentRecordId,
       @RequestParam("notebookNameField") String notebookName,
-      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
+      @RequestParam(value = "grandParentId", required = false) String grandParentFolderId,
       Principal principal) {
+    Long grandParentId = convertToLongOrNull(grandParentFolderId);
     User user = getUserByUsername(principal.getName());
     Long targetFolderId = parentRecordId;
     Folder originalParentFolder = null;

--- a/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOController.java
@@ -1,5 +1,7 @@
 package com.researchspace.webapp.integrations.protocolsio;
 
+import static com.researchspace.model.utils.Utils.convertToLongOrNull;
+
 import com.researchspace.model.User;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
@@ -48,11 +50,11 @@ public class ProtocolsIOController extends BaseController {
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public AjaxReturnObject<PIOResponse> importExternalData(
       @PathVariable("parentFolderId") Long parentFolderId,
-      @RequestParam(value = "grandParentId", required = false) Long grandParentId,
+      @RequestParam(value = "grandParentId", required = false) String grandParentFolderId,
       @RequestBody List<Protocol> protocols) {
     log.info("Importing {} protocols", protocols.size());
     List<RecordInformation> results = new ArrayList<>();
-
+    Long grandParentId = convertToLongOrNull(grandParentFolderId);
     User subject = userManager.getAuthenticatedUserInSession();
     Folder originalParentFolder = folderManager.getFolder(parentFolderId, subject);
     Long finalParentFolderId = folderManager.getImportsFolder(subject).getId();

--- a/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
@@ -108,7 +108,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     when(permissionUtils.isPermitted(
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(false);
-    notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+    notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
   }
 
   @Test(expected = IllegalStateException.class)
@@ -116,7 +116,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     when(permissionUtils.isPermitted(
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
-    notebookEditorController.openNotebook(1L, null, "", null, model, mockSession, mockPrincipal);
+    notebookEditorController.openNotebook(1L, null, "", "null", model, mockSession, mockPrincipal);
   }
 
   @Test
@@ -126,7 +126,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView results =
-        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
     assertNotNull(results);
   }
 
@@ -137,7 +137,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView result =
-        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("enforce_ontologies"));
     User aPI = createAndSaveAPi();
     Group g = createGroup("aGroup", aPI);
@@ -145,7 +145,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     grpMgr.addUserToGroup(user.getUsername(), g.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(g, user);
     result =
-        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
     assertTrue((Boolean) result.getModelMap().getAttribute("enforce_ontologies"));
   }
 
@@ -156,7 +156,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView result =
-        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
     User aPI = createAndSaveAPi();
     Group aProjectG = createGroup("aProjectGroup", aPI);
@@ -164,14 +164,14 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     grpMgr.addUserToGroup(user.getUsername(), aProjectG.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(aProjectG, user);
     result =
-        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
     Group g = createGroup("aGroup", aPI);
     g.setAllowBioOntologies(true);
     grpMgr.addUserToGroup(user.getUsername(), g.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(g, user);
     result =
-        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
     assertTrue((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
   }
 
@@ -184,7 +184,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView results =
-        notebookEditorController.openNotebook(1L, null, "", 2L, model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
     assertNotNull(results);
     assertTrue((Boolean) results.getModelMap().getAttribute("isPublished"));
   }


### PR DESCRIPTION
## Description ##
This PR fixes the iussue where an user could not import from WORD when located on the top level of the workspace.

## Pre-requisites ##
 - This PR needs to be merged first: https://github.com/rspace-os/rspace-core-model/pull/42

## Testing ##

- Please refer to the JIRA ticket https://researchspace.atlassian.net/browse/PRT-995 for the steps to reproduce
- AWS instance: https://prt-995-web-3.researchspace.com/