### PR TITLE
Rsdev 440 user deletion forms

### DIFF
--- a/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
@@ -316,7 +316,7 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
   }
 
   private void deleteForms(Long userId, Session session) {
-   // Set the temp field column to NULL to avoid FK violation during deletion
+    // Set the temp field column to NULL to avoid FK violation during deletion
     execute(
         userId,
         session,

--- a/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
@@ -315,8 +315,17 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
     execute(userId, session, "delete from OAuthApp where user_id = :id");
   }
 
-  // this will only work if user has no published forms!
   private void deleteForms(Long userId, Session session) {
+   // Set the temp field column to NULL to avoid FK violation during deletion
+    execute(
+        userId,
+        session,
+        "update FieldForm ff left join RSForm rf on ff.form_id = rf.id "
+            + "set ff.tempFieldForm_id = NULL where rf.owner_id=:id");
+
+    // Set previous version column to NULL to avoid FK violation
+    execute(userId, session, "update RSForm set previousVersion_id = NULL where owner_id=:id");
+
     execute(
         userId,
         session,

--- a/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
@@ -618,7 +618,7 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
   }
 
   @Test
-  public void deleteUserWithFormHavingPreviousVersion() throws Exception {
+  public void deleteUserFormThatReferencesPreviousVersion() throws Exception {
     User formCreator = createInitAndLoginAnyUser();
 
     RSForm originalForm = createAnyForm(formCreator);
@@ -646,7 +646,7 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
   }
 
   @Test
-  public void deleteUserWithFormHavingTempFieldFormReference() throws Exception {
+  public void deleteUserFormWithTempVersion() throws Exception {
     User formCreator = createInitAndLoginAnyUser();
 
     RSForm form1 = createAnyForm(formCreator);

--- a/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
@@ -620,11 +620,11 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
   @Test
   public void deleteUserWithFormHavingPreviousVersion() throws Exception {
     User formCreator = createInitAndLoginAnyUser();
-    
+
     RSForm originalForm = createAnyForm(formCreator);
     originalForm.publish();
     formMgr.save(originalForm);
-    
+
     RSForm newVersion = createAnyForm(formCreator);
     newVersion.publish();
     formMgr.save(newVersion);
@@ -634,13 +634,13 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
         "UPDATE RSForm SET previousVersion_id = ? WHERE id = ?",
         originalForm.getId(),
         newVersion.getId());
-    
+
     User sysadmin = logoutAndLoginAsSysAdmin();
     UserDeletionPolicy policy = unrestrictedDeletionPolicy();
-    
+
     ServiceOperationResult<User> result =
         userDeletionMgr.removeUser(formCreator.getId(), policy, sysadmin);
-    
+
     assertTrue(result.isSucceeded());
     assertUserNotExist(formCreator);
   }
@@ -648,15 +648,15 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
   @Test
   public void deleteUserWithFormHavingTempFieldFormReference() throws Exception {
     User formCreator = createInitAndLoginAnyUser();
-    
+
     RSForm form1 = createAnyForm(formCreator);
     form1.publish();
     formMgr.save(form1);
-    
+
     RSForm form2 = createAnyForm(formCreator);
     form2.publish();
     formMgr.save(form2);
-    
+
     List<Long> fieldIds =
         jdbcTemplate.queryForList(
             "SELECT id FROM FieldForm WHERE form_id IN (?, ?)",
@@ -666,16 +666,14 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
 
     // set up the temp field reference between the two forms
     jdbcTemplate.update(
-        "UPDATE FieldForm SET tempFieldForm_id = ? WHERE id = ?", 
-        fieldIds.get(0), 
-        fieldIds.get(1));
-    
+        "UPDATE FieldForm SET tempFieldForm_id = ? WHERE id = ?", fieldIds.get(0), fieldIds.get(1));
+
     User sysadmin = logoutAndLoginAsSysAdmin();
     UserDeletionPolicy policy = unrestrictedDeletionPolicy();
-    
+
     ServiceOperationResult<User> result =
         userDeletionMgr.removeUser(formCreator.getId(), policy, sysadmin);
-    
+
     assertTrue(result.isSucceeded());
     assertUserNotExist(formCreator);
   }


### PR DESCRIPTION
## Description ##
This PR fixes issues when deleting users, where deleting their forms would fail if the form was referenced as previous version or as a temporary version of another form.

The fix is to set these FK columns to null before attempting to delete.

See https://researchspace.atlassian.net/browse/RSDEV-440 for full details
