### PR TITLE
RSDEV-912: fix linking to nfs directories

### DIFF
--- a/src/main/webapp/ui/src/tinyMCE/gallery/index.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/gallery/index.tsx
@@ -70,7 +70,7 @@ parent.tinymce.PluginManager.add("gallery", function (editor) {
         remoteFiles.forEach((file) => {
           const json = {
             name: file.name,
-            linktype: "file",
+            linktype: file.isFolder ? "directory" : "file",
             fileStoreId: file.path[0].id,
             relFilePath: file.remotePath,
             nfsId: file.nfsId,


### PR DESCRIPTION
The filestore links have two flavours: 'file' or 'directory', let's support it in the new 'insert from Gallery' dialog.