### PR TITLE
Add dependency check pipeline

### DIFF
--- a/build-resources/dependency-check.groovy
+++ b/build-resources/dependency-check.groovy
@@ -28,13 +28,14 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'dbd7e93e-36f3-4ca0-8f01-2b142585abcc', variable: 'NVD_API_KEY')]) {
 
-                dependencyCheck additionalArguments: '''
+                    dependencyCheck additionalArguments: '''
                     --nvdApiKey ${NVD_API_KEY}
                     -o './'
                     -s './'
                     -f 'XML'
                     --prettyPrint''', odcInstallation: 'OWASP'
-                dependencyCheckPublisher pattern: 'dependency-check-report.xml', failedNewCritical: 1, failedNewHigh: 1
+                    dependencyCheckPublisher pattern: 'dependency-check-report.xml', failedNewCritical: 1, failedNewHigh: 1
+                }
             }
         }
     }


### PR DESCRIPTION
## Description ##
Adds back in the pipeline for running the dependency check on Jenkins.

The pipeline compiles `rspace-web`, runs the dependency check, then reports to slack if there are any new critical or high level vulns since the last scan.

Although it's not exactly usable outside of our Jenkins due to the use of some shared pipelines, I think it's better to include it in the "main" repo (i.e. not closed-source) since a) we want to minimise differences with closed-source b) it could be useful to someone c) we will likely move this to github actions in the mid-term
