### PR TITLE
Rsdev 966 bump spring patch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
-    <version>rsdev-966-bump-spring-patch-version-c9152868f8-1</version>
+    <version>2.1.1</version>
   </parent>
 
   <repositories>


### PR DESCRIPTION
https://researchspace.atlassian.net/browse/RSDEV-966

## Description ##
Uses the latest version of `rspace-parent` which uses the latest patch version of Spring 5, ahead of the move to Spring 6.

Adds exclusions to each of the rspace projects used by `rspace-web` so that only the latest version of Spring 5 is used. 

Jenkins build running all tests: https://jenkins.researchspace.com/job/rspace-web/job/rsdev-966-bump-spring-patch-version/5/console

`rspace-parent` PR: https://github.com/rspace-os/rspace-parent/pull/1
