### PR TITLE
RSDEV-1006: Fix error when trying to associate a RaID that is already associated by another user

### DIFF
--- a/src/main/java/com/researchspace/dao/RaIDDao.java
+++ b/src/main/java/com/researchspace/dao/RaIDDao.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface RaIDDao extends GenericDao<UserRaid, Long> {
 
   List<UserRaid> getAssociatedRaidByUserAndAlias(User user, String serverAlias);
+
+  List<UserRaid> getAssociatedRaidByAlias(String serverAlias);
 }

--- a/src/main/java/com/researchspace/dao/hibernate/RaIDDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/RaIDDaoHibernate.java
@@ -25,4 +25,13 @@ public class RaIDDaoHibernate extends GenericDaoHibernate<UserRaid, Long> implem
         .setParameter("serverAlias", serverAlias)
         .list();
   }
+
+  @Override
+  public List<UserRaid> getAssociatedRaidByAlias(String serverAlias) {
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery("from UserRaid ur where ur.raidServerAlias = :serverAlias", UserRaid.class)
+        .setParameter("serverAlias", serverAlias)
+        .list();
+  }
 }

--- a/src/main/java/com/researchspace/service/RaIDServiceManager.java
+++ b/src/main/java/com/researchspace/service/RaIDServiceManager.java
@@ -12,6 +12,8 @@ public interface RaIDServiceManager {
 
   Set<RaidGroupAssociationDTO> getAssociatedRaidsByUserAndAlias(User user, String raidServerAlias);
 
+  Set<RaidGroupAssociationDTO> getAssociatedRaidsByAlias(String raidServerAlias);
+
   Optional<RaidGroupAssociationDTO> getAssociatedRaidByUserAliasAndProjectId(
       User user, String raidServerAlias, Long projectGroupId);
 

--- a/src/main/java/com/researchspace/service/impl/RaIDServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RaIDServiceManagerImpl.java
@@ -36,6 +36,12 @@ public class RaIDServiceManagerImpl implements RaIDServiceManager {
   }
 
   @Override
+  public Set<RaidGroupAssociationDTO> getAssociatedRaidsByAlias(String raidServerAlias) {
+    List<UserRaid> userRaidList = raidDao.getAssociatedRaidByAlias(raidServerAlias);
+    return userRaidList.stream().map(RaidGroupAssociationDTO::new).collect(Collectors.toSet());
+  }
+
+  @Override
   public Optional<RaidGroupAssociationDTO> getAssociatedRaidByUserAliasAndProjectId(
       User user, String raidServerAlias, Long projectGroupId) {
     Optional<RaidGroupAssociationDTO> result = Optional.empty();

--- a/src/main/java/com/researchspace/webapp/integrations/raid/RaIDController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/raid/RaIDController.java
@@ -59,8 +59,7 @@ public class RaIDController extends BaseOAuth2Controller {
   private UserConnectionManager userConnection;
 
   /***
-   * Gets the list of the created raid by the user and remove from it
-   * the ones that have been already associated in RSpace
+   * Gets the list of the available raids to be associated
    *
    * @param principal
    * @return the list of RaID created by the user without the ones that have been already associated
@@ -68,7 +67,7 @@ public class RaIDController extends BaseOAuth2Controller {
   @GetMapping()
   @ResponseBody
   @ResponseStatus(HttpStatus.OK)
-  public AjaxReturnObject<Set<RaIDReferenceDTO>> getRaidListByUser(Principal principal) {
+  public AjaxReturnObject<Set<RaIDReferenceDTO>> getAvailableRaidList(Principal principal) {
     RaIDReferenceDTO errorBean = new RaIDReferenceDTO();
     BindingResult errors = new BeanPropertyBindingResult(errorBean, "RaIDReferenceDTO");
     Set<RaIDReferenceDTO> result =
@@ -296,14 +295,11 @@ public class RaIDController extends BaseOAuth2Controller {
             if (externalRaIDList != null && !externalRaIDList.isEmpty()) {
               // remove from the external list the RaID that have already been associated
               // by this user
-              Set<RaIDReferenceDTO> userRaidAlreadyAssociated =
-                  raidServiceManager
-                      .getAssociatedRaidsByUserAndAlias(
-                          userManager.getUserByUsername(principal.getName()), currentServerAlias)
-                      .stream()
+              Set<RaIDReferenceDTO> raidsAlreadyAssociated =
+                  raidServiceManager.getAssociatedRaidsByAlias(currentServerAlias).stream()
                       .map(RaidGroupAssociationDTO::getRaid)
                       .collect(Collectors.toSet());
-              externalRaIDList.removeAll(userRaidAlreadyAssociated);
+              externalRaIDList.removeAll(raidsAlreadyAssociated);
 
               result.addAll(externalRaIDList);
             }

--- a/src/test/java/com/researchspace/service/RaIDServiceManagerTest.java
+++ b/src/test/java/com/researchspace/service/RaIDServiceManagerTest.java
@@ -31,11 +31,14 @@ public class RaIDServiceManagerTest {
   public static final long USER_RAID_ID = 1L;
   public static final long PROJECT_GROUP_ID = 2L;
 
-  @InjectMocks private RaIDServiceManager raIDServiceManager = new RaIDServiceManagerImpl();
+  @InjectMocks
+  private RaIDServiceManager raIDServiceManager = new RaIDServiceManagerImpl();
 
-  @Mock private RaIDDao raidDao;
+  @Mock
+  private RaIDDao raidDao;
 
-  @Mock private GroupManager groupManager;
+  @Mock
+  private GroupManager groupManager;
 
   private User piUser;
   private Group projectGroup;
@@ -51,8 +54,9 @@ public class RaIDServiceManagerTest {
     userRaid = new UserRaid(piUser, projectGroup, SERVER_ALIAS, RAID_TITLE, RAID_IDENTIFIER);
     userRaid.setId(USER_RAID_ID);
 
-    when(raidDao.getAssociatedRaidByUserAndAlias(piUser, SERVER_ALIAS))
-        .thenReturn(List.of(userRaid));
+    when(raidDao.getAssociatedRaidByUserAndAlias(piUser, SERVER_ALIAS)).thenReturn(
+        List.of(userRaid));
+    when(raidDao.getAssociatedRaidByAlias(SERVER_ALIAS)).thenReturn(List.of(userRaid));
     when(groupManager.getGroup(projectGroup.getId())).thenReturn(projectGroup);
   }
 
@@ -61,6 +65,21 @@ public class RaIDServiceManagerTest {
     // WHEN
     Set<RaidGroupAssociationDTO> actualResult =
         raIDServiceManager.getAssociatedRaidsByUserAndAlias(piUser, SERVER_ALIAS);
+
+    // THEN
+    assertNotNull(actualResult);
+    assertEquals(1, actualResult.size());
+    RaidGroupAssociationDTO actualReferenceDTO = actualResult.iterator().next();
+    assertEquals(USER_RAID_ID, actualReferenceDTO.getRaid().getId());
+    assertEquals(SERVER_ALIAS, actualReferenceDTO.getRaid().getRaidServerAlias());
+    assertEquals(RAID_IDENTIFIER, actualReferenceDTO.getRaid().getRaidIdentifier());
+  }
+
+  @Test
+  public void testGetAssociatedRaidsByAlias() {
+    // WHEN
+    Set<RaidGroupAssociationDTO> actualResult =
+        raIDServiceManager.getAssociatedRaidsByAlias(SERVER_ALIAS);
 
     // THEN
     assertNotNull(actualResult);

--- a/src/test/java/com/researchspace/webapp/integrations/raid/RaIDControllerMCVIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/raid/RaIDControllerMCVIT.java
@@ -117,7 +117,7 @@ public class RaIDControllerMCVIT extends MVCTestBase {
   }
 
   @Test
-  public void testGetRaidListByUser() throws Exception {
+  public void testGetAvailableRaidList() throws Exception {
     // GIVEN
     Map<String, RaIDServerConfigurationDTO> serverByAlias =
         Map.of(
@@ -185,7 +185,11 @@ public class RaIDControllerMCVIT extends MVCTestBase {
             piUser.getUsername(), RAID_APP_NAME, SERVER_ALIAS_2))
         .thenReturn(Optional.empty());
 
-    // WHEN
+    // WHEN another user
+    User anotherPiUser = createAndSaveUser("anotherPi" + getRandomName(10), Constants.PI_ROLE);
+    initUser(anotherPiUser);
+    logoutAndLoginAs(anotherPiUser);
+
     result =
         mockMvc
             .perform(get("/apps/raid").principal(piUser::getUsername))
@@ -383,7 +387,8 @@ public class RaIDControllerMCVIT extends MVCTestBase {
 
     // THEN
     assertTrue(
-        extractErrorMessage(result).contains(
+        extractErrorMessage(result)
+            .contains(
                 "Not able to associate RaID to group: "
                     + "The RaID \""
                     + IDENTIFIER_ASSOCIATED_2


### PR DESCRIPTION
## Description ##
This PR fixes the error when trying to associate a RaID that is already associated by another user.

From now on the getAvailableRaids will return the list of available raids to be associated taking in consideration also the raids that other users has associated.

## Testing ##
 - GIVEN
   - Login with a **userA** and associate a **RaidX** to a Project Group
 - WHEN 
   - Logout and login with a **userB** and get the list of available raids (`GET /appds/raid`) 
 - THEN
   - Verify that the list of available raids does not contain the **RaidX**
