### PR TITLE
RSDEV-836: Fix error message when moving an owned document into a notebook owned by the same user

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
+++ b/src/main/java/com/researchspace/webapp/controller/WorkspaceController.java
@@ -592,6 +592,7 @@ public class WorkspaceController extends BaseController {
     User user = getUserByUsername(principal.getName());
     Folder usersRootFolder = folderManager.getRootFolderForUser(user);
     Folder target = null;
+    String errorReason = "";
 
     // handle input which might contain a /
     if ("/".equals(targetFolderId)) {
@@ -634,6 +635,9 @@ public class WorkspaceController extends BaseController {
                 baseRecordToMove.getId(),
                 target.getId(),
                 ex.getMessage());
+            if (ex.getMessage().contains("document into own notebook")) {
+              errorReason = "workspace.share.owned.into.shared.owned";
+            }
             break;
           }
         } else {
@@ -652,7 +656,11 @@ public class WorkspaceController extends BaseController {
     } else {
       String msgKey;
       if (moveCounter == 0) {
-        msgKey = getText("workspace.move.nothing.moved");
+        if (StringUtils.isBlank(errorReason)) {
+          msgKey = getText("workspace.move.nothing.moved");
+        } else {
+          msgKey = getText(errorReason);
+        }
       } else {
         msgKey = getText("workspace.move.some.not.moved");
       }

--- a/src/main/resources/bundles/workspace/workspace.properties
+++ b/src/main/resources/bundles/workspace/workspace.properties
@@ -172,3 +172,4 @@ document.delete.failure.msg=Document {0} cannot be deleted as it is currently ed
 workspace.move.success=Move action successful
 workspace.move.nothing.moved=Nothing was moved. You may lack permissions to move the records from their current location, or into the new location.
 workspace.move.some.not.moved=Some records were not moved. You may lack permissions to move the records from their current location, or into the new location.
+workspace.share.owned.into.shared.owned=Nothing was moved. A shared document owned by a specific user cannot be shared into a notebook owned by the same user. If the document should be a part of the notebook, the owner can `move` it into the notebook on their Workspace.


### PR DESCRIPTION
## Description ##
 - This PR fixes the error message when moving a document owned by an user **A** into a notebook owned by the same user (whoever make the operation)

## Testing ##
 - Please refer to the JIRA https://researchspace.atlassian.net/browse/RSDEV-836
 - AWS instance: https://rsdev-836-fix-error-msg-3.researchspace.com/