### PR TITLE
RSDEV-944: Amend creation of manifest.txt (RO-crate-metadata.json) to add the RaID association

### DIFF
--- a/src/main/java/com/researchspace/archive/model/ArchiveExportConfig.java
+++ b/src/main/java/com/researchspace/archive/model/ArchiveExportConfig.java
@@ -6,6 +6,7 @@ import com.researchspace.archive.ExportScope;
 import com.researchspace.core.util.progress.ProgressMonitor;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.dtos.RaidGroupAssociation;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.repository.spi.IRepository;
 import java.io.File;
@@ -41,6 +42,8 @@ public class ArchiveExportConfig implements IArchiveExportConfig {
   private String description = "";
 
   private ExportScope exportScope;
+
+  private RaidGroupAssociation raidGroupAssociation;
 
   private ProgressMonitor progressMonitor = ProgressMonitor.NULL_MONITOR;
 
@@ -171,5 +174,10 @@ public class ArchiveExportConfig implements IArchiveExportConfig {
   @Override
   public boolean isGroupScope() {
     return ExportScope.GROUP.equals(exportScope);
+  }
+
+  @Override
+  public boolean hasRaidAssociation() {
+    return this.raidGroupAssociation != null;
   }
 }

--- a/src/main/java/com/researchspace/archive/model/IArchiveExportConfig.java
+++ b/src/main/java/com/researchspace/archive/model/IArchiveExportConfig.java
@@ -5,6 +5,7 @@ import com.researchspace.archive.ArchivalMeta;
 import com.researchspace.core.util.progress.ProgressMonitor;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.dtos.RaidGroupAssociation;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.repository.spi.IRepository;
 import java.io.File;
@@ -117,4 +118,8 @@ public interface IArchiveExportConfig extends IExportConfig {
   Map<Long, NfsClient> getAvailableNfsClients();
 
   ProgressMonitor getProgressMonitor();
+
+  boolean hasRaidAssociation();
+
+  RaidGroupAssociation getRaidGroupAssociation();
 }

--- a/src/main/java/com/researchspace/model/dtos/RaidGroupAssociation.java
+++ b/src/main/java/com/researchspace/model/dtos/RaidGroupAssociation.java
@@ -1,24 +1,47 @@
 package com.researchspace.model.dtos;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.researchspace.model.raid.UserRaid;
 import com.researchspace.webapp.integrations.raid.RaIDReferenceDTO;
 import java.io.Serializable;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 public class RaidGroupAssociation implements Serializable {
 
   private Long projectGroupId;
+  private String rspaceProjectName;
   private RaIDReferenceDTO raid;
+
+  @JsonIgnore private String roCrateId;
 
   public RaidGroupAssociation(UserRaid userRaid) {
     this.projectGroupId = userRaid.getGroupAssociated().getId();
     this.raid =
         new RaIDReferenceDTO(
             userRaid.getId(), userRaid.getRaidServerAlias(), userRaid.getRaidIdentifier());
+    this.rspaceProjectName = userRaid.getGroupAssociated().getDisplayName();
+    initRoCrateId();
+  }
+
+  public RaidGroupAssociation(
+      Long projectGroupId, String rspaceProjectName, RaIDReferenceDTO raid) {
+    this.projectGroupId = projectGroupId;
+    this.raid = raid;
+    this.rspaceProjectName = rspaceProjectName;
+    initRoCrateId();
+  }
+
+  public String getRoCrateId() {
+    if (this.roCrateId == null) {
+      initRoCrateId();
+    }
+    return this.roCrateId;
+  }
+
+  private void initRoCrateId() {
+    this.roCrateId = "#project-" + this.rspaceProjectName + "-" + this.projectGroupId;
   }
 }

--- a/src/main/java/com/researchspace/model/dtos/export/ExportArchiveDialogConfigDTO.java
+++ b/src/main/java/com/researchspace/model/dtos/export/ExportArchiveDialogConfigDTO.java
@@ -4,6 +4,7 @@ import com.researchspace.archive.ExportScope;
 import com.researchspace.archive.model.ArchiveExportConfig;
 import com.researchspace.model.dtos.ExportSelection;
 import com.researchspace.model.dtos.NfsExportConfig;
+import com.researchspace.model.dtos.RaidGroupAssociation;
 import com.researchspace.model.repository.RepoDepositConfig;
 import java.util.HashSet;
 import java.util.Set;
@@ -40,6 +41,7 @@ public class ExportArchiveDialogConfigDTO {
   @Valid private ArchiveDialogConfig exportConfig;
   @Valid private NfsExportConfig nfsConfig;
   @Valid private RepoDepositConfig repositoryConfig;
+  @Valid private RaidGroupAssociation raidAssociated;
 
   public ArchiveExportConfig toArchiveExportConfig() {
     ArchiveExportConfig archiveExportCfg = new ArchiveExportConfig();
@@ -52,6 +54,7 @@ public class ExportArchiveDialogConfigDTO {
     archiveExportCfg.setDescription(exportConfig.getDescription());
     archiveExportCfg.setHasAllVersion(exportConfig.getAllVersions());
     archiveExportCfg.setExportScope(ExportScope.valueOf(exportSelection.getType().name()));
+    archiveExportCfg.setRaidGroupAssociation(this.getRaidAssociated());
 
     if (repositoryConfig != null) {
       archiveExportCfg.setDeposit(repositoryConfig.isDepositToRepository());

--- a/src/main/java/com/researchspace/model/repository/RepoDepositConfig.java
+++ b/src/main/java/com/researchspace/model/repository/RepoDepositConfig.java
@@ -1,7 +1,6 @@
 package com.researchspace.model.repository;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.researchspace.model.dtos.RaidGroupAssociation;
 import java.util.ArrayList;
 import java.util.List;
 import javax.validation.Valid;
@@ -27,7 +26,6 @@ public class RepoDepositConfig {
   private List<Long> selectedDMPs = new ArrayList<>();
 
   private boolean exportToRaid = false;
-  private RaidGroupAssociation raidAssociated;
 
   /**
    * @return {@code}true{@code} if 1 or more DMP ids were selected

--- a/src/main/java/com/researchspace/service/RaIDServiceManager.java
+++ b/src/main/java/com/researchspace/service/RaIDServiceManager.java
@@ -10,7 +10,10 @@ public interface RaIDServiceManager {
 
   UserRaid getUserRaid(Long userRaidId);
 
-  Set<RaidGroupAssociation> getAssociatedRaidsByUserAndAlias(User user, String serverAlias);
+  Set<RaidGroupAssociation> getAssociatedRaidsByUserAndAlias(User user, String raidServerAlias);
+
+  Optional<RaidGroupAssociation> getAssociatedRaidByUserAliasAndProjectId(
+      User user, String raidServerAlias, Long projectGroupId);
 
   Optional<RaidGroupAssociation> getAssociatedRaidByFolderId(User user, Long folderId);
 

--- a/src/main/java/com/researchspace/service/archive/export/AbstractArchiveExporter.java
+++ b/src/main/java/com/researchspace/service/archive/export/AbstractArchiveExporter.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
@@ -135,7 +136,6 @@ public abstract class AbstractArchiveExporter implements ArchiveExportServiceMan
       Record record = recordDao.get(rid.getDbId());
       List<AuditedRecord> versionsToExport =
           archivePlanner.getVersionsToExportForRecord(aconfig, rid, record);
-
       for (AuditedRecord ar : versionsToExport) {
         BaseRecord recordToExport = ar.getRecord();
         Number revision = ar.getRevision(); // will be null for non-all-revision export
@@ -148,16 +148,21 @@ public abstract class AbstractArchiveExporter implements ArchiveExportServiceMan
           dsb.setId("./" + recordFolder.getName());
           DataSetEntity out = dsb.build();
           roCrate.addDataEntity(out, true);
+          List<String> listIsPartOf = new LinkedList<>();
+          if (aconfig.hasRaidAssociation()) {
+            listIsPartOf.add(aconfig.getRaidGroupAssociation().getRoCrateId());
+          }
           for (RoCrateLogicalFolder logicalFolder : logicalTopLevelFolders) {
             if (recordToExport.hasParents()) {
               for (RecordToFolder parent : recordToExport.getParents()) {
                 if (recordParentIsThisFolder(parent.getFolder(), logicalFolder)) {
                   logicalFolder.addToHasPart(out.getId());
-                  out.addProperty("isPartOf", logicalFolder.getId());
+                  listIsPartOf.add(logicalFolder.getId());
                 }
               }
             }
           }
+          out.addIdListProperties("isPartOf", listIsPartOf);
           if (recordToExport.isStructuredDocument()) {
             StructuredDocument sd = recordToExport.asStrucDoc();
             if (!StringUtils.isEmpty(sd.getDocTag())) {

--- a/src/main/java/com/researchspace/service/archive/export/RoCrateHandler.java
+++ b/src/main/java/com/researchspace/service/archive/export/RoCrateHandler.java
@@ -21,10 +21,12 @@ import com.researchspace.archive.ArchiveFolder;
 import com.researchspace.archive.ArchiveManifest;
 import com.researchspace.archive.model.IArchiveExportConfig;
 import com.researchspace.model.EcatMediaFile;
+import com.researchspace.model.dtos.RaidGroupAssociation;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.archive.ExportImport;
 import edu.kit.datamanager.ro_crate.RoCrate;
 import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity;
+import edu.kit.datamanager.ro_crate.entities.contextual.ContextualEntity.ContextualEntityBuilder;
 import edu.kit.datamanager.ro_crate.entities.contextual.OrganizationEntity;
 import edu.kit.datamanager.ro_crate.entities.contextual.PersonEntity;
 import edu.kit.datamanager.ro_crate.entities.data.DataEntity;
@@ -52,6 +54,7 @@ import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.crypto.hash.Sha256Hash;
+import org.jetbrains.annotations.NotNull;
 
 public class RoCrateHandler {
 
@@ -110,7 +113,7 @@ public class RoCrateHandler {
                 rspaceParentID -> {
                   if (rspaceParentID.equals(roCrateLogicalFolderCompared.getRspaceID())) {
                     roCrateLogicalFolderCompared.addToHasPart(roCrateLogicalFolder.getId());
-                    roCrateLogicalFolder.isPartOf(roCrateLogicalFolderCompared.getId());
+                    roCrateLogicalFolder.addToIsPartOf(roCrateLogicalFolderCompared.getId());
                   }
                 });
       }
@@ -252,6 +255,10 @@ public class RoCrateHandler {
         exportedNFS.addProperty("text", "Contains remote nfs files linked by exported documents");
         roCrate.addDataEntity(exportedNFS.build(), true);
       }
+      if (aconfig.hasRaidAssociation()) {
+        ContextualEntityBuilder raidContext = createRaidContextEntity(aconfig);
+        roCrate.addContextualEntity(raidContext.build());
+      }
       // TODO - add a license when we go opensource??
       RootDataEntity rde = roCrate.getRootDataEntity();
       // Recommended to be a DOI - change this to be a DOI if we ever have one for RSpace instances
@@ -272,6 +279,18 @@ public class RoCrateHandler {
       folderRoCrateWriter.save(roCrate, exportContext.getArchiveAssmblyFlder().getPath());
       replaceSingleKeyWordsInRoCrate(exportContext);
     }
+  }
+
+  @NotNull
+  private static ContextualEntityBuilder createRaidContextEntity(IArchiveExportConfig aconfig) {
+    RaidGroupAssociation raidGroupAssociation = aconfig.getRaidGroupAssociation();
+    ContextualEntityBuilder raidContext = new ContextualEntityBuilder();
+    raidContext.addType("ResearchProject");
+    raidContext.setId(raidGroupAssociation.getRoCrateId());
+    raidContext.addProperty("name", raidGroupAssociation.getRspaceProjectName());
+    raidContext.addProperty(IDENTIFIER, raidGroupAssociation.getRaid().getBriefIdentifier());
+    raidContext.addProperty("url", raidGroupAssociation.getRaid().getRaidIdentifier());
+    return raidContext;
   }
 
   private static File makeSchemasFolder(

--- a/src/main/java/com/researchspace/service/archive/export/RoCrateLogicalFolder.java
+++ b/src/main/java/com/researchspace/service/archive/export/RoCrateLogicalFolder.java
@@ -1,6 +1,7 @@
 package com.researchspace.service.archive.export;
 
 import edu.kit.datamanager.ro_crate.entities.data.DataSetEntity;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -22,8 +23,8 @@ public class RoCrateLogicalFolder {
     roCrateDataSet.addToHasPart(id);
   }
 
-  public void isPartOf(String id) {
-    roCrateDataSet.addProperty("isPartOf", id);
+  public void addToIsPartOf(String id) {
+    roCrateDataSet.addIdListProperties("isPartOf", List.of(id));
   }
 
   public String getRspaceGlobalID() {

--- a/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
+++ b/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
@@ -420,7 +420,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
       URI baseURL,
       Supplier<ExportRecordList> exportListSupplier) {
 
-    ArchiveManifest manif = initializeArchiveManifest(expCfg.getExporter());
+    ArchiveManifest manif = initializeArchiveManifest(expCfg);
     ImmutableExportRecordList rcdList = exportListSupplier.get();
     configureArchiveMetadata(expCfg, baseURL, manif);
     try {
@@ -451,15 +451,20 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
     return null;
   }
 
-  private ArchiveManifest initializeArchiveManifest(User exporter) {
+  private ArchiveManifest initializeArchiveManifest(IArchiveExportConfig exportConfig) {
+    User userExporter = exportConfig.getExporter();
     ArchiveManifest manifest = new ArchiveManifest();
     manifest.addItem(ArchiveManifest.SOURCE, ArchiveManifest.RSPACE_SOURCE);
-    manifest.addItem("Exported by", exporter.getFullName());
+    manifest.addItem("Exported by", userExporter.getFullName());
     // RSPAC-1023
     Optional<ExternalId> extId =
-        extIdResolver.getExternalIdForUser(exporter, IdentifierScheme.ORCID);
+        extIdResolver.getExternalIdForUser(userExporter, IdentifierScheme.ORCID);
     if (extId.isPresent()) {
       manifest.addItem("OrcidID", extId.get().getIdentifier());
+    }
+    if (exportConfig.hasRaidAssociation()) {
+      manifest.addItem(
+          "ProjectID", exportConfig.getRaidGroupAssociation().getRaid().getRaidIdentifier());
     }
     getAppDBVersion(manifest);
     return manifest;

--- a/src/main/java/com/researchspace/service/impl/RaIDServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RaIDServiceManagerImpl.java
@@ -29,9 +29,25 @@ public class RaIDServiceManagerImpl implements RaIDServiceManager {
   }
 
   @Override
-  public Set<RaidGroupAssociation> getAssociatedRaidsByUserAndAlias(User user, String serverAlias) {
-    List<UserRaid> userRaidList = raidDao.getAssociatedRaidByUserAndAlias(user, serverAlias);
+  public Set<RaidGroupAssociation> getAssociatedRaidsByUserAndAlias(
+      User user, String raidServerAlias) {
+    List<UserRaid> userRaidList = raidDao.getAssociatedRaidByUserAndAlias(user, raidServerAlias);
     return userRaidList.stream().map(RaidGroupAssociation::new).collect(Collectors.toSet());
+  }
+
+  @Override
+  public Optional<RaidGroupAssociation> getAssociatedRaidByUserAliasAndProjectId(
+      User user, String raidServerAlias, Long projectGroupId) {
+    Optional<RaidGroupAssociation> result = Optional.empty();
+    Set<RaidGroupAssociation> userRaidAlreadyAssociated =
+        this.getAssociatedRaidsByUserAndAlias(user, raidServerAlias);
+    if (!userRaidAlreadyAssociated.isEmpty()) {
+      result =
+          userRaidAlreadyAssociated.stream()
+              .filter(raid -> raid.getProjectGroupId().equals(projectGroupId))
+              .findAny();
+    }
+    return result;
   }
 
   @Override

--- a/src/main/java/com/researchspace/webapp/controller/ProjectGroupController.java
+++ b/src/main/java/com/researchspace/webapp/controller/ProjectGroupController.java
@@ -92,7 +92,9 @@ public class ProjectGroupController extends BaseController {
     if (createCloudGroup.getRaid() != null) {
       validateRaidInput(createCloudGroup.getRaid());
       raidServiceManager.bindRaidToGroupAndSave(
-          creator, new RaidGroupAssociation(newLabGroup.getId(), createCloudGroup.getRaid()));
+          creator,
+          new RaidGroupAssociation(
+              newLabGroup.getId(), newLabGroup.getDisplayName(), createCloudGroup.getRaid()));
     }
     sendInvites(request, creator, listEmails, newLabGroup);
     publisher.publishEvent(new GenericEvent(creator, newLabGroup, AuditAction.CREATE));

--- a/src/main/java/com/researchspace/webapp/integrations/raid/RaIDController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/raid/RaIDController.java
@@ -139,15 +139,9 @@ public class RaIDController extends BaseOAuth2Controller {
     Optional<RaidGroupAssociation> result = Optional.empty();
     BindingResult errors = new BeanPropertyBindingResult(null, "raidGroupAssociation");
     try {
-      Set<RaidGroupAssociation> userRaidAlreadyAssociated =
-          raidServiceManager.getAssociatedRaidsByUserAndAlias(
-              userManager.getUserByUsername(principal.getName()), raidServerAlias);
-      if (!userRaidAlreadyAssociated.isEmpty()) {
-        result =
-            userRaidAlreadyAssociated.stream()
-                .filter(raid -> raid.getProjectGroupId().equals(projectGroupId))
-                .findAny();
-      }
+      result =
+          raidServiceManager.getAssociatedRaidByUserAliasAndProjectId(
+              userManager.getUserByUsername(principal.getName()), raidServerAlias, projectGroupId);
     } catch (Exception e) {
       log.error("Not able to get RaID list for the user \"{}\":", principal.getName(), e);
       errors.reject(
@@ -262,9 +256,12 @@ public class RaIDController extends BaseOAuth2Controller {
       @PathVariable String raidServerAlias,
       @RequestParam(name = "raidIdentifier") String raidIdentifier)
       throws BindException {
+
     RaidGroupAssociation input =
         new RaidGroupAssociation(
-            projectGroupId, new RaIDReferenceDTO(raidServerAlias, raidIdentifier));
+            projectGroupId,
+            groupManager.getGroup(projectGroupId).getDisplayName(),
+            new RaIDReferenceDTO(raidServerAlias, raidIdentifier));
     associateRaidToGroup(input);
   }
 

--- a/src/main/java/com/researchspace/webapp/integrations/raid/RaIDReferenceDTO.java
+++ b/src/main/java/com/researchspace/webapp/integrations/raid/RaIDReferenceDTO.java
@@ -1,27 +1,47 @@
 package com.researchspace.webapp.integrations.raid;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.researchspace.raid.model.exception.RaIDException;
 import java.io.Serializable;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode(of = {"raidServerAlias", "raidIdentifier"})
 @ToString
 public class RaIDReferenceDTO implements Serializable {
 
-  @JsonIgnore private Long id;
+  @JsonIgnore private Long id; // raid DB id
+
+  @JsonIgnore private String briefIdentifier; // format raid:10.2343/FDR364
 
   private String raidServerAlias;
-  private String raidIdentifier;
+  private String raidIdentifier; // raid URL
+
+  public RaIDReferenceDTO(Long id, String raidServerAlias, String raidIdentifier) {
+    this(raidServerAlias, raidIdentifier);
+    this.id = id;
+  }
 
   public RaIDReferenceDTO(String raidServerAlias, String raidIdentifier) {
     this.raidServerAlias = raidServerAlias;
     this.raidIdentifier = raidIdentifier;
+    try {
+      String[] raidIdentifierSplit = raidIdentifier.split("/");
+      this.briefIdentifier =
+          "raid:"
+              + raidIdentifierSplit[raidIdentifierSplit.length - 2]
+              + "/"
+              + raidIdentifierSplit[raidIdentifierSplit.length - 1];
+    } catch (Exception e) {
+      throw new RaIDException(
+          "The raid identifier \""
+              + raidIdentifier
+              + "\" "
+              + "is not on the right format. (e.g.: https:/raid.org/10.12345/ERT987)");
+    }
   }
 }

--- a/src/test/java/com/researchspace/service/RaIDServiceManagerTest.java
+++ b/src/test/java/com/researchspace/service/RaIDServiceManagerTest.java
@@ -26,7 +26,7 @@ import org.mockito.MockitoAnnotations;
 public class RaIDServiceManagerTest {
 
   private static final String SERVER_ALIAS = "raidServerAlias";
-  private static final String RAID_IDENTIFIER = "rairdIdentifier";
+  private static final String RAID_IDENTIFIER = "https://raid.org/10.12345/FJK987";
   public static final long USER_RAID_ID = 1L;
   public static final long PROJECT_GROUP_ID = 2L;
 
@@ -76,7 +76,9 @@ public class RaIDServiceManagerTest {
     raIDServiceManager.bindRaidToGroupAndSave(
         piUser,
         new RaidGroupAssociation(
-            projectGroup.getId(), new RaIDReferenceDTO(SERVER_ALIAS, RAID_IDENTIFIER)));
+            projectGroup.getId(),
+            projectGroup.getDisplayName(),
+            new RaIDReferenceDTO(SERVER_ALIAS, RAID_IDENTIFIER)));
 
     // THEN
     verify(groupManager).getGroup(projectGroup.getId());

--- a/src/test/java/com/researchspace/webapp/controller/ExportControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/ExportControllerMVCIT.java
@@ -5,9 +5,11 @@ import static com.researchspace.webapp.controller.ExportControllerTest.createExp
 import static com.researchspace.webapp.controller.ExportControllerTest.createExportArchiveConfigForUser;
 import static com.researchspace.webapp.controller.ExportControllerTest.createExportConfig;
 import static com.researchspace.webapp.controller.ExportControllerTest.createExportConfigForUser;
+import static com.researchspace.webapp.controller.ExportControllerTest.createExportRaidAndElnArchiveConfigSelectionForProjectGroup;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -18,21 +20,42 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.researchspace.Constants;
+import com.researchspace.core.util.ISearchResults;
 import com.researchspace.export.pdf.ExportToFileConfig;
+import com.researchspace.model.Group;
+import com.researchspace.model.PaginationCriteria;
+import com.researchspace.model.RoleInGroup;
 import com.researchspace.model.User;
+import com.researchspace.model.comms.CommunicationTarget;
+import com.researchspace.model.comms.Notification;
+import com.researchspace.model.comms.data.ArchiveExportNotificationData;
+import com.researchspace.model.dtos.export.ExportArchiveDialogConfigDTO;
 import com.researchspace.model.preference.Preference;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.service.RaIDServiceManager;
 import com.researchspace.testutils.RSpaceTestUtils;
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MvcResult;
 
 public class ExportControllerMVCIT extends MVCTestBase {
+
+  @Autowired private RaIDServiceManager raIDServiceManager;
 
   @Before
   public void setup() throws Exception {
@@ -184,7 +207,7 @@ public class ExportControllerMVCIT extends MVCTestBase {
   }
 
   @Test
-  public void exportBySysadminTest() throws Exception {
+  public void exportHtmlBySysadminTest() throws Exception {
     User anyUser = createInitAndLoginAnyUser();
     createBasicDocumentInRootFolderWithText(anyUser, "any text");
     User syadmin = logoutAndLoginAsSysAdmin();
@@ -195,42 +218,81 @@ public class ExportControllerMVCIT extends MVCTestBase {
     exportAndExpectSuccess(syadmin, requestContent);
   }
 
-  private void exportAndExpectSuccess(User u, String requestContent) throws Exception {
-    mockMvc
-        .perform(
-            post("/export/ajax/exportArchive")
-                .principal(u::getUsername)
-                .content(requestContent)
-                .contentType(APPLICATION_JSON_UTF8))
-        .andExpect(status().isOk())
-        .andExpect(content().string(messages.getMessage("pdfArchiving.submission.successMsg")));
+  @Test
+  public void exportFailureCauseNoRaidAssociationElnByPiTest() throws Exception {
+    // GIVEN
+    User pi1 = createAndSaveUser(getRandomAlphabeticString("pi"), Constants.PI_ROLE);
+    initUser(pi1);
+    Group projectGroup = createGroupForUsers(pi1, pi1.getUsername(), "", pi1);
+
+    logoutAndLoginAs(pi1);
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(pi1, "any text");
+    User toAdd = createAndSaveUser(getRandomAlphabeticString("other"));
+    initUser(toAdd);
+    grpMgr.addUserToGroup(pi1.getUsername(), projectGroup.getId(), RoleInGroup.DEFAULT);
+
+    ObjectMapper mapper = new ObjectMapper();
+    ExportArchiveDialogConfigDTO exportRequestDTO =
+        createExportRaidAndElnArchiveConfigSelectionForProjectGroup(
+            projectGroup.getId(),
+            projectGroup.getDisplayName(),
+            pi1.getUsername(),
+            doc.getId(),
+            doc.getName());
+    String requestContent = mapper.writeValueAsString(exportRequestDTO);
+    log.info(requestContent);
+
+    // WHEN / THEN
+    exportAndExpectFailure(pi1, exportRequestDTO, requestContent);
   }
 
-  private String retrieveExportTagsForPDFAndExpectSuccess(User u, String requestContent)
-      throws Exception {
-    return retrieveExportTagsAndExpectSuccess(
-        u, requestContent, "/export/ajax/exportRecordTagsPdfsAndDocs");
-  }
+  @Test
+  public void exportElnByPiTest() throws Exception {
+    // GIVEN
+    User pi1 = createAndSaveUser(getRandomAlphabeticString("pi"), Constants.PI_ROLE);
+    initUser(pi1);
+    Group projectGroup = createGroupForUsers(pi1, pi1.getUsername(), "", pi1);
 
-  private String retrieveExportTagsForArchiveAndExpectSuccess(User u, String requestContent)
-      throws Exception {
-    return retrieveExportTagsAndExpectSuccess(
-        u, requestContent, "/export/ajax/exportRecordTagsArchive");
-  }
+    logoutAndLoginAs(pi1);
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(pi1, "any text");
+    User toAdd = createAndSaveUser(getRandomAlphabeticString("other"));
+    initUser(toAdd);
+    grpMgr.addUserToGroup(pi1.getUsername(), projectGroup.getId(), RoleInGroup.DEFAULT);
 
-  private String retrieveExportTagsAndExpectSuccess(User u, String requestContent, String url)
-      throws Exception {
-    MvcResult result =
-        mockMvc
-            .perform(
-                post(url)
-                    .principal(u::getUsername)
-                    .content(requestContent)
-                    .contentType(APPLICATION_JSON_UTF8))
-            .andExpect(status().isOk())
-            .andReturn();
-    String[] results = getFromJsonAjaxReturnObject(result, String[].class);
-    return String.join(",", results);
+    ObjectMapper mapper = new ObjectMapper();
+    ExportArchiveDialogConfigDTO exportRequestDTO =
+        createExportRaidAndElnArchiveConfigSelectionForProjectGroup(
+            projectGroup.getId(),
+            projectGroup.getDisplayName(),
+            pi1.getUsername(),
+            doc.getId(),
+            doc.getName());
+    String requestContent = mapper.writeValueAsString(exportRequestDTO);
+    log.info(requestContent);
+
+    raIDServiceManager.bindRaidToGroupAndSave(pi1, exportRequestDTO.getRaidAssociated());
+
+    // WHEN
+    exportAndExpectSuccess(pi1, requestContent);
+
+    // THEN
+    Map<String, byte[]> mapFileByName = extractElnExportMapByFilename(pi1);
+
+    // assert entry into manifest.txt
+    String actualExportedManifest =
+        new String(mapFileByName.get("manifest.txt"), StandardCharsets.UTF_8);
+    String raidIdentifierUrl = exportRequestDTO.getRaidAssociated().getRaid().getRaidIdentifier();
+    assertTrue(actualExportedManifest.contains("ProjectID:" + raidIdentifierUrl));
+
+    // assert entries into RO-crate
+    String actualRoCrate = new String(mapFileByName.get("ro-crate-metadata.json"));
+    String projectId = "#project-" + projectGroup.getDisplayName() + "-" + projectGroup.getId();
+    actualRoCrate = flattenJson(actualRoCrate);
+    assertTrue(actualRoCrate.contains("\"isPartOf\":{\"@id\":\"" + projectId + "\"}"));
+    assertTrue(actualRoCrate.contains("\"name\":\"" + projectGroup.getDisplayName() + "\""));
+    assertTrue(actualRoCrate.contains("\"url\":\"" + raidIdentifierUrl + "\""));
+    assertTrue(actualRoCrate.contains("\"@id\":\"" + projectId + "\"}"));
+    assertTrue(actualRoCrate.contains("\"@type\":\"ResearchProject\"}"));
   }
 
   @Test
@@ -291,5 +353,126 @@ public class ExportControllerMVCIT extends MVCTestBase {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.pageSize", is(size)))
         .andReturn();
+  }
+
+  private Map<String, byte[]> extractElnExportMapByFilename(User user) throws Exception {
+    PaginationCriteria<CommunicationTarget> paginationCriteria =
+        PaginationCriteria.createDefaultForClass(CommunicationTarget.class);
+    ISearchResults<Notification> newNotifications =
+        communicationMgr.getNewNotificationsForUser(user.getUsername(), paginationCriteria);
+    Notification lastNotification = newNotifications.getFirstResult();
+    String downloadLink =
+        ((ArchiveExportNotificationData) lastNotification.getNotificationDataObject())
+            .getDownloadLink();
+    String filename = downloadLink.split("/")[downloadLink.split("/").length - 1];
+
+    byte[] downloadedElnBytes =
+        retrieveExportedFile(user, downloadLink).getResponse().getContentAsByteArray();
+
+    return createFilesMapFromZip(filename, downloadedElnBytes);
+  }
+
+  private MvcResult retrieveExportedFile(User u, String downloadLink) throws Exception {
+    return mockMvc
+        .perform(get(downloadLink.split("8080")[1]).principal(u::getUsername))
+        .andExpect(status().isOk())
+        .andReturn();
+  }
+
+  private void exportAndExpectSuccess(User u, String requestContent) throws Exception {
+    mockMvc
+        .perform(
+            post("/export/ajax/exportArchive")
+                .principal(u::getUsername)
+                .content(requestContent)
+                .contentType(APPLICATION_JSON_UTF8))
+        .andExpect(status().isOk())
+        .andExpect(content().string(messages.getMessage("pdfArchiving.submission.successMsg")));
+  }
+
+  private void exportAndExpectFailure(
+      User u, ExportArchiveDialogConfigDTO exportRequestDTO, String requestContent)
+      throws Exception {
+    mockMvc
+        .perform(
+            post("/export/ajax/exportArchive")
+                .principal(u::getUsername)
+                .content(requestContent)
+                .contentType(APPLICATION_JSON_UTF8))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    messages.getMessage(
+                        "workspace.export.msgFailure",
+                        new String[] {
+                          "Export",
+                          "The submitted RaID \""
+                              + exportRequestDTO.getRaidAssociated().getRaid().getRaidIdentifier()
+                              + "\" "
+                              + "is not currently associated to the projectId \""
+                              + exportRequestDTO.getRaidAssociated().getProjectGroupId()
+                              + "\""
+                        })));
+  }
+
+  private String retrieveExportTagsForPDFAndExpectSuccess(User u, String requestContent)
+      throws Exception {
+    return retrieveExportTagsAndExpectSuccess(
+        u, requestContent, "/export/ajax/exportRecordTagsPdfsAndDocs");
+  }
+
+  private String retrieveExportTagsForArchiveAndExpectSuccess(User u, String requestContent)
+      throws Exception {
+    return retrieveExportTagsAndExpectSuccess(
+        u, requestContent, "/export/ajax/exportRecordTagsArchive");
+  }
+
+  private String retrieveExportTagsAndExpectSuccess(User u, String requestContent, String url)
+      throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post(url)
+                    .principal(u::getUsername)
+                    .content(requestContent)
+                    .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isOk())
+            .andReturn();
+    String[] results = getFromJsonAjaxReturnObject(result, String[].class);
+    return String.join(",", results);
+  }
+
+  private static String flattenJson(String actualRoCrate) {
+    return actualRoCrate.replaceAll(" ", "").replaceAll("\n", "").replaceAll("\t", "");
+  }
+
+  private static Map<String, byte[]> createFilesMapFromZip(String filename, byte[] zipFileBytes)
+      throws IOException {
+    Map<String, byte[]> result = new LinkedHashMap<>();
+    File fileFromBytes = null;
+    try {
+      Path zipDirectory = Files.createTempDirectory(filename + "_temp_");
+      fileFromBytes = new File(zipDirectory + "/" + filename);
+      FileUtils.writeByteArrayToFile(fileFromBytes, zipFileBytes);
+
+      try (ZipFile zipFile = new ZipFile(fileFromBytes)) {
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+
+        while (entries.hasMoreElements()) {
+          ZipEntry entry = entries.nextElement();
+          if (!entry.isDirectory()) {
+            result.put(
+                entry.getName().split("/")[entry.getName().split("/").length - 1],
+                zipFile.getInputStream(entry).readAllBytes());
+          }
+        }
+      }
+    } finally {
+      if (fileFromBytes != null) {
+        FileUtils.delete(fileFromBytes);
+      }
+    }
+    return result;
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
@@ -27,7 +27,9 @@ import com.researchspace.model.apps.App;
 import com.researchspace.model.apps.UserAppConfig;
 import com.researchspace.model.core.RecordType;
 import com.researchspace.model.dtos.ExportSelection;
+import com.researchspace.model.dtos.ExportSelection.ExportType;
 import com.researchspace.model.dtos.NfsExportConfig;
+import com.researchspace.model.dtos.RaidGroupAssociation;
 import com.researchspace.model.dtos.export.ExportArchiveDialogConfigDTO;
 import com.researchspace.model.dtos.export.ExportArchiveDialogConfigDTO.ArchiveDialogConfig;
 import com.researchspace.model.dtos.export.ExportDialogConfigDTO;
@@ -50,6 +52,7 @@ import com.researchspace.service.archive.PostArchiveCompletion;
 import com.researchspace.service.impl.OntologyDocManager;
 import com.researchspace.testutils.TestFactory;
 import com.researchspace.webapp.controller.ExportController.ServerPath;
+import com.researchspace.webapp.integrations.raid.RaIDReferenceDTO;
 import java.io.File;
 import java.net.URI;
 import java.security.Principal;
@@ -174,9 +177,9 @@ public class ExportControllerTest {
     return repositoryConfig;
   }
 
-  private static ArchiveDialogConfig createArchiveDialogConfig() {
+  private static ArchiveDialogConfig createArchiveDialogConfig(String archiveType) {
     ArchiveDialogConfig archiveDialogConfig = new ArchiveDialogConfig();
-    archiveDialogConfig.setArchiveType("html");
+    archiveDialogConfig.setArchiveType(archiveType);
     archiveDialogConfig.setDescription("sample description");
     archiveDialogConfig.setMaxLinkLevel(3);
     archiveDialogConfig.setAllVersions(false);
@@ -191,7 +194,7 @@ public class ExportControllerTest {
       Long[] ids, String[] names, String[] types, boolean depositToRepository) {
     ExportArchiveDialogConfigDTO exportArchiveConfig = new ExportArchiveDialogConfigDTO();
     exportArchiveConfig.setExportSelection(createExportSelection(ids, names, types));
-    exportArchiveConfig.setExportConfig(createArchiveDialogConfig());
+    exportArchiveConfig.setExportConfig(createArchiveDialogConfig("html"));
     exportArchiveConfig.setNfsConfig(createNfsDialogConfig());
     exportArchiveConfig.setRepositoryConfig(createRepoDepositConfig(depositToRepository));
     return exportArchiveConfig;
@@ -226,10 +229,37 @@ public class ExportControllerTest {
 
     ExportArchiveDialogConfigDTO exportConfig = new ExportArchiveDialogConfigDTO();
     exportConfig.setExportSelection(exportSelection);
-    exportConfig.setExportConfig(createArchiveDialogConfig());
+    exportConfig.setExportConfig(createArchiveDialogConfig("html"));
     exportConfig.setNfsConfig(createNfsDialogConfig());
     exportConfig.setRepositoryConfig(createRepoDepositConfig(false));
 
+    return exportConfig;
+  }
+
+  public static ExportArchiveDialogConfigDTO
+      createExportRaidAndElnArchiveConfigSelectionForProjectGroup(
+          Long groupId, String rspaceProjectName, String username, Long id, String name) {
+    ExportSelection exportSelection = new ExportSelection();
+    exportSelection.setType(ExportType.SELECTION);
+    exportSelection.setUsername(username);
+    exportSelection.setExportIds(new Long[] {id});
+    exportSelection.setExportNames(new String[] {name});
+    exportSelection.setExportTypes(new String[] {"NORMAL"});
+
+    ExportArchiveDialogConfigDTO exportConfig = new ExportArchiveDialogConfigDTO();
+    exportConfig.setExportSelection(exportSelection);
+    exportConfig.setExportConfig(createArchiveDialogConfig("eln"));
+    exportConfig.setNfsConfig(createNfsDialogConfig());
+    exportConfig.setRaidAssociated(
+        new RaidGroupAssociation(
+            groupId,
+            rspaceProjectName,
+            new RaIDReferenceDTO("DEMO", "https://raid.org/10.12345/FGH896")));
+
+    RepoDepositConfig depositConfig = createRepoDepositConfig(false);
+    depositConfig.setExportToRaid(false);
+
+    exportConfig.setRepositoryConfig(depositConfig);
     return exportConfig;
   }
 

--- a/src/test/java/com/researchspace/webapp/controller/GroupControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/GroupControllerMVCIT.java
@@ -161,7 +161,9 @@ public class GroupControllerMVCIT extends MVCTestBase {
     raIDServiceManager.bindRaidToGroupAndSave(
         pi1,
         new RaidGroupAssociation(
-            g1.getId(), new RaIDReferenceDTO("raidServerAlias", "raidServerIdentifier")));
+            g1.getId(),
+            g1.getDisplayName(),
+            new RaIDReferenceDTO("raidServerAlias", "https://raid.org/10.12345/FKJ897")));
 
     // make sure group can be deleted.
     grpMgr.removeGroup(g1.getId(), pi1);

--- a/src/test/java/com/researchspace/webapp/controller/ProjectGroupControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/ProjectGroupControllerMVCIT.java
@@ -32,6 +32,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebAppConfiguration
 public class ProjectGroupControllerMVCIT extends MVCTestBase {
 
+  private static final String RAID_SERVER_ALIAS = "raidServerAlias_X";
+  private static final String RAID_IDENTIFIER = "https://raid.org/10.12345/FKHJ78";
   @Autowired private RaIDServiceManager raIDServiceManager;
 
   private User pi;
@@ -41,14 +43,14 @@ public class ProjectGroupControllerMVCIT extends MVCTestBase {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    this.pi = createAndSaveUser("pi_" + getRandomName(10), Constants.PI_ROLE);
+    this.pi = createAndSaveUser("pi" + getRandomName(10), Constants.PI_ROLE);
     initUser(this.pi);
     logoutAndLoginAs(pi);
 
     projectGroupCreationObj = new CreateCloudGroup();
     projectGroupCreationObj.setGroupName("ProjectGroupWithRaid");
     projectGroupCreationObj.setSessionUser(pi);
-    projectGroupCreationObj.setRaid(new RaIDReferenceDTO("raidServerAlias_X", "raidIdentifier_Y"));
+    projectGroupCreationObj.setRaid(new RaIDReferenceDTO(RAID_SERVER_ALIAS, RAID_IDENTIFIER));
     projectGroupCreationObj.setPiEmail(pi.getEmail());
   }
 
@@ -69,16 +71,16 @@ public class ProjectGroupControllerMVCIT extends MVCTestBase {
     assertNotNull(newProjectGroupId);
     Group newProjectGroup = grpMgr.getGroup(newProjectGroupId);
     assertNotNull(newProjectGroup.getRaid());
-    assertEquals("raidServerAlias_X", newProjectGroup.getRaid().getRaidServerAlias());
-    assertEquals("raidIdentifier_Y", newProjectGroup.getRaid().getRaidIdentifier());
+    assertEquals(RAID_SERVER_ALIAS, newProjectGroup.getRaid().getRaidServerAlias());
+    assertEquals(RAID_IDENTIFIER, newProjectGroup.getRaid().getRaidIdentifier());
     assertEquals(newProjectGroupId, newProjectGroup.getRaid().getGroupAssociated().getId());
     assertEquals(pi.getId(), newProjectGroup.getRaid().getOwner().getId());
     Long raidId = newProjectGroup.getRaid().getId();
     assertNotNull(raidId);
 
     UserRaid raidSaved = raIDServiceManager.getUserRaid(raidId);
-    assertEquals("raidServerAlias_X", raidSaved.getRaidServerAlias());
-    assertEquals("raidIdentifier_Y", raidSaved.getRaidIdentifier());
+    assertEquals(RAID_SERVER_ALIAS, raidSaved.getRaidServerAlias());
+    assertEquals(RAID_IDENTIFIER, raidSaved.getRaidIdentifier());
     assertEquals(newProjectGroupId, raidSaved.getGroupAssociated().getId());
     assertEquals(pi.getId(), raidSaved.getOwner().getId());
 

--- a/src/test/java/com/researchspace/webapp/integrations/raid/RaIDControllerMCVIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/raid/RaIDControllerMCVIT.java
@@ -209,7 +209,8 @@ public class RaIDControllerMCVIT extends MVCTestBase {
                     .principal(piUser::getUsername))
             .andExpect(status().is2xxSuccessful())
             .andReturn();
-    RaidGroupAssociation actualResult = extractRaid(result);
+    RaidGroupAssociation actualResult =
+        extractRaid(projectGroupCreationWithRaid.getGroupName(), result);
 
     assertNotNull(actualResult);
     assertEquals(newProjectGroupId, actualResult.getProjectGroupId());
@@ -241,7 +242,8 @@ public class RaIDControllerMCVIT extends MVCTestBase {
                     .principal(piUser::getUsername))
             .andExpect(status().is2xxSuccessful())
             .andReturn();
-    RaidGroupAssociation actualResult = extractRaid(result);
+    RaidGroupAssociation actualResult =
+        extractRaid(projectGroupCreationWithRaid.getGroupName(), result);
 
     // THEN a RaID is returned
     assertNotNull(actualResult);
@@ -283,7 +285,8 @@ public class RaIDControllerMCVIT extends MVCTestBase {
 
     // WHEN
     RaidGroupAssociation raidToGroupAssociation =
-        new RaidGroupAssociation(newProjectGroupId, RAID_ASSOCIATED_1);
+        new RaidGroupAssociation(
+            newProjectGroupId, projectGroupCreationWithoutRaid.getGroupName(), RAID_ASSOCIATED_1);
     result =
         mockMvc
             .perform(
@@ -349,7 +352,7 @@ public class RaIDControllerMCVIT extends MVCTestBase {
   }
 
   @NotNull
-  private RaidGroupAssociation extractRaid(MvcResult result)
+  private RaidGroupAssociation extractRaid(String groupName, MvcResult result)
       throws JsonProcessingException, UnsupportedEncodingException {
     Map mapResult = mapper.readValue(result.getResponse().getContentAsString(), Map.class);
     assertNull((mapResult.get("error")));
@@ -358,6 +361,7 @@ public class RaIDControllerMCVIT extends MVCTestBase {
         (Map<String, Map<String, String>>) mapResult.get("data");
     return new RaidGroupAssociation(
         Long.valueOf(((Map<String, Integer>) mapResult.get("data")).get("projectGroupId")),
+        groupName,
         new RaIDReferenceDTO(
             (groupAssociation.get("raid")).get("raidServerAlias"),
             groupAssociation.get("raid").get("raidIdentifier")));


### PR DESCRIPTION
## Description ##
- This PR amends the creation of `manifest.txt` and `RO-crate-metadata.json` by adding  add the RaID association.
- Please refer to [the ticket](https://researchspace.atlassian.net/browse/RSDEV-944) for the details of how it is amended

## Testing notes ##
- AWS instance: https://raid-test.researchspace.com/
- At the moment it is triky to do manual testing
 
### Automated Testing ###
2 new MVCIT tests have been added:
-  `ExportControllerMVCIT.exportElnByPiTest`: executing that you can see the specific entries in `manifest.txt` and `ro-crate-metadata.json` being created when a valid RaID association has been submitted to the export end point
-  `ExportControllerMVCIT.exportFailureCauseNoRaidAssociationElnByPiTest`: tests the validation when an unassociated RaID is submitted

### Manual Testing ###
#### TEST - Export without RaID ####
1. Login a `sysadmin1` at https://raid-test.researchspace.com/
2. Go to the [ProjectLocalNik_SHARED](https://raid-test.researchspace.com/workspace/317) folder
3. Select the file `DocToExport` and export it as `RO-Crate` 
- **THEN** 
- When the `.ELN` archive is ready:
- - Verify that **there are no** `ProjectID` entries in `manifest.txt`
- - Verify **there are no** RaID blocks in `ro-crates-metadata.json`

#### TEST - Export with RaID ####
1. Login a `sysadmin1` at https://raid-test.researchspace.com/
2. Send the following JSON to the export end point (`POST https://raid-test.researchspace.com/export/ajax/exportArchive`):
```
{
  "exportSelection": {
    "type": "selection",
    "exportIds": [
      321
    ],
    "exportNames": [
      "DocToExport"
    ],
    "exportTypes": [
      "NORMAL"
    ],
    "username": null,
    "groupId": null
  },
  "exportConfig": {
    "maxLinkLevel": 1,
    "archiveType": "eln",
    "description": "",
    "allVersions": false
  },
  "nfsConfig": {
    "includeNfsFiles": false,
    "maxFileSizeInMB": 50,
    "excludedFileExtensions": ""
  },
  "repositoryConfig": {
    "meta": null,
    "repoCfg": null,
    "appName": null,
    "depositToRepository": false,
    "selectedDMPs": [],
    "exportToRaid": false
  },
  "raidAssociated": {
    "projectGroupId": 65536,
    "rspaceProjectName": "ProjectLocalNik",
    "raid": {
      "raidServerAlias": "DEMO",
      "raidIdentifier": "https://static.demo.raid.org.au/10.83334/c74980b1"
    }
  }
}
```
 - **THEN**
 - When the `.ELN` archive is ready:
- - Verify that there is  1 `ProjectID` entry in `manifest.txt` like the following:
- - -
```
ProjectID:https://static.demo.raid.org.au/10.83334/c74980b1
```
- - Verify that there is 1 RaID block entry in `ro-crates-metadata.json`like the following:
- - - 
```
{
    "name" : "ProjectLocalNik",
    "identifier" : "raid:10.83334/c74980b1",
    "url" : "https://static.demo.raid.org.au/10.83334/c74980b1",
    "@id" : "#project-ProjectLocalNik-65536",
    "@type" : "ResearchProject"
}
```
- - Verify there is 1 `isPartOf` block entry inside the `DocToExport` dataset block of `ro-crates-metadata.json` like the following:
- - - 
```
{
    "@id" : "./doc_DocToExport-321",
    "@type" : "Dataset",
    "isPartOf" : {
      "@id" : "#project-ProjectLocalNik-65536"
    },
    "hasPart" : [ {
      "@id" : "./doc_DocToExport-321/doc_DocToExport-321_form.xml"
    }, {
      "@id" : "./doc_DocToExport-321/doc_DocToExport-321.xml"
    } ]
}
```
