### PR TITLE
address compiler warnings

### DIFF
--- a/src/main/java/com/researchspace/archive/ArchiveExternalWorkFlow.java
+++ b/src/main/java/com/researchspace/archive/ArchiveExternalWorkFlow.java
@@ -8,7 +8,9 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@EqualsAndHashCode(of = {"extId", "name", "externalService"})
+@EqualsAndHashCode(
+    of = {"extId", "externalService"},
+    callSuper = false)
 public class ArchiveExternalWorkFlow extends ArchivalGalleryMetadata {
   private @XmlElement String extId;
   private @XmlElement String externalService;

--- a/src/main/java/com/researchspace/archive/ArchiveExternalWorkFlowData.java
+++ b/src/main/java/com/researchspace/archive/ArchiveExternalWorkFlowData.java
@@ -17,7 +17,9 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode(of = {"extId", "rspaceDataId"})
+@EqualsAndHashCode(
+    of = {"extId", "rspaceDataId"},
+    callSuper = false)
 public class ArchiveExternalWorkFlowData extends ArchivalGalleryMetadata {
   private @XmlElement long rspaceDataId;
   private @XmlElement String externalService;

--- a/src/main/java/com/researchspace/archive/ArchiveExternalWorkFlowInvocation.java
+++ b/src/main/java/com/researchspace/archive/ArchiveExternalWorkFlowInvocation.java
@@ -20,7 +20,9 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode(of = {"extId"})
+@EqualsAndHashCode(
+    of = {"extId"},
+    callSuper = false)
 public class ArchiveExternalWorkFlowInvocation extends ArchivalGalleryMetadata {
   private @XmlElement String extId;
   private @XmlElement String status;


### PR DESCRIPTION
## Description ##
Addressing a couple of new compiler warnings. Neither of the changes changed how the code works.
1. adding `callSuper=false`: when subclass has `@EqualsAndHashCode`, the superclass isn't called by default. Adding this field shows it's intentional
2. Field "name" which is part of the superclass is removed as it doesn't get used in `@EqualsAndHashCode` due to being part of the superclass
