### PR TITLE
Adding missing import.

### DIFF
--- a/src/main/webapp/decorators/externalPages.jsp
+++ b/src/main/webapp/decorators/externalPages.jsp
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <%@ include file="/common/taglibs.jsp" %>
 
+<jsp:include page="/scripts/templates/blockUI.html"/>
+
 <html xmlns="http://www.w3.org/1999/xhtml">
 
 	<head>


### PR DESCRIPTION
## Description ##
- Addresses https://researchspace.atlassian.net/browse/PRT-1037
- Caused by new version of mustache no longer accepting undefined inputs to the render method
- Fixed by adding an import that provides the missing input