### PR TITLE
RSDEV-973: Fix hibernate exception when calling getGroupInfo

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/GroupApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GroupApiController.java
@@ -12,6 +12,7 @@ import com.researchspace.model.dtos.GroupSearchCriteria;
 import com.researchspace.service.GroupManager;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,13 +20,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 
-/** Gets users groups */
+/**
+ * Gets users groups
+ */
 @ApiController
 public class GroupApiController extends BaseApiController implements GroupApi {
 
   protected @Autowired GroupManager groupManager;
 
-  /** Gets groups for API client ordered by display name */
+  /**
+   * Gets groups for API client ordered by display name
+   */
   @Override
   public List<ApiGroupInfo> listCurrentUserGroups(@RequestAttribute(name = "user") User user) {
     return user.getGroups().stream()
@@ -59,13 +64,8 @@ public class GroupApiController extends BaseApiController implements GroupApi {
   @Override
   public ApiGroupInfo getUserGroupById(
       @PathVariable("id") Long id, @RequestAttribute(name = "user") User user) {
-    return user.getGroups().stream()
-        .filter(g -> g.getId().equals(id))
-        .findFirst()
-        .map(ApiGroupInfo::new)
-        .orElseThrow(
-            () ->
-                new NotFoundException(
-                    "Group with id: " + id + " not found, or the user isn't a member."));
+    Optional<ApiGroupInfo> groupInfoOptional = groupManager.getGroupInfoById(id);
+    return groupInfoOptional.orElseThrow(() -> new NotFoundException(
+        "Group with id: " + id + " not found, or the user isn't a member."));
   }
 }

--- a/src/main/java/com/researchspace/service/GroupManager.java
+++ b/src/main/java/com/researchspace/service/GroupManager.java
@@ -1,5 +1,6 @@
 package com.researchspace.service;
 
+import com.researchspace.api.v1.model.ApiGroupInfo;
 import com.researchspace.core.util.ISearchResults;
 import com.researchspace.model.Group;
 import com.researchspace.model.PaginationCriteria;
@@ -13,6 +14,7 @@ import com.researchspace.model.views.GroupInvitation;
 import com.researchspace.model.views.UserView;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.shiro.authz.AuthorizationException;
 
@@ -30,6 +32,9 @@ public interface GroupManager {
 
   /** Get a group by its id */
   Group getGroup(Long groupId);
+
+  /** Get a ApiGroupInfo by its id */
+  Optional<ApiGroupInfo> getGroupInfoById(Long groupId);
 
   /** Gets all the Groups */
   List<Group> list();

--- a/src/main/java/com/researchspace/service/impl/GroupManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/GroupManagerImpl.java
@@ -4,6 +4,7 @@ import static com.researchspace.service.RecordDeletionManager.MIN_PATH_LENGTH_TO
 import static com.researchspace.service.UserFolderCreator.SHARED_SNIPPETS_FOLDER_PREFIX;
 
 import com.researchspace.Constants;
+import com.researchspace.api.v1.model.ApiGroupInfo;
 import com.researchspace.core.util.FilterCriteria;
 import com.researchspace.core.util.ISearchResults;
 import com.researchspace.core.util.ObjectToStringPropertyTransformer;
@@ -355,6 +356,15 @@ public class GroupManagerImpl implements GroupManager {
   @Override
   public Group getGroup(Long groupId) {
     return groupDao.get(groupId);
+  }
+
+  @Override
+  public Optional<ApiGroupInfo> getGroupInfoById(Long groupId) {
+    Set<Group> groups = this.listGroupsForUser();
+    return groups.stream()
+        .filter(g -> g.getId().equals(groupId))
+        .findFirst()
+        .map(ApiGroupInfo::new);
   }
 
   @Override


### PR DESCRIPTION
Moving `getGroupInfo` implementation inside the `GroupManager` to avoid Hibernate session exception on the lazy RaID injected dependency
