### PR TITLE
Rsdev 815 stoichiometry error messages

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/ApiControllerAdvice.java
+++ b/src/main/java/com/researchspace/api/v1/controller/ApiControllerAdvice.java
@@ -12,6 +12,7 @@ import com.researchspace.core.util.throttling.TooManyRequestsException;
 import com.researchspace.service.DocumentAlreadyEditedException;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.archive.export.ExportFailureException;
+import com.researchspace.service.chemistry.ChemistryClientException;
 import com.researchspace.service.chemistry.StoichiometryException;
 import java.util.ArrayList;
 import java.util.List;
@@ -161,6 +162,14 @@ public class ApiControllerAdvice extends RestControllerAdvice {
             ApiErrorCodes.ILLEGAL_ARGUMENT.getCode(),
             ex.getLocalizedMessage(),
             "");
+    return new ResponseEntity<>(apiError, new HttpHeaders(), apiError.getStatus());
+  }
+
+  @ExceptionHandler(ChemistryClientException.class)
+  public ResponseEntity<Object> handleChemistryClientException(
+      ChemistryClientException ex, WebRequest request) {
+    HttpStatus status = ex.getStatus() != null ? ex.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+    ApiError apiError = new ApiError(status, 50001, ex.getMessage(), "");
     return new ResponseEntity<>(apiError, new HttpHeaders(), apiError.getStatus());
   }
 

--- a/src/main/java/com/researchspace/service/chemistry/ChemistryClient.java
+++ b/src/main/java/com/researchspace/service/chemistry/ChemistryClient.java
@@ -98,7 +98,6 @@ public class ChemistryClient {
           e);
 
       throw new ChemistryClientException(errorReason, status, e);
-
     } catch (RestClientException e) {
       log.error("Error calling chemistry service at url={} requestBody={}", url, body, e);
       throw new ChemistryClientException("Chemistry service call failed");

--- a/src/main/java/com/researchspace/service/chemistry/ChemistryClient.java
+++ b/src/main/java/com/researchspace/service/chemistry/ChemistryClient.java
@@ -100,11 +100,7 @@ public class ChemistryClient {
       throw new ChemistryClientException(errorReason, status, e);
 
     } catch (RestClientException e) {
-      log.error(
-          "Error calling chemistry service at url={} requestBody={}",
-          url,
-          body,
-          e);
+      log.error("Error calling chemistry service at url={} requestBody={}", url, body, e);
       throw new ChemistryClientException("Chemistry service call failed");
     }
   }

--- a/src/main/java/com/researchspace/service/chemistry/ChemistryClient.java
+++ b/src/main/java/com/researchspace/service/chemistry/ChemistryClient.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -73,7 +74,6 @@ public class ChemistryClient {
     Map<String, Object> body = new HashMap<>();
     body.put("input", chem);
     String url = chemistryServiceUrl + "/chemistry/extract";
-
     return postForElementalAnalysis(body, url);
   }
 
@@ -86,16 +86,26 @@ public class ChemistryClient {
     try {
       ResponseEntity<ElementalAnalysisDTO> response =
           restTemplate.postForEntity(url, httpEntity, ElementalAnalysisDTO.class);
-      if (response.getStatusCode().is2xxSuccessful()) {
-        return Optional.ofNullable(response.getBody());
-      } else {
-        log.warn(
-            "Unsuccessful request to: {}. Response code: {}", url, response.getStatusCodeValue());
-        return Optional.empty();
-      }
+      return Optional.ofNullable(response.getBody());
+    } catch (HttpStatusCodeException e) {
+      String errorReason = e.getResponseBodyAsString();
+      HttpStatus status = e.getStatusCode();
+      log.error(
+          "Chemistry error response from request to {}. Status: {}, Reason: {}",
+          url,
+          status.value(),
+          errorReason,
+          e);
+
+      throw new ChemistryClientException(errorReason, status, e);
+
     } catch (RestClientException e) {
-      log.warn("Error while making request to {}: {}", url, e.getMessage());
-      return Optional.empty();
+      log.error(
+          "Error calling chemistry service at url={} requestBody={}",
+          url,
+          body,
+          e);
+      throw new ChemistryClientException("Chemistry service call failed");
     }
   }
 

