### PR TITLE
PRT-1003 Fix analytics event handler in coreEditor.js

### DIFF
--- a/src/main/webapp/scripts/pages/coreEditor.js
+++ b/src/main/webapp/scripts/pages/coreEditor.js
@@ -2164,12 +2164,14 @@ $(document).ready(function () {
 });
 
 $(document).ready(function () {
-  window.tinymce.on("AddEditor", function (e) {
-    e.editor.on("ExecCommand", function (e) {
-      RS.trackEvent("user:trigger:tiny_mce_command:document_editor", { command: e.command });
+  if (window.tinymce) {
+    window.tinymce.on("AddEditor", function (e) {
+      e.editor.on("ExecCommand", function (e) {
+        RS.trackEvent("user:trigger:tiny_mce_command:document_editor", { command: e.command });
+      });
+      e.editor.on("OpenWindow", function (e) {
+        RS.trackEvent("user:open:tiny_mce_window:document_editor", { window: document.querySelector(".tox-dialog__title").textContent });
+      });
     });
-    e.editor.on("OpenWindow", function (e) {
-      RS.trackEvent("user:open:tiny_mce_window:document_editor", { window: document.querySelector(".tox-dialog__title").textContent });
-    });
-  });
+  }
 });


### PR DESCRIPTION
## Description ##
This change fixes a small bug with the recent analytics addition, wherein if the page that coreEditor.js was loaded on didn't have a tinymce editor (such as an empty notebook) then the code would fail and break the whole page
