### PR TITLE
RSDEV-940: Create end point that get folderId and returns associated RaID

### DIFF
--- a/src/main/java/com/researchspace/model/dtos/RaidGroupAssociation.java
+++ b/src/main/java/com/researchspace/model/dtos/RaidGroupAssociation.java
@@ -1,5 +1,6 @@
 package com.researchspace.model.dtos;
 
+import com.researchspace.model.raid.UserRaid;
 import com.researchspace.webapp.integrations.raid.RaIDReferenceDTO;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
@@ -13,4 +14,11 @@ public class RaidGroupAssociation implements Serializable {
 
   private Long projectGroupId;
   private RaIDReferenceDTO raid;
+
+  public RaidGroupAssociation(UserRaid userRaid) {
+    this.projectGroupId = userRaid.getGroupAssociated().getId();
+    this.raid =
+        new RaIDReferenceDTO(
+            userRaid.getId(), userRaid.getRaidServerAlias(), userRaid.getRaidIdentifier());
+  }
 }

--- a/src/main/java/com/researchspace/service/FolderNotSharedException.java
+++ b/src/main/java/com/researchspace/service/FolderNotSharedException.java
@@ -1,0 +1,12 @@
+package com.researchspace.service;
+
+public class FolderNotSharedException extends IllegalArgumentException {
+
+  public FolderNotSharedException(String message) {
+    super(message);
+  }
+
+  public FolderNotSharedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/researchspace/service/RaIDServiceManager.java
+++ b/src/main/java/com/researchspace/service/RaIDServiceManager.java
@@ -3,6 +3,7 @@ package com.researchspace.service;
 import com.researchspace.model.User;
 import com.researchspace.model.dtos.RaidGroupAssociation;
 import com.researchspace.model.raid.UserRaid;
+import java.util.Optional;
 import java.util.Set;
 
 public interface RaIDServiceManager {
@@ -10,6 +11,8 @@ public interface RaIDServiceManager {
   UserRaid getUserRaid(Long userRaidId);
 
   Set<RaidGroupAssociation> getAssociatedRaidsByUserAndAlias(User user, String serverAlias);
+
+  Optional<RaidGroupAssociation> getAssociatedRaidByFolderId(User user, Long folderId);
 
   void bindRaidToGroupAndSave(User user, RaidGroupAssociation raidToGroupAssociation);
 

--- a/src/main/java/com/researchspace/service/impl/DeleteFolderFromSharedFolderPolicy.java
+++ b/src/main/java/com/researchspace/service/impl/DeleteFolderFromSharedFolderPolicy.java
@@ -9,6 +9,7 @@ import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.RSPath;
 import com.researchspace.service.DeletionPlan;
 import com.researchspace.service.FolderDeletionOrderPolicy;
+import com.researchspace.service.FolderNotSharedException;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -31,7 +32,7 @@ public class DeleteFolderFromSharedFolderPolicy implements FolderDeletionOrderPo
           String.format(
               "The folder '%s' to be deleted - id [%d] is not in a shared folder!",
               toDelete.getName(), toDelete.getId());
-      throw new IllegalArgumentException(msg);
+      throw new FolderNotSharedException(msg);
     }
     DeletionPlan plan = new DeletionPlan(subject, path, parent);
     plan.add(toDelete);

--- a/src/main/java/com/researchspace/service/impl/GroupManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/GroupManagerImpl.java
@@ -64,6 +64,7 @@ import com.researchspace.model.views.GroupInvitation.Invitee;
 import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.model.views.UserView;
 import com.researchspace.service.FolderManager;
+import com.researchspace.service.FolderNotSharedException;
 import com.researchspace.service.GroupManager;
 import com.researchspace.service.IContentInitialiserUtils;
 import com.researchspace.service.OperationFailedMessageGenerator;
@@ -787,7 +788,7 @@ public class GroupManagerImpl implements GroupManager {
           String.format(
               "The folder '%s' is not a shared subfolder - id [%d] is not in a shared folder!",
               sharedFolder.getName(), sharedFolder.getId());
-      throw new IllegalArgumentException(msg);
+      throw new FolderNotSharedException(msg);
     }
     return this.getGroupByCommunalGroupFolderId(sharedFolderRoot.get().getId());
   }

--- a/src/main/java/com/researchspace/service/impl/RaIDServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RaIDServiceManagerImpl.java
@@ -5,10 +5,12 @@ import com.researchspace.model.Group;
 import com.researchspace.model.User;
 import com.researchspace.model.dtos.RaidGroupAssociation;
 import com.researchspace.model.raid.UserRaid;
+import com.researchspace.model.record.Folder;
+import com.researchspace.service.FolderManager;
 import com.researchspace.service.GroupManager;
 import com.researchspace.service.RaIDServiceManager;
-import com.researchspace.webapp.integrations.raid.RaIDReferenceDTO;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +20,8 @@ import org.springframework.stereotype.Service;
 public class RaIDServiceManagerImpl implements RaIDServiceManager {
 
   @Autowired private RaIDDao raidDao;
-  @Autowired private GroupManager groupManager;
+  @Autowired private GroupManager grpManager;
+  @Autowired private FolderManager folderManagerImpl;
 
   @Override
   public UserRaid getUserRaid(Long userRaidId) {
@@ -28,33 +31,34 @@ public class RaIDServiceManagerImpl implements RaIDServiceManager {
   @Override
   public Set<RaidGroupAssociation> getAssociatedRaidsByUserAndAlias(User user, String serverAlias) {
     List<UserRaid> userRaidList = raidDao.getAssociatedRaidByUserAndAlias(user, serverAlias);
-    return userRaidList.stream()
-        .map(
-            r ->
-                new RaidGroupAssociation(
-                    r.getGroupAssociated().getId(),
-                    new RaIDReferenceDTO(r.getId(), r.getRaidServerAlias(), r.getRaidIdentifier())))
-        .collect(Collectors.toSet());
+    return userRaidList.stream().map(RaidGroupAssociation::new).collect(Collectors.toSet());
+  }
+
+  @Override
+  public Optional<RaidGroupAssociation> getAssociatedRaidByFolderId(User user, Long folderId) {
+    Folder currentFolder = folderManagerImpl.getFolder(folderId, user);
+    Group projectGroup = grpManager.getGroupFromAnyLevelOfSharedFolder(user, currentFolder, null);
+    return Optional.of(new RaidGroupAssociation(projectGroup.getRaid()));
   }
 
   @Override
   public void bindRaidToGroupAndSave(User user, RaidGroupAssociation raidToGroupAssociation) {
-    Group projectGroup = groupManager.getGroup(raidToGroupAssociation.getProjectGroupId());
+    Group projectGroup = grpManager.getGroup(raidToGroupAssociation.getProjectGroupId());
     projectGroup.setRaid(
         new UserRaid(
             user,
             projectGroup,
             raidToGroupAssociation.getRaid().getRaidServerAlias(),
             raidToGroupAssociation.getRaid().getRaidIdentifier()));
-    groupManager.saveGroup(projectGroup, false, user);
+    grpManager.saveGroup(projectGroup, false, user);
   }
 
   @Override
   public void unbindRaidFromGroupAndSave(User user, Long projectGroupId) {
-    Group projectGroup = groupManager.getGroup(projectGroupId);
+    Group projectGroup = grpManager.getGroup(projectGroupId);
     Long raidIdToRemove = projectGroup.getRaid().getId();
     projectGroup.setRaid(null);
-    groupManager.saveGroup(projectGroup, false, user);
+    grpManager.saveGroup(projectGroup, false, user);
     raidDao.remove(raidIdToRemove);
   }
 }


### PR DESCRIPTION
## Description ##
This PR implements the end point `GET /apps/raid/byFolder/{folderId}` that returns the RaID associated to the project group with specific shared folder ID (or NULL if not associated)


## Testing notes
AWS instance: https://raid-test.researchspace.com

In order to test you need to:
 - create a new project group with RaID (needs UI)
 - Add a RaID to an already existing project group
 - Call the end `/apps/raid/byFolder/{sharedFolderId}` and check if the response is consistent

At the moment the UI is not ready yet.
Wer are waiting for the following UI tasks to be finished:
- https://researchspace.atlassian.net/browse/RSDEV-852 
- https://researchspace.atlassian.net/browse/RSDEV-853 
- https://researchspace.atlassian.net/browse/RSDEV-941

That means you won't be able to test it from the UI, you will need to use the BROWSER on the AWS testing (until the UI is ready):
 - Get available RaIDs for the user: 
```
GET https://raid-test.researchspace.com/apps/raid
```
 - Add a RaID to an already existing project group (end point made JUST for testing)
```
GET https://raid-test.researchspace.com/apps/raid/associate/{projectGroupId}/{raidServerAlias}?raidIdentifier={raidIdentifier_encoded}
```
 - Get the raid associated to the project group shared folder
```
GET https://raid-test.researchspace.com/apps/raid/byFolder/{sharedFolderId}
```