--- a/src/main/java/com/researchspace/service/chemistry/ChemistryClientException.java
+++ b/src/main/java/com/researchspace/service/chemistry/ChemistryClientException.java
@@ -1,11 +1,24 @@
 package com.researchspace.service.chemistry;
 
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
 public class ChemistryClientException extends RuntimeException {
+  private final HttpStatus status;
+
   public ChemistryClientException(String message) {
     super(message);
+    this.status = null;
   }
 
   public ChemistryClientException(String message, Exception cause) {
     super(message, cause);
+    this.status = null;
+  }
+
+  public ChemistryClientException(String message, HttpStatus status, Throwable cause) {
+    super(message, cause);
+    this.status = status;
   }
 }

--- a/src/main/java/com/researchspace/service/impl/StoichiometryServiceImpl.java
+++ b/src/main/java/com/researchspace/service/impl/StoichiometryServiceImpl.java
@@ -102,7 +102,7 @@ public class StoichiometryServiceImpl implements StoichiometryService {
       return stoichiometryManager.createFromAnalysis(analysis.get(), chemical, user);
     } catch (IOException e) {
       throw new StoichiometryException(
-          "Problem while creating new Stoichiometry (chemId=" + chemId + ")", e);
+          "Problem while creating new Stoichiometry: " + e.getMessage());
     }
   }
 

--- a/src/main/java/com/researchspace/service/impl/StoichiometryServiceImpl.java
+++ b/src/main/java/com/researchspace/service/impl/StoichiometryServiceImpl.java
@@ -91,17 +91,18 @@ public class StoichiometryServiceImpl implements StoichiometryService {
           "Stoichiometry already exists for reaction chemId=" + chemId + ", stoichId=" + e.getId());
     }
 
-    Optional<ElementalAnalysisDTO> analysis = chemistryProvider.getStoichiometry(chemical);
     try {
+      Optional<ElementalAnalysisDTO> analysis = chemistryProvider.getStoichiometry(chemical);
       if (analysis.isEmpty()) {
         throw new StoichiometryException(
-            "Unable to generate stoichiometry: problem generating analysis for chemical with ID "
-                + chemId);
+            "Unable to generate stoichiometry for chemId="
+                + chemId
+                + ": chemistry provider returned no analysis");
       }
       return stoichiometryManager.createFromAnalysis(analysis.get(), chemical, user);
     } catch (IOException e) {
       throw new StoichiometryException(
-          "Problem while creating new Stoichiometry: " + e.getMessage());
+          "Problem while creating new Stoichiometry (chemId=" + chemId + ")", e);
     }
   }
 


### PR DESCRIPTION
## Description ##
This change stops the masking of problems from the chemistry service back to the rspace user.

Previously, an error from the chemistry service stoichiometry endpoint would be wrapped in a StoichiometryException with a generic message. Now, we maintain the http status code and message from the chemistry service and let ChemistryClientException bubble up to the stoichiometry controller where it is handled and returned to the client. The common case for this is a user trying to generate a stoichiometry analysis for a non-reaction chemical element.

There are other interactions between `rspace-web` and `chemistry` which could be updated to handle issues better as is done here. There's a ticket on the backlog for that.

## Testing notes
1. Run `rspace-web` and the `rsdev-815-error-responses` branch of `chemistry`
2. Enable chemistry in `rspace-web`
3. Draw a single element on the canvas and INSERT
4. Click the stoichiometry icon under the embedded chemical
5. Click `Calculate Stoichiometry`

Previously, the user would see a generic error. Now, they are relayed the message from the chemical service which gives them a chance to correct the issue.

[Chemistry PR](https://github.com/rspace-os/chemistry/pull/27)
