### PR TITLE
RSDEV-988: Removing `raidTitle` non-null validation

### DIFF
--- a/src/main/java/com/researchspace/webapp/integrations/raid/RaIDController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/raid/RaIDController.java
@@ -321,9 +321,6 @@ public class RaIDController extends BaseOAuth2Controller {
         StringUtils.isNotBlank(raidGroupAssociation.getRaid().getRaidIdentifier()),
         "raidIdentifier is missing");
     Validate.isTrue(
-        StringUtils.isNotBlank(raidGroupAssociation.getRaid().getRaidTitle()),
-        "raidTitle is missing");
-    Validate.isTrue(
         StringUtils.isNotBlank(raidGroupAssociation.getRaid().getRaidServerAlias()),
         "raidServerAlias is missing");
   }

--- a/src/test/java/com/researchspace/webapp/integrations/raid/RaIDControllerMCVIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/raid/RaIDControllerMCVIT.java
@@ -317,7 +317,7 @@ public class RaIDControllerMCVIT extends MVCTestBase {
                 EXPECTED_RAID_ASSOCIATED_1.getRaidServerAlias(),
                 EXPECTED_RAID_ASSOCIATED_1.getRaidTitle(),
                 EXPECTED_RAID_ASSOCIATED_1.getRaidIdentifier()));
-    raidToGroupAssociation.getRaid().setRaidTitle("Wrong title deliberately added to be decorated");
+    raidToGroupAssociation.getRaid().setRaidTitle(null);
 
     result =
         mockMvc


### PR DESCRIPTION
## Description ##
This PR removes the `raidTitle` non-null validation when associating a raid id to a project