### PR TITLE
Metadatalanguage fix

### DIFF
--- a/src/main/java/com/researchspace/service/RepositoryDepositHandler.java
+++ b/src/main/java/com/researchspace/service/RepositoryDepositHandler.java
@@ -10,6 +10,7 @@ import com.researchspace.model.repository.RepoUIConfigInfo;
 import com.researchspace.repository.spi.RepositoryOperationResult;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -78,4 +79,7 @@ public interface RepositoryDepositHandler {
   RepoUIConfigInfo getZenodoRepoUIConfigInfo(User user) throws MalformedURLException;
 
   RepoUIConfigInfo getDigitalCommonsDataRepoUIConfigInfo(User user) throws MalformedURLException;
+
+  void addMetadataLanguageToDataverseIntegrationOptions(Map<String, Object> options)
+      throws MalformedURLException;
 }

--- a/src/main/java/com/researchspace/webapp/controller/RepositoryConfigurationController.java
+++ b/src/main/java/com/researchspace/webapp/controller/RepositoryConfigurationController.java
@@ -67,7 +67,11 @@ public class RepositoryConfigurationController extends BaseController {
     List<RepoUIConfigInfo> uiConfigs = new ArrayList<>();
     for (IntegrationInfo inf : activeInfos) {
       RepoUIConfigInfo info = getRepoUIConfigInfo(user, inf.getName());
-      info.setOptions(inf.getOptions());
+      Map<String, Object> options = inf.getOptions();
+      if (inf.getName().equals(DATAVERSE_APP_NAME)) {
+        depositHandler.addMetadataLanguageToDataverseIntegrationOptions(options);
+      }
+      info.setOptions(options);
       info.setDisplayName(inf.getDisplayName());
       uiConfigs.add(info);
     }

--- a/src/main/webapp/ui/src/Export/ExportRepo.tsx
+++ b/src/main/webapp/ui/src/Export/ExportRepo.tsx
@@ -147,6 +147,7 @@ function ExportRepo({
       crossrefFunders: [] as Array<{ name: string }>,
       selectedFunder: {},
       tags: [] as Array<Tag>,
+      metadataLanguage: "",
     })
   );
   const [fetchingTags, setFetchingTags] = useState(false);
@@ -229,6 +230,16 @@ function ExportRepo({
   }) => {
     runInAction(() => {
       state[event.target.name] = event.target.value;
+    });
+    updateRemoteConfig();
+  };
+
+  const handleMetadataLanguageChange = (event: {
+    target: { name: string; value: string };
+  }) => {
+    runInAction(() => {
+      state.otherProperties = { metadataLanguage: event.target.value };
+      state.metadataLanguage = event.target.value;
     });
     updateRemoteConfig();
   };
@@ -383,7 +394,8 @@ function ExportRepo({
               }}
               tags={state.tags}
               fetchingTags={fetchingTags}
-            />
+              metadataLanguage={state.metadataLanguage}
+              handleMetadataLanguageChange={handleMetadataLanguageChange} />
           </>
         )}
         {repo.repoName === "app.figshare" && (

--- a/src/main/webapp/ui/src/Export/ExportRepo.tsx
+++ b/src/main/webapp/ui/src/Export/ExportRepo.tsx
@@ -395,7 +395,7 @@ function ExportRepo({
               tags={state.tags}
               fetchingTags={fetchingTags}
               metadataLanguage={state.metadataLanguage}
-              handleMetadataLanguageChange={handleMetadataLanguageChange} />
+              handleMetadataLanguageChange={handleMetadataLanguageChange}/>
           </>
         )}
         {repo.repoName === "app.figshare" && (

--- a/src/main/webapp/ui/src/Export/FormatChoice.tsx
+++ b/src/main/webapp/ui/src/Export/FormatChoice.tsx
@@ -105,6 +105,9 @@ function FormatChoice({
                       //@ts-expect-error Options is poorly typed
                       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
                       label: repo.options[k]._label,
+                    //@ts-expect-error Options is poorly typed
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+                      metadataLanguages: repo.options[k].metadataLanguages,
                       ...repo,
                     } as Repo)
                 );

--- a/src/main/webapp/ui/src/Export/repositories/DataverseRepo.tsx
+++ b/src/main/webapp/ui/src/Export/repositories/DataverseRepo.tsx
@@ -117,10 +117,9 @@ export default function DataverseRepo({
           ))}
         </TextField>
       </Grid>
-      <Grid item xs={1}></Grid>
-      <Grid item xs={2}>
+      <Grid item xs={4}>
         <TextField
-          //deal with validation later
+          //TODO: deal with validation
           //error={submitAttempt && !inputValidations.subject}
           name="metadataLanguage"
           select
@@ -140,7 +139,6 @@ export default function DataverseRepo({
           ))}
         </TextField>
       </Grid>
-      <Grid item xs={1}></Grid>
       <Grid item xs={4}>
         <TextField
           name="license"

--- a/src/main/webapp/ui/src/Export/repositories/DataverseRepo.tsx
+++ b/src/main/webapp/ui/src/Export/repositories/DataverseRepo.tsx
@@ -19,6 +19,12 @@ type DataverseArgs = {
       value: string;
     };
   }) => void;
