### PR TITLE
RSDEV-986: Add raid title on the RaidAssociated object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1718,7 +1718,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>2.17.5</version>
+      <version>2.18.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/dtos/RaidGroupAssociation.java
+++ b/src/main/java/com/researchspace/model/dtos/RaidGroupAssociation.java
@@ -21,7 +21,8 @@ public class RaidGroupAssociation implements Serializable {
     this.projectGroupId = userRaid.getGroupAssociated().getId();
     this.raid =
         new RaIDReferenceDTO(
-            userRaid.getId(), userRaid.getRaidServerAlias(), userRaid.getRaidIdentifier());
+            userRaid.getId(), userRaid.getRaidServerAlias(),
+            userRaid.getRaidTitle(), userRaid.getRaidIdentifier());
     this.rspaceProjectName = userRaid.getGroupAssociated().getDisplayName();
     initRoCrateId();
   }

--- a/src/main/java/com/researchspace/service/impl/RaIDServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RaIDServiceManagerImpl.java
@@ -65,6 +65,7 @@ public class RaIDServiceManagerImpl implements RaIDServiceManager {
             user,
             projectGroup,
             raidToGroupAssociation.getRaid().getRaidServerAlias(),
+            raidToGroupAssociation.getRaid().getRaidTitle(),
             raidToGroupAssociation.getRaid().getRaidIdentifier()));
     grpManager.saveGroup(projectGroup, false, user);
   }

--- a/src/main/java/com/researchspace/service/raid/impl/RaIDServiceClientAdapterImpl.java
+++ b/src/main/java/com/researchspace/service/raid/impl/RaIDServiceClientAdapterImpl.java
@@ -105,7 +105,10 @@ public class RaIDServiceClientAdapterImpl
             getApiBaseUrl(serverAlias),
             getExistingAccessTokenOrRefreshIfExpired(username, serverAlias));
     return verboseRaidList.stream()
-        .map(r -> new RaIDReferenceDTO(serverAlias, r.getIdentifier().getId()))
+        .map(
+            r ->
+                new RaIDReferenceDTO(
+                    serverAlias, r.getTitle().get(0).getText(), r.getIdentifier().getId()))
         .collect(Collectors.toSet());
   }
 
@@ -119,7 +122,8 @@ public class RaIDServiceClientAdapterImpl
             getExistingAccessTokenOrRefreshIfExpired(username, serverAlias),
             raidPrefix,
             raidSuffix);
-    return new RaIDReferenceDTO(serverAlias, verboseRaid.getIdentifier().getId());
+    return new RaIDReferenceDTO(
+        serverAlias, verboseRaid.getTitle().get(0).getText(), verboseRaid.getIdentifier().getId());
   }
 
   @Override

--- a/src/main/java/com/researchspace/webapp/integrations/raid/RaIDController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/raid/RaIDController.java
@@ -127,7 +127,7 @@ public class RaIDController extends BaseOAuth2Controller {
    *
    * @param projectGroupId
    * @param raidServerAlias
-   * @return the raid DTO if there is an association, otherwise null
+   * @return the raid DTO if there is an association, otherwise empty object
    */
   @GetMapping("/{raidServerAlias}/projects/{projectGroupId}")
   @ResponseBody
@@ -153,7 +153,7 @@ public class RaIDController extends BaseOAuth2Controller {
       ErrorList el = inputValidator.populateErrorList(errors, new ErrorList());
       return new AjaxReturnObject<>(null, el);
     }
-    return new AjaxReturnObject<>(result.orElse(null), null);
+    return new AjaxReturnObject<>(result.orElse(new RaidGroupAssociation()), null);
   }
 
   /***
@@ -161,7 +161,7 @@ public class RaIDController extends BaseOAuth2Controller {
    *
    * @param sharedFolderId the folder ID of the ProjectGroup shared folder
    * @param principal logged user
-   * @return the RaID associated or NULL
+   * @return the RaID associated or empty
    */
   @GetMapping("/byFolder/{sharedFolderId}")
   @ResponseBody
@@ -198,7 +198,7 @@ public class RaIDController extends BaseOAuth2Controller {
     if (errors.hasErrors()) {
       el = inputValidator.populateErrorList(errors, new ErrorList());
     }
-    return new AjaxReturnObject<>(result.orElse(null), el);
+    return new AjaxReturnObject<>(result.orElse(new RaidGroupAssociation()), el);
   }
 
   @PostMapping("/associate")
@@ -249,11 +249,12 @@ public class RaIDController extends BaseOAuth2Controller {
   }
 
   // TODO[nik]:  remove the GET once the UI is complete RSDEV-852 and RSDEV-853
