### PR TITLE
Revert "RSDEV-822 misleading description for explicit access list (#499)

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Fields/AccessPermissions/index.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/AccessPermissions/index.tsx
@@ -183,7 +183,9 @@ function AccessPermissions<FieldOwner extends HasEditableFields<Fields>>({
                         <Grid item>
                           <OptionHeading>Explicit access list</OptionHeading>
                           <OptionExplanation>
-                            Accessible only to members of the following groups the owner belongs to.
+                            Accessible to only those who are in a lab or
+                            collaboration group that is listed in the table
+                            below, which can be any group in the system.
                           </OptionExplanation>
                         </Grid>
                         <Grid item>


### PR DESCRIPTION

This reverts commit 23c465f7877133b9bfdcc7b393061f7929b1e0b1.

## Description ##
Reverting on request of Vaida.