+  handleMetadataLanguageChange: (event: {
+    target: {
+      name: "metadataLanguage";
+      value: string;
+    };
+  }) => void;
   inputValidations: StandardValidations;
   submitAttempt: boolean;
   updatePeople: (people: Array<Person>) => void;
@@ -35,6 +41,7 @@ type DataverseArgs = {
     version: string;
   }>;
   fetchingTags: boolean;
+  metadataLanguage: string;
 };
 
 /**
@@ -52,6 +59,8 @@ export default function DataverseRepo({
   title,
   description,
   subject,
+  metadataLanguage,
+  handleMetadataLanguageChange,
   license,
   tags,
   onTagsChange,
@@ -87,7 +96,7 @@ export default function DataverseRepo({
           value={description}
         />
       </Grid>
-      <Grid item xs={5}>
+      <Grid item xs={4}>
         <TextField
           error={submitAttempt && !inputValidations.subject}
           name="subject"
@@ -108,8 +117,31 @@ export default function DataverseRepo({
           ))}
         </TextField>
       </Grid>
-      <Grid item xs={2}></Grid>
-      <Grid item xs={5}>
+      <Grid item xs={1}></Grid>
+      <Grid item xs={2}>
+        <TextField
+          //deal with validation later
+          //error={submitAttempt && !inputValidations.subject}
+          name="metadataLanguage"
+          select
+          label="Metadata language"
+          defaultValue={null}
+          // @ts-expect-error React event handlers are not parameterised by the name prop
+          onChange={handleMetadataLanguageChange}
+          helperText="Please select your metadata language"
+          margin="normal"
+          fullWidth
+          value={metadataLanguage}
+        >
+          {[{ name: "Hungarian", langCode: "hu" }, { name: "English", langCode: "en" }].map((option) => (
+            <MenuItem key={option.name} value={option.langCode}>
+              {option.name}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Grid>
+      <Grid item xs={1}></Grid>
+      <Grid item xs={4}>
         <TextField
           name="license"
           select

--- a/src/main/webapp/ui/src/Export/repositories/DataverseRepo.tsx
+++ b/src/main/webapp/ui/src/Export/repositories/DataverseRepo.tsx
@@ -117,13 +117,13 @@ export default function DataverseRepo({
           ))}
         </TextField>
       </Grid>
-      <Grid item xs={4}>
+      {repo.metadataLanguages.length > 0 && (<Grid item xs={4}>
         <TextField
           //TODO: deal with validation
-          //error={submitAttempt && !inputValidations.subject}
+          error={submitAttempt && !inputValidations.subject}
           name="metadataLanguage"
           select
-          label="Metadata language"
+          label="Metadata language *"
           defaultValue={null}
           // @ts-expect-error React event handlers are not parameterised by the name prop
           onChange={handleMetadataLanguageChange}
@@ -132,13 +132,13 @@ export default function DataverseRepo({
           fullWidth
           value={metadataLanguage}
         >
-          {[{ name: "Hungarian", langCode: "hu" }, { name: "English", langCode: "en" }].map((option) => (
-            <MenuItem key={option.name} value={option.langCode}>
-              {option.name}
+          {repo.metadataLanguages.map((option) => (
+            <MenuItem key={option.title} value={option.locale}>
+              {option.title}
             </MenuItem>
           ))}
         </TextField>
-      </Grid>
+      </Grid>)}
       <Grid item xs={4}>
         <TextField
           name="license"

--- a/src/main/webapp/ui/src/Export/repositories/common.ts
+++ b/src/main/webapp/ui/src/Export/repositories/common.ts
@@ -63,7 +63,7 @@ export type Repo = {
    * associate with the export.
    */
   linkedDMPs: Array<Plan> | null;
-
+  metadataLanguages: Array<Record<string,string>>;
   label?: string;
   repoCfg: unknown;
 };


### PR DESCRIPTION
## Description ##
Closes this issue: https://github.com/rspace-os/rspace-web/issues/478
Before exporting, RSpace makes an API call to Dataverse querying the possible metadata languages for each Dataverse collection. If there are metadata languages configured on the Dataverse server, the Dataverse export form has a new input field for choosing one.
I also worked on Dataverse itself, the Dataverse Java client and the Dataverse adaptor. This PR only works with the changes presented in the following PRs:
- https://github.com/IQSS/dataverse/pull/11857
- https://github.com/IQSS/dataverse-client-java/pull/31
- https://github.com/rspace-os/rspace-dataverse-adapter/pull/3

## Design decisions
Configuring available metadata languages on the integration form and keeping track of the possible changes would put too much administrative burden on the user., so I decided it would be better to gather this information automatically.

## Testing notes
Checkout the other pull requests first and set up a Dataverse instance with some metadata languages configured.