-  @GetMapping("/associate/{projectGroupId}/{raidServerAlias}")
+  @GetMapping("/associate/{projectGroupId}/{raidServerAlias}/{raidTitle}")
   @ResponseStatus(HttpStatus.CREATED)
   public void associateRaidToGroup_GET(
       @PathVariable Long projectGroupId,
       @PathVariable String raidServerAlias,
+      @PathVariable String raidTitle,
       @RequestParam(name = "raidIdentifier") String raidIdentifier)
       throws BindException {
 
@@ -261,7 +262,7 @@ public class RaIDController extends BaseOAuth2Controller {
         new RaidGroupAssociation(
             projectGroupId,
             groupManager.getGroup(projectGroupId).getDisplayName(),
-            new RaIDReferenceDTO(raidServerAlias, raidIdentifier));
+            new RaIDReferenceDTO(raidServerAlias, raidTitle, raidIdentifier));
     associateRaidToGroup(input);
   }
 
@@ -306,6 +307,9 @@ public class RaIDController extends BaseOAuth2Controller {
     Validate.isTrue(
         StringUtils.isNotBlank(raidGroupAssociation.getRaid().getRaidIdentifier()),
         "raidIdentifier is missing");
+    Validate.isTrue(
+        StringUtils.isNotBlank(raidGroupAssociation.getRaid().getRaidTitle()),
+        "raidTitle is missing");
     Validate.isTrue(
         StringUtils.isNotBlank(raidGroupAssociation.getRaid().getRaidServerAlias()),
         "raidServerAlias is missing");

--- a/src/main/java/com/researchspace/webapp/integrations/raid/RaIDReferenceDTO.java
+++ b/src/main/java/com/researchspace/webapp/integrations/raid/RaIDReferenceDTO.java
@@ -1,6 +1,8 @@
 package com.researchspace.webapp.integrations.raid;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.researchspace.raid.model.exception.RaIDException;
 import java.io.Serializable;
 import lombok.Data;
@@ -19,15 +21,21 @@ public class RaIDReferenceDTO implements Serializable {
   @JsonIgnore private String briefIdentifier; // format raid:10.2343/FDR364
 
   private String raidServerAlias;
+
+  @JsonInclude(value = Include.NON_NULL)
+  private String raidTitle;
+
   private String raidIdentifier; // raid URL
 
-  public RaIDReferenceDTO(Long id, String raidServerAlias, String raidIdentifier) {
-    this(raidServerAlias, raidIdentifier);
+  public RaIDReferenceDTO(
+      Long id, String raidServerAlias, String raidTitle, String raidIdentifier) {
+    this(raidServerAlias, raidTitle, raidIdentifier);
     this.id = id;
   }
 
-  public RaIDReferenceDTO(String raidServerAlias, String raidIdentifier) {
+  public RaIDReferenceDTO(String raidServerAlias, String raidTitle, String raidIdentifier) {
     this.raidServerAlias = raidServerAlias;
+    this.raidTitle = raidTitle;
     this.raidIdentifier = raidIdentifier;
     try {
       String[] raidIdentifierSplit = raidIdentifier.split("/");

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-986.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-986.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <changeSet id="2026-01-20" context="run" author="nico">
+    <comment>Add Title column to UserRaid table</comment>
+    <addColumn tableName="UserRaid">
+      <column type="VARCHAR(255)" name="raid_title" >
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -159,6 +159,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-923.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-907.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-849.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-986.xml"/>
 
     <!--  ensure that customUpdates-changeLog.xml always runs LAST! -->
     <include relativeToChangelogFile="true" file="customUpdates-changeLog.xml"/>

--- a/src/test/java/com/researchspace/service/RaIDServiceManagerTest.java
+++ b/src/test/java/com/researchspace/service/RaIDServiceManagerTest.java
@@ -27,6 +27,7 @@ public class RaIDServiceManagerTest {
 
   private static final String SERVER_ALIAS = "raidServerAlias";
   private static final String RAID_IDENTIFIER = "https://raid.org/10.12345/FJK987";
+  private static final String RAID_TITLE = "Raid Title 1";
   public static final long USER_RAID_ID = 1L;
   public static final long PROJECT_GROUP_ID = 2L;
 
@@ -47,7 +48,7 @@ public class RaIDServiceManagerTest {
     projectGroup = TestFactory.createAnyGroup(piUser);
     projectGroup.setId(PROJECT_GROUP_ID);
     projectGroup.setGroupType(GroupType.PROJECT_GROUP);
-    userRaid = new UserRaid(piUser, projectGroup, SERVER_ALIAS, RAID_IDENTIFIER);
+    userRaid = new UserRaid(piUser, projectGroup, SERVER_ALIAS, RAID_TITLE, RAID_IDENTIFIER);
     userRaid.setId(USER_RAID_ID);
 
     when(raidDao.getAssociatedRaidByUserAndAlias(piUser, SERVER_ALIAS))
@@ -78,7 +79,7 @@ public class RaIDServiceManagerTest {
         new RaidGroupAssociation(
             projectGroup.getId(),
             projectGroup.getDisplayName(),
-            new RaIDReferenceDTO(SERVER_ALIAS, RAID_IDENTIFIER)));
+            new RaIDReferenceDTO(SERVER_ALIAS, RAID_TITLE, RAID_IDENTIFIER)));
 
     // THEN
     verify(groupManager).getGroup(projectGroup.getId());

--- a/src/test/java/com/researchspace/service/raid/impl/RaIDServiceClientAdapterTest.java
+++ b/src/test/java/com/researchspace/service/raid/impl/RaIDServiceClientAdapterTest.java
@@ -161,7 +161,10 @@ public class RaIDServiceClientAdapterTest extends SpringTransactionalTest {
     when(mockedRaidClient.getRaIDList(API_BASE_URL, OLD_ACCESS_TOKEN)).thenReturn(expectedRaidList);
     Set<RaIDReferenceDTO> expectedRaidReferenceDTOList =
         expectedRaidList.stream()
-            .map(el -> new RaIDReferenceDTO(SERVER_ALIAS, el.getIdentifier().getId()))
+            .map(
+                el ->
+                    new RaIDReferenceDTO(
+                        SERVER_ALIAS, el.getTitle().get(0).getText(), el.getIdentifier().getId()))
             .collect(Collectors.toSet());
     raidServiceClientAdapter.performCreateAccessToken(user.getUsername(), SERVER_ALIAS, AUTH_CODE);
 
@@ -179,7 +182,10 @@ public class RaIDServiceClientAdapterTest extends SpringTransactionalTest {
     when(mockedRaidClient.getRaID(API_BASE_URL, OLD_ACCESS_TOKEN, RAID_PREFIX, RAID_SUFFIX))
         .thenReturn(expectedRaid);
     RaIDReferenceDTO expectedRaidReferenceDTO =
-        new RaIDReferenceDTO(SERVER_ALIAS, expectedRaid.getIdentifier().getId());
+        new RaIDReferenceDTO(
+            SERVER_ALIAS,
+            expectedRaid.getTitle().get(0).getText(),
+            expectedRaid.getIdentifier().getId());
     raidServiceClientAdapter.performCreateAccessToken(user.getUsername(), SERVER_ALIAS, AUTH_CODE);
 
     // WHEN

--- a/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
@@ -254,7 +254,7 @@ public class ExportControllerTest {
         new RaidGroupAssociation(
             groupId,
             rspaceProjectName,
-            new RaIDReferenceDTO("DEMO", "https://raid.org/10.12345/FGH896")));
+            new RaIDReferenceDTO("DEMO", "Raid Title1", "https://raid.org/10.12345/FGH896")));
 
     RepoDepositConfig depositConfig = createRepoDepositConfig(false);
     depositConfig.setExportToRaid(false);

--- a/src/test/java/com/researchspace/webapp/controller/GroupControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/GroupControllerMVCIT.java
@@ -163,7 +163,8 @@ public class GroupControllerMVCIT extends MVCTestBase {
         new RaidGroupAssociation(
             g1.getId(),
             g1.getDisplayName(),
-            new RaIDReferenceDTO("raidServerAlias", "https://raid.org/10.12345/FKJ897")));
+            new RaIDReferenceDTO(
+                "raidServerAlias", "Raid Title1", "https://raid.org/10.12345/FKJ897")));
 
     // make sure group can be deleted.
     grpMgr.removeGroup(g1.getId(), pi1);

--- a/src/test/java/com/researchspace/webapp/controller/ProjectGroupControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/ProjectGroupControllerMVCIT.java
@@ -34,6 +34,7 @@ public class ProjectGroupControllerMVCIT extends MVCTestBase {
 
   private static final String RAID_SERVER_ALIAS = "raidServerAlias_X";
   private static final String RAID_IDENTIFIER = "https://raid.org/10.12345/FKHJ78";
+  private static final String RAID_TITLE = "Raid Title 1";
   @Autowired private RaIDServiceManager raIDServiceManager;
 
   private User pi;
@@ -50,7 +51,8 @@ public class ProjectGroupControllerMVCIT extends MVCTestBase {
     projectGroupCreationObj = new CreateCloudGroup();
     projectGroupCreationObj.setGroupName("ProjectGroupWithRaid");
     projectGroupCreationObj.setSessionUser(pi);
-    projectGroupCreationObj.setRaid(new RaIDReferenceDTO(RAID_SERVER_ALIAS, RAID_IDENTIFIER));
+    projectGroupCreationObj.setRaid(
+        new RaIDReferenceDTO(RAID_SERVER_ALIAS, RAID_TITLE, RAID_IDENTIFIER));
     projectGroupCreationObj.setPiEmail(pi.getEmail());
   }
 

--- a/src/test/java/com/researchspace/webapp/integrations/raid/RaIDControllerMCVIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/raid/RaIDControllerMCVIT.java
@@ -61,10 +61,11 @@ public class RaIDControllerMCVIT extends MVCTestBase {
   private static final String API_BASE_URL_2 = "https://demo2.raid.au";
   private static final String SERVER_ALIAS_1 = "alias1";
   private static final String SERVER_ALIAS_2 = "alias2";
+  private static final String RAID_TITLE_1 = "Raid Title 1";
   private static final String IDENTIFIER_ASSOCIATED_1 =
       "https://static.demo.raid.org.au/10.83334/c74980b1";
   private static final RaIDReferenceDTO RAID_ASSOCIATED_1 =
-      new RaIDReferenceDTO(SERVER_ALIAS_1, IDENTIFIER_ASSOCIATED_1);
+      new RaIDReferenceDTO(SERVER_ALIAS_1, RAID_TITLE_1, IDENTIFIER_ASSOCIATED_1);
 
   @Autowired private RaIDController raidController;
 
@@ -124,6 +125,7 @@ public class RaIDControllerMCVIT extends MVCTestBase {
     alreadyAssociatedRaidForServerAlias1 =
         new RaIDReferenceDTO(
             SERVER_ALIAS_1,
+            RAID_TITLE_1,
             mapper
                 .readValue(
                     IOUtils.resourceToString(
@@ -148,7 +150,10 @@ public class RaIDControllerMCVIT extends MVCTestBase {
                     IOUtils.resourceToString(
                         "/TestResources/raid/json/raid-list.json", Charset.defaultCharset()),
                     RaID[].class))
-            .map(r -> new RaIDReferenceDTO(SERVER_ALIAS_1, r.getIdentifier().getId()))
+            .map(
+                r ->
+                    new RaIDReferenceDTO(
+                        SERVER_ALIAS_1, r.getTitle().get(0).getText(), r.getIdentifier().getId()))
             .collect(Collectors.toSet());
     when(mockedRaidClientAdapter.getRaIDList(piUser.getUsername(), SERVER_ALIAS_1))
         .thenReturn(configuredRaidList1);
@@ -159,7 +164,10 @@ public class RaIDControllerMCVIT extends MVCTestBase {
                     IOUtils.resourceToString(
                         "/TestResources/raid/json/raid-list-2.json", Charset.defaultCharset()),
                     RaID[].class))
-            .map(r -> new RaIDReferenceDTO(SERVER_ALIAS_2, r.getIdentifier().getId()))
+            .map(
+                r ->
+                    new RaIDReferenceDTO(
+                        SERVER_ALIAS_2, r.getTitle().get(0).getText(), r.getIdentifier().getId()))
             .collect(Collectors.toSet());
     when(mockedRaidClientAdapter.getRaIDList(piUser.getUsername(), SERVER_ALIAS_2))
         .thenReturn(configuredRaidList2);
@@ -347,7 +355,10 @@ public class RaIDControllerMCVIT extends MVCTestBase {
     assertTrue((boolean) mapResult.get("success"));
     return ((List<Map<String, String>>) mapResult.get("data"))
         .stream()
-            .map(el -> new RaIDReferenceDTO(el.get("raidServerAlias"), el.get("raidIdentifier")))
+            .map(
+                el ->
+                    new RaIDReferenceDTO(
+                        el.get("raidServerAlias"), el.get("raidTitle"), el.get("raidIdentifier")))
             .collect(Collectors.toSet());
   }
 
@@ -363,7 +374,8 @@ public class RaIDControllerMCVIT extends MVCTestBase {
         Long.valueOf(((Map<String, Integer>) mapResult.get("data")).get("projectGroupId")),
         groupName,
         new RaIDReferenceDTO(
-            (groupAssociation.get("raid")).get("raidServerAlias"),
+            groupAssociation.get("raid").get("raidServerAlias"),
+            groupAssociation.get("raid").get("raidTitle"),
             groupAssociation.get("raid").get("raidIdentifier")));
   }
 


### PR DESCRIPTION
## Description ##
This PR adds the `raidTitle` into the RaID object model to be saved on database and showed to the user bu the UI (related UI tasks: RSDEV-853 and RSDEV-852) 