### PR TITLE
RSDEV-942: Extend `exportArchive` end point to be able to get `raidAssociated` option

### DIFF
--- a/src/main/java/com/researchspace/model/repository/RepoDepositConfig.java
+++ b/src/main/java/com/researchspace/model/repository/RepoDepositConfig.java
@@ -1,6 +1,7 @@
 package com.researchspace.model.repository;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.researchspace.model.dtos.RaidGroupAssociation;
 import java.util.ArrayList;
 import java.util.List;
 import javax.validation.Valid;
@@ -24,6 +25,9 @@ public class RepoDepositConfig {
 
   /** A list of 0 or more selected DMPUser internal IDs */
   private List<Long> selectedDMPs = new ArrayList<>();
+
+  private boolean exportToRaid = false;
+  private RaidGroupAssociation raidAssociated;
 
   /**
    * @return {@code}true{@code} if 1 or more DMP ids were selected


### PR DESCRIPTION
## Description ##
This PR just add the `associatedRaid` input option for the UI to pass as a parameter on the end point `/export/ajax/exportArchive`

## Testing notes ##
- AWS instance: https://raid-test.researchspace.com
- Export anything and verify there is no errors: the flow needs to be the same AS-IS (since anyways the UI is not passing the new option yet)