### PR TITLE
PRT-1007: Make sure to open the document into the document when opened outside of the notebook context

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/StructuredDocumentController.java
+++ b/src/main/java/com/researchspace/webapp/controller/StructuredDocumentController.java
@@ -564,21 +564,6 @@ public class StructuredDocumentController extends BaseController {
     User user = userManager.getUserByUsername(principal.getName(), true);
     DocumentEditContext docEditContext = getDocEditContext(recordId, user);
     StructuredDocument structuredDocument = docEditContext.getStructuredDocument();
-
-    // notebook entries should be opened in notebook view (RSPAC-501)
-    if (structuredDocument.isNotebookEntry() && fromNotebook == null && !msTeamsDocView) {
-      boolean redirectToNotebook = false;
-      if (user.equals(structuredDocument.getOwner())) {
-        // if you're an owner, and the doc is part of your notebook
-        redirectToNotebook = structuredDocument.getNonSharedParentNotebook() != null;
-      } else {
-        // user is not an owner, but one of the parent notebook was shared with him
-        redirectToNotebook = canUserAccessAnyOfParentNotebooks(user, structuredDocument);
-      }
-      if (redirectToNotebook) {
-        return new ModelAndView(redirectToNotebookView(structuredDocument, settingsKey));
-      }
-    }
     EditStatus res = docEditContext.getEditStatus();
     // Opening Basic Documents in "Edit Mode" when editMode flag is true or coming
     // from notebook view
@@ -697,15 +682,6 @@ public class StructuredDocumentController extends BaseController {
     createBreadcrumb(model, document, rootRecord, parent);
   }
 
-  private boolean canUserAccessAnyOfParentNotebooks(User user, StructuredDocument doc) {
-    for (Notebook nb : doc.getParentNotebooks()) {
-      if (permissionUtils.isPermitted(nb, PermissionType.READ, user)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private void addGroupAttributes(Model model, User usr) {
     Set<Group> groups = groupManager.listGroupsForUser();
     model.addAttribute("groups", groups);
@@ -730,12 +706,6 @@ public class StructuredDocumentController extends BaseController {
       model.addAttribute("parentId", breadcrumb.getParentFolderId());
     }
     return breadcrumb;
-  }
-
-  protected String redirectToNotebookView(StructuredDocument notebookEntry, String settingsKey) {
-    return "redirect:"
-        + NotebookEditorController.getNotebookViewUrl(
-            notebookEntry.getParentNotebook().getId(), notebookEntry.getId(), settingsKey);
   }
 
   /**

--- a/src/test/java/com/researchspace/webapp/controller/SDocController2IT.java
+++ b/src/test/java/com/researchspace/webapp/controller/SDocController2IT.java
@@ -589,7 +589,6 @@ public class SDocController2IT extends RealTransactionSpringTestBase {
     // for user, the doc should open it in document view
     logoutAndLoginAs(user);
     String documentViewUrl = StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_VIEW_NAME;
-    String notebookRedirectUrl = controller.redirectToNotebookView(doc, "");
     ModelAndView userOpensDocument =
         controller.openDocument(
             doc.getId(), "", false, false, null, modelTss, mockHttpSession, user::getUsername);
@@ -600,9 +599,9 @@ public class SDocController2IT extends RealTransactionSpringTestBase {
     ModelAndView piOpensDocument =
         controller.openDocument(
             doc.getId(), "", false, false, null, modelTss, mockHttpSession, pi::getUsername);
-    assertEquals(notebookRedirectUrl, piOpensDocument.getViewName());
+    assertEquals(documentViewUrl, piOpensDocument.getViewName());
 
-    // for second user, who sees it as a part of pi's shared notebook, should open in notebook view
+    // for second user, who sees it as a part of pi's shared notebook, still open in doc view
     logoutAndLoginAs(secondUser);
     ModelAndView secondUserOpensDocument =
         controller.openDocument(
@@ -614,7 +613,7 @@ public class SDocController2IT extends RealTransactionSpringTestBase {
             modelTss,
             mockHttpSession,
             secondUser::getUsername);
-    assertEquals(notebookRedirectUrl, secondUserOpensDocument.getViewName());
+    assertEquals(documentViewUrl, secondUserOpensDocument.getViewName());
 
     // for other user, who sees it as individually shared doc, should open in document view
     logoutAndLoginAs(otherUser);

--- a/src/test/java/com/researchspace/webapp/controller/SDocControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/SDocControllerMVCIT.java
@@ -374,9 +374,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     // create a record from the template
     this.mockMvc
         .perform(
-            post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                    + "/createFromTemplate/"
-                    + sd.getParent().getId())
+            post(STRUCTURED_DOCUMENT_EDITOR_URL + "/createFromTemplate/" + sd.getParent().getId())
                 .param("template", template.getId() + "")
                 .principal(mockPrincipal))
         .andReturn();
@@ -547,8 +545,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult result =
         this.mockMvc
             .perform(
-                get(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/getPotentialWitnesses")
+                get(STRUCTURED_DOCUMENT_EDITOR_URL + "/getPotentialWitnesses")
                     .param("recordId", setup.structuredDocument.getId() + "")
                     .principal(mockPrincipal))
             .andReturn();
@@ -563,8 +560,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult result1 =
         this.mockMvc
             .perform(
-                post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/ajax/proceedSigning/")
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/ajax/proceedSigning/")
                     .param("recordId", setup.structuredDocument.getId() + "")
                     .param("statement", "any")
                     .param("witnesses[]", new String[] {setup.user.getUsername()})
@@ -586,10 +582,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     final int initialRecordsCount = (int) getRecordCountInFolderForUser(rootFolder);
     this.mockMvc
         .perform(
-            post(
-                    StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/create/{recordId}",
-                    rootFolder + "")
+            post(STRUCTURED_DOCUMENT_EDITOR_URL + "/create/{recordId}", rootFolder + "")
                 .param("template", form.getId() + "")
                 .principal(new MockPrincipal(u.getUsername())))
         .andExpect(status().is3xxRedirection())
@@ -613,10 +606,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult resultUrl =
         this.mockMvc
             .perform(
-                post(
-                        StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                            + "/create/{recordId}",
-                        sharedFolderId + "")
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/create/{recordId}", sharedFolderId + "")
                     .param("template", form.getId() + "")
                     .principal(new MockPrincipal(u.getUsername())))
             .andExpect(status().is3xxRedirection())
@@ -661,10 +651,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     resultUrl =
         this.mockMvc
             .perform(
-                post(
-                        StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                            + "/create/{recordId}",
-                        notebookId)
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/create/{recordId}", notebookId)
                     .param("template", form.getId() + "")
                     .param("grandParentId", sharedFolderId + "")
                     .principal(new MockPrincipal(u.getUsername())))
@@ -698,8 +685,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     this.mockMvc
         .perform(
             post(
-                    StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/createEntry/{notebookid}",
+                    STRUCTURED_DOCUMENT_EDITOR_URL + "/createEntry/{notebookid}",
                     notebook.getId() + "")
                 .principal(new MockPrincipal(u.getUsername())))
         .andExpect(status().is3xxRedirection())
@@ -718,8 +704,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult defaultEntry =
         mockMvc
             .perform(
-                post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/ajax/createEntry")
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/ajax/createEntry")
                     .param("notebookId", notebook.getId().toString())
                     .principal(user::getUsername))
             .andReturn();
@@ -730,8 +715,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult namedEntry =
         mockMvc
             .perform(
-                post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/ajax/createEntry")
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/ajax/createEntry")
                     .param("notebookId", notebook.getId().toString())
                     .param("entryName", testName)
                     .principal(user::getUsername))
@@ -777,29 +761,24 @@ public class SDocControllerMVCIT extends MVCTestBase {
     this.mockMvc
         .perform(
             get(
-                    StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/{entryId}?fromNotebook={notebookId}",
+                    STRUCTURED_DOCUMENT_EDITOR_URL + "/{entryId}?fromNotebook={notebookId}",
                     notebookEntryId + "",
                     notebook.getId() + "")
                 .principal(user::getUsername))
         .andExpect(status().is2xxSuccessful())
         .andReturn();
 
-    // ...but opening notebook entry for view should redirect to notebook view (RSPAC-501)
+    // ...and also opening notebook entry (outside of the notebook) will still open the document view (PRT-1007)
     MvcResult redirectResult =
         this.mockMvc
             .perform(
-                get(
-                        StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL + "/{entryId}",
-                        notebookEntryId + "")
+                get(STRUCTURED_DOCUMENT_EDITOR_URL + "/{entryId}", notebookEntryId + "")
                     .principal(user::getUsername))
-            .andExpect(status().is3xxRedirection())
+            .andExpect(status().is2xxSuccessful())
             .andReturn();
 
-    String expectedUrl =
-        "redirect:"
-            + NotebookEditorController.getNotebookViewUrl(notebook.getId(), notebookEntryId, "");
-    assertEquals(expectedUrl, redirectResult.getModelAndView().getViewName());
+    assertEquals(
+        STRUCTURED_DOCUMENT_EDITOR_URL, "/" + redirectResult.getModelAndView().getViewName());
   }
 
   @Test
@@ -810,8 +789,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult result =
         this.mockMvc
             .perform(
-                post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/ajax/description")
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/ajax/description")
                     .param("recordId", doc.getId() + "")
                     .param("description", desc)
                     .principal(u::getUsername))
@@ -825,8 +803,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     result =
         this.mockMvc
             .perform(
-                post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/ajax/description")
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/ajax/description")
                     .param("recordId", doc.getId() + "")
                     .param("description", longDesc)
                     .principal(u::getUsername))
@@ -840,8 +817,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     result =
         this.mockMvc
             .perform(
-                post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/ajax/description")
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/ajax/description")
                     .param("recordId", doc.getId() + "")
                     .param("description", tooLongDesc)
                     .principal(u::getUsername))
@@ -859,8 +835,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult unauthorisedResult =
         this.mockMvc
             .perform(
-                post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/ajax/description")
+                post(STRUCTURED_DOCUMENT_EDITOR_URL + "/ajax/description")
                     .param("recordId", doc.getId() + "")
                     .param("description", desc)
                     .principal(piUser::getUsername))
@@ -975,8 +950,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult result =
         this.mockMvc
             .perform(
-                get(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
-                        + "/ajax/getUpdatedFields")
+                get(STRUCTURED_DOCUMENT_EDITOR_URL + "/ajax/getUpdatedFields")
                     .param("recordId", doc.getId() + "")
                     .param("modificationDate", modifiedDate.getTime() + "")
                     .principal(mockPrincipal))
@@ -994,7 +968,7 @@ public class SDocControllerMVCIT extends MVCTestBase {
     MvcResult result =
         this.mockMvc
             .perform(
-                post(StructuredDocumentController.STRUCTURED_DOCUMENT_EDITOR_URL
+                post(STRUCTURED_DOCUMENT_EDITOR_URL
                         + "/ajax/deleteStructuredDocument/"
                         + structuredDocument.getId())
                     .principal(mockPrincipal))


### PR DESCRIPTION
## Description
This PR make sure that a document (that is part of a notebook) opened outside of the notebook context (i.e.: it is singularly shared, without sharing the whole parent notebook) is visualised in the structured opening view (instead of the notebook edit view)

## Why this change 
We had to do this change since we have introduced the concept of `grandParentId`.
In fact, when we open a document outside of the notebook context the whole concept of `parentId` and `grandParentId` does not fit (the document has actully got a `parentNotebook`, but it is opened inside a shared folder (as per `breadcrumbs`) that does not contain the `parentNotebook` that has not been fully shared)

## Testing notes
- Please follow steps to reproduce inside the jira ticket: [PRT-1007](https://researchspace.atlassian.net/browse/PRT-1007)
- ✅ Successfully tested on AWS instance https://prt-1007-notebook-editor-3.researchspace.com ✅ 