### PR TITLE
Don't generate webpack stats unless in CI environment

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -37,6 +37,7 @@ on:
 
 env:
   RS_FILE_BASE: /tmp/${{ github.ref_name }}-filestore
+  CI: "true"
 
 jobs:
 #  initialize:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
 
     environment {
         BUILD_FAILURE_EMAIL_LIST = 'dev@researchspace.com'
+        CI = 'true'
         RS_FILE_BASE = "/var/lib/jenkins/userContent/${BRANCH_NAME}-filestore"
         SANITIZED_DBNAME = branchToDbName("${BRANCH_NAME}")
         DOCKER_AMI = 'ami-069082aeb2787a3ba'

--- a/src/main/webapp/ui/webpack.config.mjs
+++ b/src/main/webapp/ui/webpack.config.mjs
@@ -2,6 +2,8 @@ import path from 'node:path';
 import webpack from "webpack";
 import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 
+const isCi = process.env.CI === "true" || process.env.CI === "1";
+
 /** @type {import('webpack').Configuration} */
 const config = {
   entry: {
@@ -101,7 +103,7 @@ const config = {
       analyzerMode: Boolean(process.env.FRONTEND_BUILD_STATS)
         ? "server"
         : "disabled",
-      generateStatsFile: true,
+      generateStatsFile: isCi,
     }),
   ],
   optimization: {


### PR DESCRIPTION
## Description ##
Don't generate webpack stats unless we're in CI mode, to reduce overhead when building locally.
