### PR TITLE
RSDEV-895: handle notebook view even if grandparentId cannot be inferred

### DIFF
--- a/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerMVCIT.java
@@ -1,12 +1,19 @@
 package com.researchspace.webapp.controller;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
+import com.researchspace.Constants;
+import com.researchspace.core.testutil.CoreTestUtils;
 import com.researchspace.model.User;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.Notebook;
+import com.researchspace.testutils.TestGroup;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -65,6 +72,45 @@ public class NotebookEditorControllerMVCIT extends MVCTestBase {
                     .principal(new MockPrincipal(other.getUsername())))
             .andReturn();
     assert (result2.getResolvedException() instanceof RecordAccessDeniedException);
+  }
+
+  @Test
+  public void openNotebookWithoutParentContext() throws Exception {
+    TestGroup g1 = createTestGroup(1);
+    User u1 = g1.u1();
+    logoutAndLoginAs(u1);
+
+    Notebook nb = createNotebookWithNEntries(getRootFolderForUser(u1).getId(), "nb", 1, u1);
+    shareNotebookWithGroup(u1, nb, g1.getGroup(), "read");
+
+    // retrieve notebook with just an id, e.g. when navigating through globalId url
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/notebookEditor/" + nb.getId()).principal(new MockPrincipal(u1.getUsername())))
+            .andReturn();
+    assertNull(result.getResolvedException());
+    assertNotNull(result.getModelAndView());
+    assertEquals(nb.getId(), result.getModelAndView().getModel().get("selectedNotebookId"));
+    assertTrue(
+        ((ActionPermissionsDTO) result.getModelAndView().getModel().get("permDTO"))
+            .isCreateRecord());
+
+    // now try retrieving as a sysadmin, who has global read permission
+    User sysadmin = createAndSaveUser(CoreTestUtils.getRandomName(10), Constants.SYSADMIN_ROLE);
+    initUser(sysadmin);
+    result =
+        mockMvc
+            .perform(
+                get("/notebookEditor/" + nb.getId())
+                    .principal(new MockPrincipal(sysadmin.getUsername())))
+            .andReturn();
+    assertNull(result.getResolvedException());
+    assertNotNull(result.getModelAndView());
+    assertEquals(nb.getId(), result.getModelAndView().getModel().get("selectedNotebookId"));
+    assertFalse(
+        ((ActionPermissionsDTO) result.getModelAndView().getModel().get("permDTO"))
+            .isCreateRecord());
   }
 
   private Long getFirstEntryId(Notebook notebook) {

--- a/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
@@ -3,6 +3,7 @@ package com.researchspace.webapp.controller;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
@@ -37,7 +38,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
@@ -63,7 +63,6 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
   NotebookEditorRecordManagerStub recordManagerStub;
   @Mock IPermissionUtils permissionUtils;
   @Mock BreadcrumbGenerator breadcrumbGenerator;
-  MockHttpSession mockSession = null;
   @Mock private User anonymousUser;
 
   Principal mockPrincipal =
@@ -74,7 +73,6 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
           return user.getUsername();
         }
       };
-  @Mock private User userMock;
 
   @Before
   public void setUp() throws Exception {
@@ -93,7 +91,6 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     notebookEditorController.setRecordManager(recordManagerStub);
     notebookEditorController.setPermissionUtils(permissionUtils);
     notebookEditorController.setServletContext(servletContext);
-    mockSession = new MockHttpSession();
   }
 
   @After
@@ -108,15 +105,18 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     when(permissionUtils.isPermitted(
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(false);
-    notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
+    notebookEditorController.openNotebook(1L, null, "", "2", model, mockPrincipal);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void handleRequestNoGrandParentId() throws AuthorizationException {
     when(permissionUtils.isPermitted(
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
-    notebookEditorController.openNotebook(1L, null, "", "null", model, mockSession, mockPrincipal);
+
+    ModelAndView resp =
+        notebookEditorController.openNotebook(1L, null, null, null, model, mockPrincipal);
+    assertEquals(1L, resp.getModel().get("selectedNotebookId"));
   }
 
   @Test
@@ -126,7 +126,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView results =
-        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockPrincipal);
     assertNotNull(results);
   }
 
@@ -137,15 +137,14 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView result =
-        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("enforce_ontologies"));
     User aPI = createAndSaveAPi();
     Group g = createGroup("aGroup", aPI);
     g.setEnforceOntologies(true);
     grpMgr.addUserToGroup(user.getUsername(), g.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(g, user);
-    result =
-        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
+    result = notebookEditorController.openNotebook(1L, null, "", "2", model, mockPrincipal);
     assertTrue((Boolean) result.getModelMap().getAttribute("enforce_ontologies"));
   }
 
@@ -156,22 +155,20 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView result =
-        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
     User aPI = createAndSaveAPi();
     Group aProjectG = createGroup("aProjectGroup", aPI);
     aProjectG.setGroupType(GroupType.PROJECT_GROUP);
     grpMgr.addUserToGroup(user.getUsername(), aProjectG.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(aProjectG, user);
-    result =
-        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
+    result = notebookEditorController.openNotebook(1L, null, "", "2", model, mockPrincipal);
     assertFalse((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
     Group g = createGroup("aGroup", aPI);
     g.setAllowBioOntologies(true);
     grpMgr.addUserToGroup(user.getUsername(), g.getId(), RoleInGroup.DEFAULT);
     grpMgr.saveGroup(g, user);
-    result =
-        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
+    result = notebookEditorController.openNotebook(1L, null, "", "2", model, mockPrincipal);
     assertTrue((Boolean) result.getModelMap().getAttribute("allow_bioOntologies"));
   }
 
@@ -184,7 +181,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))
         .thenReturn(true);
     ModelAndView results =
-        notebookEditorController.openNotebook(1L, null, "", "2", model, mockSession, mockPrincipal);
+        notebookEditorController.openNotebook(1L, null, "", "2", model, mockPrincipal);
     assertNotNull(results);
     assertTrue((Boolean) results.getModelMap().getAttribute("isPublished"));
   }


### PR DESCRIPTION
It turns out there are legitimate cases where user may want to see the notebook that is not attached to their folder hierarchy at all, e.g. in case of a System Admin who has global read permission. 

The changes in this PR are handling this scenario, and should alleviate the reports we occasionally get since 1.115 is out, that user in particular navigation/globalId usage scenario cannot access notebook they should be able to see.

If user has read permission to the notebook, but the `grandparentId` parameter cannot be inferred, the breadcrumb trail shows just the notebook, and UI doesn't show 'create' action - which is the same behaviour as it was before 1.115.