### PR TITLE
RSDEV-1062: Add new `Instrument` and `InstrumentTemplate`

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Run fast tests
         run: |
-          ./mvnw clean test -Dfast=true -DRS_FILE_BASE=${RS_FILE_BASE} \
+          ./mvnw clean test -U -Dfast=true -DRS_FILE_BASE=${RS_FILE_BASE} \
             -Djava-version=${{ matrix.java-version }} \
             -Djava-vendor=${{ inputs.java_vendor || 'temurin' }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -612,11 +612,17 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>snapgene-java-client</artifactId>
       <version>1.0.3</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.rspace-os</groupId>
+          <artifactId>rspace-core-util</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-audit</artifactId>
-      <version>0.14.3</version>
+      <version>0.14.4</version>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
@@ -1365,6 +1371,12 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-dataverse-adapter</artifactId>
       <version>3.0.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.rspace-os</groupId>
+          <artifactId>rspace-core-util</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <!-- dataverse-rspace-adaptor internally-conflicting dependency,
@@ -1435,12 +1447,12 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-util</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>2.21.2</version>
+      <version>2.22.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>
@@ -1491,6 +1503,16 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-figshare-adapter</artifactId>
       <version>1.1.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.rspace-os</groupId>
+          <artifactId>rspace-repository-spi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.github.rspace-os</groupId>
+          <artifactId>rspace-core-util</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
@@ -1581,6 +1603,10 @@
           <groupId>org.jetbrains</groupId>
           <artifactId>annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.github.rspace-os</groupId>
+          <artifactId>rspace-core-util</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1651,6 +1677,10 @@
       <artifactId>rspace-rest-api-utils</artifactId>
       <version>1.3.4</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.github.rspace-os</groupId>
+          <artifactId>rspace-core-util</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
@@ -1831,6 +1861,12 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-snapgene-adapter</artifactId>
       <version>1.0.3</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.rspace-os</groupId>
+          <artifactId>rspace-core-util</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/src/main/java/com/axiope/model/record/init/AntibodySampleTemplate.java
+++ b/src/main/java/com/axiope/model/record/init/AntibodySampleTemplate.java
@@ -8,11 +8,11 @@ import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
 import com.researchspace.model.inventory.field.InventoryRadioFieldDef;
 import com.researchspace.model.inventory.field.InventoryStringField;
 import com.researchspace.model.inventory.field.InventoryTextField;
-import com.researchspace.model.inventory.field.SampleField;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.units.QuantityInfo;
 import com.researchspace.model.units.RSUnitDef;
@@ -44,12 +44,12 @@ public class AntibodySampleTemplate extends BuiltinContent implements SampleTemp
     sample.setStorageTempMax(QuantityInfo.of(5, RSUnitDef.CELSIUS));
     sample.setStorageTempMin(QuantityInfo.of(3, RSUnitDef.CELSIUS));
 
-    SampleField id = new InventoryTextField("Identifier");
+    InventoryEntityField id = new InventoryTextField("Identifier");
     sample.addSampleField(id);
-    SampleField antigen = new InventoryStringField("Antigen");
+    InventoryEntityField antigen = new InventoryStringField("Antigen");
     sample.addSampleField(antigen);
 
-    SampleField pep = new InventoryStringField("Peptide");
+    InventoryEntityField pep = new InventoryStringField("Peptide");
     sample.addSampleField(pep);
 
     InventoryChoiceFieldDef speciesFieldChoiceDef = new InventoryChoiceFieldDef();
@@ -90,7 +90,7 @@ public class AntibodySampleTemplate extends BuiltinContent implements SampleTemp
     InventoryChoiceField apps = new InventoryChoiceField(appFieldForm, "Applications");
     sample.addSampleField(apps);
 
-    SampleField dilutions = new InventoryTextField("Dilutions");
+    InventoryEntityField dilutions = new InventoryTextField("Dilutions");
     sample.addSampleField(dilutions);
 
     InventoryRadioFieldDef raisedInDef = new InventoryRadioFieldDef();

--- a/src/main/java/com/axiope/model/record/init/BacterialSampleTemplate.java
+++ b/src/main/java/com/axiope/model/record/init/BacterialSampleTemplate.java
@@ -3,9 +3,9 @@ package com.axiope.model.record.init;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSampleName;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryStringField;
 import com.researchspace.model.inventory.field.InventoryTextField;
-import com.researchspace.model.inventory.field.SampleField;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.units.QuantityInfo;
 import com.researchspace.model.units.RSUnitDef;
@@ -48,7 +48,7 @@ public class BacterialSampleTemplate extends BuiltinContent implements SampleTem
     sample.setStorageTempMin(QuantityInfo.of(-30, RSUnitDef.CELSIUS));
     sample.setDescription("Description of a bacterial culture");
     sample.setTemplate(true);
-    SampleField id = new InventoryTextField("Identifier");
+    InventoryEntityField id = new InventoryTextField("Identifier");
     sample.addSampleField(id);
 
     for (String fieldKey : stringFieldKeys1) {

--- a/src/main/java/com/axiope/model/record/init/FFPESampleTemplate.java
+++ b/src/main/java/com/axiope/model/record/init/FFPESampleTemplate.java
@@ -8,9 +8,9 @@ import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
 import com.researchspace.model.inventory.field.InventoryDateField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryNumberField;
 import com.researchspace.model.inventory.field.InventoryTextField;
-import com.researchspace.model.inventory.field.SampleField;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.units.QuantityInfo;
 import com.researchspace.model.units.RSUnitDef;
@@ -48,27 +48,28 @@ public class FFPESampleTemplate extends BuiltinContent implements SampleTemplate
             + " blocks from the same procedure should stored together in a single draw.");
     sample.setTags("FFPE,tissue,slide,section,pathology");
 
-    SampleField id = new InventoryTextField("Identifier");
+    InventoryEntityField id = new InventoryTextField("Identifier");
     sample.addSampleField(id);
-    SampleField donorNumber = new InventoryNumberField("Donor number");
+    InventoryEntityField donorNumber = new InventoryNumberField("Donor number");
     sample.addSampleField(donorNumber);
-    SampleField blockNumber = new InventoryNumberField("Block number");
+    InventoryEntityField blockNumber = new InventoryNumberField("Block number");
     sample.addSampleField(blockNumber);
-    SampleField genderRace = new InventoryTextField("Gender,Race");
+    InventoryEntityField genderRace = new InventoryTextField("Gender,Race");
     sample.addSampleField(genderRace);
-    SampleField heightWeightAge = new InventoryTextField("Height (cm), Weight (kg), BMI");
+    InventoryEntityField heightWeightAge = new InventoryTextField("Height (cm), Weight (kg), BMI");
     sample.addSampleField(heightWeightAge);
 
-    SampleField pathReport = new InventoryTextField("Pathology report as text if available");
+    InventoryEntityField pathReport =
+        new InventoryTextField("Pathology report as text if available");
     sample.addSampleField(pathReport);
 
-    SampleField diagnosis = new InventoryTextField("Indication / Diagnosis");
+    InventoryEntityField diagnosis = new InventoryTextField("Indication / Diagnosis");
     sample.addSampleField(diagnosis);
 
-    SampleField date_of_birth_of_donor = new InventoryDateField("Date of birth of donor");
+    InventoryEntityField date_of_birth_of_donor = new InventoryDateField("Date of birth of donor");
     sample.addSampleField(date_of_birth_of_donor);
 
-    SampleField dateOfProcedure =
+    InventoryEntityField dateOfProcedure =
         new InventoryDateField("Date of surgical procedure (creation of sample)");
     sample.addSampleField(dateOfProcedure);
 

--- a/src/main/java/com/axiope/model/record/init/SyntheticWaxSampleTemplate.java
+++ b/src/main/java/com/axiope/model/record/init/SyntheticWaxSampleTemplate.java
@@ -8,10 +8,10 @@ import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
 import com.researchspace.model.inventory.field.InventoryDateField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryNumberField;
 import com.researchspace.model.inventory.field.InventoryTextField;
 import com.researchspace.model.inventory.field.InventoryTimeField;
-import com.researchspace.model.inventory.field.SampleField;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.units.QuantityInfo;
 import com.researchspace.model.units.RSUnitDef;
@@ -48,13 +48,13 @@ public class SyntheticWaxSampleTemplate extends BuiltinContent implements Sample
             + " sqaure portions cut from main block using Acme wax block cutter.");
     sample.setTags("wax");
 
-    SampleField id = new InventoryTextField("Identifier");
+    InventoryEntityField id = new InventoryTextField("Identifier");
     sample.addSampleField(id);
-    SampleField productionDate = new InventoryDateField("Production Date");
+    InventoryEntityField productionDate = new InventoryDateField("Production Date");
     sample.addSampleField(productionDate);
-    SampleField productionTime = new InventoryTimeField("Production Time");
+    InventoryEntityField productionTime = new InventoryTimeField("Production Time");
     sample.addSampleField(productionTime);
-    SampleField batchNumber = new InventoryNumberField("Batch Number");
+    InventoryEntityField batchNumber = new InventoryNumberField("Batch Number");
     sample.addSampleField(batchNumber);
 
     InventoryChoiceFieldDef choiceFieldDef = new InventoryChoiceFieldDef();

--- a/src/main/java/com/researchspace/api/v1/InstrumentsApi.java
+++ b/src/main/java/com/researchspace/api/v1/InstrumentsApi.java
@@ -1,0 +1,30 @@
+/**
+ * RSpace Inventory API Access your RSpace Inventory programmatically. All requests require
+ * authentication.
+ */
+package com.researchspace.api.v1;
+
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.model.User;
+import javax.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@RequestMapping("/api/inventory/v1/instruments")
+public interface InstrumentsApi {
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  ApiInstrument createNewInstrument(
+      @RequestBody @Valid ApiInstrument instrument, BindingResult errors, User user)
+      throws BindException;
+
+  @GetMapping(value = "/{id}")
+  ApiInstrument getInstrumentById(Long id, User user);
+}

--- a/src/main/java/com/researchspace/api/v1/controller/BaseApiInventoryController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/BaseApiInventoryController.java
@@ -14,6 +14,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.service.inventory.BasketApiManager;
 import com.researchspace.service.inventory.ContainerApiManager;
+import com.researchspace.service.inventory.InstrumentApiManager;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
 import com.researchspace.service.inventory.SampleApiManager;
 import com.researchspace.service.inventory.SubSampleApiManager;
@@ -41,6 +42,8 @@ public class BaseApiInventoryController extends BaseApiController {
   public static final String API_INVENTORY_V1 = "/api/inventory/v1";
   public static final String SAMPLES_ENDPOINT = "/samples";
   public static final String SAMPLE_TEMPLATES_ENDPOINT = "/sampleTemplates";
+  public static final String INSTRUMENTS_ENDPOINT = "/instruments";
+  public static final String INSTRUMENT_TEMPLATES_ENDPOINT = "/instrumentTemplates";
   public static final String SUBSAMPLES_ENDPOINT = "/subSamples";
   public static final String CONTAINERS_ENDPOINT = "/containers";
   public static final String SEARCH_ENDPOINT = "/search";
@@ -53,6 +56,7 @@ public class BaseApiInventoryController extends BaseApiController {
   protected @Autowired InventoryPermissionUtils invPermissions;
   protected @Autowired InventoryEditLockTracker tracker;
 
+  protected @Autowired InstrumentApiManager instrumentApiMgr;
   protected @Autowired SampleApiManager sampleApiMgr;
   protected @Autowired SubSampleApiManager subSampleApiMgr;
   protected @Autowired ContainerApiManager containerApiMgr;
@@ -159,8 +163,12 @@ public class BaseApiInventoryController extends BaseApiController {
         return subSampleApiMgr.assertUserCanEditSubSample(recordOid.getDbId(), user);
       case IC:
         return containerApiMgr.assertUserCanEditContainer(recordOid.getDbId(), user);
+      case IN:
+        return instrumentApiMgr.assertUserCanEditInstrument(recordOid.getDbId(), user);
+      case NT:
+        return instrumentApiMgr.assertUserCanEditInstrumentTemplate(recordOid.getDbId(), user);
       case SF:
-        return sampleApiMgr.assertUserCanEditSampleField(recordOid.getDbId(), user);
+        return instrumentApiMgr.assertUserCanEditInventoryEntityField(recordOid.getDbId(), user);
       default:
         throw new IllegalArgumentException(
             "unsupported global id type: " + recordOid.getIdString());
@@ -177,8 +185,12 @@ public class BaseApiInventoryController extends BaseApiController {
         return subSampleApiMgr.assertUserCanReadSubSample(recordOid.getDbId(), user);
       case IC:
         return containerApiMgr.assertUserCanReadContainer(recordOid.getDbId(), user);
+      case IN:
+        return instrumentApiMgr.assertUserCanReadInstrument(recordOid.getDbId(), user);
+      case NT:
+        return instrumentApiMgr.assertUserCanReadInstrumentTemplate(recordOid.getDbId(), user);
       case SF:
-        return sampleApiMgr.assertUserCanReadSampleField(recordOid.getDbId(), user);
+        return instrumentApiMgr.assertUserCanReadInventoryEntityField(recordOid.getDbId(), user);
       default:
         throw new IllegalArgumentException(
             "unsupported global id type: " + recordOid.getIdString());

--- a/src/main/java/com/researchspace/api/v1/controller/InstrumentApiPostFullValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InstrumentApiPostFullValidator.java
@@ -1,0 +1,68 @@
+package com.researchspace.api.v1.controller;
+
+import com.researchspace.api.v1.controller.InstrumentsApiController.ApiInstrumentFullPost;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.service.ApiFieldsHelper;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import java.util.List;
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+/** Validator for creating a new instrument */
+@Component
+public class InstrumentApiPostFullValidator implements Validator {
+
+  @Autowired private ApiFieldsHelper fieldHelper;
+  private static final String INSTRUMENT_ENTITY_NAME_TYPE = "instrument";
+
+  @Override
+  public boolean supports(Class<?> clazz) {
+    return clazz.isAssignableFrom(ApiInstrumentFullPost.class);
+  }
+
+  @Data
+  @AllArgsConstructor
+  public static class ErrorAggregator implements Consumer<String> {
+    Errors errors;
+
+    @Override
+    public void accept(String errorMessage) {
+      if (!StringUtils.isEmpty(errorMessage)) {
+        errors.reject("", errorMessage);
+      }
+    }
+  }
+
+  @Override
+  public void validate(Object target, Errors errors) {
+    ApiInstrumentFullPost apiInstrumentPost = (ApiInstrumentFullPost) target;
+    validateFieldsAndTemplateFields(errors, apiInstrumentPost);
+  }
+
+  private void validateFieldsAndTemplateFields(
+      Errors errors, ApiInstrumentFullPost apiInstrumentPost) {
+    if (apiInstrumentPost.getTemplate() != null) {
+      List<ApiInventoryEntityField> incomingApiFields =
+          apiInstrumentPost.getApiInstrument().getFields();
+      List<InventoryEntityField> templateFields = apiInstrumentPost.getTemplate().getActiveFields();
+
+      if (!incomingApiFields.isEmpty()) {
+        // run validation against template fields
+        fieldHelper.checkApiFieldsMatchingFormFields(
+            incomingApiFields,
+            templateFields,
+            apiInstrumentPost.getUser(),
+            new ErrorAggregator(errors));
+      }
+
+      fieldHelper.validateMandatoryFieldsForEntityPost(
+          INSTRUMENT_ENTITY_NAME_TYPE, incomingApiFields, templateFields, errors);
+    }
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/controller/InstrumentApiPostValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InstrumentApiPostValidator.java
@@ -1,0 +1,41 @@
+package com.researchspace.api.v1.controller;
+
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentEntityInfo;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+@Component
+public class InstrumentApiPostValidator extends InstrumentApiValidator implements Validator {
+
+  @Override
+  public boolean supports(Class<?> clazz) {
+    return ApiInstrument.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(Object target, Errors errors) {
+    ApiInstrumentEntityInfo apiInstrumentPost =
+        coreValidationForInstrumentsAndTemplatesPost(target, errors);
+    validateApiExtraFieldsInNewInstrument(apiInstrumentPost, errors);
+  }
+
+  ApiInstrumentEntityInfo coreValidationForInstrumentsAndTemplatesPost(
+      Object target, Errors errors) {
+    ApiInstrumentEntityInfo apiInstrumentPost = (ApiInstrumentEntityInfo) target;
+    ValidationUtils.rejectIfEmptyOrWhitespace(
+        errors, "name", "errors.required", new Object[] {"name"}, "name is required");
+    validateNameTooLong(apiInstrumentPost.getName(), errors);
+    validateDescriptionTooLong(apiInstrumentPost.getDescription(), errors);
+    validateTags(apiInstrumentPost.getTags(), errors);
+    validateInventoryRecordQuantity(apiInstrumentPost, errors);
+    return apiInstrumentPost;
+  }
+
+  private void validateApiExtraFieldsInNewInstrument(
+      ApiInstrumentEntityInfo apiInstrument, Errors errors) {
+    validateExtraFields(apiInstrument, errors);
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/controller/InstrumentApiValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InstrumentApiValidator.java
@@ -1,0 +1,18 @@
+package com.researchspace.api.v1.controller;
+
+import com.researchspace.model.inventory.Instrument;
+import java.util.Set;
+
+/*
+ * Helper methods for validating properties of InstrumentEntities
+ */
+abstract class InstrumentApiValidator extends InventoryRecordValidator {
+
+  private final Set<String> reservedInstrumentsFieldNames =
+      (new Instrument()).getReservedFieldNames();
+
+  @Override
+  protected Set<String> getReservedFieldNames() {
+    return reservedInstrumentsFieldNames;
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/controller/InstrumentsApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InstrumentsApiController.java
@@ -1,0 +1,110 @@
+package com.researchspace.api.v1.controller;
+
+import com.researchspace.api.v1.InstrumentsApi;
+import com.researchspace.api.v1.model.ApiContainerInfo;
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import javax.validation.Valid;
+import javax.ws.rs.NotFoundException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiController
+public class InstrumentsApiController extends BaseApiInventoryController implements InstrumentsApi {
+
+  @Autowired private InstrumentApiPostValidator instrumentApiPostValidator;
+  @Autowired private InstrumentApiPostFullValidator instrumentApiPostFullValidator;
+
+  @Value("${inventory.instrument.enabled:false}")
+  private boolean inventoryInstrumentEnabled;
+
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class ApiInstrumentFullPost {
+
+    ApiInstrument apiInstrument;
+    User user;
+    // may be null
+    InstrumentTemplate template;
+  }
+
+  @Override
+  public ApiInstrument createNewInstrument(
+      @RequestBody @Valid ApiInstrument apiInstrument,
+      BindingResult errors,
+      @RequestAttribute(name = "user") User user)
+      throws BindException {
+    assertIsInventoryInstrumentEnabled();
+    validateCreateInstrumentInput(apiInstrument, errors, user);
+
+    if (apiInstrument.getNewTargetLocation() != null) {
+      ApiContainerInfo parentContainer = new ApiContainerInfo();
+      parentContainer.setId(apiInstrument.getNewTargetLocation().getContainerId());
+      apiInstrument.setParentContainer(parentContainer);
+      apiInstrument.setParentLocation(apiInstrument.getNewTargetLocation().getContainerLocation());
+    }
+
+    ApiInstrument result = instrumentApiMgr.createNewApiInstrument(apiInstrument, user);
+    buildAndAddInventoryRecordLinks(result);
+
+    return result;
+  }
+
+  @Override
+  public ApiInstrument getInstrumentById(
+      @PathVariable Long id, @RequestAttribute(name = "user") User user) {
+    assertIsInventoryInstrumentEnabled();
+
+    ApiInstrument instrument = retrieveApiInstrumentIfExists(id, user);
+    buildAndAddInventoryRecordLinks(instrument);
+    return instrument;
+  }
+
+  private void assertIsInventoryInstrumentEnabled() {
+    if (!inventoryInstrumentEnabled) {
+      throw new UnsupportedOperationException(
+          "The inventory Instrument is not enabled in this RSpace instance");
+    }
+  }
+
+  /* errors might already be populated with simple validation errors using javax.validation annotations
+   * by Spring's automatic validation */
+  public void validateCreateInstrumentInput(
+      ApiInstrument apiInstrument, BindingResult errors, User user) throws BindException {
+
+    // TODO[nik]: implement this on RSDEV-1059, until that, it will be always null
+    // reinstate this: InstrumentTemplate instrumentTemplate =
+    //                                            verifyTemplate(apiInstrument, errors, user);
+    InstrumentTemplate instrumentTemplate = null;
+
+    // we validate the posted object. We can set errors on individual fields in this validator (
+    // doesn't need template)
+    inputValidator.validate(apiInstrument, instrumentApiPostValidator, errors);
+
+    // here we validate using other information as well as what's posted. errors are 'global' errors
+    ApiInstrumentFullPost allData =
+        new ApiInstrumentFullPost(apiInstrument, user, instrumentTemplate);
+
+    inputValidator.validate(allData, instrumentApiPostFullValidator, errors);
+    // this will collate all errors together.
+    throwBindExceptionIfErrors(errors);
+  }
+
+  private ApiInstrument retrieveApiInstrumentIfExists(Long id, User user) {
+    boolean exists = instrumentApiMgr.instrumentExists(id);
+    if (!exists) {
+      throw new NotFoundException(createNotFoundMessage("Inventory Instrument ", id));
+    }
+    return instrumentApiMgr.getApiInstrumentById(id, user);
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/controller/SampleApiPostFullValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleApiPostFullValidator.java
@@ -1,11 +1,11 @@
 package com.researchspace.api.v1.controller;
 
 import com.researchspace.api.v1.controller.SamplesApiController.ApiSampleFullPost;
-import com.researchspace.api.v1.model.ApiSampleField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.api.v1.service.ApiFieldsHelper;
 import com.researchspace.model.inventory.Sample;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.units.RSUnitDef;
 import java.util.List;
 import java.util.function.Consumer;
@@ -23,6 +23,7 @@ import org.springframework.validation.Validator;
 public class SampleApiPostFullValidator implements Validator {
 
   @Autowired private ApiFieldsHelper fieldHelper;
+  private static final String SAMPLE_ENTITY_NAME_TYPE = "sample";
 
   @Data
   @AllArgsConstructor
@@ -72,8 +73,8 @@ public class SampleApiPostFullValidator implements Validator {
 
   private void validateFieldsAndTemplateFields(Errors errors, ApiSampleFullPost apiSamplePost) {
     if (apiSamplePost.getTemplate() != null) {
-      List<ApiSampleField> incomingApiFields = apiSamplePost.getApiSample().getFields();
-      List<SampleField> templateFields = apiSamplePost.getTemplate().getActiveFields();
+      List<ApiInventoryEntityField> incomingApiFields = apiSamplePost.getApiSample().getFields();
+      List<InventoryEntityField> templateFields = apiSamplePost.getTemplate().getActiveFields();
 
       if (!incomingApiFields.isEmpty()) {
         // run validation against template fields
@@ -84,44 +85,8 @@ public class SampleApiPostFullValidator implements Validator {
             new ErrorAggregator(errors));
       }
 
-      validateMandatoryFieldsForSamplePost(incomingApiFields, templateFields, errors);
-    }
-  }
-
-  private void validateMandatoryFieldsForSamplePost(
-      List<ApiSampleField> incomingApiFields, List<SampleField> templateFields, Errors errors) {
-
-    for (int i = 0; i < templateFields.size(); i++) {
-      SampleField templateField = templateFields.get(i);
-      if (templateField.isMandatory()) {
-        boolean hasApiFieldForTemplateField = incomingApiFields.size() > i;
-        boolean isOptionsStoringField = templateField.isOptionsStoringField();
-        if (isOptionsStoringField) {
-          List<String> selectedOptions =
-              hasApiFieldForTemplateField
-                  ? incomingApiFields.get(i).getSelectedOptions()
-                  : templateField.getSelectedOptions();
-          if (CollectionUtils.isEmpty(selectedOptions)) {
-            errors.rejectValue(
-                "fields",
-                "errors.inventory.sample.mandatory.field.no.selection",
-                new Object[] {templateField.getName()},
-                "no option selected for mandatory field");
-          }
-        } else {
-          String incomingContent =
-              hasApiFieldForTemplateField
-                  ? incomingApiFields.get(i).getContent()
-                  : templateField.getFieldData();
-          if (!templateField.isValidValueForMandatoryField(incomingContent)) {
-            errors.rejectValue(
-                "fields",
-                "errors.inventory.sample.mandatory.field.empty",
-                new Object[] {templateField.getName()},
-                "no content for mandatory field");
-          }
-        }
-      }
+      fieldHelper.validateMandatoryFieldsForEntityPost(
+          SAMPLE_ENTITY_NAME_TYPE, incomingApiFields, templateFields, errors);
     }
   }
 

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldPostValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldPostValidator.java
@@ -1,7 +1,7 @@
 package com.researchspace.api.v1.controller;
 
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
-import com.researchspace.api.v1.model.ApiSampleField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -12,7 +12,7 @@ public class SampleTemplateFieldPostValidator extends SampleTemplateFieldValidat
 
   @Override
   public void validate(Object target, Errors errors) {
-    ApiSampleField apiTemplateField = (ApiSampleField) target;
+    ApiInventoryEntityField apiTemplateField = (ApiInventoryEntityField) target;
 
     // check field name
     String fieldName = apiTemplateField.getName();

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldPutValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldPutValidator.java
@@ -1,6 +1,6 @@
 package com.researchspace.api.v1.controller;
 
-import com.researchspace.api.v1.model.ApiSampleField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -11,7 +11,7 @@ public class SampleTemplateFieldPutValidator extends SampleTemplateFieldValidato
 
   @Override
   public void validate(Object target, Errors errors) {
-    ApiSampleField apiTemplateField = (ApiSampleField) target;
+    ApiInventoryEntityField apiTemplateField = (ApiInventoryEntityField) target;
 
     // check field name valid, if provided
     String fieldName = apiTemplateField.getName();

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldValidator.java
@@ -2,7 +2,7 @@ package com.researchspace.api.v1.controller;
 
 import com.researchspace.api.v1.model.ApiField;
 import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
-import com.researchspace.api.v1.model.ApiSampleField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.model.inventory.Sample;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -39,7 +39,7 @@ abstract class SampleTemplateFieldValidator implements Validator {
           new Object[] {fieldName, reservedFieldNamesString},
           "reserved field name");
     }
-    // check length matches limit for SampleField.name column
+    // check length matches limit for InventoryEntityField.name column
     if (StringUtils.length(fieldName) > 50) {
       errors.rejectValue(
           "name",
@@ -51,12 +51,12 @@ abstract class SampleTemplateFieldValidator implements Validator {
 
   /** Checks if incoming field content is valid for the field type. */
   protected void validateIncomingTemplateFieldContent(
-      Errors errors, ApiSampleField apiTemplateField) {
+      Errors errors, ApiInventoryEntityField apiTemplateField) {
     // check field content - this requires type to be provided
     if (apiTemplateField.getType() != null) {
       try {
         // this internally calls model.validate
-        apiFieldToModelFieldFactory.apiSampleFieldToModelField(apiTemplateField);
+        apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiTemplateField);
       } catch (IllegalArgumentException e) {
         errors.rejectValue(
             "content",

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplatePostValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplatePostValidator.java
@@ -1,6 +1,6 @@
 package com.researchspace.api.v1.controller;
 
-import com.researchspace.api.v1.model.ApiSampleField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiSampleTemplatePost;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -16,7 +16,7 @@ public class SampleTemplatePostValidator extends SampleTemplateValidator {
   }
 
   @Override
-  protected Validator getIncomingFieldValidator(ApiSampleField incomingField) {
+  protected Validator getIncomingFieldValidator(ApiInventoryEntityField incomingField) {
     return templateFieldPostValidator;
   }
 

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplatePutValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplatePutValidator.java
@@ -1,6 +1,6 @@
 package com.researchspace.api.v1.controller;
 
-import com.researchspace.api.v1.model.ApiSampleField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -16,7 +16,7 @@ public class SampleTemplatePutValidator extends SampleTemplateValidator {
   }
 
   @Override
-  protected Validator getIncomingFieldValidator(ApiSampleField incomingField) {
+  protected Validator getIncomingFieldValidator(ApiInventoryEntityField incomingField) {
     return incomingField.isNewFieldRequest()
         ? templateFieldPostValidator
         : templateFieldPutValidator;

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplateValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplateValidator.java
@@ -1,6 +1,6 @@
 package com.researchspace.api.v1.controller;
 
-import com.researchspace.api.v1.model.ApiSampleField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiSubSampleAlias;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.units.RSUnitDef;
@@ -18,11 +18,11 @@ public abstract class SampleTemplateValidator extends SampleApiPostValidator {
   protected @Autowired SampleTemplateFieldPostValidator templateFieldPostValidator;
   protected @Autowired SampleTemplateFieldPutValidator templateFieldPutValidator;
 
-  protected abstract Validator getIncomingFieldValidator(ApiSampleField incomingField);
+  protected abstract Validator getIncomingFieldValidator(ApiInventoryEntityField incomingField);
 
-  protected void validateFields(Errors errors, List<ApiSampleField> incomingFields) {
+  protected void validateFields(Errors errors, List<ApiInventoryEntityField> incomingFields) {
     int k = 0;
-    for (ApiSampleField aef : incomingFields) {
+    for (ApiInventoryEntityField aef : incomingFields) {
       errors.pushNestedPath(String.format("fields[%d]", k++));
       ValidationUtils.invokeValidator(getIncomingFieldValidator(aef), aef, errors);
       errors.popNestedPath();

--- a/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
@@ -11,6 +11,7 @@ import com.researchspace.api.v1.model.ApiSampleInfo;
 import com.researchspace.api.v1.model.ApiSampleSearchResult;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.api.v1.model.ApiSubSample;
+import com.researchspace.api.v1.model.ApiTargetLocation;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
@@ -170,8 +171,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   }
 
   private void placeNewSubSamplesInRequestedContainersAndLocations(
-      List<ApiSubSample> subSamples,
-      List<ApiSampleWithFullSubSamples.ApiSampleSubSampleTargetLocation> targetLocations) {
+      List<ApiSubSample> subSamples, List<ApiTargetLocation> targetLocations) {
 
     for (int i = 0; i < subSamples.size(); i++) {
       ApiContainerInfo parentContainer = new ApiContainerInfo();

--- a/src/main/java/com/researchspace/api/v1/model/ApiContainerInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiContainerInfo.java
@@ -86,6 +86,9 @@ public class ApiContainerInfo extends ApiInventoryRecordInfo {
   @JsonProperty("canStoreContainers")
   private Boolean canStoreContainers;
 
+  @JsonProperty("canStoreInstruments")
+  private Boolean canStoreInstruments;
+
   @JsonProperty("parentContainers")
   private List<ApiContainerInfo> parentContainers = new ArrayList<>();
 
@@ -153,6 +156,7 @@ public class ApiContainerInfo extends ApiInventoryRecordInfo {
             container.getContentCountContainers()));
     setCanStoreContainers(container.isCanStoreContainers());
     setCanStoreSamples(container.isCanStoreSamples());
+    setCanStoreInstruments(container.isCanStoreInstruments());
     setCustomImage(container.getImageFileProperty() != null);
     setCType(container.getContainerType().name());
     setLocationsImageFileProperty(container.getLocationsImageFileProperty());
@@ -242,9 +246,19 @@ public class ApiContainerInfo extends ApiInventoryRecordInfo {
       if (!getCanStoreContainers() && !dbContainer.getStoredContainers().isEmpty()) {
         throw new IllegalArgumentException(
             "Cannot set canStoreContainers to false, as this container is already storing"
-                + " subcontainers");
+                + " containers");
       }
       dbContainer.setCanStoreContainers(getCanStoreContainers());
+      contentChanged = true;
+    }
+    if (getCanStoreInstruments() != null
+        && !getCanStoreInstruments().equals(dbContainer.isCanStoreInstruments())) {
+      if (!getCanStoreInstruments() && !dbContainer.getStoredInstruments().isEmpty()) {
+        throw new IllegalArgumentException(
+            "Cannot set canStoreInstruments to false, as this container is already storing"
+                + " instruments");
+      }
+      dbContainer.setCanStoreInstruments(getCanStoreInstruments());
       contentChanged = true;
     }
     return contentChanged;

--- a/src/main/java/com/researchspace/api/v1/model/ApiFieldToModelFieldFactory.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiFieldToModelFieldFactory.java
@@ -2,18 +2,21 @@ package com.researchspace.api.v1.model;
 
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
 import com.researchspace.model.inventory.field.InventoryRadioFieldDef;
-import com.researchspace.model.inventory.field.SampleField;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
-/** Maps incoming template ApiField to SampleField based on value of 'type' property */
+/**
+ * Maps incoming template ApiInventoryEntityField to InventoryEntityField based on value of 'type'
+ * property
+ */
 @Component
 public class ApiFieldToModelFieldFactory {
 
-  public SampleField apiSampleFieldToModelField(ApiSampleField field) {
-    SampleField toAdd = null;
+  public InventoryEntityField apiInventoryFieldToModelField(ApiInventoryEntityField field) {
+    InventoryEntityField toAdd = null;
     switch (field.getType()) {
       case STRING:
       case TEXT:
@@ -24,7 +27,7 @@ public class ApiFieldToModelFieldFactory {
       case REFERENCE:
       case URI:
       case IDENTIFIER:
-        toAdd = SampleField.fromFieldTypeString(field.getType().toString());
+        toAdd = InventoryEntityField.fromFieldTypeString(field.getType().toString());
         break;
       case CHOICE:
         InventoryChoiceFieldDef def = new InventoryChoiceFieldDef();
@@ -61,7 +64,7 @@ public class ApiFieldToModelFieldFactory {
     return toAdd;
   }
 
-  private boolean definitionIsEmpty(ApiSampleField field) {
+  private boolean definitionIsEmpty(ApiInventoryEntityField field) {
     return field.getDefinition() == null
         || CollectionUtils.isEmpty(field.getDefinition().getOptions());
   }

--- a/src/main/java/com/researchspace/api/v1/model/ApiInstrument.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInstrument.java
@@ -1,0 +1,109 @@
+/** RSpace Inventory API Access your RSpace Inventory programmatically. */
+package com.researchspace.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.researchspace.core.util.jsonserialisers.ISO8601DateTimeDeserialiser;
+import com.researchspace.core.util.jsonserialisers.ISO8601DateTimeSerialiser;
+import com.researchspace.model.inventory.Instrument;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/** API representation of an Inventory Instrument, with information about Instruments. */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@JsonPropertyOrder({
+  "id",
+  "globalId",
+  "name",
+  "description",
+  "created",
+  "createdBy",
+  "lastModified",
+  "modifiedBy",
+  "modifiedByFullName",
+  "canBeDeleted",
+  "deleted",
+  "deletedDate",
+  "iconId",
+  "tags",
+  "type",
+  "attachments",
+  "barcodes",
+  "identifiers",
+  "owner",
+  "permittedActions",
+  "sharingMode",
+  "templateId",
+  "templateVersion",
+  "revisionId",
+  "version",
+  "historicalVersion",
+  "fields",
+  "extraFields",
+  "sharedWith",
+  "parentContainers",
+  "parentLocation",
+  "lastNonWorkbenchParent",
+  "lastMoveDate",
+  "storedInContainer",
+  "_links"
+})
+public class ApiInstrument extends ApiInstrumentEntity {
+
+  @JsonProperty(value = "newTargetLocation", access = Access.WRITE_ONLY)
+  private ApiTargetLocation newTargetLocation;
+
+  @JsonProperty(value = "parentContainers", access = Access.READ_ONLY)
+  private List<ApiContainerInfo> parentContainers = new ArrayList<>();
+
+  @JsonProperty(value = "parentLocation", access = Access.READ_ONLY)
+  private ApiContainerLocation parentLocation;
+
+  @JsonProperty(value = "lastNonWorkbenchParent", access = Access.READ_ONLY)
+  private ApiContainerInfo lastNonWorkbenchParent;
+
+  @EqualsAndHashCode.Exclude
+  @JsonProperty(value = "lastMoveDate", access = Access.READ_ONLY)
+  @JsonSerialize(using = ISO8601DateTimeSerialiser.class)
+  @JsonDeserialize(using = ISO8601DateTimeDeserialiser.class)
+  private Long lastMoveDateMillis;
+
+  /* location fields */
+  @JsonProperty(value = "storedInContainer", access = Access.READ_ONLY)
+  private boolean storedInContainer;
+
+  /** default constructor used by jackson deserializer */
+  public ApiInstrument() {
+    super();
+    super.setType(ApiInventoryRecordType.INSTRUMENT);
+    super.setTemplate(false);
+    super.setCanBeDeleted(true);
+  }
+
+  public ApiInstrument(Instrument instrument) {
+    super(instrument);
+
+    if (instrument.getParentLocation() != null) {
+      parentLocation = new ApiContainerLocation(instrument.getParentLocation());
+      populateParentContainers(instrument.getParentContainer());
+    }
+    if (instrument.getLastNonWorkbenchParent() != null) {
+      setLastNonWorkbenchParent(new ApiContainerInfo(instrument.getLastNonWorkbenchParent()));
+    }
+    if (instrument.getLastMoveDate() != null) {
+      setLastMoveDateMillis(Date.from(instrument.getLastMoveDate()).getTime());
+    }
+    setStoredInContainer(instrument.isStoredInContainer());
+
+    super.setCanBeDeleted(!instrument.isStoredInContainer());
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/model/ApiInstrumentEntity.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInstrumentEntity.java
@@ -1,0 +1,140 @@
+/** RSpace Inventory API Access your RSpace Inventory programmatically. */
+package com.researchspace.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InstrumentEntity;
+import com.researchspace.model.inventory.field.ExtraField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/** API representation of an Inventory ApiInstrumentEntity */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@JsonPropertyOrder({
+  "id",
+  "globalId",
+  "name",
+  "description",
+  "created",
+  "createdBy",
+  "lastModified",
+  "modifiedBy",
+  "modifiedByFullName",
+  "canBeDeleted",
+  "deleted",
+  "deletedDate",
+  "iconId",
+  "tags",
+  "type",
+  "attachments",
+  "barcodes",
+  "identifiers",
+  "owner",
+  "permittedActions",
+  "sharingMode",
+  "templateId",
+  "templateVersion",
+  "template",
+  "revisionId",
+  "version",
+  "historicalVersion",
+  "fields",
+  "extraFields",
+  "sharedWith",
+  "_links"
+})
+public abstract class ApiInstrumentEntity extends ApiInstrumentEntityInfo {
+
+  @JsonProperty("fields")
+  protected List<ApiInventoryEntityField> fields = new ArrayList<>();
+
+  @JsonProperty("extraFields")
+  protected List<ApiExtraField> extraFields = new ArrayList<>();
+
+  @JsonProperty(value = "sharedWith")
+  private List<ApiGroupInfoWithSharedFlag> sharedWith;
+
+  @JsonProperty(value = "canBeDeleted", access = Access.READ_ONLY)
+  private Boolean canBeDeleted;
+
+  public ApiInstrumentEntity(InstrumentEntity instrumentEntity) {
+    super(instrumentEntity);
+    for (InventoryEntityField field : instrumentEntity.getActiveFields()) {
+      fields.add(new ApiInventoryEntityField(field));
+    }
+    for (ExtraField extraField : instrumentEntity.getActiveExtraFields()) {
+      extraFields.add(new ApiExtraField(extraField));
+    }
+    sharedWith = new ArrayList<>();
+  }
+
+  /**
+   * @param dbInstrumentEntity db entity to which incoming changes should be applied
+   * @return if any change was applied
+   */
+  public boolean applyChangesToDatabaseInstrument(InstrumentEntity dbInstrumentEntity, User user) {
+    boolean contentChanged = super.applyChangesToDatabaseInstrument(dbInstrumentEntity);
+
+    if (fields != null) {
+      List<ApiInventoryEntityField> modifiedFields =
+          fields.stream()
+              .filter(f -> !(f.isNewFieldRequest() || f.isDeleteFieldRequest()))
+              .collect(Collectors.toList());
+
+      for (ApiInventoryEntityField field : modifiedFields) {
+        if (field.getId() == null) {
+          throw new IllegalArgumentException("'id' property not provided for a field");
+        }
+        Optional<InventoryEntityField> dbFieldOpt =
+            dbInstrumentEntity.getActiveFields().stream()
+                .filter(sf -> Objects.equals(sf.getId(), field.getId()))
+                .findFirst();
+        if (!dbFieldOpt.isPresent()) {
+          throw new IllegalArgumentException(
+              "Field id: "
+                  + field.getId()
+                  + " doesn't match any of the field ids of current instrument");
+        }
+        InventoryEntityField dbField = dbFieldOpt.get();
+        if (dbInstrumentEntity.isTemplate()) {
+          contentChanged |= field.applyChangesToDatabaseTemplateField(dbField, user);
+        } else {
+          contentChanged |= field.applyChangesToDatabaseField(dbField, user);
+        }
+      }
+    }
+    contentChanged |=
+        applyChangesToDatabaseExtraFields(
+            extraFields, dbInstrumentEntity.getActiveExtraFields(), user);
+    contentChanged |=
+        applyChangesToDatabaseBarcodes(getBarcodes(), dbInstrumentEntity.getActiveBarcodes());
+    contentChanged |=
+        applyChangesToDatabaseIdentifiers(
+            getIdentifiers(), dbInstrumentEntity.getActiveIdentifiers(), user);
+    contentChanged |= applyChangesToSharingMode(dbInstrumentEntity, user);
+
+    return contentChanged;
+  }
+
+  @Override
+  protected void nullifyListsForLimitedView(ApiInventoryRecordInfo apiInvRec) {
+    super.nullifyListsForLimitedView(apiInvRec);
+    ApiInstrumentEntity apiInstrument = (ApiInstrumentEntity) apiInvRec;
+    apiInstrument.setFields(null);
+    apiInstrument.setExtraFields(null);
+    apiInstrument.setSharedWith(null);
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/model/ApiInstrumentEntityInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInstrumentEntityInfo.java
@@ -1,0 +1,162 @@
+/** RSpace Inventory API Access your RSpace Inventory programmatically. */
+package com.researchspace.api.v1.model;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.researchspace.api.v1.controller.BaseApiInventoryController;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InstrumentEntity;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/** API representation of an Inventory Instrument */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@ToString(callSuper = true)
+@JsonPropertyOrder({
+  "id",
+  "globalId",
+  "name",
+  "description",
+  "created",
+  "createdBy",
+  "lastModified",
+  "modifiedBy",
+  "modifiedByFullName",
+  "deleted",
+  "deletedDate",
+  "iconId",
+  "tags",
+  "type",
+  "attachments",
+  "barcodes",
+  "identifiers",
+  "owner",
+  "permittedActions",
+  "sharingMode",
+  "templateId",
+  "templateVersion",
+  "template",
+  "revisionId",
+  "version",
+  "historicalVersion",
+  "_links"
+})
+public class ApiInstrumentEntityInfo extends ApiInventoryRecordInfo {
+
+  @JsonProperty("templateId")
+  @JsonInclude(value = NON_NULL)
+  private Long templateId;
+
+  @JsonProperty("templateVersion")
+  @JsonInclude(value = NON_NULL)
+  private Long templateVersion;
+
+  @JsonProperty(value = "template", access = Access.READ_ONLY)
+  private boolean template;
+
+  /* to use when generating image/thumbnail links on controller level, but not sent to front-end */
+  @JsonIgnore private boolean templateImageAvailable;
+
+  @JsonProperty("revisionId")
+  private Long revisionId;
+
+  @JsonProperty("version")
+  private Long version;
+
+  @JsonProperty("historicalVersion")
+  private boolean historicalVersion;
+
+  @JsonProperty(value = "forceDelete", access = Access.WRITE_ONLY)
+  private boolean forceDelete;
+
+  public ApiInstrumentEntityInfo(InstrumentEntity instrumentEntity) {
+    super(instrumentEntity);
+    if (instrumentEntity.isInstrument()) {
+      Instrument in = (Instrument) instrumentEntity;
+      this.setTemplateId(in.getParentTemplateId());
+      this.setTemplate(false);
+      this.setTemplateVersion(in.getTemplateLinkedVersion());
+    } else { // then it is an InstrumentTemplate
+      this.setTemplate(true);
+    }
+    this.setVersion(instrumentEntity.getVersion());
+  }
+
+  protected boolean applyChangesToDatabaseInstrument(InstrumentEntity instrument) {
+    return super.applyChangesToDatabaseInventoryRecord(instrument);
+  }
+
+  @Override
+  public void buildAndAddInventoryRecordLinks(UriComponentsBuilder baseUrlBuilder) {
+    super.buildAndAddInventoryRecordLinks(baseUrlBuilder);
+
+    if (getIconId() != null) {
+      String iconPath =
+          BaseApiInventoryController.INSTRUMENT_TEMPLATES_ENDPOINT
+              + "/"
+              + getId()
+              + "/icon/"
+              + getIconId();
+      String iconLink = buildLinkForForPath(baseUrlBuilder, iconPath);
+      addLink(ApiLinkItem.builder().link(iconLink).rel(ApiLinkItem.ICON_REL).build());
+
+      if (!isCustomImage()) {
+        if (isTemplateImageAvailable()
+            && getImageFileProperty() != null
+            && getThumbnailFileProperty() != null) {
+          addMainImageLink(baseUrlBuilder);
+          addThumbnailLink(baseUrlBuilder);
+        } else {
+          addLink(iconLink, ApiLinkItem.THUMBNAIL_REL);
+          addLink(iconLink, ApiLinkItem.IMAGE_REL);
+        }
+      }
+    }
+  }
+
+  protected String getSelfLinkEndpoint() {
+    if (isTemplate()) {
+      return BaseApiInventoryController.INSTRUMENT_TEMPLATES_ENDPOINT;
+    }
+    return BaseApiInventoryController.INSTRUMENTS_ENDPOINT;
+  }
+
+  @Override
+  public LinkableApiObject buildAndAddSelfLink(
+      final String endpoint, String pathStartingWithId, UriComponentsBuilder baseUrl) {
+    if (revisionId != null) {
+      pathStartingWithId += "/revisions/" + revisionId;
+    }
+    return super.buildAndAddSelfLink(endpoint, pathStartingWithId, baseUrl);
+  }
+
+  /**
+   * Boolean test for whether this instrument has a non-default templateIcon id (non-null, > 0)
+   *
+   * @return
+   */
+  @JsonIgnore
+  public boolean hasIconImage() {
+    return getIconId() != null && getIconId() > 0;
+  }
+
+  @Override
+  protected void populateLimitedViewCopy(ApiInventoryRecordInfo apiInvRecCopy) {
+    super.populateLimitedViewCopy(apiInvRecCopy);
+    ApiInstrumentEntityInfo limitedViewCopy = (ApiInstrumentEntityInfo) apiInvRecCopy;
+    limitedViewCopy.setTemplate(this.template); // can be null
+    limitedViewCopy.setTemplateId(getTemplateId());
+    limitedViewCopy.setTemplateVersion(getTemplateVersion());
+    limitedViewCopy.setTemplateImageAvailable(isTemplateImageAvailable());
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/model/ApiInstrumentTemplate.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInstrumentTemplate.java
@@ -1,0 +1,56 @@
+package com.researchspace.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@JsonPropertyOrder({
+  "id",
+  "globalId",
+  "name",
+  "description",
+  "created",
+  "createdBy",
+  "lastModified",
+  "modifiedBy",
+  "modifiedByFullName",
+  "canBeDeleted",
+  "deleted",
+  "deletedDate",
+  "iconId",
+  "tags",
+  "type",
+  "attachments",
+  "barcodes",
+  "identifiers",
+  "owner",
+  "permittedActions",
+  "sharingMode",
+  "revisionId",
+  "version",
+  "historicalVersion",
+  "fields",
+  "extraFields",
+  "sharedWith",
+  "_links"
+})
+public class ApiInstrumentTemplate extends ApiInstrumentEntity {
+
+  /** default constructor used by jackson deserializer */
+  public ApiInstrumentTemplate() {
+    super();
+    setType(ApiInventoryRecordType.INSTRUMENT_TEMPLATE);
+    super.setTemplate(true);
+    super.setCanBeDeleted(true);
+  }
+
+  public ApiInstrumentTemplate(InstrumentTemplate instrumentTemplate) {
+    super(instrumentTemplate);
+    super.setCanBeDeleted(true); // always true for now
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
@@ -9,9 +9,9 @@ import com.researchspace.model.User;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
 import com.researchspace.model.inventory.field.InventoryRadioFieldDef;
-import com.researchspace.model.inventory.field.SampleField;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -40,7 +40,7 @@ import lombok.ToString;
       "attachment",
       "_links"
     })
-public class ApiSampleField extends ApiField {
+public class ApiInventoryEntityField extends ApiField {
 
   @JsonProperty("attachment")
   private ApiInventoryFile attachment;
@@ -102,7 +102,7 @@ public class ApiSampleField extends ApiField {
     }
   }
 
-  public ApiSampleField(SampleField field) {
+  public ApiInventoryEntityField(InventoryEntityField field) {
     setId(field.getId());
     setType(ApiFieldType.valueOf(field.getType().toString()));
     setColumnIndex(field.getColumnIndex());
@@ -139,7 +139,7 @@ public class ApiSampleField extends ApiField {
   }
 
   /** Method for modifying instance of sample field. Currently only updates field content. */
-  public boolean applyChangesToDatabaseField(SampleField dbField, User user) {
+  public boolean applyChangesToDatabaseField(InventoryEntityField dbField, User user) {
     boolean contentChanged = applyContentChangesToDbField(dbField);
     if (contentChanged) {
       dbField.setModificationDate(new Date().getTime());
@@ -148,7 +148,7 @@ public class ApiSampleField extends ApiField {
   }
 
   /** Method for modifying instance of template field. Updates field's content and meta-data. */
-  public boolean applyChangesToDatabaseTemplateField(SampleField dbField, User user) {
+  public boolean applyChangesToDatabaseTemplateField(InventoryEntityField dbField, User user) {
     boolean contentChanged = false;
     if (getName() != null) {
       if (!getName().equals(dbField.getName())) {
@@ -219,7 +219,7 @@ public class ApiSampleField extends ApiField {
     dbChoiceField.setSelectedOptions(newSelectedOptions);
   }
 
-  private boolean applyContentChangesToDbField(SampleField dbField) {
+  private boolean applyContentChangesToDbField(InventoryEntityField dbField) {
     boolean contentChanged = false;
 
     // for choice/radio the content comes/goes through selectedOptions

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
@@ -15,6 +15,8 @@ import com.researchspace.model.User;
 import com.researchspace.model.inventory.Barcode;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.DigitalObjectIdentifier;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
@@ -41,6 +43,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @ToString(callSuper = true)
 @NoArgsConstructor
 public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObject {
+
   @JsonProperty("description")
   private String description;
 
@@ -90,7 +93,9 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
     SAMPLE,
     SUBSAMPLE,
     CONTAINER,
-    SAMPLE_TEMPLATE
+    SAMPLE_TEMPLATE,
+    INSTRUMENT,
+    INSTRUMENT_TEMPLATE
   }
 
   @JsonProperty(value = "attachments")
@@ -128,6 +133,7 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
   @AllArgsConstructor
   @NoArgsConstructor
   public static class ApiGroupInfoWithSharedFlag {
+
     @JsonProperty(value = "group")
     private ApiGroupBasicInfo groupInfo;
 
@@ -162,6 +168,10 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
       return new ApiSubSampleInfoWithSampleInfo((SubSample) invRecord);
     } else if (invRecord.isContainer()) {
       return new ApiContainerInfo((Container) invRecord);
+    } else if (invRecord.isInstrument()) {
+      return new ApiInstrumentEntityInfo((Instrument) invRecord);
+    } else if (invRecord.isInstrumentTemplate()) {
+      return new ApiInstrumentEntityInfo((InstrumentTemplate) invRecord);
     } else {
       throw new IllegalArgumentException("unsupported type: " + invRecord);
     }
@@ -176,6 +186,10 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
       return new ApiSubSample((SubSample) invRecord);
     } else if (invRecord.isContainer()) {
       return new ApiContainer((Container) invRecord);
+    } else if (invRecord.isInstrument()) {
+      return new ApiInstrument((Instrument) invRecord);
+    } else if (invRecord.isInstrumentTemplate()) {
+      return new ApiInstrumentTemplate((InstrumentTemplate) invRecord);
     } else {
       throw new IllegalArgumentException("unsupported type: " + invRecord);
     }
@@ -199,9 +213,6 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
       setDeletedDate(invRecord.getDeletedDate().getTime());
     }
     setIconId(invRecord.getIconId());
-    if (invRecord.getQuantityInfo() != null) {
-      setQuantity(new ApiQuantityInfo(invRecord));
-    }
     setApiTagInfo(invRecord.getTagMetaData());
     setType(ApiInventoryRecordType.valueOf(invRecord.getType().toString()));
     setSharingMode(ApiInventorySharingMode.valueOf(invRecord.getSharingMode().toString()));
@@ -678,6 +689,10 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
       result = new ApiSubSample();
     } else if (ApiInventoryRecordType.CONTAINER.equals(type)) {
       result = new ApiContainer();
+    } else if (ApiInventoryRecordType.INSTRUMENT.equals(type)) {
+      result = new ApiInstrument();
+    } else if (ApiInventoryRecordType.INSTRUMENT_TEMPLATE.equals(type)) {
+      result = new ApiInstrumentTemplate();
     } else {
       throw new IllegalArgumentException(
           "unrecognized type in provided ApiInventoryRecordInfo: " + type);

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleInfo.java
@@ -122,6 +122,9 @@ public class ApiSampleInfo extends ApiInventoryRecordInfo {
   public ApiSampleInfo(Sample sample) {
     super(sample);
 
+    if (sample.getQuantityInfo() != null) {
+      setQuantity(new ApiQuantityInfo(sample));
+    }
     // Sample will have null quantity without subsamples, but for API we should rather return zero
     if (getQuantity() == null) {
       setQuantity(new ApiQuantityInfo(BigDecimal.ZERO, sample.getDefaultUnitId()));

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplatePost.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplatePost.java
@@ -3,7 +3,7 @@ package com.researchspace.api.v1.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSampleName;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.units.RSUnitDef;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,15 +29,15 @@ public class ApiSampleTemplatePost extends ApiSampleTemplateInfo {
   private Integer defaultUnitId = RSUnitDef.MILLI_LITRE.getId();
 
   @JsonProperty("fields")
-  protected List<ApiSampleField> fields = new ArrayList<>();
+  protected List<ApiInventoryEntityField> fields = new ArrayList<>();
 
   @JsonProperty(value = "sharedWith")
   private List<ApiGroupInfoWithSharedFlag> sharedWith;
 
   public ApiSampleTemplatePost(Sample template) {
     super(template);
-    for (SampleField f : template.getActiveFields()) {
-      fields.add(new ApiSampleField(f));
+    for (InventoryEntityField f : template.getActiveFields()) {
+      fields.add(new ApiInventoryEntityField(f));
     }
   }
 }

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleWithFullSubSamples.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleWithFullSubSamples.java
@@ -8,12 +8,9 @@ import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSample;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -74,19 +71,7 @@ public class ApiSampleWithFullSubSamples extends ApiSampleWithoutSubSamples {
   private Integer newSampleSubSamplesCount;
 
   @JsonProperty(value = "newSampleSubSampleTargetLocations", access = Access.WRITE_ONLY)
-  private List<ApiSampleSubSampleTargetLocation> newSampleSubSampleTargetLocations;
-
-  @Getter
-  @Setter
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class ApiSampleSubSampleTargetLocation {
-    @JsonProperty("containerId")
-    private Long containerId;
-
-    @JsonProperty("location")
-    private ApiContainerLocation containerLocation;
-  }
+  private List<ApiTargetLocation> newSampleSubSampleTargetLocations;
 
   public ApiSampleWithFullSubSamples(Sample sample) {
     super(sample);

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleWithoutSubSamples.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleWithoutSubSamples.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.field.ExtraField;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -64,7 +64,7 @@ import lombok.ToString;
 public class ApiSampleWithoutSubSamples extends ApiSampleInfo {
 
   @JsonProperty("fields")
-  protected List<ApiSampleField> fields = new ArrayList<>();
+  protected List<ApiInventoryEntityField> fields = new ArrayList<>();
 
   @JsonProperty("extraFields")
   protected List<ApiExtraField> extraFields = new ArrayList<>();
@@ -75,8 +75,8 @@ public class ApiSampleWithoutSubSamples extends ApiSampleInfo {
   protected ApiSampleWithoutSubSamples(Sample sample) {
     super(sample);
 
-    for (SampleField field : sample.getActiveFields()) {
-      fields.add(new ApiSampleField(field));
+    for (InventoryEntityField field : sample.getActiveFields()) {
+      fields.add(new ApiInventoryEntityField(field));
     }
     for (ExtraField extraField : sample.getActiveExtraFields()) {
       extraFields.add(new ApiExtraField(extraField));
@@ -91,7 +91,7 @@ public class ApiSampleWithoutSubSamples extends ApiSampleInfo {
     }
 
     List<ApiInventoryFile> allAttachments = new ArrayList<>(super.getAllAttachments());
-    for (ApiSampleField sf : getFields()) {
+    for (ApiInventoryEntityField sf : getFields()) {
       if (sf.getAttachment() != null) {
         allAttachments.add(sf.getAttachment());
       }
@@ -107,16 +107,16 @@ public class ApiSampleWithoutSubSamples extends ApiSampleInfo {
     boolean contentChanged = super.applyChangesToDatabaseSample(dbSample);
 
     if (fields != null) {
-      List<ApiSampleField> modifiedFields =
+      List<ApiInventoryEntityField> modifiedFields =
           fields.stream()
               .filter(f -> !(f.isNewFieldRequest() || f.isDeleteFieldRequest()))
               .collect(Collectors.toList());
 
-      for (ApiSampleField field : modifiedFields) {
+      for (ApiInventoryEntityField field : modifiedFields) {
         if (field.getId() == null) {
           throw new IllegalArgumentException("'id' property not provided for a field");
         }
-        Optional<SampleField> dbFieldOpt =
+        Optional<InventoryEntityField> dbFieldOpt =
             dbSample.getActiveFields().stream()
                 .filter(sf -> Objects.equals(sf.getId(), field.getId()))
                 .findFirst();
@@ -126,7 +126,7 @@ public class ApiSampleWithoutSubSamples extends ApiSampleInfo {
                   + field.getId()
                   + " doesn't match any of the field ids of current sample");
         }
-        SampleField dbField = dbFieldOpt.get();
+        InventoryEntityField dbField = dbFieldOpt.get();
         if (dbSample.isTemplate()) {
           contentChanged |= field.applyChangesToDatabaseTemplateField(dbField, user);
         } else {

--- a/src/main/java/com/researchspace/api/v1/model/ApiSubSampleInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSubSampleInfo.java
@@ -87,6 +87,9 @@ public class ApiSubSampleInfo extends ApiInventoryRecordInfo {
   public ApiSubSampleInfo(SubSample subSample) {
     super(subSample);
 
+    if (subSample.getQuantityInfo() != null) {
+      setQuantity(new ApiQuantityInfo(subSample));
+    }
     if (subSample.getParentLocation() != null) {
       parentLocation = new ApiContainerLocation(subSample.getParentLocation());
       populateParentContainers(subSample.getParentContainer());

--- a/src/main/java/com/researchspace/api/v1/model/ApiTargetLocation.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiTargetLocation.java
@@ -1,0 +1,21 @@
+package com.researchspace.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiTargetLocation implements Serializable {
+
+  @JsonProperty("containerId")
+  private Long containerId;
+
+  @JsonProperty("location")
+  private ApiContainerLocation containerLocation;
+}

--- a/src/main/java/com/researchspace/api/v1/service/ApiFieldsHelper.java
+++ b/src/main/java/com/researchspace/api/v1/service/ApiFieldsHelper.java
@@ -2,6 +2,7 @@ package com.researchspace.api.v1.service;
 
 import com.researchspace.api.v1.model.ApiDocumentField;
 import com.researchspace.api.v1.model.ApiField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.linkedelements.RichTextUpdater;
 import com.researchspace.model.EcatAudio;
 import com.researchspace.model.EcatChemistryFile;
@@ -16,6 +17,7 @@ import com.researchspace.model.field.Field;
 import com.researchspace.model.field.FieldForm;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.field.ValidatingField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.permissions.SecurityLogger;
@@ -33,6 +35,7 @@ import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
 
 /** To deal with API fields conversion when fields are sent between RSpace server and API client. */
 @Component
@@ -308,6 +312,52 @@ public class ApiFieldsHelper {
   public void checkApiFieldsMatchingFormFields(
       List<? extends ApiField> apiFields, List<FieldForm> formFields, User user) {
     checkApiFieldsMatchingFormFields(apiFields, formFields, user, this::consumeErrorMsgAndThrowIAE);
+  }
+
+  /**
+   * Checks if the provided entity apiFields (of Samples or Instrument or InstrumentTemplate) are
+   * matching templateFields and alsop if they are mandatory.
+   *
+   * <p>Otherwise add the errors if there are problems.
+   */
+  public void validateMandatoryFieldsForEntityPost(
+      String entityTypeName,
+      List<ApiInventoryEntityField> incomingApiFields,
+      List<InventoryEntityField> templateFields,
+      Errors errors) {
+
+    for (int i = 0; i < templateFields.size(); i++) {
+      InventoryEntityField templateField = templateFields.get(i);
+      if (templateField.isMandatory()) {
+        boolean hasApiFieldForTemplateField = incomingApiFields.size() > i;
+        boolean isOptionsStoringField = templateField.isOptionsStoringField();
+        if (isOptionsStoringField) {
+          List<String> selectedOptions =
+              hasApiFieldForTemplateField
+                  ? incomingApiFields.get(i).getSelectedOptions()
+                  : templateField.getSelectedOptions();
+          if (CollectionUtils.isEmpty(selectedOptions)) {
+            errors.rejectValue(
+                "fields",
+                "errors.inventory." + entityTypeName + ".mandatory.field.no.selection",
+                new Object[] {templateField.getName()},
+                "no option selected for mandatory field");
+          }
+        } else {
+          String incomingContent =
+              hasApiFieldForTemplateField
+                  ? incomingApiFields.get(i).getContent()
+                  : templateField.getFieldData();
+          if (!templateField.isValidValueForMandatoryField(incomingContent)) {
+            errors.rejectValue(
+                "fields",
+                "errors.inventory." + entityTypeName + ".mandatory.field.empty",
+                new Object[] {templateField.getName()},
+                "no content for mandatory field");
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/researchspace/dao/InstrumentEntityDao.java
+++ b/src/main/java/com/researchspace/dao/InstrumentEntityDao.java
@@ -1,0 +1,10 @@
+package com.researchspace.dao;
+
+import com.researchspace.model.inventory.InstrumentEntity;
+
+/** For DAO operations on Inventory InstrumentEntity. */
+public interface InstrumentEntityDao<T extends InstrumentEntity> extends GenericDao<T, Long> {
+
+  /** Should be only called in unit tests (I think). Sets stored default template owner to null. */
+  void resetDefaultTemplateOwner();
+}

--- a/src/main/java/com/researchspace/dao/InventoryEntityFieldDao.java
+++ b/src/main/java/com/researchspace/dao/InventoryEntityFieldDao.java
@@ -1,0 +1,12 @@
+package com.researchspace.dao;
+
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+
+public interface InventoryEntityFieldDao extends GenericDao<InventoryEntityField, Long> {
+
+  GlobalIdentifier getInstrumentEntityGlobalIdFromFieldId(Long fieldId);
+
+  InventoryRecord getParentInventoryEntityFromFieldId(Long fieldId);
+}

--- a/src/main/java/com/researchspace/dao/hibernate/InstrumentDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/InstrumentDaoHibernateImpl.java
@@ -1,0 +1,30 @@
+package com.researchspace.dao.hibernate;
+
+import com.researchspace.dao.InstrumentEntityDao;
+import com.researchspace.model.inventory.Instrument;
+import org.springframework.stereotype.Repository;
+
+@Repository(value = "instrumentDao")
+public class InstrumentDaoHibernateImpl extends InventoryDaoHibernate<Instrument, Long>
+    implements InstrumentEntityDao<Instrument> {
+
+  private String defaultTemplateOwner;
+
+  public InstrumentDaoHibernateImpl(Class<Instrument> persistentClass) {
+    super(persistentClass);
+  }
+
+  public InstrumentDaoHibernateImpl() {
+    super(Instrument.class);
+  }
+
+  /*
+   * ============
+   *  for tests
+   * ============
+   */
+  @Override
+  public void resetDefaultTemplateOwner() {
+    defaultTemplateOwner = null;
+  }
+}

--- a/src/main/java/com/researchspace/dao/hibernate/InstrumentTemplateDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/InstrumentTemplateDaoHibernateImpl.java
@@ -1,0 +1,31 @@
+package com.researchspace.dao.hibernate;
+
+import com.researchspace.dao.InstrumentEntityDao;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository(value = "instrumentTemplateDao")
+public class InstrumentTemplateDaoHibernateImpl
+    extends InventoryDaoHibernate<InstrumentTemplate, Long>
+    implements InstrumentEntityDao<InstrumentTemplate> {
+
+  private String defaultTemplateOwner;
+
+  public InstrumentTemplateDaoHibernateImpl(Class<InstrumentTemplate> persistentClass) {
+    super(persistentClass);
+  }
+
+  public InstrumentTemplateDaoHibernateImpl() {
+    super(InstrumentTemplate.class);
+  }
+
+  /*
+   * ============
+   *  for tests
+   * ============
+   */
+  @Override
+  public void resetDefaultTemplateOwner() {
+    defaultTemplateOwner = null;
+  }
+}

--- a/src/main/java/com/researchspace/dao/hibernate/InventoryEntityFieldDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/InventoryEntityFieldDaoHibernateImpl.java
@@ -1,0 +1,41 @@
+package com.researchspace.dao.hibernate;
+
+import com.researchspace.dao.GenericDaoHibernate;
+import com.researchspace.dao.InventoryEntityFieldDao;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import javax.ws.rs.NotFoundException;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InventoryEntityFieldDaoHibernateImpl
+    extends GenericDaoHibernate<InventoryEntityField, Long> implements InventoryEntityFieldDao {
+
+  public InventoryEntityFieldDaoHibernateImpl(Class<InventoryEntityField> persistentClass) {
+    super(persistentClass);
+  }
+
+  public InventoryEntityFieldDaoHibernateImpl() {
+    super(InventoryEntityField.class);
+  }
+
+  public InventoryRecord getParentInventoryEntityFromFieldId(Long fieldId) {
+    InventoryEntityField field = this.get(fieldId);
+    if (field == null) {
+      throw new NotFoundException("No inventory entity field with id: " + fieldId);
+    }
+    return field.getInventoryRecord();
+  }
+
+  @Override
+  public GlobalIdentifier getInstrumentEntityGlobalIdFromFieldId(Long fieldId) {
+    InventoryEntityField field =
+        sessionFactory
+            .getCurrentSession()
+            .createQuery("from InventoryEntityField where id=:fieldId", InventoryEntityField.class)
+            .setParameter("fieldId", fieldId)
+            .getSingleResult();
+    return field.getInstrumentEntity().getOid();
+  }
+}

--- a/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
@@ -12,8 +12,8 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
-import com.researchspace.model.inventory.field.SampleField;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -132,10 +132,10 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
 
   @Override
   public GlobalIdentifier getSampleGlobalIdFromFieldId(Long fieldId) {
-    SampleField field =
+    InventoryEntityField field =
         sessionFactory
             .getCurrentSession()
-            .createQuery("from SampleField where id=:fieldId", SampleField.class)
+            .createQuery("from InventoryEntityField where id=:fieldId", InventoryEntityField.class)
             .setParameter("fieldId", fieldId)
             .getSingleResult();
     if (field == null) {

--- a/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
@@ -33,6 +33,8 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
   private static final String COM_ID = "com_id";
   private static final String ECAT_COMM = "ecat_comm";
   private static final String FIELD = "Field";
+  private static final String INVENTORY_ENTITY_FIELD = "InventoryEntityField";
+  private static final String SUB_SAMPLE = "SubSample";
   private @Autowired SessionFactory sessionFactory;
   private @Autowired UserDao userDao;
 
@@ -161,7 +163,6 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
   }
 
   private void deleteInventoryItems(Long userId, Session session) {
-
     /* start with baskets deletion */
     execute(
         userId,
@@ -201,17 +202,17 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
           userId,
           session,
           format(
-              "delete sfRelTable from %s_AUD sfRelTable left join SampleField sf on"
-                  + " sfRelTable.sampleField_id = sf.id left join Sample s on sf.sample_id=s.id"
-                  + " where s.owner_id = :id",
+              "delete sfRelTable from %s_AUD sfRelTable left join InventoryEntityField sf on"
+                  + " sfRelTable.inventoryEntityField_id = sf.id left join Sample s on"
+                  + " sf.sample_id=s.id where s.owner_id = :id",
               table));
       execute(
           userId,
           session,
           format(
-              "delete sfRelTable from %s sfRelTable left join SampleField sf on"
-                  + " sfRelTable.sampleField_id = sf.id left join Sample s on sf.sample_id=s.id"
-                  + " where s.owner_id = :id",
+              "delete sfRelTable from %s sfRelTable left join InventoryEntityField sf on"
+                  + " sfRelTable.inventoryEntityField_id = sf.id left join Sample s on"
+                  + " sf.sample_id=s.id where s.owner_id = :id",
               table));
     }
 
@@ -219,8 +220,8 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
     execute(
         userId,
         session,
-        "update SampleField sf left join Sample s on sf.sample_id = s.id set templateField_id ="
-            + " NULL where s.owner_id=:id");
+        "update InventoryEntityField sf left join Sample s on sf.sample_id = s.id set"
+            + " templateField_id = NULL where s.owner_id=:id");
 
     // delete sample-connected entities (including subsamples)
     List<String> sampleRelatedTables =
@@ -229,8 +230,8 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
             INVENTORY_FILE,
             BARCODE,
             DIGITAL_OBJECT_IDENTIFIER,
-            "SampleField",
-            "SubSample");
+            INVENTORY_ENTITY_FIELD,
+            SUB_SAMPLE);
     for (String table : sampleRelatedTables) {
       execute(
           userId,
@@ -254,8 +255,78 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
     execute(userId, session, "delete from Sample_AUD where owner_id = :id");
     execute(userId, session, "delete from Sample where owner_id = :id");
 
-    /* start container deletion */
+    /* start Instrument deletion */
+    // delete Instrument field connected entities
+    List<String> instrumentFieldRelatedTables = toList(INVENTORY_FILE);
+    for (String table : instrumentFieldRelatedTables) {
+      execute(
+          userId,
+          session,
+          format(
+              "delete sfRelTable from %s_AUD sfRelTable left join InventoryEntityField ief on"
+                  + " sfRelTable.inventoryEntityField_id = ief.id left join InstrumentEntity ins on"
+                  + " ief.instrumentEntity_id = ins.id"
+                  + " where ins.owner_id = :id",
+              table));
+      execute(
+          userId,
+          session,
+          format(
+              "delete sfRelTable from %s sfRelTable left join InventoryEntityField ief on"
+                  + " sfRelTable.inventoryEntityField_id = ief.id left join InstrumentEntity ins on"
+                  + " ief.instrumentEntity_id = ins.id"
+                  + " where ins.owner_id = :id",
+              table));
+    }
+    // set instrument field FKs to null before deleting
+    execute(
+        userId,
+        session,
+        "update InventoryEntityField ief left join InstrumentEntity ins"
+            + " on ief.instrumentEntity_id = ins.id"
+            + " set templateField_id = NULL where ins.owner_id=:id");
 
+    // delete instrument-connected entities
+    List<String> instrumentRelatedTables =
+        toList(
+            EXTRA_FIELD,
+            INVENTORY_FILE,
+            BARCODE,
+            DIGITAL_OBJECT_IDENTIFIER,
+            INVENTORY_ENTITY_FIELD);
+    for (String table : instrumentRelatedTables) {
+      execute(
+          userId,
+          session,
+          format(
+              "delete instrConnTable from %s_AUD instrConnTable left join InstrumentEntity ie on "
+                  + " instrConnTable.instrumentEntity_id = ie.id"
+                  + " where ie.owner_id = :id",
+              table));
+      execute(
+          userId,
+          session,
+          format(
+              "delete instrConnTable from %s instrConnTable left join InstrumentEntity ie "
+                  + " on instrConnTable.instrumentEntity_id = ie.id "
+                  + " where ie.owner_id = :id",
+              table));
+    }
+
+    // set sample template FKs to null before deleting samples
+    execute(
+        userId,
+        session,
+        "update InstrumentEntity set instrumentTemplate_id = NULL where owner_id=:id");
+    execute(
+        userId,
+        session,
+        "update InstrumentEntity_AUD set instrumentTemplate_id = NULL where owner_id=:id");
+    execute(userId, session, "delete from InstrumentEntity_AUD where owner_id = :id");
+    execute(userId, session, "delete from InstrumentEntity where owner_id = :id");
+    /* end Instrument deletion */
+
+    /* start container deletion */
     // reset parent locations before removing locations, but just for containers as subsamples are
     // deleted at this point
     execute(userId, session, "update Container set parentLocation_id = NULL where owner_id = :id");

--- a/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
@@ -15,8 +15,8 @@ import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiContainerInfo;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInventoryDOI;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiQuantityInfo;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleInfo;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleTemplatePost;
@@ -38,6 +38,7 @@ import com.researchspace.service.ApiAvailabilityHandler;
 import com.researchspace.service.fieldmark.FieldmarkServiceClientAdapter;
 import com.researchspace.service.fieldmark.FieldmarkServiceManager;
 import com.researchspace.service.inventory.ContainerApiManager;
+import com.researchspace.service.inventory.InstrumentApiManager;
 import com.researchspace.service.inventory.InventoryFileApiManager;
 import com.researchspace.service.inventory.InventoryIdentifierApiManager;
 import com.researchspace.service.inventory.SampleApiManager;
@@ -82,6 +83,7 @@ public class FieldmarkServiceManagerImpl implements FieldmarkServiceManager {
   private @Autowired InventoryFileApiManager inventoryFileManager;
   private @Autowired ContainerApiManager containerApiMgr;
   private @Autowired SampleApiManager sampleApiMgr;
+  private @Autowired InstrumentApiManager instrumentApiManager;
 
   @Override
   public List<FieldmarkNotebook> getFieldmarkNotebookList(User user) {
@@ -145,7 +147,7 @@ public class FieldmarkServiceManagerImpl implements FieldmarkServiceManager {
         }
         // for each ATTACHMENT field get "globalID" and "content" (having file identifier) and
         // then upload the right file
-        for (ApiSampleField currentField : createdSample.getFields()) {
+        for (ApiInventoryEntityField currentField : createdSample.getFields()) {
           if (ApiFieldType.ATTACHMENT.equals(currentField.getType())) {
             String sampleFieldGlobalId = currentField.getGlobalId();
 
@@ -212,7 +214,7 @@ public class FieldmarkServiceManagerImpl implements FieldmarkServiceManager {
     throwBindExceptionIfErrors(bindingResult);
     String fileName = uploadPost.getFileName();
     GlobalIdentifier parentFieldGlobalId = new GlobalIdentifier(uploadPost.getParentGlobalId());
-    sampleApiMgr.assertUserCanEditSampleField(parentFieldGlobalId.getDbId(), user);
+    instrumentApiManager.assertUserCanEditInventoryEntityField(parentFieldGlobalId.getDbId(), user);
 
     MultipartFile file = new FieldmarkMultipartFile(fileExtractor.getFieldValue(), fileName);
     try (InputStream is = file.getInputStream()) {

--- a/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkToRSpaceApiConverter.java
+++ b/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkToRSpaceApiConverter.java
@@ -12,13 +12,13 @@ import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
 import com.researchspace.api.v1.model.ApiQuantityInfo;
-import com.researchspace.api.v1.model.ApiSampleField;
-import com.researchspace.api.v1.model.ApiSampleField.ApiInventoryFieldDef;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleTemplatePost;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
-import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples.ApiSampleSubSampleTargetLocation;
+import com.researchspace.api.v1.model.ApiTargetLocation;
 import com.researchspace.fieldmark.model.FieldmarkNotebookMetadata;
 import com.researchspace.fieldmark.model.utils.FieldmarkDateExtractor;
 import com.researchspace.fieldmark.model.utils.FieldmarkDatetimeExtractor;
@@ -72,7 +72,7 @@ public class FieldmarkToRSpaceApiConverter {
   private static int createSampleTemplateFieldFromDTO(
       Entry<String, FieldmarkTypeExtractor> fieldDTO,
       int columnIndex,
-      List<ApiSampleField> fieldsPost) {
+      List<ApiInventoryEntityField> fieldsPost) {
     switch (fieldDTO.getValue().getSimpleTypeName()) {
       case "String":
         columnIndex = addFieldToSampleTemplate(fieldDTO.getKey(), TEXT, columnIndex, fieldsPost);
@@ -117,8 +117,8 @@ public class FieldmarkToRSpaceApiConverter {
       String name,
       ApiFieldType type,
       int columnIndex,
-      List<ApiSampleField> sampleTemplateFieldList) {
-    ApiSampleField fieldRSpace = new ApiSampleField();
+      List<ApiInventoryEntityField> sampleTemplateFieldList) {
+    ApiInventoryEntityField fieldRSpace = new ApiInventoryEntityField();
     fieldRSpace.setName(name);
     fieldRSpace.setType(type);
     fieldRSpace.setColumnIndex(columnIndex++);
@@ -175,11 +175,11 @@ public class FieldmarkToRSpaceApiConverter {
             recordDTO.getIdentifier() + " - " + recordDTO.getTimestamp());
 
     Map<String, Long> idsByFieldName = new HashMap<>();
-    for (ApiSampleField field : sampleTemplate.getFields()) {
+    for (ApiInventoryEntityField field : sampleTemplate.getFields()) {
       idsByFieldName.put(field.getName(), field.getId());
     }
 
-    List<ApiSampleField> currentFieldList = new LinkedList<>();
+    List<ApiInventoryEntityField> currentFieldList = new LinkedList<>();
     int columnIndex = 1;
     for (Entry<String, FieldmarkTypeExtractor> currentFieldDTO : recordDTO.getFields().entrySet()) {
       if (!currentFieldDTO.getValue().isDoiIdentifier()) {
@@ -194,7 +194,7 @@ public class FieldmarkToRSpaceApiConverter {
     samplePost.setNewSampleSubSamplesCount(1);
     samplePost.setQuantity(new ApiQuantityInfo(BigDecimal.valueOf(1), RSUnitDef.DIMENSIONLESS));
     samplePost.setNewSampleSubSampleTargetLocations(
-        List.of(new ApiSampleSubSampleTargetLocation(containerId, null)));
+        List.of(new ApiTargetLocation(containerId, null)));
     samplePost.setStorageTempMin(new ApiQuantityInfo(BigDecimal.valueOf(-15), RSUnitDef.CELSIUS));
     samplePost.setStorageTempMax(new ApiQuantityInfo(BigDecimal.valueOf(30), RSUnitDef.CELSIUS));
 
@@ -205,7 +205,7 @@ public class FieldmarkToRSpaceApiConverter {
 
   private static int createSampleFieldFromDTO(
       Entry<String, FieldmarkTypeExtractor> currentFieldDTO,
-      List<ApiSampleField> currentFieldList,
+      List<ApiInventoryEntityField> currentFieldList,
       Map<String, Long> idsByFieldName,
       int columnIndex) {
     switch (currentFieldDTO.getValue().getSimpleTypeName()) {
@@ -325,8 +325,8 @@ public class FieldmarkToRSpaceApiConverter {
       String content,
       ApiFieldType type,
       int columnIndex,
-      List<ApiSampleField> sampleTemplateFieldList) {
-    ApiSampleField fieldRSpace = new ApiSampleField();
+      List<ApiInventoryEntityField> sampleTemplateFieldList) {
+    ApiInventoryEntityField fieldRSpace = new ApiInventoryEntityField();
     fieldRSpace.setDeleteFieldRequest(false);
     fieldRSpace.setDeleteFieldOnSampleUpdate(false);
     fieldRSpace.setMandatory(false);

--- a/src/main/java/com/researchspace/service/inventory/ContainerApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/ContainerApiManager.java
@@ -13,7 +13,7 @@ import com.researchspace.model.inventory.InventoryRecord;
 import javax.ws.rs.NotFoundException;
 
 /** Handles API actions around Inventory Container. */
-public interface ContainerApiManager extends InventoryApiManager {
+public interface ContainerApiManager extends InventoryApiManager<Container> {
 
   /**
    * Get all top-level not-deleted containers that user can see. Optionally limit to containers

--- a/src/main/java/com/researchspace/service/inventory/InstrumentApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/InstrumentApiManager.java
@@ -1,0 +1,45 @@
+package com.researchspace.service.inventory;
+
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentEntity;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InstrumentEntity;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import com.researchspace.model.inventory.InventoryRecord;
+
+/** Handles API actions around Inventory Instrument. */
+public interface InstrumentApiManager extends InventoryApiManager<InstrumentEntity> {
+
+  /** Checks if instrument with given id exists */
+  boolean instrumentExists(long id);
+
+  boolean instrumentTemplateExists(long id);
+
+  /**
+   * Creates the Instrument according to provided apiInstrument definition, including fields, extra
+   * fields.
+   *
+   * @returns newly created instrument
+   */
+  ApiInstrument createNewApiInstrument(ApiInstrument apiInstrument, User user);
+
+  /**
+   * @returns ApiInstrument with a given id
+   */
+  ApiInstrument getApiInstrumentById(Long id, User user);
+
+  ApiInstrumentEntity getApiInstrumentTemplateById(Long id, User user);
+
+  Instrument assertUserCanEditInstrument(Long dbId, User user);
+
+  Instrument assertUserCanReadInstrument(Long dbId, User user);
+
+  InstrumentTemplate assertUserCanEditInstrumentTemplate(Long dbId, User user);
+
+  InstrumentTemplate assertUserCanReadInstrumentTemplate(Long dbId, User user);
+
+  InventoryRecord assertUserCanEditInventoryEntityField(Long id, User user);
+
+  InventoryRecord assertUserCanReadInventoryEntityField(Long id, User user);
+}

--- a/src/main/java/com/researchspace/service/inventory/InventoryApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryApiManager.java
@@ -12,7 +12,7 @@ import java.io.InputStream;
 import java.util.List;
 import org.springframework.context.ApplicationEventPublisher;
 
-public interface InventoryApiManager {
+public interface InventoryApiManager<T> {
 
   void createImagesForRecord(InventoryRecord invRecord, String base64Image, User user)
       throws IOException;
@@ -40,6 +40,8 @@ public interface InventoryApiManager {
    */
   ApiInventorySearchResult convertToApiInventorySearchResult(
       Long totalHits, Integer pageNumber, List<? extends InventoryRecord> dbRecords, User user);
+
+  T getIfExists(Long id);
 
   /*
    * ==============

--- a/src/main/java/com/researchspace/service/inventory/InventoryPermissionUtils.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryPermissionUtils.java
@@ -12,6 +12,7 @@ import com.researchspace.model.UserGroup;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.elninventory.ListOfMaterials;
 import com.researchspace.model.inventory.Container;
+import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.InventoryRecord.InventorySharingMode;
 import com.researchspace.model.inventory.MovableInventoryRecord;
@@ -166,6 +167,11 @@ public class InventoryPermissionUtils {
       }
       for (Container cont : container.getStoredContainers()) {
         if (canAccessDirectlyWithSharingPermission(cont, user)) {
+          return true;
+        }
+      }
+      for (Instrument instr : container.getStoredInstruments()) {
+        if (canAccessDirectlyWithSharingPermission(instr, user)) {
           return true;
         }
       }

--- a/src/main/java/com/researchspace/service/inventory/SampleApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/SampleApiManager.java
@@ -19,7 +19,7 @@ import java.util.List;
 import javax.ws.rs.NotFoundException;
 
 /** Handles API actions around Inventory Sample. */
-public interface SampleApiManager extends InventoryApiManager {
+public interface SampleApiManager extends InventoryApiManager<Sample> {
 
   /**
    * Get All not-deleted samples that user can see. Optionally limit to samples belonging to
@@ -68,18 +68,6 @@ public interface SampleApiManager extends InventoryApiManager {
    * @return
    */
   Sample assertUserCanEditSample(Long id, User user);
-
-  /** Returns Sample that has a field with given id if it exists and user has read permission */
-  Sample assertUserCanReadSampleField(Long id, User user);
-
-  /**
-   * Returns Sample that has a field with given id if it exists and user has edit permission
-   *
-   * @param id id of a sample field
-   * @param user
-   * @return
-   */
-  Sample assertUserCanEditSampleField(Long id, User user);
 
   /**
    * Retuns Sample entity if it exists and user can delete/restore it

--- a/src/main/java/com/researchspace/service/inventory/SubSampleApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/SubSampleApiManager.java
@@ -13,7 +13,7 @@ import com.researchspace.service.inventory.impl.SubSampleDuplicateConfig;
 import java.util.List;
 
 /** Handles API actions around Inventory SubSample. */
-public interface SubSampleApiManager extends InventoryApiManager {
+public interface SubSampleApiManager extends InventoryApiManager<SubSample> {
 
   /**
    * Get not-deleted subsamples that user can see. Optionally limit to samples belonging to a

--- a/src/main/java/com/researchspace/service/inventory/csvexport/CsvContainerExporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvexport/CsvContainerExporter.java
@@ -5,7 +5,7 @@ import com.researchspace.archive.ExportScope;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Container.ContainerType;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -54,7 +54,7 @@ public class CsvContainerExporter extends InventoryItemCsvExporter {
     return columnNames;
   }
 
-  protected String getColumnNameForContainerField(SampleField sf) {
+  protected String getColumnNameForContainerField(InventoryEntityField sf) {
     String connectedTemplateGlobalId = sf.getTemplateField().getSample().getGlobalIdentifier();
     return String.format("%s (%s, %s)", sf.getName(), sf.getType(), connectedTemplateGlobalId);
   }

--- a/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleExporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleExporter.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.researchspace.archive.ExportScope;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -58,15 +58,15 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
     return columnNames;
   }
 
-  private List<SampleField> getSampleFieldsFromAllSamples(List<Sample> samples) {
+  private List<InventoryEntityField> getSampleFieldsFromAllSamples(List<Sample> samples) {
     return samples.stream().flatMap(s -> s.getActiveFields().stream()).collect(Collectors.toList());
   }
 
   protected List<String> getSampleFieldColumnNamesForCsv(
-      List<SampleField> extraFields, CsvExportMode exportMode) {
+      List<InventoryEntityField> extraFields, CsvExportMode exportMode) {
     List<String> columnNames = new ArrayList<>();
     if (CsvExportMode.FULL.equals(exportMode) && extraFields != null) {
-      for (SampleField sf : extraFields) {
+      for (InventoryEntityField sf : extraFields) {
         String sampleFieldColumName = getColumnNameForSampleField(sf);
         if (!columnNames.contains(sampleFieldColumName)) {
           columnNames.add(sampleFieldColumName);
@@ -76,7 +76,7 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
     return columnNames;
   }
 
-  protected String getColumnNameForSampleField(SampleField sf) {
+  protected String getColumnNameForSampleField(InventoryEntityField sf) {
     String connectedTemplateGlobalId = sf.getTemplateField().getSample().getGlobalIdentifier();
     return String.format("%s (%s, %s)", sf.getName(), sf.getType(), connectedTemplateGlobalId);
   }
@@ -160,7 +160,7 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
         numberOfCsvColumns, itemProperties);
 
     if (CsvExportMode.FULL.equals(exportMode) && sample.getActiveExtraFields() != null) {
-      for (SampleField sf : sample.getActiveFields()) {
+      for (InventoryEntityField sf : sample.getActiveFields()) {
         String valueForProp = sf.getData();
         int columnIndexForValue = csvColumnNames.indexOf(getColumnNameForSampleField(sf));
         itemProperties.set(columnIndexForValue, valueForProp != null ? valueForProp : "");

--- a/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleTemplateExporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleTemplateExporter.java
@@ -2,7 +2,7 @@ package com.researchspace.service.inventory.csvexport;
 
 import com.researchspace.archive.ExportScope;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.springframework.stereotype.Component;
@@ -22,7 +22,7 @@ public class CsvSampleTemplateExporter extends CsvSampleExporter {
     return TEMPLATE_EXPORTABLE_PROPS;
   }
 
-  protected String getColumnNameForSampleField(SampleField sf) {
+  protected String getColumnNameForSampleField(InventoryEntityField sf) {
     return String.format("%s (%s)", sf.getName(), sf.getType());
   }
 

--- a/src/main/java/com/researchspace/service/inventory/csvimport/CsvSampleImporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/CsvSampleImporter.java
@@ -1,12 +1,12 @@
 package com.researchspace.service.inventory.csvimport;
 
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryImportResult;
 import com.researchspace.api.v1.model.ApiInventoryImportSampleImportResult;
 import com.researchspace.api.v1.model.ApiInventoryImportSampleParseResult;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordType;
 import com.researchspace.api.v1.model.ApiQuantityInfo;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleTemplatePost;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
@@ -16,7 +16,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.record.IRecordFactory;
 import com.researchspace.model.units.RSUnitDef;
 import java.io.IOException;
@@ -71,7 +71,7 @@ public class CsvSampleImporter extends InventoryItemCsvImporter {
     for (String columnName : sampleParseResult.getColumnNames()) {
       String fieldName = sampleParseResult.getFieldNameForColumnName().get(columnName);
       List<String> fieldValues = sampleParseResult.getColumnNameToValuesMap().get(columnName);
-      SampleField field =
+      InventoryEntityField field =
           importedFieldCreator.getSuggestedSampleFieldForNameAndValues(fieldName, fieldValues);
       template.addSampleField(field);
 
@@ -89,7 +89,7 @@ public class CsvSampleImporter extends InventoryItemCsvImporter {
   }
 
   private void populateResultWithRadioOptionsForColumn(
-      SampleField field,
+      InventoryEntityField field,
       String columnName,
       List<String> fieldValues,
       ApiInventoryImportSampleParseResult result) {
@@ -104,7 +104,7 @@ public class CsvSampleImporter extends InventoryItemCsvImporter {
   }
 
   private void populateResultWithQuantityTypeForColumn(
-      SampleField field,
+      InventoryEntityField field,
       String columnName,
       List<String> fieldValues,
       ApiInventoryImportSampleParseResult result) {
@@ -246,8 +246,9 @@ public class CsvSampleImporter extends InventoryItemCsvImporter {
               setDefaultFieldFromMappedColumn(apiSample, fieldName, value, user);
             }
           } else {
-            ApiSampleField sampleField = new ApiSampleField();
-            ApiSampleField templateField = template.getFields().get(apiSample.getFields().size());
+            ApiInventoryEntityField sampleField = new ApiInventoryEntityField();
+            ApiInventoryEntityField templateField =
+                template.getFields().get(apiSample.getFields().size());
             sampleField.setName(templateField.getName());
             sampleField.setType(templateField.getType());
             if (!StringUtils.isBlank(value)) {

--- a/src/main/java/com/researchspace/service/inventory/csvimport/InventoryImportSampleFieldCreator.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/InventoryImportSampleFieldCreator.java
@@ -2,6 +2,7 @@ package com.researchspace.service.inventory.csvimport;
 
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.field.InventoryDateField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryIdentifierField;
 import com.researchspace.model.inventory.field.InventoryNumberField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
@@ -10,7 +11,6 @@ import com.researchspace.model.inventory.field.InventoryStringField;
 import com.researchspace.model.inventory.field.InventoryTextField;
 import com.researchspace.model.inventory.field.InventoryTimeField;
 import com.researchspace.model.inventory.field.InventoryUriField;
-import com.researchspace.model.inventory.field.SampleField;
 import com.researchspace.model.units.QuantityInfo;
 import com.researchspace.model.units.RSUnitDef;
 import java.util.ArrayList;
@@ -39,7 +39,8 @@ public class InventoryImportSampleFieldCreator {
   /** Ratio of distinct values to all values below which the radio type is suggested. */
   public static final double RADIO_REPEATING_OPTIONS_RATIO = 0.76;
 
-  public SampleField getSuggestedSampleFieldForNameAndValues(String name, List<String> values) {
+  public InventoryEntityField getSuggestedSampleFieldForNameAndValues(
+      String name, List<String> values) {
 
     List<String> nonEmptyValues =
         values.stream().filter(opt -> StringUtils.isNotBlank(opt)).collect(Collectors.toList());
@@ -96,7 +97,7 @@ public class InventoryImportSampleFieldCreator {
     return new HashMap<>();
   }
 
-  private boolean isSuggestedFieldForValues(Set<String> values, SampleField field) {
+  private boolean isSuggestedFieldForValues(Set<String> values, InventoryEntityField field) {
     return !values.isEmpty() && values.stream().allMatch(v -> field.isSuggestedFieldForData(v));
   }
 

--- a/src/main/java/com/researchspace/service/inventory/impl/ContainerApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/ContainerApiManagerImpl.java
@@ -41,7 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service("containerApiManager")
-public class ContainerApiManagerImpl extends InventoryApiManagerImpl
+public class ContainerApiManagerImpl extends InventoryApiManagerImpl<Container>
     implements ContainerApiManager {
 
   public static final String CONTAINER_DEFAULT_NAME = "Generic Container";
@@ -424,7 +424,7 @@ public class ContainerApiManagerImpl extends InventoryApiManagerImpl
   }
 
   @Override
-  Container getIfExists(Long id) {
+  public Container getIfExists(Long id) {
     boolean exists = containerDao.exists(id);
     if (!exists) {
       throw new NotFoundException("No container with id: " + id);

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentApiManagerImpl.java
@@ -1,0 +1,282 @@
+package com.researchspace.service.inventory.impl;
+
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentEntity;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.dao.InstrumentEntityDao;
+import com.researchspace.dao.InventoryEntityFieldDao;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.events.InventoryAccessEvent;
+import com.researchspace.model.events.InventoryCreationEvent;
+import com.researchspace.model.inventory.Container;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InstrumentEntity;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.service.inventory.InstrumentApiManager;
+import com.researchspace.service.inventory.InventoryMoveHelper;
+import com.researchspace.service.inventory.SampleApiManager;
+import java.io.IOException;
+import java.util.List;
+import javax.ws.rs.NotFoundException;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InstrumentApiManagerImpl extends InventoryApiManagerImpl<InstrumentEntity>
+    implements InstrumentApiManager {
+
+  public static final String INSTRUMENT_DEFAULT_NAME = "Generic Instrument";
+
+  private @Autowired InstrumentEntityDao<Instrument> instrumentDao;
+  private @Autowired InstrumentEntityDao<InstrumentTemplate> instrumentTemplateDao;
+  private @Autowired InventoryEntityFieldDao inventoryEntityFieldDao;
+  private @Autowired SampleApiManager sampleApiManager;
+  private @Autowired InventoryMoveHelper inventoryMoveHelper;
+
+  @Override
+  public boolean instrumentExists(long id) {
+    return instrumentDao.exists(id);
+  }
+
+  @Override
+  public boolean instrumentTemplateExists(long id) {
+    return instrumentTemplateDao.exists(id);
+  }
+
+  @Override
+  public ApiInstrument createNewApiInstrument(ApiInstrument apiInstrument, User user) {
+
+    InstrumentEntity instrumentTemplate =
+        getInstrumentTemplateIfPresentOnRequest(apiInstrument, user);
+
+    String instrumentName = getNameForIncomingApiInstrument(apiInstrument);
+    return createInstrument(instrumentName, apiInstrument, instrumentTemplate, user);
+  }
+
+  private InstrumentEntity getInstrumentTemplateIfPresentOnRequest(
+      ApiInstrument apiInstrument, User user) {
+    InstrumentEntity template = null;
+    Long templateId = apiInstrument.getTemplateId();
+    // if templateId is null (we're creating a new instrument),
+    // but if not null, we expect it to exist
+    if (templateId != null) {
+      template = assertUserCanReadInstrumentTemplate(templateId, user);
+    }
+    return template;
+  }
+
+  private String getNameForIncomingApiInstrument(ApiInstrumentEntity instrumentRequest) {
+    return StringUtils.isNotBlank(instrumentRequest.getName())
+        ? instrumentRequest.getName()
+        : INSTRUMENT_DEFAULT_NAME;
+  }
+
+  private ApiInstrument createInstrument(
+      String instrumentName,
+      ApiInstrument apiInstrument,
+      InstrumentEntity instrTemplate,
+      User user) {
+    Instrument instrumentToSave =
+        recordFactory.createInstrument(instrumentName, user, instrTemplate);
+
+    setBasicFieldsFromNewIncomingApiInventoryRecord(instrumentToSave, apiInstrument, user);
+    if (instrTemplate != null) {
+      // might be null from incoming API request, but here we want to reference template icon id
+      instrumentToSave.setIconId(instrTemplate.getIconId());
+    }
+    if (!apiInstrument.getFields().isEmpty()) {
+      saveNewApiFieldsIntoInstrumentFields(
+          apiInstrument.getFields(), instrumentToSave.getActiveFields(), user);
+    } else {
+      assertDefaultFieldsValid(instrumentToSave.getActiveFields());
+    }
+    setLocationForNewInstrument(apiInstrument, instrumentToSave, user);
+
+    Instrument savedInstrument = instrumentDao.save(instrumentToSave);
+    saveIncomingInstrumentImage(savedInstrument, apiInstrument, user);
+
+    publisher.publishEvent(new InventoryCreationEvent(savedInstrument, user));
+
+    ApiInstrument apiResultInstrument = new ApiInstrument(savedInstrument);
+    if (instrTemplate != null) {
+      apiResultInstrument.setTemplateId(instrTemplate.getId());
+    }
+    populateOutgoingApiInstrumentEntity(apiResultInstrument, savedInstrument, user);
+
+    return apiResultInstrument;
+  }
+
+  private void setLocationForNewInstrument(
+      ApiInstrument apiInstrument, Instrument instrumentToSave, User user) {
+    inventoryMoveHelper.moveRecordToTargetParentAndLocation(
+        instrumentToSave,
+        apiInstrument.getParentContainer(),
+        apiInstrument.getParentLocation(),
+        user);
+    setWorkbenchAsParentForNewInstrument(instrumentToSave, user);
+  }
+
+  private void setWorkbenchAsParentForNewInstrument(Instrument instrument, User user) {
+    Container workbench = containerDao.getWorkbenchForUser(user);
+    setWorkbenchAsParentForNewInventoryRecord(workbench, instrument);
+  }
+
+  private void assertDefaultFieldsValid(List<InventoryEntityField> activeFields) {
+    for (InventoryEntityField field : activeFields) {
+      field.assertFieldDataValid(field.getFieldData());
+    }
+  }
+
+  private void saveNewApiFieldsIntoInstrumentFields(
+      List<ApiInventoryEntityField> apiFieldList,
+      List<InventoryEntityField> inventoryEntityFieldList,
+      User user) {
+
+    if (apiFieldList.size() != inventoryEntityFieldList.size()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Number of incoming instrument fields [%d]"
+                  + " doesn't match number of template fields [%d]",
+              apiFieldList.size(), inventoryEntityFieldList.size()));
+    }
+
+    for (int i = 0; i < apiFieldList.size(); i++) {
+      ApiInventoryEntityField apiField = apiFieldList.get(i);
+      String newFieldContent = apiField.getContent();
+      InventoryEntityField inventoryEntityField = inventoryEntityFieldList.get(i);
+
+      if (inventoryEntityField.isOptionsStoringField()) {
+        inventoryEntityField.setSelectedOptions(apiField.getSelectedOptions());
+      } else {
+        inventoryEntityField.setFieldData(newFieldContent);
+      }
+    }
+  }
+
+  @Override
+  public ApiInstrument getApiInstrumentById(Long id, User user) {
+    return getInstrumentById(id, user);
+  }
+
+  @Override
+  public ApiInstrumentEntity getApiInstrumentTemplateById(Long id, User user) {
+    return getInstrumentTemplateById(id, user);
+  }
+
+  @Override
+  public Instrument assertUserCanEditInstrument(Long dbId, User user) {
+    Instrument instrument = instrumentDao.get(dbId);
+    invPermissions.assertUserCanEditInventoryRecord(instrument, user);
+    return instrument;
+  }
+
+  @Override
+  public Instrument assertUserCanReadInstrument(Long dbId, User user) {
+    Instrument instrument = instrumentDao.get(dbId);
+    invPermissions.assertUserCanReadOrLimitedReadInventoryRecord(instrument, user);
+    return instrument;
+  }
+
+  @Override
+  public InstrumentTemplate assertUserCanEditInstrumentTemplate(Long dbId, User user) {
+    InstrumentTemplate instrumentTemplate = instrumentTemplateDao.get(dbId);
+    invPermissions.assertUserCanEditInventoryRecord(instrumentTemplate, user);
+    return instrumentTemplate;
+  }
+
+  @Override
+  public InstrumentTemplate assertUserCanReadInstrumentTemplate(Long dbId, User user) {
+    InstrumentTemplate instrumentTemplate = instrumentTemplateDao.get(dbId);
+    invPermissions.assertUserCanReadOrLimitedReadInventoryRecord(instrumentTemplate, user);
+    return instrumentTemplate;
+  }
+
+  @Override
+  public InventoryRecord assertUserCanReadInventoryEntityField(Long id, User user) {
+    InventoryRecord parentEntity = inventoryEntityFieldDao.getParentInventoryEntityFromFieldId(id);
+    GlobalIdentifier entityGlobalId = parentEntity.getOid();
+    switch (parentEntity.getType()) {
+      case SAMPLE:
+        return sampleApiManager.assertUserCanReadSample(entityGlobalId.getDbId(), user);
+      case INSTRUMENT:
+        return this.assertUserCanReadInstrument(entityGlobalId.getDbId(), user);
+      case INSTRUMENT_TEMPLATE:
+        return this.assertUserCanReadInstrumentTemplate(entityGlobalId.getDbId(), user);
+      default:
+        throw new IllegalArgumentException(
+            "unsupported global id type: " + entityGlobalId.getIdString());
+    }
+  }
+
+  @Override
+  public InventoryRecord assertUserCanEditInventoryEntityField(Long id, User user) {
+    InventoryRecord parentEntity = inventoryEntityFieldDao.getParentInventoryEntityFromFieldId(id);
+    GlobalIdentifier entityGlobalId = parentEntity.getOid();
+    switch (parentEntity.getType()) {
+      case SAMPLE:
+        return sampleApiManager.assertUserCanEditSample(entityGlobalId.getDbId(), user);
+      case INSTRUMENT:
+        return this.assertUserCanEditInstrument(entityGlobalId.getDbId(), user);
+      case INSTRUMENT_TEMPLATE:
+        return this.assertUserCanEditInstrumentTemplate(entityGlobalId.getDbId(), user);
+      default:
+        throw new IllegalArgumentException(
+            "unsupported global id type: " + entityGlobalId.getIdString());
+    }
+  }
+
+  private ApiInstrument getInstrumentById(Long id, User user) {
+    Instrument instrument = assertUserCanReadInstrument(id, user);
+    publisher.publishEvent(new InventoryAccessEvent(instrument, user));
+    ApiInstrument result = new ApiInstrument(instrument);
+    populateOutgoingApiInstrumentEntity(result, instrument, user);
+    return result;
+  }
+
+  private ApiInstrumentEntity getInstrumentTemplateById(Long id, User user) {
+    InstrumentTemplate instrumentTemplate = assertUserCanReadInstrumentTemplate(id, user);
+    publisher.publishEvent(new InventoryAccessEvent(instrumentTemplate, user));
+    ApiInstrumentTemplate result = new ApiInstrumentTemplate(instrumentTemplate);
+    populateOutgoingApiInstrumentEntity(result, instrumentTemplate, user);
+    return result;
+  }
+
+  private void populateOutgoingApiInstrumentEntity(
+      ApiInstrumentEntity apiInstrument, InstrumentEntity instrument, User user) {
+    if (apiInstrument != null) { // populate only if it is already created
+      setOtherFieldsForOutgoingApiInventoryRecord(apiInstrument, instrument, user);
+      populateSharingPermissions(apiInstrument.getSharedWith(), instrument);
+    }
+  }
+
+  /**
+   * Save incoming instrument image.
+   *
+   * @throws IOException
+   * @returns true if any i mages were saved
+   */
+  private boolean saveIncomingInstrumentImage(
+      InstrumentEntity dbInstrument, ApiInstrumentEntity apiInstrument, User user) {
+    return saveIncomingImage(
+        dbInstrument,
+        apiInstrument,
+        user,
+        Instrument.class,
+        instrument -> instrumentDao.save(instrument));
+  }
+
+  @Override
+  public InstrumentEntity getIfExists(Long id) {
+    if (instrumentExists(id)) {
+      return instrumentDao.get(id);
+    } else if (instrumentTemplateExists(id)) {
+      return instrumentTemplateDao.get(id);
+    }
+    throw new NotFoundException("No Instrument or InstrumentTemplate found with id: " + id);
+  }
+}

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
@@ -61,7 +61,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
 
 @Slf4j
-public abstract class InventoryApiManagerImpl implements InventoryApiManager {
+public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
+    implements InventoryApiManager<T> {
 
   static final int THUMBNAIL_MAX_SIZE_IN_PX = 150;
   final Long DEFAULT_ICON_ID = -1L;
@@ -389,8 +390,6 @@ public abstract class InventoryApiManagerImpl implements InventoryApiManager {
       movableInvRec.moveToNewParent(targetOwnerWorkbench);
     }
   }
-
-  abstract <T extends InventoryRecord> T getIfExists(Long id);
 
   /**
    * Locks the item for edit (if it wasn't locked before), or extend the pre-existing lock.

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImpl.java
@@ -1,6 +1,8 @@
 package com.researchspace.service.inventory.impl;
 
 import com.researchspace.core.util.MediaUtils;
+import com.researchspace.dao.InstrumentEntityDao;
+import com.researchspace.dao.InventoryEntityFieldDao;
 import com.researchspace.dao.InventoryFileDao;
 import com.researchspace.dao.SampleDao;
 import com.researchspace.files.service.FileStore;
@@ -9,10 +11,11 @@ import com.researchspace.model.FileProperty;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
 import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.record.IRecordFactory;
 import com.researchspace.service.BaseRecordManager;
 import com.researchspace.service.FileDuplicateStrategy;
@@ -44,6 +47,8 @@ public class InventoryFileApiManagerImpl implements InventoryFileApiManager {
   private @Autowired InventoryFileDao inventoryFileDao;
   private @Autowired InventoryPermissionUtils invPermissions;
   private @Autowired SampleDao sampleDao;
+  private @Autowired InstrumentEntityDao<Instrument> instrumentEntityDao;
+  private @Autowired InventoryEntityFieldDao inventoryEntityFieldDao;
   private @Autowired MessageSourceUtils messages;
   private @Autowired IRecordFactory recordFactory;
   private @Autowired BaseRecordManager baseRecordManager;
@@ -128,7 +133,7 @@ public class InventoryFileApiManagerImpl implements InventoryFileApiManager {
 
     if (GlobalIdPrefix.SF.equals(globalIdToAttachTo.getPrefix())) {
       Sample sample = (Sample) invRec;
-      SampleField field = sample.getFieldById(globalIdToAttachTo.getDbId()).orElse(null);
+      InventoryEntityField field = sample.getFieldById(globalIdToAttachTo.getDbId()).orElse(null);
       if (field == null) {
         throwNotFoundException(globalIdToAttachTo.getDbId(), "Sample field");
       }
@@ -147,10 +152,20 @@ public class InventoryFileApiManagerImpl implements InventoryFileApiManager {
    */
   private GlobalIdentifier getGlobalIdOfParentInventoryItem(GlobalIdentifier invRecGlobalId) {
     if (GlobalIdPrefix.SF.equals(invRecGlobalId.getPrefix())) {
-      GlobalIdentifier parentInvItemOid =
-          sampleDao.getSampleGlobalIdFromFieldId(invRecGlobalId.getDbId());
+      InventoryEntityField field = inventoryEntityFieldDao.get(invRecGlobalId.getDbId());
+      GlobalIdentifier parentInvItemOid;
+      String whatsMissed = "";
+      if (field.getSample() != null) {
+        parentInvItemOid = sampleDao.getSampleGlobalIdFromFieldId(invRecGlobalId.getDbId());
+        whatsMissed = "Sample";
+      } else {
+        parentInvItemOid =
+            inventoryEntityFieldDao.getInstrumentEntityGlobalIdFromFieldId(
+                invRecGlobalId.getDbId());
+        whatsMissed = "Instrument Entity";
+      }
       if (parentInvItemOid == null) {
-        throwNotFoundException(invRecGlobalId.getDbId(), "Sample field");
+        throwNotFoundException(invRecGlobalId.getDbId(), whatsMissed + " field");
       }
       return parentInvItemOid;
     }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -2,10 +2,10 @@ package com.researchspace.service.inventory.impl;
 
 import com.axiope.search.InventorySearchConfig.InventorySearchDeletedOption;
 import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
 import com.researchspace.api.v1.model.ApiSample;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleInfo;
 import com.researchspace.api.v1.model.ApiSampleSearchResult;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
@@ -22,7 +22,6 @@ import com.researchspace.core.util.jsonserialisers.LocalDateDeserialiser;
 import com.researchspace.dao.SampleDao;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
-import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.events.InventoryAccessEvent;
 import com.researchspace.model.events.InventoryCreationEvent;
 import com.researchspace.model.events.InventoryDeleteEvent;
@@ -37,7 +36,7 @@ import com.researchspace.model.inventory.InventorySeriesNamingHelper;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSample;
-import com.researchspace.model.inventory.field.SampleField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.record.IActiveUserStrategy;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.InventoryMoveHelper;
@@ -57,7 +56,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service("sampleApiManager")
-public class SampleApiManagerImpl extends InventoryApiManagerImpl implements SampleApiManager {
+public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
+    implements SampleApiManager {
 
   public static final String SAMPLE_DEFAULT_NAME = "Generic Sample";
 
@@ -132,18 +132,6 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
     Sample sample = getIfExists(id);
     invPermissions.assertUserCanEditInventoryRecord(sample, user);
     return sample;
-  }
-
-  @Override
-  public Sample assertUserCanReadSampleField(Long id, User user) {
-    GlobalIdentifier sampleOid = getSampleGlobalIdByFieldIdIfExists(id);
-    return assertUserCanReadSample(sampleOid.getDbId(), user);
-  }
-
-  @Override
-  public Sample assertUserCanEditSampleField(Long id, User user) {
-    GlobalIdentifier sampleOid = getSampleGlobalIdByFieldIdIfExists(id);
-    return assertUserCanEditSample(sampleOid.getDbId(), user);
   }
 
   @Override
@@ -262,8 +250,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
     return apiResultSample;
   }
 
-  private void assertDefaultFieldsValid(List<SampleField> activeFields) {
-    for (SampleField field : activeFields) {
+  private void assertDefaultFieldsValid(List<InventoryEntityField> activeFields) {
+    for (InventoryEntityField field : activeFields) {
       field.assertFieldDataValid(field.getFieldData());
     }
   }
@@ -314,25 +302,27 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
   }
 
   private void saveNewApiFieldsIntoSampleFields(
-      List<? extends ApiSampleField> apiFieldList, List<SampleField> sampleFieldList, User user) {
+      List<? extends ApiInventoryEntityField> apiFieldList,
+      List<InventoryEntityField> inventoryEntityFieldList,
+      User user) {
 
-    if (apiFieldList.size() != sampleFieldList.size()) {
+    if (apiFieldList.size() != inventoryEntityFieldList.size()) {
       throw new IllegalArgumentException(
           String.format(
               "Number of incoming sample fields [%d]"
                   + " doesn't match number of template fields [%d]",
-              apiFieldList.size(), sampleFieldList.size()));
+              apiFieldList.size(), inventoryEntityFieldList.size()));
     }
 
     for (int i = 0; i < apiFieldList.size(); i++) {
-      ApiSampleField apiField = apiFieldList.get(i);
+      ApiInventoryEntityField apiField = apiFieldList.get(i);
       String newFieldContent = apiField.getContent();
-      SampleField sampleField = sampleFieldList.get(i);
+      InventoryEntityField inventoryEntityField = inventoryEntityFieldList.get(i);
 
-      if (sampleField.isOptionsStoringField()) {
-        sampleField.setSelectedOptions(apiField.getSelectedOptions());
+      if (inventoryEntityField.isOptionsStoringField()) {
+        inventoryEntityField.setSelectedOptions(apiField.getSelectedOptions());
       } else {
-        sampleField.setFieldData(newFieldContent);
+        inventoryEntityField.setFieldData(newFieldContent);
       }
     }
   }
@@ -469,8 +459,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  Sample getIfExists(Long id) {
+  public Sample getIfExists(Long id) {
     return getIfExists(id, false);
   }
 
@@ -488,14 +477,6 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
       populateSubSampleParentContainerChain(ss);
     }
     return s;
-  }
-
-  private GlobalIdentifier getSampleGlobalIdByFieldIdIfExists(Long id) {
-    GlobalIdentifier oid = sampleDao.getSampleGlobalIdFromFieldId(id);
-    if (oid == null) {
-      throw new NotFoundException("No sample field with id: " + id);
-    }
-    return oid;
   }
 
   @Override
@@ -757,8 +738,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
   }
 
   private void createFields(ApiSampleTemplatePost apiSample, Sample sample) {
-    for (ApiSampleField field : apiSample.getFields()) {
-      SampleField toAdd = apiFieldToModelFieldFactory.apiSampleFieldToModelField(field);
+    for (ApiInventoryEntityField field : apiSample.getFields()) {
+      InventoryEntityField toAdd = apiFieldToModelFieldFactory.apiInventoryFieldToModelField(field);
       sample.addSampleField(toAdd);
     }
   }
@@ -789,9 +770,10 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
   private boolean createDeleteRequestedFieldsInDbSampleTemplate(
       ApiSampleWithoutSubSamples apiSample, Sample dbTemplate) {
     boolean changed = false;
-    for (ApiSampleField apiField : apiSample.getFields()) {
+    for (ApiInventoryEntityField apiField : apiSample.getFields()) {
       if (apiField.isNewFieldRequest()) {
-        SampleField toAdd = apiFieldToModelFieldFactory.apiSampleFieldToModelField(apiField);
+        InventoryEntityField toAdd =
+            apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
         dbTemplate.addSampleField(toAdd);
         changed = true;
       }
@@ -801,7 +783,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl implements Sam
               "'id' property not provided "
                   + "for a template field with 'deleteFieldRequest' flag");
         }
-        Optional<SampleField> dbFieldOpt =
+        Optional<InventoryEntityField> dbFieldOpt =
             dbTemplate.getActiveFields().stream()
                 .filter(sf -> apiField.getId().equals(sf.getId()))
                 .findFirst();

--- a/src/main/java/com/researchspace/service/inventory/impl/SubSampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SubSampleApiManagerImpl.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 @Service("subSampleApiManager")
-public class SubSampleApiManagerImpl extends InventoryApiManagerImpl
+public class SubSampleApiManagerImpl extends InventoryApiManagerImpl<SubSample>
     implements SubSampleApiManager {
 
   private @Autowired SubSampleDao subSampleDao;
@@ -110,8 +110,8 @@ public class SubSampleApiManagerImpl extends InventoryApiManagerImpl
     return result;
   }
 
-  @SuppressWarnings("unchecked")
-  protected SubSample getIfExists(Long id) {
+  @Override
+  public SubSample getIfExists(Long id) {
     boolean exists = subSampleDao.exists(id);
     if (!exists) {
       throw new NotFoundException("No SubSample with id: " + id);

--- a/src/main/resources/bundles/inventory/inventory.properties
+++ b/src/main/resources/bundles/inventory/inventory.properties
@@ -18,6 +18,10 @@ errors.inventory.sample.mandatory.field.no.selection=Field ''{0}'' is mandatory,
 errors.inventory.sample.unit.incompatible.with.template=Sample quantity unit {0} ({1}) is incompatible with template quantity unit {2} ({3})
 errors.inventory.subsample.unit.incompatible.with.sample=Subsample quantity ''{0}'' is incompatible with quantity unit used by parent sample ({1})
 
+errors.inventory.instrument.mandatory.field.empty=Field ''{0}'' is mandatory, but provided value was empty
+errors.inventory.instrument.mandatory.field.no.selection=Field ''{0}'' is mandatory, but no option is provided
+
+
 errors.inventory.import.templateInfo.empty='templateInfo' property must be provided and describe a template for imported samples
 errors.inventory.import.fieldMappings.missingName='fieldMappings' property must be provided and contain at least a mapping for 'name' field
 

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -132,6 +132,9 @@
         <mapping class="com.researchspace.model.inventory.Sample"/>
         <mapping class="com.researchspace.model.inventory.SubSample"/>
         <mapping class="com.researchspace.model.inventory.SubSampleNote"/>
+
+        <mapping class="com.researchspace.model.inventory.Instrument"/>
+        <mapping class="com.researchspace.model.inventory.InstrumentTemplate"/>
     
         <mapping class="com.researchspace.model.inventory.Container"/>
         <mapping class="com.researchspace.model.inventory.ContainerLocation"/>

--- a/src/main/resources/sqlUpdates/DatabaseChangeGuidelines.md
+++ b/src/main/resources/sqlUpdates/DatabaseChangeGuidelines.md
@@ -13,8 +13,8 @@ This document is written in Markdown format.
 - Explicitly set charset and collation:  `character set utf8mb4 collate  utf8mb4_unicode_ci`.
   (As an example, see src/main/resources/sqlUpdates/changeLog-1.76.xml : ```<sql>alter table ClustermarketEquipment engine=InnoDB, CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;</sql>```)
   This is to overcome variations in collation between different OS/MariaDB countries.
-- Does it need an accompanying _AUD table to record revision history?   
-- If it has FK references to any BaseRecord or User/Group table, we need to update UserDeletionManagerImpl to support the 'Delete User' use case.
+- Does it need an accompanying _AUD table to record revision history? 
+- If it has FK references to any BaseRecord or User/Group table, we need to update `UserDeletionManagerImpl` to support the 'Delete User' use case.
 - If you've written some JUnit tests that extend from RealTRansactionSpringTestBase (i.e. test  cases that run real transactions) then remember to add to the 'DatabaseCleaner.cleanUp' method
   the table name in the list of tables to delete after a test run -  this keeps the database clean between test runs. The order in which rows are removed is important, to avoid FK constraint errors.
 - Is this a table that is defined as a Hibernate entity? Sometimes a 3rd party library (e.g. liquibase, spring-social, chemistry tables) requires its own table that is not created or managed by Hibernate. In this case you may need to edit scripts in the *maven* folder.

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1062.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1062.xml
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <!--
+      ChangeSet 1: Create InstrumentEntity table (including all columns and inline FK definitions)
+  -->
+  <changeSet id="2026-04-14-instrumentEntity" context="run" author="nico">
+    <createTable tableName="InstrumentEntity">
+      <column name="id" type="bigint">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="createdBy" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="creationDate" type="datetime">
+        <constraints nullable="false"/>
+      </column>
+      <column name="creationDateMillis" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="description" type="varchar(250)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="modificationDate" type="datetime">
+        <constraints nullable="false"/>
+      </column>
+      <column name="modificationDateMillis" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="modifiedBy" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="deleted" type="bit" defaultValueNumeric="0">
+        <constraints nullable="false"/>
+      </column>
+      <column name="name" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="iconId" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="tags" type="varchar(8000)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="deletedDate" type="datetime">
+        <constraints nullable="true"/>
+      </column>
+      <column name="imageFileProperty_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="thumbnailFileProperty_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="currMaxColIndex" type="int">
+        <constraints nullable="true"/>
+      </column>
+      <column name="version" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="sharingMode" type="int" defaultValueNumeric="0">
+        <constraints nullable="true"/>
+      </column>
+      <column name="acl" type="longtext">
+        <constraints nullable="true"/>
+      </column>
+      <column name="tagMetaData" type="longtext">
+        <constraints nullable="true"/>
+      </column>
+      <column name="owner_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="DTYPE" type="varchar(20)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="instrumentTemplate_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="templateLinkedVersion" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="parentLocation_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="lastNonWorkbenchParent_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="lastMoveDate" type="datetime(6)">
+        <constraints nullable="true"/>
+      </column>
+    </createTable>
+
+    <addForeignKeyConstraint
+      constraintName="FK_Instr_to_ImgFileProp"
+      baseTableName="InstrumentEntity"
+      baseColumnNames="imageFileProperty_id"
+      referencedTableName="FileProperty"
+      referencedColumnNames="id"/>
+
+    <addForeignKeyConstraint
+      constraintName="FK_Instr_to_InstrTemplate"
+      baseTableName="InstrumentEntity"
+      baseColumnNames="instrumentTemplate_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+
+    <addForeignKeyConstraint
+      constraintName="FK_Instr_to_ThumbFileProp"
+      baseTableName="InstrumentEntity"
+      baseColumnNames="thumbnailFileProperty_id"
+      referencedTableName="FileProperty"
+      referencedColumnNames="id"/>
+
+    <addForeignKeyConstraint
+      constraintName="FK_Instr_to_User"
+      baseTableName="InstrumentEntity"
+      baseColumnNames="owner_id"
+      referencedTableName="User"
+      referencedColumnNames="id"/>
+
+    <addForeignKeyConstraint
+      constraintName="FK_Instr_to_LastNonWorkbCont"
+      baseTableName="InstrumentEntity"
+      baseColumnNames="lastNonWorkbenchParent_id"
+      referencedTableName="Container"
+      referencedColumnNames="id"/>
+
+    <addForeignKeyConstraint
+      constraintName="FK_Instr_to_ContLocation"
+      baseTableName="InstrumentEntity"
+      baseColumnNames="parentLocation_id"
+      referencedTableName="ContainerLocation"
+      referencedColumnNames="id"/>
+  </changeSet>
+
+  <!--
+      ChangeSet 2: Create InstrumentEntity_AUD table (Audit table for InstrumentEntity)
+  -->
+  <changeSet id="2026-06-14-instrumententity-aud" context="run" author="nico">
+
+    <createTable tableName="InstrumentEntity_AUD">
+
+      <!-- Primary Key columns -->
+      <column name="id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="REV" type="int">
+        <constraints nullable="false"/>
+      </column>
+      <column name="REVTYPE" type="tinyint">
+        <constraints nullable="true"/>
+      </column>
+
+      <!-- Regular columns (all nullable in audit tables) -->
+      <column name="createdBy" type="varchar(255)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="creationDate" type="datetime">
+        <constraints nullable="true"/>
+      </column>
+      <column name="creationDateMillis" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="description" type="varchar(250)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="modificationDate" type="datetime">
+        <constraints nullable="true"/>
+      </column>
+      <column name="modificationDateMillis" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="modifiedBy" type="varchar(255)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="deleted" type="bit">
+        <constraints nullable="true"/>
+      </column>
+      <column name="name" type="varchar(255)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="iconId" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="tags" type="varchar(8000)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="deletedDate" type="datetime">
+        <constraints nullable="true"/>
+      </column>
+      <column name="imageFileProperty_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="thumbnailFileProperty_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="currMaxColIndex" type="int">
+        <constraints nullable="true"/>
+      </column>
+      <column name="version" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="sharingMode" type="int">
+        <constraints nullable="true"/>
+      </column>
+      <column name="acl" type="longtext">
+        <constraints nullable="true"/>
+      </column>
+      <column name="tagMetaData" type="longtext">
+        <constraints nullable="true"/>
+      </column>
+      <column name="owner_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="DTYPE" type="varchar(20)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="instrumentTemplate_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="templateLinkedVersion" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="parentLocation_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="lastNonWorkbenchParent_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="lastMoveDate" type="datetime(6)">
+        <constraints nullable="true"/>
+      </column>
+
+    </createTable>
+
+    <!-- Set composite primary key -->
+    <addPrimaryKey tableName="InstrumentEntity_AUD"
+      columnNames="id, REV"
+      constraintName="PK_InstrumentEntity_AUD"/>
+
+    <!-- Foreign key to REVINFO table -->
+    <addForeignKeyConstraint
+      constraintName="FK_InstrEntityRev_to_RevInfo"
+      baseTableName="InstrumentEntity_AUD"
+      baseColumnNames="REV"
+      referencedTableName="REVINFO"
+      referencedColumnNames="REV"/>
+
+  </changeSet>
+
+
+  <!--
+      ChangeSet 3: Rename SampleField → InventoryEntityField and its AUDIT table
+        Also updating the hibernate_sequences table to set the next_val for InventoryEntityField
+        to a value above the current max id, to avoid potential
+        PK conflicts with existing SampleField records
+  -->
+  <changeSet id="2026-04-14-renameSampleField" context="run" author="nico">
+    <comment>Rename SampleField to InventoryEntityField and its AUDIT table and also
+      updating the hibernate_sequences table</comment>
+    <renameTable oldTableName="SampleField"
+      newTableName="InventoryEntityField"/>
+
+    <renameTable oldTableName="SampleField_AUD"
+      newTableName="InventoryEntityField_AUD"/>
+
+    <sql>
+      UPDATE hibernate_sequences
+      SET sequence_name = 'InventoryEntityField'
+      WHERE sequence_name = 'SampleField';
+    </sql>
+
+  </changeSet>
+
+  <!--
+      ChangeSet 4: Modifications to InventoryEntityField (and AUDIT table)
+      - Add instrumentEntity_id column + FK
+      - Make sample_id nullable
+      - Add deleteOnInstrumentUpdate column
+      - drop and recreate foreignkey to InventoryEntityField
+  -->
+  <changeSet id="2026-04-14-inventoryEntityField" context="run" author="nico">
+    <!-- Add instrumentEntity_id to main table and AUDIT -->
+    <addColumn tableName="InventoryEntityField">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addColumn tableName="InventoryEntityField_AUD">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+
+    <!-- Add deleteOnInstrumentUpdate column  -->
+    <addColumn tableName="InventoryEntityField">
+      <column name="deleteOnInstrumentUpdate" type="bit" defaultValueNumeric="0">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="InventoryEntityField_AUD">
+      <column name="deleteOnInstrumentUpdate" type="bit"/>
+    </addColumn>
+
+    <!-- FK on main table -->
+    <addForeignKeyConstraint
+      constraintName="FK_InvEntField_to_InstrEntity"
+      baseTableName="InventoryEntityField"
+      baseColumnNames="instrumentEntity_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+
+    <!-- Modify sample_id field to allow NULL values -->
+    <sql>
+      ALTER TABLE InventoryEntityField MODIFY sample_id bigint NULL;
+    </sql>
+
+    <!-- Drop old foreign key from InventoryEntityField -->
+    <dropForeignKeyConstraint
+      constraintName="FK_3y0km9bpfi2oxanow35t16fdq"
+      baseTableName="InventoryEntityField"/>
+    <!-- Add new foreign key on InventoryEntityField.templateField_id -->
+    <addForeignKeyConstraint
+      constraintName="FK_templField_to_InvEntityField"
+      baseTableName="InventoryEntityField"
+      baseColumnNames="templateField_id"
+      referencedTableName="InventoryEntityField"
+      referencedColumnNames="id"/>
+
+  </changeSet>
+
+
+  <!--
+      ChangeSet 5: Add instrumentEntity_id + FK to all InventoryRecordConnectedEntity tables
+      (Barcode, BasketItem, DigitalObjectIdentifier, ExtraField, InventoryFile (for this dropping
+      and recreating the FK as well), MaterialUsage, StoichiometryInventoryLink)
+  -->
+  <changeSet id="2026-04-14-inventoryConnectedEntities" context="run" author="nico">
+
+    <!-- Barcode + AUDIT -->
+    <addColumn tableName="Barcode">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addColumn tableName="Barcode_AUD">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addForeignKeyConstraint
+      constraintName="FK_Barcode_to_InstrEntity"
+      baseTableName="Barcode"
+      baseColumnNames="instrumentEntity_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+
+    <!-- BasketItem (no AUDIT in original script) -->
+    <addColumn tableName="BasketItem">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addForeignKeyConstraint
+      constraintName="FK_BasketItem_to_InstrEntity"
+      baseTableName="BasketItem"
+      baseColumnNames="instrumentEntity_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+
+    <!-- DigitalObjectIdentifier + AUDIT -->
+    <addColumn tableName="DigitalObjectIdentifier">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addColumn tableName="DigitalObjectIdentifier_AUD">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addForeignKeyConstraint
+      constraintName="FK_DigitObjIdent_to_InstrEntity"
+      baseTableName="DigitalObjectIdentifier"
+      baseColumnNames="instrumentEntity_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+
+    <!-- ExtraField + AUDIT -->
+    <addColumn tableName="ExtraField">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addColumn tableName="ExtraField_AUD">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addForeignKeyConstraint
+      constraintName="FK_ExtraField_to_InstrEntity"
+      baseTableName="ExtraField"
+      baseColumnNames="instrumentEntity_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+
+    <!-- InventoryFile + AUDIT -->
+    <addColumn tableName="InventoryFile">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addColumn tableName="InventoryFile_AUD">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addForeignKeyConstraint
+      constraintName="FK_InventoryFile_to_InstrEntity"
+      baseTableName="InventoryFile"
+      baseColumnNames="instrumentEntity_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+    <!-- Drop old foreign key from InventoryFile -->
+    <dropForeignKeyConstraint
+      constraintName="FK_qy05jb7phinbki3tip3q5okdj"
+      baseTableName="InventoryFile"/>
+    <!-- Add new foreign key on InventoryFile.sampleField_id -->
+    <addForeignKeyConstraint
+      constraintName="FK_InvFile_to_InventoryEntityField"
+      baseTableName="InventoryFile"
+      baseColumnNames="sampleField_id"
+      referencedTableName="InventoryEntityField"
+      referencedColumnNames="id"/>
+    <!-- Rename sampleField_id to inventoryEntityField_id -->
+    <renameColumn
+      tableName="InventoryFile"
+      oldColumnName="sampleField_id"
+      newColumnName="inventoryEntityField_id"
+      columnDataType="bigint"/>
+    <renameColumn
+      tableName="InventoryFile_AUD"
+      oldColumnName="sampleField_id"
+      newColumnName="inventoryEntityField_id"
+      columnDataType="bigint"/>
+
+
+    <!-- MaterialUsage + AUDIT -->
+    <addColumn tableName="MaterialUsage">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addColumn tableName="MaterialUsage_AUD">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addForeignKeyConstraint
+      constraintName="FK_MaterialUsage_to_InstrEntity"
+      baseTableName="MaterialUsage"
+      baseColumnNames="instrumentEntity_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+
+    <!-- StoichiometryInventoryLink + AUDIT -->
+    <addColumn tableName="StoichiometryInventoryLink">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addColumn tableName="StoichiometryInventoryLink_AUD">
+      <column name="instrumentEntity_id" type="bigint"/>
+    </addColumn>
+    <addForeignKeyConstraint
+      constraintName="FK_StoichInvLink_to_InstrEntity"
+      baseTableName="StoichiometryInventoryLink"
+      baseColumnNames="instrumentEntity_id"
+      referencedTableName="InstrumentEntity"
+      referencedColumnNames="id"/>
+  </changeSet>
+
+  <!--
+      ChangeSet 6: Container / Container_AUD changes
+      Adding canStoreInstruments and contentCountInstruments columns
+  -->
+  <changeSet id="2026-04-14-container" context="run" author="nico">
+    <!-- Container table -->
+    <addColumn tableName="Container">
+      <column name="canStoreInstruments" type="bit" defaultValueNumeric="1"/>
+      <column name="contentCountInstruments" type="int" defaultValueNumeric="0"/>
+    </addColumn>
+    <dropColumn tableName="Container" columnName="quantityNumericValue"/>
+    <dropColumn tableName="Container" columnName="quantityUnitId"/>
+    <!-- Container_AUD table -->
+    <addColumn tableName="Container_AUD">
+      <column name="canStoreInstruments" type="bit" defaultValueNumeric="1">
+        <constraints nullable="true"/>
+      </column>
+      <column name="contentCountInstruments" type="int" defaultValueNumeric="0">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+    <dropColumn tableName="Container_AUD" columnName="quantityNumericValue"/>
+    <dropColumn tableName="Container_AUD" columnName="quantityUnitId"/>
+  </changeSet>
+
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -167,7 +167,9 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1022.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1079-remove-ascenscia.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-335-remove-jove.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-1062.xml"/>
 
-    <!--  ensure that customUpdates-changeLog.xml always runs LAST! -->
+
+  <!--  ensure that customUpdates-changeLog.xml always runs LAST! -->
     <include relativeToChangelogFile="true" file="customUpdates-changeLog.xml"/>
 </databaseChangeLog>

--- a/src/main/webapp/WEB-INF/pages/public/apiDocs.jsp
+++ b/src/main/webapp/WEB-INF/pages/public/apiDocs.jsp
@@ -58,7 +58,7 @@
 
 <body>
 
-    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
+<svg xmlns="http://www.w3.org/2000/svg" style="position:absolute;width:0;height:0">
       <defs>
         <symbol viewBox="0 0 20 20" id="unlocked">
           <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>

--- a/src/main/webapp/resources/rspace_api_inventory_specs_beta_instruments.yaml
+++ b/src/main/webapp/resources/rspace_api_inventory_specs_beta_instruments.yaml
@@ -1,0 +1,3944 @@
+swagger: '2.0'
+info:
+  title: RSpace Inventory API
+  description: >
+    Welcome to the RSpace Inventory API.
+
+  version: "2.14"
+  termsOfService: >-
+    Currently unrestricted, subject to usage limits returned in X-Rate-Limit headers.
+  license:
+    name: Apache2 License
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+  contact:
+    name: RSpace API Support
+    email: support@researchspace.com
+basePath: /api/inventory/v1
+produces:
+  - application/json
+consumes:
+  - application/json
+security:
+  - ApiKeySecurity: [ ]
+  - OAuthJWT: [ ]
+securityDefinitions:
+  ApiKeySecurity:
+    description: Authentication system based on API Key.
+    type: apiKey
+    in: header
+    name: apiKey
+  OAuthJWT:
+    description: |
+      ##### Please note: you must change 'Client credentials location' from \"Authorization header\" to \"Request body\".
+    type: oauth2
+    flow: password
+    tokenUrl: /oauth/token
+    scopes:
+      all: Grants access to all API
+paths:
+  /workbenches:
+    get:
+      summary: Get all Workbenches visible to the current User
+      description: >
+        Returns the list with info objects about all workbenches that user can read.
+      produces:
+        - application/json
+      tags:
+        - Workbench
+      responses:
+        '200':
+          description: A list of ContainerInfo objects.
+  '/workbenches/{workbenchId}':
+    get:
+      summary: Retrieve a specific Workbench by its ID
+      description: >
+        Gets details of a specific workbench container, including the summary of its content. The actual content
+        will be present in `locations` property, but only if request is made with `includeContent` parameter set to true.
+      produces:
+        - application/json
+      tags:
+        - Workbench
+      parameters:
+        - $ref: '#/parameters/workbenchIdParam'
+        - in: query
+          name: includeContent
+          description: if set to `true` the `locations` property is populated with content of the workbench
+          default: false
+          type: boolean
+      responses:
+        '200':
+          description: A Workbench
+          schema:
+            $ref: '#/definitions/Container'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /instruments:
+    post:
+      summary: Create a new Instrument
+      description: >-
+
+        Creates a new Instrument in RSpace Inventory.
+        
+        Content body is a JSON object defining properties of the instrument:
+                 - `name` is the only required property.
+                 - `fields` array contains values for fields coming from the instrument template. The ordering is important as the content is assigned to  subsequent template fields.
+                 - All fields except Choice and Radio fields, fields are defined as `{"content": <value>}` objects, where `<value>` is appropriate for the field type. Radio and Choice fields are defined as `"selectedOptions": ["<option1>", "<option2>"...]`
+                 - If `templateId` is set, `fields` can be omitted, in which case the instrument will be created using default values supplied by the instrument template (if any).
+                 - For Attachment fields, the `content` field is used to describe the attached file, and it is not possible to attach the actual file in this request. To attach the file, use `/files POST` setting `parentGlobalId` to the Id of the field once this instrument is created.
+                 - `extraFields` array contains values for additional fields that can be added independently from template fields. The order of the fields in array is not important, but each field need to specify `type` and `name`.
+
+        ## Examples of the request body
+        
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{ "name": "Generic instrument" }` | Creates a Instrument named "Generic instrument", based on Basic Instrument template, with empty content 
+
+        `{ "name": "Instrument with image", "newBase64Image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQIAAAESAQMAAAAsV 0mIAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAGUExURf///wAAAFXC034AAAAJcEhZcwAADsMAAA7 DAcdvqGQAAABWSURBVGje7dUhDsAgEETR5VYcv8fCgUEg1rXdhOR9/ZKRE5LO2kwbH4snHe8EQRAEQWxR88g+m yAIgiDeCo9MEARBEP+Lmr/1yARBEARxhyj5fSktYgFPS1k85Tqe JQAAAABJRU5ErkJggg==" }` | As previous example, but includes an image of the instrument in Base64. 
+
+        `{ "name": "Instrument stored in a LIST container", "newTargetLocation": { "containerId": 11, "location": {} } }` | Creates an instrument placed into a `LIST` container (with `id=11`), location MUST be empty.
+
+        `{ "name": "Instrument stored in a GRID container", "newTargetLocation": { "containerId": 21, "location": { "coordX": 1, "coordY": 1} }` | Creates an instrument placed into a `GRID` container (with `id=21`), grid coordinates MUST be provided.
+
+        `{ "name": "Instrument stored in a LIST container", "newTargetLocation": { "containerId": 31, "location": { "id": 32 } } }` | Creates an instrument placed into a `VISUAL` container (with `id=31`), the id of a target location MUST be provided.
+        
+        `{ "name": "My Instrument", "templateId": 1 }` | Creates a new Instrument based on Instrument Template with `id = 1`, with default field values 
+
+        `{ "name": "My Instrument",  "templateId": 22, "fields": [{}, {}, {"content": "some data"}] }` | Creates a new Instrument based on template with `id = 22`, with default field values for the first two fields and explicit value for the 3rd field. 
+
+        `{ "name": "My Complex API Instrument #1", "description": "my description", "templateId": 2, "fields": [{ "content": "5.0" }, { "content": "2020-05-13" }, { "content": "a string"}, { "content": "<p>MyText content</p>" }, { "content": "https://www.researchspace.com" }, { "content": "SD12345" }, { "content": "description of an attached file" }, { "selectedOptions": ["option1"] }, { "selectedOptions": ["optionA"] }], "extraFields": [ { "name": "my instrument extra field", "type": "text", "content" :"extra instrument content (text)" } ] }` | Creates a complex Instrument based on a specific template (with id `2`) which contains 9 fields of various types. In order these are number, date, string, text, uri, reference, attachment, radio, choice.
+
+      tags:
+        - Instruments (not enabled)
+      parameters:
+        - in: body
+          name: instrument
+          description: 'An instrument, with optional fields'
+          required: true
+          schema:
+            $ref: '#/definitions/Instrument'
+      responses:
+        '201':
+          description: >-
+            Success. Returned object represents a created instrument.
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+  '/instruments/{instrumentId}':
+    get:
+      summary: Retrieve a complete Instrument by ID
+      description: |
+        Gets a complete Instrument
+      produces:
+        - application/json
+      tags:
+        - Instruments (not enabled)
+      parameters:
+        - $ref: '#/parameters/instrumentIdParam'
+      responses:
+        '200':
+          description: An Instrument
+          schema:
+            $ref: '#/definitions/Instrument'
+        '404':
+          $ref: '#/responses/NotFound'
+
+
+  /samples:
+    get:
+      summary: Get all Samples visible to the current User
+      description: >
+        Returns a paginated list of summary information about Samples visible to the current user.
+
+        | Request | Explanation |
+
+        | --- | --- |
+
+        /samples?pageSize=10| Gets first 10 samples
+
+        /samples?ownedBy=user1a| Gets page of samples owned by user1a (assuming current user can see them)
+
+      produces:
+        - application/json
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/ownedByParam'
+        - $ref: '#/parameters/deletedItemsParam'
+        - $ref: '#/parameters/pageNumberParam'
+        - $ref: '#/parameters/pageSizeParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        '200':
+          description: A list of SampleInfo objects.
+    post:
+      summary: Create a new Sample with one or more SubSamples
+      description: >-
+
+        Creates a new Sample in RSpace Inventory.
+
+        Content body is a JSON object defining properties of the sample:
+         - `name` is the only required property.
+         - `fields` array contains values for fields coming from the sample template. The ordering is important as the content is assigned to  subsequent template fields.
+         - All fields except Choice and Radio fields, fields are defined as `{"content": <value>}`objects, where `<value>` is appropriate for the field type.  Radio and Choice fields are defined as `"selectedOptions": ["<option1>", "<option2>"...]`
+         - If `templateId` is set, `fields` can be omitted, in which case the sample will be created using default values supplied by the template (if any).
+         - For Attachment fields, the `content` field is used to describe the attached file, and it is not possible to attach the actual file in this request. To attach the file, use `/files POST` setting `parentGlobalId` to the Id of the field once this sample is created.
+         - `extraFields` array contains values for additional fields that can be added independently from template fields. The order of the fields in array is not important, but each field need to specify `type` and `name`.
+
+        Optionally `newSampleSubSamplesCount` field can be set to create multiple default subsamples for a sample. If sample's `quantity` is provided, it will be divided to calculate quantity of each default subsample.
+        By default subsamples are placed in user's Workbench, but if `newSampleSubSampleTargetLocations` array is provided it'll override target location for each created default subsample.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{ "name": "Generic sample" }` | Creates a Sample named "Generic sample", based on Basic Sample template, with empty content, and `sampleSource` default of `LAB_CREATED`.
+
+        `{ "name": "Sample with image", "newBase64Image":
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQIAAAESAQMAAAAsV 0mIAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAGUExURf///wAAAFXC034AAAAJcEhZcwAADsMAAA7 DAcdvqGQAAABWSURBVGje7dUhDsAgEETR5VYcv8fCgUEg1rXdhOR9/ZKRE5LO2kwbH4snHe8EQRAEQWxR88g+m yAIgiDeCo9MEARBEP+Lmr/1yARBEARxhyj5fSktYgFPS1k85Tqe JQAAAABJRU5ErkJggg==" }` | As previous example, but includes an image of the sample in Base64.
+
+        `{ "name": "Sample with default subsamples", "newSampleSubSamplesCount": 3, "newSampleSubSampleTargetLocations":
+        [ { "containerId": 11, "location": {} }, { "containerId": 21, "location": { "coordX": 1, "coordY": 1} }, { "containerId": 31, "location": { "id": 32 } } ] }`
+        | Creates a sample with three default subsamples, each placed within a different container. When placing into LIST container (with id=11) location should be empty;
+        when placing within GRID container (with `id=21`) grid coordinates have to be provided; when placing in VISUAL container (with id=31), the id of a target location must be provided.
+
+        `{ "name": "My Sample", "tags": [{"value":"api"}], "quantity": { "unitId" : "3", "numericValue" : "50" }, "subSamples": [ { "name": "subSample A", "parentContainers": [ { "id": 11 } ] }, { "name": "subSample B", "parentContainers": [ { "id": 11 } ] } ] }`
+        | Creates a sample named "My Sample", with 50ml quantity and a non-ontology 'api' tag, with two subsamples placed inside a container with `id = 11`.
+
+        `{ "name": "My Sample", "tags": [{"value":"api","uri":"http://uri","ontologyName":"name","ontologyVersion":"version"}], "quantity": { "unitId" : "3", "numericValue" : "50" }, "subSamples": [ { "name": "subSample A", "parentContainers": [ { "id": 11 } ] }, { "name": "subSample B", "parentContainers": [ { "id": 11 } ] } ] }`
+        | Creates a sample named "My Sample", with 50ml quantity and an 'api' tag from uploaded ontology (with uri/name/version), with two subsamples placed inside a container with `id = 11`.
+
+        `{ "name": "My Sample", "quantity": { "unitId" : "3", "numericValue" : "50" },"expiryDate":"2021-06-30", "subSamples": [ { "name": "subSample A", "parentLocation": { "id": 21 } } ] }`
+        | Creates a sample named "My Sample", with 50ml quantity and an expiration date, with one subsample named "subSample A" placed inside a container location with `id = 21`.
+
+        `{ "name": "My Refrigerated Sample", "quantity": { "unitId" : "3", "numericValue" : "10" }, "newSampleSubSamplesCount": 2, "storageTempMin" : { "numericValue" : 3.00, "unitId" : 8 }, "storageTempMax" : { "numericValue" : 5.00, "unitId" : 8 } }`
+        | Creates 10ml sample with a specified storage temperature. The sample will contain two subsamples, 5ml each.
+
+        `{ "name": "My Sample", "sampleSource": "VENDOR_SUPPLIED", "templateId": 1 }` | Creates a new Sample based on template with `id = 1`, non-default value for `sampleSource`, with default field values and no subsamples.
+
+        `{ "name": "My Sample",  "templateId": 22, "fields": [{}, {}, {"content": "some data"}] }` | Creates a new Sample based on template with `id = 22`, with default field values  for the first two fields and explicit value for the 3rd field.
+
+        `{ "name": "My Complex API Sample #1", "description": "my description", "templateId": 2, 
+        "fields": [ { "content": "5.0" }, { "content": "2020-05-13" }, { "content": "a string"}, { "content": "<p>MyText content</p>" }, { "content": "https://www.researchspace.com" }, { "content": "SD12345" }, { "content": "description of an attached file" }, { "selectedOptions": ["option1"] }, { "selectedOptions": ["optionA"] }], "extraFields": [ { "name": "my sample extra field", "type": "text", "content" :"extra sample content (text)" } ], "subSamples": [ { "name": "Subsample of My Complex Api Sample", "extraFields": [ { "name": "my subsample extra field", "type": "number", "content": "5.15" } ], "notes": [ { "content": "my note" } ] } ] }`
+        | Creates a complex Sample based on a specific template (with id `2`) which contains 9 fields of various types. In order these are number,date,string,text,uri,reference,attachment,radio,choice.
+      tags:
+        - Samples
+      parameters:
+        - in: body
+          name: sample
+          description: 'A sample, with optional fields and subsamples'
+          required: true
+          schema:
+            $ref: '#/definitions/Sample'
+      responses:
+        '201':
+          description: >-
+            Success. Returned object represents a created sample.
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+  '/samples/{sampleId}':
+    get:
+      summary: Retrieve a complete Sample by ID
+      description: |
+        Gets a complete Sample, including summary information about subSamples.
+      produces:
+        - application/json
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+      responses:
+        '200':
+          description: A Sample
+          schema:
+            $ref: '#/definitions/Sample'
+        '404':
+          $ref: '#/responses/NotFound'
+    put:
+      summary: Update a Sample
+      description: |
+        Updates an existing Sample. The endpoint allows updating properties of the sample and its fields, but not those of its subsamples - these should be updated through the separate `/subSamples` endpoint. Also, this endpoint won't change the owner of the sample - use `/samples/{sampleId}/actions/changeOwner` endpoint for transferring the sample to another user.
+
+        Extra fields belonging to the sample can be updated, added and deleted as a part update action. To create a new extra field, include its definition with additional `newFieldRequest` property set to `true`. To delete an extra field, include a `deleteFieldRequest` property set to `true`.
+
+        The request body should be a JSON object that specifies the details of the update, and must be parsable into `#/definitions/Sample` model.
+
+        This endpoint requires `UPDATE` permission to the Sample.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+        | --- | --- |
+        `{}` | Update Sample's last modified date, but doesn't change any of the properties.
+        `{ "name": "new name", "tags": [{"value":"new tag","uri":"http://uri","ontologyName":"name","ontologyVersion":"version"}] }` | Updates sample 'name' and replaces 'tags' with newly provided ones
+        `{ "fields": [ { "id": 11, "content": "2020-01-09" } ] }` | Updates sample field (with id 11) with new content
+        `{ "extraFields": [ { "id": 21, "content": "...updated" }, { "newFieldRequest": true, "name": "my field", "content": "new field" }, { "id": 22, "deleteFieldRequest": true } ] }` | Updates extra field 21 with new content, deletes extra field 22, and creates new text extra field
+        `{ "identifiers": [ { "id": 23, "title": "updated title", "publisher": "ResearchsSpace", "publicationYear": 2023 } ] }` | Update title property of existing sample's IGSN identifier with id 23
+        `{ "sharingMode": "WHITELIST", "sharedWith": [ {"group": { "uniqueName": "user3GroupOiCr" }, "shared": true} ] }` | Update sharing setup of the sample, so it's now shared only with user3GroupOiCr
+
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+        - $ref: '#/parameters/sampleBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - sample is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+    delete:
+      summary: Delete a Sample
+      description: |
+        Mark sample as deleted, so it won't appear in Inventory UI and default listings. All subsamples belonging to the sample will also be deleted.
+
+        Delete action will stop by default, if subsamples belonging to deleted sample are stored inside container(s). This can be changed by passing "forceDelete" query parameter set to `true`. The default behaviour is so the UI can prompt the user that deleting sample will cause removal of subsamples from their current containers, and ask them for confirmation.
+
+        This action requires `UPDATE` permission to the Sample.
+
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+        - in: query
+          name: forceDelete
+          description: Proceed with sample deletion even if there are subsamples currently stored inside containers.
+          default: false
+          type: boolean
+      responses:
+        '204':
+          description: No content
+
+  '/samples/{sampleId}/restore':
+    put:
+      summary: Restore deleted Sample
+      description: |
+        Restores deleted sample. The subsamples that were active during sample deletion are also restored,
+        and moved to user's Workbench.
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+      responses:
+        '200':
+          description: >-
+            Success - sample is restored.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+  '/samples/{sampleId}/image/{timestamp}':
+    get:
+      summary: 'Gets a full image connected to the Sample'
+      description:
+        Returns full image uploaded for the sample.
+      produces:
+        - image/png
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/samples/{sampleId}/thumbnail/{timestamp}':
+    get:
+      summary: 'Gets a thumbnail image connected to the Sample'
+      description:
+        Returns a reduced-size image uploaded for the sample.
+      produces:
+        - image/png
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/samples/{sampleId}/actions/changeOwner':
+    put:
+      summary: Transfer the Sample to the new owner
+      description: |
+        Updates 'owner' field of existing Sample. No other changes to the sample are processed. Use  `/samples/{sampleId}` PUT endpoint to update other fields of the sample.
+
+        This action requires `CHANGE_OWNER` permission to the sample.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+        | --- | --- |
+        `{ "owner": { "username": "newOwner" } }` | Changes owner of a sample to newOwner (requires `CHANGE_OWNER` permission). |
+
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+        - $ref: '#/parameters/sampleBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - sample is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+  '/samples/{sampleId}/actions/duplicate':
+    post:
+      summary: Duplicate a Sample
+      description: |
+
+        Generates a deep copy of the sample, including fields, extra fields, images but excluding subsamples. A single subsample will be created with the same quantity as the total quantity of the original sample.
+
+        E.g. original sample S has 10 subsamples of 5ml. After duplication, S-copy will have 1 subsample of 50ml. You can then use `subSample/{id}/actions/duplicate` or  `subSample/{id}/actions/split` to edit the new subsample amounts.
+
+        This action requires `UPDATE` permission to the Sample.
+      produces:
+        - application/json
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+      responses:
+        '201':
+          description: The new, duplicate sample.
+          schema:
+            $ref: '#/definitions/Sample'
+
+  '/samples/{sampleId}/actions/updateToLatestTemplateVersion':
+    post:
+      summary: Update the Sample to match latest definition of its connected Sample Template
+      description: |
+        If the Sample Template used to create a Sample is updated, the changes only affect future samples created from that template. Calling this endpoint for a given sample will modify it according to changes in the latest template, e.g. will add or rename the field, add new possible radio field option, etc. If template changes cannot be applied to the sample, an error will be returned and sample will not be updated.
+
+        If the template update is non-destructive, e.g. a field was added or renamed, a new radio field option was added etc., the previously created sample can be always updated. Under certain conditions it is also possible to propagate potentially destructive changes to the template, e.g. field deletion or removing radio field option. As a general rule that is possible if the sample doesn't have any content in deleted field.
+
+        If the latest template has new fields that the sample doesn't, these fields are added to the sample, but without setting any default value (even if template field has one). That's to avoid the situation where some samples have field values that user didn't explicitly set nor confirm.
+
+        User must have UPDATE permissions for the sample, and read permissions for the template to run the update action.
+
+        ### Algorithm for for updating sample (S) to latest template version (T)
+        - check difference between T and S properties:
+          - if T has new subsample alias, update subsample alias of S
+        - for each S field check difference between S field and connected T field:
+          - if the connected T field was deleted:
+            - if the S field value is empty, delete the S field
+            - if the S field value is not empty, REJECT WHOLE UPDATE ATTEMPT
+          - if the connected T field was renamed, rename the S field
+          - if the connected T field was reordered (i.e. moved up or down), reorder the S field
+          - if the connected T field is radio/choice, and there is new option set:
+            - if the S field value is found within new T option set, update the S field option set
+            - if the S field value is not found with new T option set, REJECT WHOLE UPDATE ATTEMPT
+        - for each T field, if there is no connected S field (i.e. it's a new field added to T):
+          - add the field to S, with empty value (even if T field has a default value, it shouldn't be used)
+
+      produces:
+        - application/json
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+      responses:
+        '200':
+          description: The sample updated to latest version of the template.
+          schema:
+            $ref: '#/definitions/Sample'
+
+  '/samples/{sampleId}/revisions':
+    get:
+      summary: 'Gets historical revisions of the Sample'
+      description:
+        Returns list of historical revisions saved for the Sample, starting from the earliest revision.
+      produces:
+        - application/json
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+      responses:
+        '200':
+          description: A list of revision information objects.
+
+  '/samples/{sampleId}/revisions/{revisionId}':
+    get:
+      summary: 'Gets historical revision of the Sample'
+      description:
+        Returns full details of a historical revision saved for the Sample.
+      produces:
+        - application/json
+      tags:
+        - Samples
+      parameters:
+        - $ref: '#/parameters/sampleIdParam'
+        - $ref: '#/parameters/revisionIdParam'
+      responses:
+        '200':
+          description: A Sample, as it was at a requested historical revision
+          schema:
+            $ref: '#/definitions/Sample'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  '/samples/validateNameForNewSample':
+    get:
+      summary: Check if given string is valid for naming a new Sample
+      tags:
+        - Samples
+      consumes:
+        - text/plain
+      parameters:
+        - in: query
+          name: name
+          type: string
+          required: true
+          description: Name to check.
+      responses:
+        '200':
+          description: JSON object with 'valid' field (true/false) and 'message' field if there is a problem with a name
+          schema:
+            type: string
+
+  /subSamples:
+    get:
+      summary: Get all SubSamples visible to the current User
+      description: >
+        Returns a paginated list of summary information about SubSamples visible to the current user.
+
+         | Request | Explanation |
+
+         | --- | --- |
+
+         /subSamples?pageSize=10| Gets first 10 subSamples
+
+         /subSamples?ownedBy=user1a| Gets page of subSamples owned by user1a (assuming current user can see them)
+
+      produces:
+        - application/json
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/ownedByParam'
+        - $ref: '#/parameters/deletedItemsParam'
+        - $ref: '#/parameters/pageNumberParam'
+        - $ref: '#/parameters/pageSizeParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        '200':
+          description: A list of SubSampleInfo objects.
+
+    post:
+      summary: Create one or more SubSamples
+      description: >-
+
+        Creates completely new SubSamples in a given Sample.
+        This action requires `UPDATE` permission to the Sample.
+
+        ## Examples of request body:
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{ "sampleId": 12, "numSubSamples" : "1" }` | Creates one new subsample within sample with id=12, with default quantity |
+        
+        `{ "sampleId": 12, "numSubSamples" : "3", "singleSubSampleQuantity": { "numericValue": 7.33, "unitId": 3 } }` | Creates 2 new subsamples within sample with id=12, each with quantity of 7.3 ml |
+
+      produces:
+        - application/json
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleCreateParam'
+      responses:
+        '201':
+          description: A list of newly created subsamples.
+          schema:
+            $ref: '#/definitions/SubSample'
+
+  '/subSamples/{subSampleId}':
+    get:
+      summary: Retrieve a SubSample by ID
+      description: >
+        Retrieve a complete SubSample by ID.
+      produces:
+        - application/json
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+      responses:
+        '200':
+          description: A SubSample
+          schema:
+            $ref: '#/definitions/SubSample'
+        '404':
+          $ref: '#/responses/NotFound'
+    put:
+      summary: Update a SubSample with given ID
+      description: |
+        Updates existing subsample with provided id. The request body should be a JSON object that specifies the details of the update, and must be parsable into `#/definitions/SubSample` model.
+
+        This action requires `UPDATE` permission to the SubSample.
+
+        ## Extra fields
+
+        Extra fields belonging to the subsample can be updated, added and deleted as a partial
+        update action. To create a new extra field, include its definition with additional
+        `newFieldRequest` property set to `true`. To delete an extra field, include a
+        `deleteFieldRequest` property set to `true`.
+
+        ## Notes
+
+        Subsample notes cannot be updated. To add a note to the subsample send POST
+        request to the `/subSamples/{subSampleId}/notes` endpoint.
+
+        ## Moving a subsample
+
+        To move a subsample to another container, provide the target container as a first element in `parentContainers` array. For grid/image container you'll also have to provide details of target location in `parentLocation` field: for grid container the provided provided location needs to specify target coordinates, for image container it needs to specify location id.
+
+        When moving multiple items use `/bulk` endpoint with `"operationType": 'MOVE'`.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{ "name": "new Name" }` | Updates a name of the subsample.
+
+        `{"quantity": { "numericValue": 7.32, "unitId": 3 }}` | Updates the subsample's quantity. Note that the unitId must be compatible (volume, mass, etc) with the original quantity
+
+
+        `{ "extraFields": [ { "id": 21, "content": "...updated" }, { "newFieldRequest": true, "name": "my field", "content": "new field" }, { "id": 22, "deleteFieldRequest": true } ] }` | Updates extra field 21 with new content, deletes extra field 22, and creates new text extra field
+        
+        `{  "identifiers": [ { "id": 31, "geoLocations": [ { "geoLocationPlace": "testPlace", "geoLocationPoint": { "pointLatitude": "1.0", "pointLongitude": "2.0" }, 
+            "geoLocationBox": { "eastBoundLongitude": "-68.211", "northBoundLatitude": "42.893", "southBoundLatitude": "41.090", "westBoundLongitude": "-71.032" },
+            "geoLocationPolygon": [ { "polygonPoint": { "pointLatitude": "41.991", "pointLongitude": "-71.032" } },
+              { "polygonPoint": { "pointLatitude": "42.893", "pointLongitude": "-69.622" } }, { "polygonPoint": { "pointLatitude": "41.991", "pointLongitude": "-68.211" } },
+              { "polygonPoint": { "pointLatitude": "41.090", "pointLongitude": "-69.622" } }, { "polygonPoint": { "pointLatitude": "41.991", "pointLongitude": "-71.032" } } ],
+            "geoLocationInPolygonPoint": { "pointLatitude": "42.0", "pointLongitude": "-70.1" }
+         } ] } ] }` 
+        | Updates IGSN identifier with details of geoLocation
+
+        `{ "parentContainers": [ { "id": "11"} ] }`
+        | Move this subsample into list container 11, without specifying exact location (this will work for list containers)
+
+        `{ "parentContainers": [ { "id": "16"} ],  "parentLocation" : { "coordX": 2, "coordY": 3 } }`
+        | Move this subsample into grid container 16, with specifying location coordinates (this will work for grid containers)
+
+        `{ "parentLocation": { "id": "21"} } }`
+        | Move this subsample into container location 21 (this will work if location 21 belongs to an image container)
+
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+        - $ref: '#/parameters/subSampleBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - subsample is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+    delete:
+      summary: Delete a SubSample
+      description: |
+        Mark subsample as deleted, so it won't appear in Inventory UI and default listings. The subsample will also be removed from its current location.
+
+        This action requires `UPDATE` permission to the SubSample.
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+      responses:
+        '204':
+          description: No content
+
+  '/subSamples/{subSampleId}/restore':
+    put:
+      summary: Restore deleted SubSample
+      description: |
+        Restores deleted subsample and moves it to  user's Workbench.
+        If the parent sample of restored subsample is also deleted, it will be restored, but without restoring any other subsamples.
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+      responses:
+        '200':
+          description: >-
+            Success - subsample is restored.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+  '/subSamples/{subSampleId}/notes':
+    post:
+      summary: Create a new SubSample note.
+      description: >-
+
+        The POST request sent to `/subSamples/{subSampleId}/notes` endpoint creates
+        a new subsample note.
+
+        The request body should be a JSON object that specifies the details  of
+        the note that should be created and must be parsable into
+        #/definitions/SubSampleNote model.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{ "content" : "subsample note #1" }` | Creates a new note with some content.
+
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+        - $ref: '#/parameters/subSampleNoteBodyParam'
+      responses:
+        '201':
+          description: >-
+            Success - new note was added. Returned object represents latest subsample.
+          schema:
+            $ref: '#/definitions/SubSample'
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+
+  '/subSamples/{subSampleId}/parentSample':
+    get:
+      summary: Retrieve a parent Sample
+      description: >
+        Retrieve a complete parent Sample using ID of a child subsample.
+
+        Returns Sample in the same format as `/samples/{sampleId}` endpoint.
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+      responses:
+        '200':
+          description: A Sample
+          schema:
+            $ref: '#/definitions/Sample'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  '/subSamples/{subSampleId}/actions/duplicate':
+    post:
+      summary: Duplicate a subsample
+      description: |
+        Generates a deep copy of the subsample.
+
+        This action requires `UPDATE` permission to the SubSample.
+      produces:
+        - application/json
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+      responses:
+        '201':
+          description: The new, duplicate subsample.
+          schema:
+            $ref: '#/definitions/SubSample'
+
+  '/subSamples/{subSampleId}/actions/split':
+    post:
+      summary: Splits a subsample
+      description: >-
+
+        Generates a deep copy of the subsample, either distributing quantity equally amongst copies, or setting the quantity of each the same as the original, depending on whether `split` is true or false.
+
+
+        This action requires `UPDATE` permission to the SubSample.
+
+        ## Examples of request body:
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{ "numSubSamples" : "2", "split": "false" }` | Creates 1 duplicate, with the same quantity as the original - this is identical to calling `/actions/duplicate` |
+
+        `{ "numSubSamples" : "10", "split": "true" }` | Creates 9 duplicates, distributing the  original quantity equally. If you had 1 subsample of 100ml, this will result 10 subsamples of 10ml each - the original, plus 9 new duplicates. |
+
+        `{ "numSubSamples" : "10", "split": "false" }` | Creates 9 duplicates, duplicating quantity. If you had 1 subsample of 100ml, this will result in 10 subsamples of 100ml each - the original, plus 9 new duplicates. |
+      produces:
+        - application/json
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+        - $ref: '#/parameters/subSampleSplitParam'
+      responses:
+        '201':
+          description: A list of  duplicates subsamples.
+          schema:
+            $ref: '#/definitions/SubSample'
+
+  '/subSamples/{subSampleId}/image/{timestamp}':
+    get:
+      summary: 'Gets a full image connected to the SubSample'
+      description:
+        Returns full image uploaded for the sample.
+      produces:
+        - image/png
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/subSamples/{subSampleId}/thumbnail/{timestamp}':
+    get:
+      summary: 'Gets a thumbnail image connected to the SubSample'
+      description:
+        Returns a reduced-size image uploaded for the subsample.
+      produces:
+        - image/png
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/subSamples/{subSampleId}/revisions':
+    get:
+      summary: 'Gets historical revisions of the SubSample'
+      description:
+        Returns list of historical revisions saved for the SubSample, starting from the earliest revision.
+      produces:
+        - application/json
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+      responses:
+        '200':
+          description: A list of revision information objects.
+
+  '/subSamples/{subSampleId}/revisions/{revisionId}':
+    get:
+      summary: 'Gets historical revision of the SubSample'
+      description:
+        Returns full details of a historical revision saved for the SubSample.
+      produces:
+        - application/json
+      tags:
+        - SubSamples
+      parameters:
+        - $ref: '#/parameters/subSampleIdParam'
+        - $ref: '#/parameters/revisionIdParam'
+      responses:
+        '200':
+          description: A SubSample, as it was at a requested historical revision
+          schema:
+            $ref: '#/definitions/SubSample'
+        '404':
+          $ref: '#/responses/NotFound'
+
+
+  /sampleTemplates:
+    get:
+      summary: 'List Sample Templates visible to the current user'
+      description: >
+        Provides a paginated list of Sample Templates visible to the current user. That includes pre-defined global templates available for every RSpace user.
+
+        This endpoint can be used to retrieve the IDs of the templates from which Samples can be created.
+
+        Sample templates have almost identical data attributes to Samples themselves. Templates can be distinguished by `template=true` property.
+
+        List of returned templates can be limited to templates belonging to the paricular user by passing their username in 'ownedBy' parameter.
+
+      produces:
+        - application/json
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/ownedByParam'
+        - $ref: '#/parameters/deletedItemsParam'
+        - $ref: '#/parameters/pageNumberParam'
+        - $ref: '#/parameters/pageSizeParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        '200':
+          description: A List of Sample Templates
+          schema:
+            title: SampleTemplate List Results
+            properties:
+              totalHits:
+                type: number
+              pageNumber:
+                type: number
+              templates:
+                $ref: '#/definitions/SampleTemplateList'
+              _links:
+                $ref: '#/definitions/LinkItemList'
+
+    post:
+      summary: Create a new SampleTemplate
+      description: |
+        Create a new SampleTemplate, supplying the field definitions.
+
+        ## Mandatory content for SampleTemplates
+
+        Every template must have the following  properties set.
+
+          - name
+          - defaultUnitId
+
+        ## Types of  field
+
+        Zero more SampleFields define additional metadata fields for the sample.
+
+      consumes:
+        - application/json
+        - application/x-yaml
+      tags:
+        - Sample Templates
+      parameters:
+        - name: template
+          in: body
+          description: 'A sampleTemplate definition, with fields'
+          required: true
+          schema:
+            $ref: '#/definitions/SampleTemplatePost'
+
+      responses:
+        '201':
+          description: Sample Template
+          schema:
+            $ref: '#/definitions/SampleTemplate'
+          examples:
+            application/json:
+              id: 1867776
+              globalId: ST1867776
+              name: Antibody Template
+              lastModified: '2020-05-18T13:34:01.814Z'
+              type: SAMPLE
+              subsampleAlias:
+                name: aliquot
+                plural: aliquots
+              defaultUnitId: 3
+              fields:
+                - name: A String Field
+                  type: String
+                  content: Some default value
+                - name: A choice field
+                  type: choice
+                  definition:
+                    options: [ '4', '6', '8' ]
+                    multiple: true
+                  selectedOptions: [ '4', '8' ]
+                - name: A radio field
+                  type: radio
+                  definition:
+                    options: [ '4,', '6', '8' ]
+              _links:
+                - link: 'https://myrspace.com/api/inventory/v1/sampleTemplates/1867776'
+                  rel: self
+
+  '/sampleTemplates/{sampleTemplateId}':
+    get:
+      summary: Retrieve an inventory template by ID
+      description: >
+        Retrieve a sample template  by ID
+      produces:
+        - application/json
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+      responses:
+        '200':
+          description: Sample Template definition
+          schema:
+            $ref: '#/definitions/SampleTemplate'
+        '404':
+          $ref: '#/responses/NotFound'
+    put:
+      summary: Update a Sample Template
+      description: >
+        Updates  properties of an existing  template
+        and its fields.
+
+        The request body should be a JSON object that specifies the details  of
+        the update, and must be parsable into `#/definitions/Sample` model.
+
+        This action requires `UPDATE` permission to the template.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{}` | Update last modified date of the template, but doesn't change any of the properties.
+
+        `{ "name": "new name", "tags": [{"value":"new tags","uri":"http://uri","ontologyName":"name","ontologyVersion":"version"}] }` | Updates template 'name' and replaces 'tags' with newly provided ones
+
+        `{ "sharingMode": "WHITELIST", "sharedWith": [ {"group": { "uniqueName": "user3GroupOiCr" }, "shared": true} ] }` | Update sharing setup of the template, so it's now shared only with user3GroupOiCr
+
+        `{ "fields": [ { "id": 21, "name": "newName", "content": "...newContent" },
+        { "newFieldRequest": true, "name": "my field", "type": "string", "content": "new field" },
+        { "id": 22, "deleteFieldRequest": true, "deleteFieldOnSampleUpdate": true } ] }` | Updates field 21
+        with new name default content, deletes field 22 (with option to remove from pre-existing samples
+        when these are updated to latest template definition), and adds a new string field
+
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+        - $ref: '#/parameters/sampleBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - template is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+    delete:
+      summary: Delete a Sample Template
+      description: >
+        Mark a sample template as deleted, so it won't appear in Inventory UI and default listings.
+
+        This action requires `UPDATE` permission to the template.
+
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+      responses:
+        '204':
+          description: No content
+
+  '/sampleTemplates/{sampleTemplateId}/restore':
+    put:
+      summary: Restore deleted Sample Template
+      description: |
+        Restores deleted sample template.
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+      responses:
+        '200':
+          description: >-
+            Success - sample template is restored.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+  '/sampleTemplates/{sampleTemplateId}/versions/{version}':
+    get:
+      summary: 'Gets a particular version of a Sample Template'
+      description: |
+        When retrieving sample template through GET request to `/sampleTemplates/` endpoints you normally see the latest (current) version of the template. Each template has a 'version' property, which starts at 1, and is increased with every update to the template.
+
+        Use this endpoint to retrieve full details of a particular historical version of the template.
+
+        You can check `historicalVersion` boolean flag to distinguish if returned template points to current (latest) version, or historical one. Historical template will also have a `globalId` with version number, and populated `revisionId` field.
+
+      produces:
+        - application/json
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+        - $ref: '#/parameters/versionParam'
+      responses:
+        '200':
+          description: A template, as it was at a requested historical revision
+          schema:
+            $ref: '#/definitions/Sample'
+        '404':
+          $ref: '#/responses/NotFound'
+
+
+  '/sampleTemplates/{sampleTemplateId}/image/{timestamp}':
+    get:
+      summary: 'Gets a full image connected to the Sample Template'
+      description:
+        Returns full image uploaded for the template.
+      produces:
+        - image/png
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/sampleTemplates/{sampleTemplateId}/thumbnail/{timestamp}':
+    get:
+      summary: 'Gets a thumbnail image connected to the Sample Template'
+      description:
+        Returns a reduced-size image uploaded for the template.
+      produces:
+        - image/png
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/sampleTemplates/{sampleTemplateId}/icon':
+    post:
+      summary: Set or replace a new display icon for a template
+      description: >
+
+        Upload a display icon for a template. It should be viewable at 96x96px resolution.
+
+        This action requires `UPDATE` permission to the template.
+
+      produces:
+        - application/json
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+        - name: file
+          in: formData
+          type: file
+          required: true
+      consumes:
+        - multipart/form-data
+      responses:
+        '201':
+          description: Updated SampleTemplate object with new iconId
+          schema:
+            $ref: '#/definitions/SampleTemplateInfo'
+
+  '/sampleTemplates/{sampleTemplateId}/icon/{iconId}':
+    get:
+      summary: 'Gets the icon for the template, if set'
+      description:
+        Templates can have an icon set for them, to help with visual identification of templates in a list. This methods retrieves the bytes of the image. The IDs can be obtained from an ApiSampleTemplate response  from a `templates/` listing.
+
+      produces:
+        - application/octet-stream
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+        - name: iconId
+          description: The id for the formIcon
+          type: integer
+          format: int64
+          in: path
+          required: true
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+
+  '/sampleTemplates/{sampleTemplateId}/actions/changeOwner':
+    put:
+      summary: Transfer the Sample Template to the new owner
+      description: |
+        Updates 'owner' field of existing Sample Template. No other changes to the sample are processed. Use  `/sampleTemplates/{sampleId}` PUT endpoint to update other fields of the template.
+
+        This action requires `CHANGE_OWNER` permission to the template.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+        | --- | --- |
+        `{ "owner": { "username": "newOwner" } }` | Changes owner of a template to newOwner (requires `CHANGE_OWNER` permission). |
+
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+        - $ref: '#/parameters/sampleBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - sample template is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+  '/sampleTemplates/{sampleTemplateId}/actions/updateSamplesToLatestTemplateVersion':
+    post:
+      summary: Update user's samples created from the template to match its latest definition
+      description: |
+        If the Sample Template used to create a Sample is updated, the changes only affect future samples created from that template. Calling this endpoint will modify pre-existing user samples according to changes in the template. e.g. will add or rename the field, add new possible radio field option, etc. If there is a problem with updating a particular sample that sample is skipped, but the process continues for other samples created from the template.
+
+        Calling this endpoint updates all the samples referencing the non-latest version of the template that user has access to. The detailed update algorithm is described in description of `/samples/{sampleId}/actions/updateToLatestTemplateVersion` POST endpoint
+
+        Result contains list of updated samples/found problems.
+
+        This action checks `UPDATE` permission to the samples.
+
+      produces:
+        - application/json
+      tags:
+        - Sample Templates
+      parameters:
+        - $ref: '#/parameters/sampleTemplateIdParam'
+      responses:
+        '200':
+          description: >-
+            Success.
+
+  /containers:
+    get:
+      summary: Get top-level Containers visible to the current User
+      description: >
+        Containers endpoint returns a paginated list of summary information about top-level Containers visible to the current user.
+
+        | Request | Explanation |
+
+        | --- | --- |
+
+        /containers?pageSize=10| Gets first 10 containers
+
+        /containers?ownedBy=user1a| Gets page of top-level container owned by user1a (assuming current user can see them)
+
+      produces:
+        - application/json
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/ownedByParam'
+        - $ref: '#/parameters/deletedItemsParam'
+        - $ref: '#/parameters/pageNumberParam'
+        - $ref: '#/parameters/pageSizeParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        '200':
+          description: A list of ContainerInfo objects.
+    post:
+      summary: Create a new Container
+      description: >-
+
+        The POST request sent to `/containers` endpoint creates a new Container in RSpace Inventory. As well as standard metadata, the POST request can define parent container or location, extra fields, and internal locations. The "name" is the only required property; others are optional.
+
+
+        Note that if you want to place a newly created container inside a specific parent container, the required properties are different depending on the type of that parent container:
+         - if parent container is a LIST container, you should provide just the id of a target parent
+         - if parent container is a VISUAL container, you should provide just the id of a target location
+         - if parent container is a GRID container, you should provide the id of a target parent, and coordinates of a target location
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{ "name": "My Container", "cType": "LIST" }` | Creates a  List Container with given name, in the Workbench.
+
+        `{ "name": "-70 freezer", "cType": "LIST", "removeFromParentContainerRequest": true }` | Creates a  List Container with given name, as a top-level container.
+
+        `{ "name": "My Container", "cType": "LIST", "tags": [{"value":"api"}], "extraFields": [{ "name": "myData", "content" : "extra text content" }] }`
+        | Creates  Container named "My Container", with a non-ontology tag and extra field, in Workbench
+
+        `{ "name": "My Subcontainer #1", "cType": "LIST", "parentContainers": [ { "id": 11 } ] }`
+        | Creates default Container named "My Subcontainer", placed inside a list container with id = 11.
+
+        `{ "name": "My Subcontainer #2", "cType": "LIST", "parentLocation": { "id": 21 } }`
+        | Creates container named "My Subcontainer #2", placed inside a visual container's location with id = 21.
+
+        `{ "name": "My Subcontainer #3", "cType": "LIST", "parentContainers": [ { "id": 31} ], "parentLocation": { "coordX": 2, "coordY": 3 } }`
+        | Creates container named "My Subcontainer #3", placed inside a grid container with id = 31, in a 2nd cell of a 3rd row.
+
+        `{ "name": "24-well plate", "cType": "GRID", "gridLayout": { "columnsNumber": 6, "rowsNumber": 4} }`
+        | Creates grid container with 6x4 dimensions.
+
+        `{ "name": "4-shelf box (image Container)", "newBase64LocationsImage": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQIAAAESAQMAAAAsV 0mIAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAGUExURf///wAAAFXC034AAAAJcEhZcwAADsMAAA7 DAcdvqGQAAABWSURBVGje7dUhDsAgEETR5VYcv8fCgUEg1rXdhOR9/ZKRE5LO2kwbH4snHe8EQRAEQWxR88g+m yAIgiDeCo9MEARBEP+Lmr/1yARBEARxhyj5fSktYgFPS1k85Tqe JQAAAABJRU5ErkJggg==", "cType": "IMAGE", "locations": [ { "coordX" : 10, "coordY": 15}, { "coordX" : 10, "coordY": 25} ]}` | Creates image Container, with a couple of marked locations.
+
+      tags:
+        - Containers
+      parameters:
+        - in: body
+          name: container
+          description: 'A container, with optional fields and locations'
+          required: true
+          schema:
+            $ref: '#/definitions/Container'
+      responses:
+        '201':
+          description: >-
+            Success. Returned object represents created container.
+          schema:
+            $ref: '#/definitions/Container'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+  '/containers/{containerId}':
+    get:
+      summary: Retrieve a complete Container, by ID
+      description: >
+        Gets a complete Container, including the summary of its content.  The actual content will be present
+        in `locations` property, but only if request is made with `includeContent` parameter set to true.
+      produces:
+        - application/json
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+        - in: query
+          name: includeContent
+          description: if set to `true` the `locations` property is populated with content of the container
+          default: false
+          type: boolean
+      responses:
+        '200':
+          description: A container
+          schema:
+            $ref: '#/definitions/Container'
+        '404':
+          $ref: '#/responses/NotFound'
+    put:
+      summary: Update a Container with given ID
+      description: >
+        Updates an existing container with provided ID.
+
+        The request body should be a JSON object that specifies the details  of
+        the update, and must be parsable into `#/definitions/Container` model.
+
+        This action requires `UPDATE` permission to the container.
+
+        ## Extra fields
+
+        Extra fields belonging to the container can be updated, added and deleted as a part
+        update action. To create a new extra field pass its definition with additional
+        `newFieldRequest` property set to `true`. To delete an extra field pass a
+        `deleteFieldRequest` property set to `true`.
+
+        ## Moving a container
+
+        To move a container,  provide the target container as a first element in `parentContainers` array. For grid/image container you'll also have to provide details of target location in `parentLocation` field: for grid container, provided location needs to specify target coordinates; for image container it needs to specify location id.
+
+         To move a container outside of any other container set `removeFromParentContainerRequest` flag to true in request body. As a result the container will be shown on top level in "Containers" listing.
+
+        When moving multiple items use `/bulk` endpoint with `"operationType": 'MOVE'`.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        `{ "name": "new Name" }` | Updates a name of the container.
+
+        `{ "extraFields": [ { "id": 21, "content": "...updated" }, { "newFieldRequest": true, "name": "my field", "content": "new field" }, { "id": 22, "deleteFieldRequest": true } ] }` | Updates extra field 21 with new content, deletes extra field 22, and creates new text extra field
+
+        `{ "locations": [ { "id": 21, "coordX": "5" }, { "newLocationRequest": true, "coordX": "5", "coordY": "6" }, { "id": 22, "deleteLocationRequest": true } ] }` | Updates Image Container locations: location 21 is assigned new coordX, location 22 is deleted, and new location (5, 6) is created
+
+        `{ "gridLayout": { "columnsNumber": 4, "rowsNumber": 4} }`
+        | Updates grid container layout with new dimensions.
+
+        `{ "parentContainers": [ { "id": "11"} ] }`
+        | Move this container into list container 11, without specifying exact location (this will work for a list container)
+
+        `{ "parentLocation": { "id": "21"} } }`
+        | Move this container into container location 21 (this will work if container location 21 belongs to an image container)
+
+        `{ "removeFromParentContainerRequest": true }`
+        | Move this container out of its current location, so it is a top-level container.
+
+        `{ "newBase64Image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQIAAAESAQMAAAAsV 0mIAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAGUExURf///wAAAFXC034AAAAJcEhZcwAADsMAAA7 DAcdvqGQAAABWSURBVGje7dUhDsAgEETR5VYcv8fCgUEg1rXdhOR9/ZKRE5LO2kwbH4snHe8EQRAEQWxR88g+m yAIgiDeCo9MEARBEP+Lmr/1yARBEARxhyj5fSktYgFPS1k85Tqe JQAAAABJRU5ErkJggg=="  }` | Updates main image of the Container
+
+        `{ "sharingMode": "WHITELIST", "sharedWith": [ {"group": { "uniqueName": "user3GroupOiCr" }, "shared": true} ] }` | Update sharing setup of the container, so it's now shared only with user3GroupOiCr
+
+
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+        - $ref: '#/parameters/containerBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - container is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+    delete:
+      summary: Delete a Container
+      description: >
+        Mark container as deleted, so it won't appear in Inventory UI and default listings. The container will also be removed from it's current location.
+
+        Only empty containers can be deleted - move the content out first.
+
+        This action requires `UPDATE` permission to the container.
+
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+      responses:
+        '204':
+          description: No content
+
+  '/containers/{containerId}/restore':
+    put:
+      summary: Restore deleted Container
+      description: |
+        Restores deleted container and moves it to current user's Bench.
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+      responses:
+        '200':
+          description: >-
+            Success - container is restored.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+  '/containers/{containerId}/image/{timestamp}':
+    get:
+      summary: 'Gets a full image connected to the Container'
+      description:
+        Returns a full image uploaded for the container.
+      produces:
+        - image/png
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/containers/{containerId}/thumbnail/{timestamp}':
+    get:
+      summary: 'Gets a thumbnail image connected to the Container'
+      description:
+        Returns a reduced-size image uploaded for the container.
+      produces:
+        - image/png
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/containers/{containerId}/locationsImage/{timestamp}':
+    get:
+      summary: 'Gets a locations image connected to the Container'
+      description:
+        Returns an image used as the background for drawing locations.
+      produces:
+        - application/json
+        - image/png
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+        - $ref: '#/parameters/timeStampParam'
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  '/containers/{containerId}/actions/changeOwner':
+    put:
+      summary: Transfer the Container to the new owner
+      description: |
+        Updates pdates 'owner' field of existing Container. No other changes to the container are processed. Use  `/containers/{containerId}` PUT endpoint to update other fields of the container.
+
+        This action requires `CHANGE_OWNER` permission to the container.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+        | --- | --- |
+        `{ "owner": { "username": "newOwner" } }` | Changes owner of a container to newOwner (requires `CHANGE_OWNER` permission). |
+
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+        - $ref: '#/parameters/containerBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - container is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+        '500':
+          $ref: '#/responses/LicenseProblem'
+
+  '/containers/{containerId}/actions/duplicate':
+    post:
+      summary: Duplicate a container
+      description: |
+        Generates a deep copy of the container.
+
+        This action requires `UPDATE` permission to the container.
+      produces:
+        - application/json
+      tags:
+        - Containers
+      parameters:
+        - $ref: '#/parameters/containerIdParam'
+      responses:
+        '201':
+          description: The new, duplicate subsample.
+          schema:
+            $ref: '#/definitions/Container'
+
+  /search:
+    get:
+      summary: Search through inventory items
+      description: >
+        Returns a paginated list of summary information about inventory items (samples, subsamples, containers and templates) matching search query.
+
+         Search can be limited with 'parentGlobalId' parameter, to include only:
+          a) children (content) of a particular container or workbench
+          b) samples created from a particular template
+          c) subsamples of a given sample
+
+        If 'parentGlobalId' is provided the 'query' parameter can be empty (which returns all children).
+
+         Search can be also limited with 'ownedBy' parameter, to include only items belonging to that user.
+
+        | Query | Explanation |
+
+        | --- | --- |
+
+        /search?query=pcr | Gets samples and subsamples containing the word 'pcr'.
+
+        /search?query=mice&resultType=SUBSAMPLE&orderBy=name%20asc | Get subsamples containing the word 'mice', ordered by subsample name ascending.
+
+      produces:
+        - application/json
+      tags:
+        - Search
+      parameters:
+        - $ref: '#/parameters/queryParam'
+        - $ref: '#/parameters/resultTypeParam'
+        - $ref: '#/parameters/parentGlobalIdParam'
+        - $ref: '#/parameters/ownedByParam'
+        - $ref: '#/parameters/deletedItemsParam'
+        - $ref: '#/parameters/pageNumberParam'
+        - $ref: '#/parameters/pageSizeParam'
+        - $ref: '#/parameters/orderByParam'
+      responses:
+        '200':
+          description: A list of InventoryRecordInfo objects.
+
+  /barcodes:
+    get:
+      summary: 'Gets a barcode image for requested content'
+      description:
+        Get a PNG image representing barcode (or QR code) of the requested content.
+
+      produces:
+        - application/json
+        - image/png
+      tags:
+        - Barcodes
+      parameters:
+        - name: content
+          in: query
+          type: string
+          required: true
+          description: content to put into barcode
+        - name: barcodeType
+          in: query
+          type: string
+          default: BARCODE
+          enum:
+            - BARCODE
+            - QR
+          description: type of requested barcode
+        - name: imageWidth
+          in: query
+          type: integer
+          format: int8
+          description: requested minimal width of the generated barcode image
+        - name: imageHeight
+          in: query
+          type: integer
+          format: int8
+          description: requested minimal height of the generated barcode image
+      responses:
+        '200':
+          description: File as bytes.
+          schema:
+            type: file
+
+  /bulk:
+    post:
+      summary: Request an operation on a set of Inventory items
+      description: >-
+
+        The POST request sent to `/bulk` endpoint executes an operation on a set of items.
+
+
+        Items passed to `/bulk` endpoint can represent samples, subsamples, containers or any mix of the types. Each item has to have `type` parameter provided, one of:
+        `SAMPLE`, `SUBSAMPLE`, `CONTAINER` or `SAMPLE_TEMPLATE`.
+
+        ## Supported operations
+
+        Request body has to provide top-level `operationType` field specifying requested action, which can be one of: `CREATE`, `UPDATE`, `DELETE`, `RESTORE`, `DUPLICATE`, `MOVE`, `CHANGE_OWNER`.
+
+
+        In principle, the operation executed for a set of items will be the same as calling particular create (POST), update (UPDATE), delete (DELETE), or /duplicate (POST) endpoint directly for each item. The exception is MOVE operation, which executes move for all items 'at once' to support more complex move scenarios like swapping the items inside a container.
+
+        ## Handling mid-operation errors
+
+        By default, if an error is encountered during bulk operation, the whole operation is reverted. This can be changed by setting `"rollbackOnError":false` parameter in the request body. With `"rollbackOnError":false` the operation is executed in a separate transaction for each provided item, and if an error is encountered when processing the particular item, that item is skipped, but the operation continues.
+
+
+        `MOVE` operation cannot be called with `"rollbackOnError":false` i.e. will always revert if error is encountered. That's because implementation details don't allow for commiting partial move result.
+
+        ## Accessing functionality available through query parameters
+
+        Individual  endpoints may support extra query parameters for additional functionality. For bulk operations, these can be reproduced by setting field with the same name as query parameter, in the JSON body.
+
+
+        For example: /samples DELETE endpoint supports additional "forceDelete" setting with query parameter. For bulk delete operation the same behaviour can be achieved by passing sample item as { "type": "SAMPLE", "id": "<id>", "forceDelete": <true/false> }.
+
+
+        *Note* that `type` has to appear as the first property in the JSON object defining each item. This is required by the JSON-parsing library used by RSpace.
+
+        ## Examples of the request body
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        { "operationType": "CREATE", "records": [ { "type": "SAMPLE", "name": "mySample",  "newSampleSubSamplesCount": 2 }, { "type": "CONTAINER", "cType": "LIST", "name": "myContainer" } ] } | Create a sample (with two default subsamples) and a list container.
+
+        { "operationType": "UPDATE", "records": [ { "type": "SUBSAMPLE", "id": "851970", "name":"mySample.updated", "tags":[{"value":"apiEdited","uri":"http://uri","ontologyName":"name","ontologyVersion":"version"}] }, { "type": "SUBSAMPLE", "id": "851971", "tags":"apiEdited", "parentContainers": [ { "id": 720896} ] } ] } | Rename and tag first subsample, tag and move another.
+
+        { "operationType": "MOVE", "records": [ { "type": "SUBSAMPLE", "id": "851970", "parentContainers": [ { "id": 720896} ], "parentLocation": { "coordX": 1, "coordY": 1 } }, { "type": "CONTAINER", "id": "851971", "removeFromParentContainerRequest": true } ] } | Move one subsamples into grid container location, move another container to top-level containers.
+
+        { "operationType": "DELETE", "rollbackOnError": false, "records": [ { "type": "SAMPLE", "id": "851970", "forceDelete": true }, { "type": "CONTAINER", "id": "851971" } ] } | Delete a sample and a container, proceed even if sample has problematic subsamples ("forceDelete": true) and if one of the records cannot be deleted ("rollbackOnError": false).
+
+        { "operationType": "RESTORE", "rollbackOnError": false, "records": [ { "type": "SUBSAMPLE", "id": "851970" }, { "type": "CONTAINER", "id": "851971" } ] } | Restores deleted subsample and a container. If restored subsample belongs to a sample that was deleted, that sample is restored too.
+
+        { "operationType": "CHANGE_OWNER", "records": [ { "type": "SAMPLE", "id": "851970", "owner" : { "username": "newOwner"} }, { "type": "CONTAINER", "id": "851971", "owner" : { "username": "newOwner"} } ] } | Transfers a sample and a container to another user.
+
+      tags:
+        - Bulk Operations
+      parameters:
+        - $ref: '#/parameters/bulkOperationBodyParam'
+      responses:
+        '201':
+          description: >-
+            Success.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+
+  '/import/parseFile':
+    post:
+      summary: Parse the incoming CSV file for import UI
+      description: >
+
+
+
+        ### Parsing containers/subsamples CSV file
+
+        When provided `recordType` parameter has value: `CONTAINERS` or `SUBSAMPLES`, the endpoint verifies basic structure of the data and returns the object containing:
+
+          * `columnNames`: array of column names in CSV file.
+          * `columnsWithoutBlankValue`: array of column names which CSV lines have no blank value
+          * `rowsCount`: number of data rows found in CSV file
+
+
+        ### Parsing samples CSV file
+
+        When provided `recordType` parameter has value: `SAMPLES`, the endpoint verifies basic structure of the data and suggests the template definition that could be used for running an actual import with `/import/importFiles` endpoint.
+
+
+        Upon successful parsing the response object contains:
+          * `templateInfo`: a definition of a suggested template. The template definition can be modified by the client, or can be used immediately to populate `importSettings.sampleSettings.templateInfo` parameter required by `/import/importFiles` endpoint
+          * `fieldNameForColumnName`: map that allows finding suggested field name for given CSV colum name. It could be that column name used in CSV file is not a valid RSpace template field name, in which case the field suggested for `templateInfo` will have a name adjusted to match the rules.
+          * `radioOptionsForColumn`: it could be that particular column in CSV file should be converted to Radio/Choice field, but the parsing algorithm suggested another field type. In such case the client can adjust `templateInfo` field definition and populate radio definition using this map
+          * `quantityUnitForColumn`: lists the columns that could be converted to "Quantity" field, with the id of suggested quantity unit
+          * `columnNames` list of column names in CSV file. This are the names that should be provided in `fieldMappings` object used by `/import/importFiles`.
+          * `columnsWithoutBlankValue`: array of column names which CSV lines have no blank value
+          * `rowsCount`: number of data rows found in CSV file
+
+      produces:
+        - application/json
+      tags:
+        - Import
+      parameters:
+        - name: file
+          in: formData
+          type: file
+          required: true
+        - name: recordType
+          in: query
+          type: string
+          default: SAMPLES
+          enum:
+            - SAMPLES
+            - SUBSAMPLES
+            - CONTAINERS
+      consumes:
+        - multipart/form-data
+      responses:
+        '200':
+          description: Parse results.
+
+  '/import/importFiles':
+    post:
+      summary: Import Containers, Samples and SubSamples from CSV files
+      description: >-
+
+        Allows import of up to three CSV files describing samples and/or subSamples and/or containers. Providing multiple files allows referencing rows in one file with rows in another file, e.g. saying that particular subSample from subSample CSV should be part of a particular samples from sample CSV file placed in a particular container from container CSV. If the files don't need to reference each other it may be easier to to import them separately.
+
+
+        `importSettings` must be a JSON object that contains settings for one or more imported csv file:
+           * `containerSettings` for containers (skip if not importing containers)
+           * `sampleSettings` for samples (skip if not importing samples)
+           * `subSampleSettings` for subSamples (skip if not importing subSamples)
+
+
+        There is a limit on size of CSV files. By default CSVs can containe no more than 500 containers, 1000 samples or 2000 subSamples.
+
+
+        ## Containers import
+
+        Import content of CSV file as inventory containers, possibly set up in a hierarchy.
+
+
+        `containerSettings` must be a JSON object with a following property:
+           * `fieldMappings` field that is used to map CSV columns to standard container fields, for setting up containers hierarchy, and for marking CSV columns that should be ignored.
+
+        To map CSV column name to standard container field set property of `fieldMappings` with a name of CSV column and a value being one of: `name`, `description`, `tags`. To ignore CSV column set value to null.
+
+
+        To set up containers hierarchy add column mappings into `import identifier` and `parent container import id`. The `import identifier` must be a column with unique values that are references in `parent container import id` column.
+
+
+        Created containers will be placed by default in a new container that is created on user's Bench during import. To put a container into container already existing in the system, put the global id of that existing container in container CSV column mapped to `parent container global id`.
+
+
+        ## Samples import
+
+        Imports content of CSV file as samples based on newly created, or pre-existing sample template.
+
+
+        `sampleSettings` must be a JSON object with following properties:
+           * `templateInfo` field containing either full definition for a new sample template (same as used in sample template POST api, or as retrived by `/import/parseFile` endpoint), or with `id` property pointing to existing sample template that should be used
+           * `fieldMappings` field that is used to map CSV columns to standard sample fields (optional, apart from `name`), for pointing to parent container (optional), and for marking CSV columns that should be ignored.
+
+
+        To map CSV column name to standard sample field set property of `fieldMappings` with a name of CSV column and a value being one of: `name`, `description`, `tags`, `source`, `expiry date`, `quantity`. To ignore CSV column set value to null.
+
+
+        The values from CSV columns not mentioned in `fieldMappings` will be imported into sample fields defined by the template, in the order of fields in the template (i.e. 1st CSV column into 1st sample field, 2nd into 2nd, etc.).
+        The number of CSV columns mapped into sample fields has to exactly match the number of template fields, i.e. CSV file must have a column for every template field, in the right order.
+
+
+        Each imported sample will have, by default, a single subsample, placed in a new container created on user's Bench during import. To put a default subsample into one of the containers imported through containers CSV in the same import operation the sample CSV column can be mapped to `parent container import id`, with values corresponding to values in containers CSV mapped to `import identifier`. To put a default subsample into preexisting container put the global id of that container in sample CSV column mapped to `parent container global id`.
+
+
+        ## SubSample import
+
+        Imports content of CSV file as subSamples of pre-existing samples, or of samples being imported as a part of the same import operation.
+
+
+        Each of the subSamples must reference parent sample through a value in column mapped to either `parent sample import id` or `parent sample global id`. In the first case the value needs to correspond to 'import identifier' value in samples CSV imported in the same operation (which means samples CSV, and `sampleSettings` must also be present in POST request). Second case i.e. importing into pre-existing samples doesn't require samples CSV, in that case value in column mapped to `parent sample global id` should be a global id of a pre-existing sample that is editable by the current user.
+
+
+        `subSampleSettings` must be a JSON object with a following property:
+           * `fieldMappings` field that is used to map CSV columns to standard subSample fields (optional, apart from `name` mapping which is required), for pointing to parent sample (required), for pointing to parent container (optional), and for marking CSV columns that should be ignored.
+
+        To map CSV column name to standard subSample field set property of `fieldMappings` with a name of CSV column and a value being one of: `name`, `description`, `tags`. To ignore CSV column set value to null.
+
+
+        Created subSamples will be placed by default in a new container that is created on user's Bench during import. To put a subsample into one of the containers imported through containers CSV in the same import operation the subSample CSV column can be mapped to `parent container import id`, with values corresponding to values in containers CSV mapped to `import identifier`. To put a subsample into preexisting container put the global id of that container in subSample CSV column mapped to `parent container global id`.
+
+
+        ## Import results
+
+        Import result object contains:
+          * `containerResults`, `sampleResults` and `subSampleResults` objects with details of container/sample/subsamples imports
+          * `status` property, which for successful import will be set to "COMPLETED".
+
+        If any error occurs before/during import process, then all changes are reverted, i.e. nothing is created unless the import completes with status "COMPLETED".
+
+        ## Examples of the `importSettings` object
+
+        | importSettings | Explanation |
+
+        | --- | --- |
+
+        { "sampleSettings": { "templateInfo": { ... }, "fieldMappings" : { "Antibody Name": "name" } } } |
+        Import samples, use CSV column named 'Antibody Name' for the name of the imported sample
+
+        { "sampleSettings": { "templateInfo": { ... }, "fieldMappings" : { "Name": "name", "Alternative name": "description", "Dummy Data": null, "Best Before": "expiry date" } } } |
+        Import samples, use CSV column named 'Name' for a name of imported sample, "Alternative name" as a description of imported sample, and 'Best Before' as an expiry date.
+        Also ignore CSV column named 'Dummy Data'.
+
+        { "sampleSettings": { "templateInfo": { "id": 12 }, "fieldMappings" : { ... } } } |
+        Import samples, use CSV lines to create samples based on pre-existing template with id = 12.
+
+        { "containerSettings": { "fieldMappings" : { "Name": "name", "Import Id": "import identifier", "Parent Container Import Id": "parent container import id" } } } |
+        Import hierarchy of containers.
+
+        { "containerSettings": { "fieldMappings" : { "Name": "name", "Import Id": "import identifier" } }, "sampleSettings": { "templateInfo": { ... }, "fieldMappings" : { "Name": "name", "Parent Container Import Id": "parent container import id" } } } |
+        Combined sample/container import that can also move default subsamples created during sample import into imported containers (with "parent container import id" -> "import identifier" mappings).
+
+        { "containerSettings" : { "fieldMappings" : { "Name": "name", "Import Id": "import identifier" } }, "sampleSettings": { "templateInfo": { ... }, "fieldMappings" : { "Name": "name", "Import Id": "import identifier" } }, "subSampleSettings": { "fieldMappings" : { "Name": "name", "Parent Sample Import Id": "parent sample import id", "Parent Container Import Id": "parent container import id" } } } |
+        Combined container/sample/subSample import that puts subSamples into imported samples, and can also move imported subSamples into imported containers (with "paret container import id" -> "import identifier" mappings)
+
+        { "subSampleSettings": { "fieldMappings" : { "Name": "name", "Parent Sample Global Id": "parent sample global id", "Parent Container Global Id": "parent container global id" } } } |
+        Import subSamples into pre-existing samples and containers.
+
+      produces:
+        - application/json
+      tags:
+        - Import
+      parameters:
+        - name: containersFile
+          in: formData
+          type: file
+        - name: samplesFile
+          in: formData
+          type: file
+        - name: subSamplesFile
+          in: formData
+          type: file
+        - name: importSettings
+          in: formData
+          type: string
+          description: JSON settings string for import operation.
+          required: true
+      consumes:
+        - multipart/form-data
+      responses:
+        '200':
+          description: Import results.
+
+  /fieldmark/notebooks:
+    get:
+      summary: List Fieldmark notebooks that could be imported by the current user
+      description: >-
+        Return the list of Fieldmark notebooks that are readable by the current RSpace user.
+        
+        The pre-requisite is that user enables Fieldmark App on RSpace Apps page, and saves their Fieldmark API token.
+      produces:
+        - application/json
+      tags:
+        - Import
+      responses:
+        '200':
+          description: >-
+            Returns a list of notebook Ids for the given user
+
+  /fieldmark/notebooks/igsnCandidateFields:
+    get:
+      summary: List Fieldmark fields (of a given notebook) that could be imported as IGSN
+      description: >-
+        Return the list Fieldmark fields (of a given notebook) that could be imported as IGSN
+        
+        The pre-requisite is that user enables Fieldmark App on RSpace Apps page, and saves their Fieldmark API token.
+      produces:
+        - application/json
+      tags:
+        - Import
+      parameters:
+        - name: notebookId
+          in: query
+          description: The notebookId to check
+          type: string
+          required: true
+      responses:
+        '200':
+          description: >-
+            Returns a list of fields that can be imported as Igsn
+
+  /import/fieldmark/notebook:
+    post:
+      summary: >-
+        Import a notebook from Fieldmark into the RSpace Inventory
+      description: >-
+        Import a notebook from Fieldmark into the RSpace Inventory by mapping:
+         - Fieldmark notebook to a RSpace Container
+         - Fieldmark Record to a RSpace Sample
+        
+        
+        It will also create a RSpace Sample Template for all the Samples created.
+        
+        
+        NOTE: At the moment this import supports ONLY Fieldmark notebook with a single FormID
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Import
+      parameters:
+        - name: FieldmarkApiImportRequest
+          in: body
+          description: >-
+            The ID for the Fieldmark notebook. 
+            The notebook ID is returned in `project_id` property 
+            of the `/fieldmark/notebooks` response (*required*)
+            
+            The name of the field you want to be imported as DOI identifier (*optional*).
+            DataCite and Inventory MUST be enabled by the admin in order to map to DOi Identifiers
+          required: true
+          schema:
+            $ref: '#/definitions/FieldmarkApiImportRequest'
+      responses:
+        '201':
+          description: >-
+            The Fieldmark notebook has been correctly imported into RSpace
+          schema:
+            $ref: '#/definitions/FieldmarkApiImportResult'
+
+
+  '/export':
+    post:
+      summary: Export Containers, Samples and SubSamples as CSV files
+      description: >-
+
+        `exportSettings` is a required parameter, which must be a JSON object containing one of the following properties:
+           * `globalIds` with an array of global ids of inventory items that should be included in export
+           * `users` with an array of usernames of users whose inventory items should be included in export
+
+
+        `exportSettings` may also contain optional properties:
+           * `exportMode` with a value of `COMPACT` or `FULL`. Default is `FULL`, which means both basic data and custom/template field content is included in export. `COMPACT` mode only exports basic data, without fields
+           * `includeSubsamplesInSample` with a true/false boolean value. Default is `true`, which means subsamples of exported samples are included in export. `false` means the sample's subsamples are excluded
+           * `includeContainerContent` with a true/false boolean value. Default is `false`, which means content of the exported container will not be included in export. `true` means that subsamples and subcontainers stored inside exported container will be exported too (including content of these subcontainers, and their content, etc.)
+
+        ## Examples of the `exportSettings` object
+
+        | exportSettings | Explanation |
+
+        | --- | --- |
+
+        { "globalIds": [ "SS11", "SS12", "SS13" ] } |
+        Export selection of items (3 subsamples with id: 11, 12, 13)
+
+        { "globalIds": [ "SA21", "SS11", "SS12" ], "includeSubsamplesInSample": false } |
+        Export selection of items (a samples and 2 subsamples), without subsamples of an exported sample
+
+        { "globalIds": [ "IC6" ], "includeContainerContent": true } |
+        Export a container IC6, including all it's content.
+
+        { "users": [ "user1a" ], "exportMode": "COMPACT" } |
+        Export basic metadata of all inventory items belonging to user1a.
+
+        { "users": [ "user1a" ], "resultFileType": "SINGLE_CSV" } |
+        Export data of all inventory items belonging to user1a with results put into single CSV file, rather than ZIP archive.
+
+        ## Result
+
+        Successful export action will return details of executed export task, including links to created archive file in `"_links"` property. The link for direct download through UI (assumes client has active web session) is marked with `"rel": "downloadLink"`. The link for download through API is marked as `"rel": "enclosure"`.
+
+      produces:
+        - application/json
+      tags:
+        - Export
+      parameters:
+        - name: exportSettings
+          in: formData
+          type: string
+          description: JSON settings string for export operation.
+          required: true
+      consumes:
+        - multipart/form-data
+      responses:
+        '200':
+          description: Results of export task. "_links" array will contain URIs pointing to exported file.
+          schema:
+            $ref: '#/definitions/Job'
+
+  '/editLocks/{globalId}':
+    post:
+      summary: Lock the inventory item for editing
+      description: >
+        Creates an edit lock for an item. When an item is locked, only the user having a lock will be able to modify the it. Lock expires automatically after some time (typically 15-30 minutes). It  can be also released by calling DELETE endpoint.
+
+        User who locked the item can call the endpoint again to extend the lock.
+
+        You must have UPDATE permission for the item to lock it.
+
+      produces:
+        - application/json
+      tags:
+        - Edit Locks
+      parameters:
+        - $ref: '#/parameters/globalIdParam'
+      responses:
+        '200':
+          description: Lock is set.
+
+    delete:
+      summary: Release edit lock from the inventory item
+      description: >
+        Removes edit lock from the item. You must be an owner of the current lock for the operation to succeed.
+
+      produces:
+        - application/json
+      tags:
+        - Edit Locks
+      parameters:
+        - $ref: '#/parameters/globalIdParam'
+      responses:
+        '200':
+          description: Lock is released.
+
+  '/files':
+    post:
+      summary: Upload file as an attachment to the inventory item or sample field
+      description: >
+
+        Uploads a file as an attachment to the inventory item or sample field of 'attachment' type.
+
+        `fileSettings` must be a JSON object with the following properties:
+           * `parentGlobalId` property pointing to the inventory item, or sample field, for which this attachment is uploaded.
+           * `fileName` (optional) property containing a name for the file. If not present, the name connected with an uploaded stream will be used
+
+        #### Examples of the `fileSettings` object
+
+        | fileSettings | Explanation |
+
+        | --- | --- |
+
+        { "parentGlobalId": "IC8" } | Add file as attachment to container with id=8, use filename as an attachment name
+
+        { "parentGlobalId": "SA10", "fileName": "test.txt" } | Add file as attachment to sample with id=10, set the attachment name to "test.txt"
+
+        { "parentGlobalId": "SF11" } | Add file as attachment to a sample field with id=11. This must be an 'attachment' type field.
+
+
+      produces:
+        - application/json
+      tags:
+        - Attached Files
+      parameters:
+        - name: file
+          in: formData
+          type: file
+          required: true
+        - name: fileSettings
+          in: formData
+          type: string
+          description: json settings string for upload file operation.
+          required: true
+      consumes:
+        - multipart/form-data
+      responses:
+        '200':
+          description: Details of uploaded attachment (ApiInventoryFile object).
+
+  '/files/{fileId}':
+    get:
+      summary: Retrieves details of an inventory attachment
+      description: Gets a single ApiInventoryFile by its id.
+      produces:
+        - application/json
+      tags:
+        - Attached Files
+      parameters:
+        - $ref: '#/parameters/inventoryFileIdParam'
+      responses:
+        '200':
+          description: A File object.
+          schema:
+            $ref: '#/definitions/File'
+        '404':
+          description: 'File does not exist, or you can''t access it.'
+
+    delete:
+      summary: Delete inventory attachment
+      description: Marks inventory file as deleted, so it won't appear on attachments list.
+      produces:
+        - application/json
+      tags:
+        - Attached Files
+      parameters:
+        - $ref: '#/parameters/inventoryFileIdParam'
+      responses:
+        '200':
+          description: An ApiInventoryFile object.
+          schema:
+            $ref: '#/definitions/File'
+        '404':
+          description: 'File does not exist, or you can''t access it.'
+
+  '/files/{fileId}/file':
+    get:
+      summary: Gets binary content of an inventory attachment
+      description: >
+        Downloads file contents. The content type of the response will be the
+        `contentType` of the enclosing media item.
+
+        When calling the endpoint with swagger-ui set the 'Response Content
+        Type' to `application/octet-stream` to get a working 'Download file'
+        link in response body, or switch the type to `application/json`to debug
+        any server error messages.
+      produces:
+        - application/json
+      tags:
+        - Attached Files
+      parameters:
+        - $ref: '#/parameters/inventoryFileIdParam'
+      responses:
+        '200':
+          description: Binary content of the attachment file
+
+  '/files/{fileId}/chemFileDetails':
+    get:
+      summary: Get chemical attachment details
+      description: >
+        Parses attached inventory file into chemical details object.
+
+        Basically equivalent of ELN endpoint `/chemical/ajax/loadChemElements`, but asks for inventory file id as a parameter, rather than chemId.
+
+
+        Requires chemistry conversion service to be properly configured and available.
+      produces:
+        - application/json
+      tags:
+        - Attached Files
+      parameters:
+        - $ref: '#/parameters/inventoryFileIdParam'
+      responses:
+        '200':
+          description: Chemical details object
+
+  '/files/image/{contentsHash}':
+    get:
+      summary: Gets the file data for the image file with the given contents hash.
+      description: >
+        Gets the contents of the file matching the contentsHash. Contents hash is used here to improve
+        cache-ability of the images since any images which are the same in any container, sample, or 
+        sub-samples will have the same hash.
+      produces:
+        - application/json
+        - application/octet-stream
+      tags:
+        - Image Files
+      parameters:
+        - $ref: '#/parameters/contentsHashParam'
+      responses:
+        '200':
+          description: Image file bytes
+        '401':
+          description: Not authorised to read the image file
+        '404':
+          description: Image file with given contents hash not found
+
+  '/attachments':
+    post:
+      summary: Attach existing Gallery item to the inventory item or sample field
+      description: >
+
+        Attaches existing Gallery file to the inventory item or sample field of 'attachment' type.
+
+        Body must be a JSON object with the following properties:
+           * `parentGlobalId` property pointing to the inventory item, or sample field, for which this attachment is uploaded.
+           * `mediaFileGlobalId` property pointing to the Gallery item that should be connected as an attachment.
+
+      produces:
+        - application/json
+      tags:
+        - Attached Gallery Items
+      parameters:
+        - in: body
+          name: attachmentDetails
+          type: string
+          description: json settings string for attaching gallery file operation.
+          required: true
+          example: { "parentGlobalId": "IC8", "mediaFileGlobalId": "GL12" }
+      responses:
+        '200':
+          description: Details of connected attachment (ApiInventoryFile object).
+
+
+  '/identifiers':
+    get:
+      summary: Get all the identifiers created by the `user` with a given `state`
+      description: >
+        It will return a list of identifiers that are created by the specific `user` 
+        and having the specific `state`. 
+
+        Moreover you can specify the filter `isAssociated` in case you want ONLY the Identifiers 
+        that have already been bound to a record.
+        
+        You can specify a DOI for the parameter `identifier` in one of the supported formats:
+         * `10.47366/3bgk.v5n1a3`
+         * `https://doi.org/10.47366/3bgk.v5n1a3`
+
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      parameters:
+        - name: state
+          description: The state of the Identifier you want to filter in the list
+          type: string
+          in: query
+          required: false
+        - name: isAssociated
+          in: query
+          type: boolean
+          required: false
+          description: Filter only the Identifiers that are already associated to a record
+        - name: identifier
+          description: The identifier you want to search
+          type: string
+          in: query
+          required: false
+      responses:
+        '200':
+          description: The list is successfully returned
+
+    post:
+      summary: Register a new DataCite IGSN identifier for an inventory item
+      description: >
+        Creates an identifier for the requested inventory item. Requires object with one "parentGlobalId" property as a request body.
+
+        You must have UPDATE permission for the item to create an identifier for it.
+
+        ## Example request body
+
+        | POST request body | Explanation |
+
+        | --- | --- |
+
+        { "parentGlobalId": "IC8" } | Register new identifier for a container with id=8
+
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            "$ref": "#/definitions/BasicObject"
+      responses:
+        '201':
+          description: Identifier is created
+
+
+  '/identifiers/bulk/{count}':
+    post:
+      summary: Register a number of DataCite IGSN identifier without associating them to any inventory item
+      description: >
+        Register a number of DataCite IGSN identifier without associating them to any inventory item
+
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      parameters:
+        - name: count
+          description: The id for the formIcon
+          type: integer
+          format: int64
+          in: path
+          required: true
+      responses:
+        '201':
+          description: Identifiers are created
+
+
+  '/identifiers/{doiId}/assign':
+    post:
+      summary: Assign a DataCite IGSN identifier to any inventory item
+      description: >
+        Assign a DataCite IGSN identifier to any inventory item
+        
+        The existing identifier MUST be:
+         * Unassigned
+         * not deleted
+         * in `draft`state
+        
+        It requires object with one `parentGlobalId` property as a request body.
+
+        You must have UPDATE permission for the item to create an identifier for it.
+
+        ## Example request body
+
+        | POST request body | Explanation |
+
+        | --- | --- |
+
+        { "parentGlobalId": "SS12" } | Register new identifier for a SubSample with id=12
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      parameters:
+        - name: doiId
+          type: string
+          in: path
+          required: true
+          description: The database ID of the identifier
+        - name: body
+          in: body
+          required: true
+          schema:
+            "$ref": "#/definitions/BasicObject"
+          description: The globalId of the inventory Item (for example "SS12")
+      responses:
+        '201':
+          description: Identifier is assigned to the inventory item
+
+
+  '/identifiers/{doiId}':
+    delete:
+      summary: Delete a draft DataCite IGSN identifier that was not associated or that was registered for the inventory item
+      description: >
+        Attempts to delete a connected DataCite IGSN identifier.
+
+        You must have UPDATE permission for the item to delete its identifier.
+
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      parameters:
+        - $ref: '#/parameters/digitalObjectIdentifierIdParam'
+      responses:
+        '200':
+          description: Identifier is created
+
+  '/identifiers/{doiId}/publish':
+    post:
+      summary: Publish an identifier, and the connected inventory item
+      description: >
+        Publishes DataCite IGSN identifier and connected record.
+
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      parameters:
+        - $ref: '#/parameters/digitalObjectIdentifierIdParam'
+      responses:
+        '200':
+          description: Identifier and inventory item are published.
+
+  '/identifiers/{doiId}/retract':
+    post:
+      summary: Retract an identifier, and unpublish connected inventory item
+      description: >
+        Retracts DataCite IGSN identifier and hides previously published connected record.
+
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      parameters:
+        - $ref: '#/parameters/digitalObjectIdentifierIdParam'
+      responses:
+        '200':
+          description: Identifier is retracted and inventory item is hidden.
+
+  '/identifiers/testDataCiteConnection':
+    get:
+      summary: Test connection settings saved for DataCite integration
+      description: >
+        Test connection settings saved for DataCite integration
+      produces:
+        - application/json
+      tags:
+        - IGSN Identifiers
+      responses:
+        '200':
+          description: boolean saying whether connection was successful
+
+  '/baskets':
+    get:
+      summary: 'Get all baskets belonging to the current user'
+      description:
+        Return info for all baskets belonging to the current user.
+      produces:
+        - application/json
+      tags:
+        - Baskets
+      responses:
+        '200':
+          description: List of baskets belonging to the current user
+
+    post:
+      summary: Create new basket
+      description: >
+
+        { "name": "List A" } | Create new empty basket named  "List A"
+
+      parameters:
+        - $ref: '#/parameters/basketPostParam'
+      produces:
+        - application/json
+      tags:
+        - Baskets
+      responses:
+        '200':
+          description: A new basket created for the current user
+
+  '/baskets/{basketId}':
+    get:
+      summary: 'Get a specific basket'
+      description:
+        Endpoint returning a single basket, with content.
+      produces:
+        - application/json
+      tags:
+        - Baskets
+      parameters:
+        - $ref: '#/parameters/basketIdParam'
+      responses:
+        '200':
+          description: Basket with content
+    put:
+      summary: Update details of specific basket
+      description: >
+
+        Only "name" change support for now.
+
+        { "name": "List A2" } | Modifies basket name to "List A2"
+
+      tags:
+        - Baskets
+      parameters:
+        - $ref: '#/parameters/basketIdParam'
+        - $ref: '#/parameters/basketBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - container is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+    delete:
+      summary: Remove a specific basket
+      description: >
+        .
+      produces:
+        - application/json
+      tags:
+        - Baskets
+      parameters:
+        - $ref: '#/parameters/basketIdParam'
+      responses:
+        '200':
+          description: The basket is removed.
+
+  '/baskets/{basketId}/addItems':
+    post:
+      summary: 'Add inventory item(s) to a given basket'
+      description:
+        Add items to basket, by providing the array of items global ids.
+      produces:
+        - application/json
+      tags:
+        - Baskets
+      parameters:
+        - $ref: '#/parameters/basketIdParam'
+        - $ref: '#/parameters/basketItemsParam'
+      responses:
+        '200':
+          description: items added
+
+  '/baskets/{basketId}/removeItems':
+    post:
+      summary: 'Remove inventory item(s) from a given basket'
+      description:
+        Remove items from basket, by providing the array of items global ids.
+      produces:
+        - application/json
+      tags:
+        - Baskets
+      parameters:
+        - $ref: '#/parameters/basketIdParam'
+        - $ref: '#/parameters/basketItemsParam'
+
+      responses:
+        '200':
+          description: items removed
+
+  '/listOfMaterials/forDocument/{docId}':
+    get:
+      summary: 'Get all lists of materials used in ELN document'
+      description: >
+        Returns all  lists of materials connected to given ELN document.
+
+
+        Note: lists of materials returned by this endpoint each have `elnDocument` property set to `null`. This is to avoid repeating the information, as every list references the same document.
+
+      produces:
+        - application/json
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/docIdParam'
+      responses:
+        '200':
+          description: List of material usages registered for each field of the document
+
+  '/listOfMaterials/forField/{elnFieldId}':
+    get:
+      summary: 'Get all list of materials used for a field in ELN document'
+      description: >
+        Return list of materials connected to a field in an ELN document.
+
+
+        Note: lists of materials returned by this endpoint each have `elnDocument` property set to `null`. This is to avoid repeating the information, as every list references the same document.
+
+      produces:
+        - application/json
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/elnFieldIdParam'
+      responses:
+        '200':
+          description: List of material usages registered for a field of the document
+
+  '/listOfMaterials/forInventoryItem/{globalId}':
+    get:
+      summary: 'Get all list of materials containing a specific inventory item'
+      description:
+        Return list of materials that are using a specific sample/subsample/container.
+      produces:
+        - application/json
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/globalIdParam'
+      responses:
+        '200':
+          description: List of material usages containing a specific inventory item
+
+  '/listOfMaterials':
+    post:
+      summary: Register new list of materials for a particular ELN field
+      description: >
+        Register usage of an ELN materials within ELN document.
+
+        ## Example POST requests
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        { "name": "List A", "elnFieldId": 123 } | Create new empty list of materials, named "List A", attached to document field with id 123.
+
+      produces:
+        - application/json
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/listOfMaterialsBodyParam'
+      responses:
+        '200':
+          description: A registered material usage
+
+  '/listOfMaterials/{lomId}':
+    get:
+      summary: 'Get a specific list of materials'
+      description:
+        Endpoint returning a single list of materials connected to an ELN document field.
+      produces:
+        - application/json
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/lomIdParam'
+      responses:
+        '200':
+          description: List of material usages registered for each field of the document
+    put:
+      summary: Save a specific list of materials
+      description: >
+
+        Update usage of an ELN materials within ELN document.
+
+        If `usedQuantity` is specified, the client can also request simultanous update of connected
+        inventory item. This is done by passing `"updateInventoryQuantity": true` param. The
+        quantity of the connected item will be reduced by the quantity used in the list of materials.
+        If used quantity is larger than current quantity of connected item, then quantity of connected
+        item is set to zero (i.e. it is never negative).
+
+        If the list of materials was already saved with `usedQuantity` for given item, and new
+        `usedQuantity` is different, the `updateInventoryQuantity` param will adjust quantity of connected
+        item by a difference between old and new used quantity. E.g. if previously saved `usedQuantity`
+        was 5 units, and new `usedQuantity` is 6 units, and `updateInventoryQuantity` is set, then
+        quantity of connected item will be reduced by 1 unit.
+
+        ## Example PUT requests
+
+        | Body | Explanation |
+
+        | --- | --- |
+
+        { "materials": [ ] } | Removes all materials fom the list
+
+        { "materials": [ { "invRec": { "id": 123, "type": "CONTAINER"} } ] } | Sets the list of used materials to one item - container with id 123.
+
+        { "materials": [ { "invRec": { "id": 123, "type": "CONTAINER"} }, { "invRec": { "id": 234, "type": "SUBSAMPLE" }, "usedQuantity": { "unitId": 3, "numericValue": 5 }, "updateInventoryQuantity": true } ] } | Sets the list of used materials to two items - container with id 123, and 5ml of subsample with id 234. Also reduces the current quantity of subsample 234 by 5ml.
+
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/lomIdParam'
+        - $ref: '#/parameters/listOfMaterialsBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - container is updated.
+        '404':
+          $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+    delete:
+      summary: Remove a specific list of materials
+      description: >
+        .
+      produces:
+        - application/json
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/lomIdParam'
+      responses:
+        '200':
+          description: The List of Materials is removed.
+
+  '/listOfMaterials/{lomId}/canEdit':
+    get:
+      summary: 'Can current user edit a specific list of materials'
+      description:
+        Endpoint calculates if user can edit a list of materials with given id,
+        i.e. whether this list of materials belongs to an experiment that user can edit
+      produces:
+        - application/json
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/lomIdParam'
+      responses:
+        '200':
+          description: true/false depending if user can edit the list of materials
+
+  '/listOfMaterials/{lomId}/revisions/{revisionId}':
+    get:
+      summary: 'Gets historical revision of a specific list of materials'
+      description:
+        Returns historical revision of a specific list of materials.
+      produces:
+        - application/json
+      tags:
+        - ELN integration
+      parameters:
+        - $ref: '#/parameters/lomIdParam'
+        - $ref: '#/parameters/revisionIdParam'
+      responses:
+        '200':
+          description: A list of materials, as it was at a requested historical revision
+        '404':
+          $ref: '#/responses/NotFound'
+
+  '/public/view/{publicLink}':
+    get:
+      summary: 'Get published inventory item by public link'
+      description: returns
+      produces:
+        - application/json
+      tags:
+        - Published Items
+      parameters:
+        - $ref: '#/parameters/publicLinkParam'
+      responses:
+        '200':
+          description: A public view of the published item
+        '404':
+          $ref: '#/responses/NotFound'
+
+  '/system/settings':
+    get:
+      summary: 'Get settings'
+      description: returns settings
+      produces:
+        - application/json
+      tags:
+        - System Settings (System Admin only)
+      responses:
+        '200':
+          description: List of baskets belonging to the current user
+    put:
+      summary: 'Update settings'
+      description: update settings
+      tags:
+        - System Settings (System Admin only)
+      parameters:
+        - $ref: '#/parameters/inventorySettingsBodyParam'
+      responses:
+        '200':
+          description: >-
+            Success - settings are updated.
+        '422':
+          $ref: '#/responses/UnprocessableQuery'
+
+
+definitions:
+  BasicObject:
+    type: object
+  InventoryRecordInfo:
+    description: Basic information common for RSpace Inventory Entities
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier for the item.
+      globalId:
+        type: string
+        description: A unique identifier amongst all RSpace data types.
+      name:
+        type: string
+        description: The Sample's name.
+      description:
+        type: string
+        description: The Sample's description.
+      created:
+        type: string
+        format: date-time
+        description: The creation time of the item.
+      createdBy:
+        type: string
+        description: Username of the item's creator.
+      lastModified:
+        type: string
+        format: date-time
+        description: The last modification time of the item.
+      modifiedBy:
+        type: string
+        description: Username of the last person modifiying the item.
+      modifiedByFullName:
+        type: string
+        description: Full name of the last person modifiying the item.
+      deleted:
+        type: boolean
+        description: Whether item is deleted or not.
+      deletedDate:
+        type: string
+        format: date-time
+        description: For deleted item - date of deletion
+      iconId:
+        type: integer
+        format: int64
+        description: The item's icon identifier.
+      quantity:
+        $ref: '#/definitions/Quantity'
+      tags:
+        $ref: '#/definitions/TagList'
+      type:
+        type: string
+        description: Type of the inventory item, must be one of allowed values.
+        enum:
+          - SAMPLE
+          - SUBSAMPLE
+          - CONTAINER
+          - SAMPLE_TEMPLATE
+      attachments:
+        $ref: '#/definitions/FileList'
+      barcodes:
+        $ref: '#/definitions/BarcodeList'
+      owner:
+        $ref: '#/definitions/User'
+      permittedActions:
+        type: array
+        description: List of actions that current user can perform with the item
+        items:
+          type: string
+          enum:
+            - READ
+            - LIMITED_READ
+            - UPDATE
+            - CHANGE_OWNER
+      sharingMode:
+        type: string
+        description: The sharing mode of the inventory item
+        enum:
+          - OWNER_GROUPS
+          - WHITELIST
+          - OWNER_ONLY
+  MovableInventoryRecordInfo:
+    allOf:
+      - $ref: '#/definitions/InventoryRecordInfo'
+      - properties:
+          parentContainers:
+            $ref: '#/definitions/ContainerList'
+          parentLocation:
+            $ref: '#/definitions/ContainerLocationInfo'
+          lastNonWorkbenchParent:
+            $ref: '#/definitions/ContainerInfo'
+          lastMoveDate:
+            type: string
+            format: date-time
+            description: The date when item was moved last time
+
+  SampleInfo:
+    description: Basic information about RSpace Inventory Sample.
+    allOf:
+      - $ref: '#/definitions/InventoryRecordInfo'
+      - properties:
+          templateId:
+            type: number
+            description: Identifier of the template used to create this sample. May be unset if this sample was not created from  a Template
+            example: 1
+          templateVersion:
+            type: number
+            description: Version of the connected template
+          template:
+            type: boolean
+            description: Flag descirbing whether this sample is a template
+            example:
+              false
+          revisionId:
+            type: number
+            description: Revision id of the sample
+          version:
+            type: number
+            description: Version number
+          historicalVersion:
+            type: boolean
+            description: Whether object represents a historical, or latest, version of the sample
+          subSampleAlias:
+            description: Alias to use for describing a single or multiple subsamples of this sample
+            properties:
+              alias:
+                type: string
+              plural:
+                type: string
+          subSampleCount:
+            type: number
+            description: Number of subsamples belonging to the sample
+          storageTempMin:
+            $ref: '#/definitions/Quantity'
+          storageTempMax:
+            $ref: '#/definitions/Quantity'
+
+          sampleSource:
+            type: string
+            description: The source of the sample, must be one of allowed values.
+            enum:
+              - LAB_CREATED
+              - VENDOR_SUPPLIED
+              - OTHER
+          expiryDate:
+            type: string
+            format: date
+            description: Optional date at which a sample expires, in ISO-8601 format
+  Sample:
+    example:
+      name: Generic Sample
+    description: The complete information on a Sample
+    allOf:
+      - $ref: '#/definitions/SampleInfo'
+      - properties:
+          sharedWith:
+            $ref: '#/definitions/GroupShareInfoList'
+          fields:
+            $ref: '#/definitions/SampleFieldList'
+          extraFields:
+            $ref: '#/definitions/ExtraFieldList'
+          subSamples:
+            $ref: '#/definitions/SubSampleList'
+
+
+
+  InstrumentInfo:
+    description: Basic information about RSpace Inventory Instrument.
+    allOf:
+      - $ref: '#/definitions/InventoryRecordInfo'
+      - properties:
+          templateId:
+            type: number
+            description: Identifier of the template used to create this instrument. May be unset if this instrument was not created from  a Template
+            example: 1
+          templateVersion:
+            type: number
+            description: Version of the connected template
+          revisionId:
+            type: number
+            description: Revision id of the instrument
+          version:
+            type: number
+            description: Version number
+          historicalVersion:
+            type: boolean
+            description: Whether object represents a historical, or latest, version of the sample
+          sampleSource:
+            type: string
+            description: The source of the sample, must be one of allowed values.
+            enum:
+              - LAB_CREATED
+              - VENDOR_SUPPLIED
+              - OTHER
+
+  Instrument:
+    example:
+      name: Generic Instrument
+    description: The complete information on a Sample
+    allOf:
+      - $ref: '#/definitions/SampleInfo'
+      - properties:
+          sharedWith:
+            $ref: '#/definitions/GroupShareInfoList'
+          fields:
+            $ref: '#/definitions/SampleFieldList'
+          extraFields:
+            $ref: '#/definitions/ExtraFieldList'
+
+
+  ApiTagInfo:
+    description: Information about an RSpace inventory Tag
+    properties:
+      value:
+        type: string
+        description: tag value used in search and displayed.
+      uri:
+        type: string
+        description: A unique identifier.
+      ontologyName:
+        type: string
+        description: The name of the ontology this tag data is contained in.
+      ontologyVersion:
+        type: string
+        description: The version of the ontology this tag data is contained in.
+
+  SubSampleInfo:
+    description: Information about RSpace inventory SubSample
+    allOf:
+      - $ref: '#/definitions/MovableInventoryRecordInfo'
+  SubSample:
+    description: Full details of RSpace inventory SubSample
+    allOf:
+      - $ref: '#/definitions/SubSampleInfo'
+      - properties:
+          sample:
+            $ref: '#/definitions/SampleInfo'
+          extraFields:
+            $ref: '#/definitions/ExtraFieldList'
+          notes:
+            $ref: '#/definitions/SubSampleNoteList'
+  SubSampleList:
+    description: List of the subsample information objects
+    type: array
+    items:
+      $ref: '#/definitions/SubSampleInfo'
+
+  SubSampleNote:
+    description: Full details of RSpace inventory SubSample
+    properties:
+      created:
+        type: string
+        format: date-time
+        description: The creation time of the Sample.
+      createdBy:
+        $ref: '#/definitions/User'
+      content:
+        type: string
+        description: content of the note
+        example: <p>test note</p>
+  SubSampleNoteList:
+    description: List of the subsample notes
+    type: array
+    items:
+      $ref: '#/definitions/SubSampleNote'
+
+  SubSampleSplit:
+    description: Configure duplication behaviour.
+    allOf:
+      - properties:
+          numSubSamples:
+            type: integer
+            format: int64
+            description: The number of subsamples you require, including the original.
+          split:
+            type: boolean
+            description: Whether to split the quantity equally amongst copies, or not.
+    example:
+      numSubSamples: 2
+      split: true
+
+  SubSampleCreateNew:
+    description: Configure create new subsamples behaviour.
+    allOf:
+      - properties:
+          sampleId:
+            type: number
+            description: Id of the sample for which to create subsamples.
+          numSubSamples:
+            type: integer
+            format: int64
+            description: The number of subsamples you require, including the original.
+    example:
+      sampleId: 12
+      numSubSamples: 1
+
+  TagList:
+    description: List of the tag information objects
+    type: array
+    items:
+      $ref: '#/definitions/ApiTagInfo'
+
+  FieldmarkApiImportRequest:
+    description: Representation of Fieldmark Api import request
+    properties:
+      notebookId:
+        type: string
+        description: Unique identifier Fieldmark notebook
+        example: "1726126204618-rspace-igsn-demo"
+      identifier:
+        type: string
+        description: Name of the field you want to be the Doi Identifier
+        example: "FieldName"
+  FieldmarkApiImportResult:
+    description: Representation of Fieldmark Api import result
+    properties:
+      containerGlobalId:
+        type: string
+        description: Unique Global RSpace identifier for the created container
+        example: "IC196609"
+      containerName:
+        type: string
+        description: Name of the container
+        example: "Container RSpace IGSN Demo - 2024-11-28 12:29:40"
+      sampleTemplateGlobalId:
+        type: string
+        description: Unique Global RSpace identifier for the created container
+        example: "IT163840"
+      sampleGlobalIds:
+        type: integer
+        description: Global RSpace identifiers for the created samples
+        items:
+          type: string
+        example: [ "SA163841", "SA163842", "SA163843" ]
+
+
+  ContainerInfo:
+    description: Basic information about Inventory Container.
+    allOf:
+      - $ref: '#/definitions/MovableInventoryRecordInfo'
+      - properties:
+          locationsCount:
+            type: number
+            description: Number of defined locations in the container
+          contentSummary:
+            description: Summary information about content of the container
+            properties:
+              totalCount:
+                type: number
+                description: Total number of items stored directly in this container
+              subSamplesCount:
+                type: number
+                description: Number of subsamples stored directly in this container
+              containerCount:
+                type: number
+                description: Number of containers stored directly in this container
+          cType:
+            type: string
+            description: container type, one of LIST / GRID / IMAGE
+          gridLayout:
+            description: Information about the grid layout (GRID containers only)
+            properties:
+              columnsNumber:
+                type: number
+                description: Number of subsamples stored directly in this container
+              rowsNumber:
+                type: number
+                description: Number of subsamples stored directly in this container
+              columnsLabelType:
+                type: string
+                description: Columns naming mode one of ABC, CBA, N123, N321
+                enum:
+                  - ABC
+                  - CBA
+                  - N123
+                  - N321
+              rowsLabelType:
+                type: string
+                description: Rows naming mode, one of ABC, CBA, N123, N321
+                enum:
+                  - ABC
+                  - CBA
+                  - N123
+                  - N321
+          canStoreSamples:
+            type: boolean
+            description: Whether object represents a historical, or latest, version of the sample
+          canStoreContainers:
+            type: boolean
+            description: Whether object represents a historical, or latest, version of the sample
+  Container:
+    description: A Cntainer with extra fields, locations, and content
+    example:
+      name: My Container
+      cType: LIST
+    allOf:
+      - $ref: '#/definitions/ContainerInfo'
+      - properties:
+          extraFields:
+            $ref: '#/definitions/ExtraFieldList'
+          locations:
+            $ref: '#/definitions/ContainerLocationList'
+  ContainerList:
+    description: List of the container information objects
+    type: array
+    items:
+      $ref: '#/definitions/ContainerInfo'
+
+  ContainerLocationInfo:
+    description: Info on location within the container
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier of the location.
+        example: 32127
+      coordX:
+        type: number
+        description: First coordinate of the location within the container
+        example: 4
+      coordY:
+        type: number
+        description: Second coordiante of the location within the container
+        example: 1
+  ContainerLocationList:
+    description: List of container locations
+    type: array
+    items:
+      $ref: '#/definitions/ContainerLocationInfo'
+
+  SampleTemplateInfo:
+    description: Summary information about a Sample Template.
+    allOf:
+      - $ref: '#/definitions/SampleInfo'
+      - properties:
+          type:
+            example: SAMPLE_TEMPLATE
+          defaultUnitId:
+            type: integer
+            description: The id of a template unit, from the /units endpoint
+  SampleTemplateList:
+    description: List of the fields in a Sample or SubSample
+    type: array
+    items:
+      $ref: '#/definitions/SampleTemplateInfo'
+
+  SampleTemplate:
+    description: Full information about Inventory SampleTemplate
+    allOf:
+      - $ref: '#/definitions/SampleTemplateInfo'
+      - properties:
+          fields:
+            $ref: '#/definitions/SampleFieldList'
+
+
+  SampleTemplatePost:
+    description: 'Definition of a new SampleTemplate, including fields'
+    properties:
+      name:
+        type: string
+        description: A required display name for the template/
+        minLength: 1
+      defaultUnitId:
+        type: integer
+        description: The id of a unit to measure the amount of the sample. (A mass, volume or dimensionless unit from /units )
+      subSampleAlias:
+        description: Alias to use for describing a single or multiple subsamples of this sample
+        properties:
+          alias:
+            type: string
+          plural:
+            type: string
+      tags:
+        $ref: '#/definitions/TagList'
+      fields:
+        $ref: '#/definitions/SampleFieldList'
+    example:
+      name: Restriction enzyme.
+      description: A template for commercial restriction enzymes used in our lab
+      tags: [ { "value": "enzyme" }, { "value": "molbiol" } ]
+      subSampleAlias:
+        alias: subsample
+        plural: subsamples
+      defaultUnitId: 3
+      sampleSource: VENDOR_SUPPLIED
+      fields:
+        - name: Recognition sequence length
+          type: Radio
+          definition:
+            options: [ '4', '6', '8', 'other' ]
+        - name: Incubation Temperature (C)
+          type: Number
+          content: 37
+        - name: Cut-type
+          type: Radio
+          definition:
+            options: [ 'Blunt', 'Overhanging' ]
+        - name: Recognition Site
+          type: String
+        - name: Vendor
+          type: Radio
+          definition:
+            options: [ 'Invitrogen', 'NEB', 'Amersham', 'Sigma' ]
+          selectedOptions: [ 'Amersham' ]
+        - name: Webpage
+          type: URI
+
+  Quantity:
+    description: A quantity of something, described as a decimal value and a unit.
+    properties:
+      numericValue:
+        type: number
+        description: decimal number of any precision
+      unitId:
+        type: integer
+        description: id of a quantity unit
+
+  SampleField:
+    description: |
+      A field in a sample or subsample.
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier for the InventoryEntityField
+      globalId:
+        type: string
+        description: A unique identifier amongst all RSpace data types.
+      name:
+        type: string
+        description: The name of the field.
+      lastModified:
+        type: string
+        format: date-time
+        description: The last modified time of this InventoryEntityField, in ISO-8601 format.
+      type:
+        type: string
+        description: The data type of this field
+        enum:
+          - string
+          - text
+          - choice
+          - radio
+          - date
+          - number
+          - time
+          - attachment
+          - reference
+          - uri
+      content:
+        type: string
+        description: |
+          The content as a string. For SampleFields of type 'text' this will be HTML.
+      definition:
+        type: object
+        description: Some field types require a definition - e.g. radio/choice fields must show what are valid choice options
+        properties:
+          options:
+            type: array
+            description: The possible values defined for this field
+            items:
+              type: string
+          multiple:
+            type: boolean
+            description: Whether multiple values are allowed (choice fields only).
+      selectedOptions:
+        type: array
+        description: list of selected values for radio/choice field
+        items:
+          type: string
+  SampleFieldList:
+    description: List of the fields in a Sample
+    type: array
+    items:
+      $ref: '#/definitions/SampleField'
+
+  ExtraField:
+    description: Information about extra field.
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier for the ExtraField.
+      globalId:
+        type: string
+        description: A unique identifier amongst all RSpace data types.
+      type:
+        type: string
+        description: The type of the field, allowed values are 'text' or 'number'.
+      name:
+        type: string
+        description: The name of the field.
+      content:
+        type: string
+        description: Current content of the field.
+      parentGlobalId:
+        type: string
+        description: A unique identifier amongst all RSpace data types.
+    required: [ parentGlobalId ]
+    example:
+      type: text
+      name: My Field
+      content: My string field content
+      parentGlobalId: SA1342
+  ExtraFieldList:
+    description: List of the extra fields of inventory record
+    type: array
+    items:
+      $ref: '#/definitions/ExtraField'
+
+  Barcode:
+    description: Information about item's barcode.
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier for the Barcode.
+      data:
+        type: string
+        description: Data encoded by the barcode
+      format:
+        type: string
+        description: (optional) The format of barcode, could be 'QR' or 'BARCODE'.
+      description:
+        type: string
+        description: Additional information about the barcode
+      created:
+        type: string
+        format: date-time
+        description: >-
+          The creation time of the file (the time it was first uploaded to
+          RSpace), in ISO-8601 format.
+      createdBy:
+        type: string
+        description: Username of the user who created the barcode
+
+  BarcodeList:
+    description: List of barcodes
+    type: array
+    items:
+      $ref: '#/definitions/Barcode'
+
+  File:
+    description: >-
+      Metadata for an image, attachment or linked resource object, but without its binary data.
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier for the File item.
+        example: 32768
+      globalId:
+        type: string
+        description: A unique identifier amongst all RSpace data types.
+        example: IF32768
+      name:
+        type: string
+        description: File name of the attachment.
+        example: "bright_sky.jpg"
+      parentGlobalId:
+        type: string
+        description: Unique identifier of the parent inventory record.
+        example: SA3242
+      type:
+        type: string
+        description: RSpace-type of the attachment.
+        enum:
+          - GENERAL
+          - CHEMICAL
+      contentMimeType:
+        type: string
+        description: Mime-type of the attachment.
+        example: image/jpeg
+      extension:
+        type: string
+        description: File extension.
+        example: jpg
+      size:
+        type: integer
+        format: int64
+        description: 'Size, in bytes, of the file.'
+        example: 3178259
+      created:
+        type: string
+        format: date-time
+        description: >-
+          The creation time of the file (the time it was first uploaded to
+          RSpace), in ISO-8601 format.
+      createdBy:
+        type: string
+        description: Username of the attachment's creator.
+        example: "robday"
+      deleted:
+        type: boolean
+        description: Whether item is deleted or not.
+      _links:
+        $ref: '#/definitions/LinkItemList'
+  FileList:
+    description: List of file attachments
+    type: array
+    items:
+      $ref: '#/definitions/File'
+
+  Job:
+    description: A Job with an additional result object. A job still  in ''RUNNING'' state  will have a null result object.
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier for the Job
+      status:
+        type: string
+        description: 'Current status of the job, such as ''RUNNING'' or  ''COMPLETED'' '
+      percentComplete:
+        type: number
+        description: Reports progress of the job, as a percentage of completion. For a completed job, will be 100%.
+
+  LinkItemList:
+    description: >
+      List of metadata links. Usually contains 'self' link, for paginated result
+      also 'next', 'prev', 'first' and 'last' links.
+    type: array
+    minItems: 0
+    items:
+      $ref: '#/definitions/LinkItem'
+  LinkItem:
+    description: A metadata link.
+    properties:
+      link:
+        type: string
+        description: URL.
+      rel:
+        type: string
+        description: >
+          The relation, an IANA registered relation type as listed
+          https://www.iana.org/assignments/link-relations/link-relations.xml
+    example:
+      link: 'https://myrspace.com/api/inventory/v1/files/123'
+      type: self
+  User:
+    description: Representation of a User.
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier for the User.
+        example: 23
+      username:
+        type: string
+        description: Unique username for the User.
+        minLength: 6
+        example: fbloggs
+      email:
+        type: string
+        description: Email address for User.
+        pattern: \S+@\S+
+        example: bloggs@uni.edu
+      firstName:
+        type: string
+        description: First name of the User.
+        example: Fred
+      lastName:
+        type: string
+        description: Last name of the User.
+        example: Bloggs
+      homeFolderId:
+        type: number
+        description: The id of the home ELN folder. May be empty if account has not yet been initialised.
+        example: 24556
+      workbenchId:
+        type: number
+        description: The id of the user's Inventory Workbench. May be empty if account has not yet been initialised.
+        example: 24557
+
+  GroupInfo:
+    description: Basic information about a LabGroup.
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique identifier of the Group.
+        example: 32127
+      globalId:
+        type: string
+        description: Unique globalId of the Group.
+        example: GP32127
+      name:
+        type: string
+        description: Name of the group.
+        example: "userGroup 1"
+      uniqueName:
+        type: string
+        description: Unique (RSpace-generated) name of the group.
+        example: "userGroup1kPV"
+  GroupShareInfo:
+    properties:
+      group:
+        $ref: '#/definitions/GroupInfo'
+      shared:
+        type: boolean
+        description: whether item is shared with this group
+      itemOwnerGroup:
+        type: boolean
+        description: whether item's owner belong to the group
+  GroupShareInfoList:
+    description: List of group sharing information for the inventory item
+    type: array
+    items:
+      $ref: '#/definitions/GroupShareInfo'
+
+  Error:
+    description: Error object
+    properties:
+      status:
+        type: string
+        description: Text representation of Http Status Code.
+      httpCode:
+        type: integer
+        description: HttpStatusCode
+      internalCode:
+        type: integer
+        description: Internal error code to report to RSpace API support team.
+      message:
+        type: string
+        description: Human-readable error message
+      errors:
+        description: Optional information on errors on individual fields.
+        type: array
+        items:
+          type: string
+    example:
+      httpCode: 422
+      internalCode: 42201
+      message: Query could not be processed.
+parameters:
+  timeStampParam:
+    name: timestamp
+    in: path
+    type: string
+    required: true
+    description: Ignored by RSpace server; can be any string. Applications using caching can use the timestamp to determine if to reload.
+  sampleIdParam:
+    name: sampleId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the sample.
+  instrumentIdParam:
+    name: instrumentId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the instrument.
+  sampleBodyParam:
+    name: sample
+    in: body
+    description: 'A Sample object'
+    required: true
+    schema:
+      $ref: '#/definitions/Sample'
+  subSampleIdParam:
+    name: subSampleId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: An identifier of the subsample.
+  subSampleBodyParam:
+    name: subSample
+    in: body
+    description: 'A SubSample object'
+    required: true
+    schema:
+      $ref: '#/definitions/SubSample'
+  subSampleNoteBodyParam:
+    name: subSampleNote
+    in: body
+    description: 'A SubSample note'
+    required: true
+    schema:
+      $ref: '#/definitions/SubSampleNote'
+  subSampleSplitParam:
+    name: subSampleSplit
+    in: body
+    description: 'Configuration of duplication behaviour for subsamples'
+    required: false
+    schema:
+      $ref: '#/definitions/SubSampleSplit'
+  subSampleCreateParam:
+    name: subSampleCreate
+    in: body
+    description: 'Configuration of create action for subsamples'
+    required: false
+    schema:
+      $ref: '#/definitions/SubSampleCreateNew'
+  revisionIdParam:
+    name: revisionId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A revision number of the inventory item
+  versionParam:
+    name: version
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A version number of the inventory item
+  extraFieldIdParam:
+    name: extraFieldId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: An identifier of the extra field.
+  extraFieldBodyParam:
+    name: extraField
+    in: body
+    description: 'An extra field object'
+    required: true
+    schema:
+      $ref: '#/definitions/ExtraField'
+  sampleTemplateIdParam:
+    name: sampleTemplateId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: An identifier of the sample template.
+  workbenchIdParam:
+    name: workbenchId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the workbench.
+  containerIdParam:
+    name: containerId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the container.
+  containerBodyParam:
+    name: container
+    in: body
+    description: 'A Container object'
+    required: true
+    schema:
+      $ref: '#/definitions/Container'
+  queryParam:
+    name: query
+    in: query
+    description: Global search query for inventory recods. Required, unless 'parentGlobalId' parameter is provided.
+    type: string
+  resultTypeParam:
+    name: resultType
+    in: query
+    description: Optional subtype of requested inventory items.
+    type: string
+    enum:
+      - SAMPLE
+      - SUBSAMPLE
+      - CONTAINER
+      - TEMPLATE
+  deletedItemsParam:
+    name: deletedItems
+    in: query
+    description: Option deciding about inclusion of deleted items in results (default is EXCLUDED i.e. deleted items are not returned).
+    type: string
+    enum:
+      - EXCLUDE
+      - INCLUDE
+      - DELETED_ONLY
+  globalIdParam:
+    name: globalId
+    in: path
+    type: string
+    required: true
+    description: A global identifier of the Inventory item.
+  parentGlobalIdParam:
+    name: parentGlobalId
+    in: query
+    type: string
+    description: Must be a global id of a Container (IC), Workbench (BE), Sample (SA), or Sample Template (IT).
+      Limits the results to items being stored inside a container (or workbench), to
+      subsamples of a given sample, or to samples created from given template.
+  docIdParam:
+    name: docId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the ELN document.
+  elnFieldIdParam:
+    name: elnFieldId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the field within ELN document.
+  inventoryFileIdParam:
+    name: fileId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the inventory file.
+  digitalObjectIdentifierIdParam:
+    name: doiId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the digital inventory identifier.
+  lomIdParam:
+    name: lomId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the list of materials.
+  listOfMaterialsBodyParam:
+    name: listOfMaterialsBody
+    in: body
+    description: Details of inventory item usage within an ELN document
+    required: true
+    schema:
+      example:
+        name: list A
+        description: Subsample X from container Y, used in step N of the experiment.
+        elnFieldId: 1025
+        materials:
+          - invRec: { id: 123, type: "SUBSAMPLE" }
+            usedQuantity: { unitId: 3, numericValue: 5 }
+          - invRec: { id: 52, type: "CONTAINER" }
+            usedQuantity: null
+  inventorySettingsBodyParam:
+    name: inventorySettingsBody
+    in: body
+    description: Settings to update
+    required: true
+    schema:
+      example:
+        datacite:
+          serverUrl: "https://api.test.datacite.org/"
+          username: "AJFO.JIJEMD"
+          password: "<AJFO.JIJEMD password>"
+          repositoryPrefix: "10.82316"
+          enabled: "true"
+  basketIdParam:
+    name: basketId
+    in: path
+    type: integer
+    format: int64
+    required: true
+    description: A unique identifier of the basket.
+  basketPostParam:
+    name: basketPost
+    in: body
+    description: Details to use for creation of new basket
+    schema:
+      example:
+        name: list A
+        globalIds:
+          - "SA123"
+          - "SS234"
+          - "IC12"
+  basketBodyParam:
+    name: basketBody
+    in: body
+    description: Details of basket to create or update
+    required: true
+    schema:
+      example:
+        name: list A
+  basketItemsParam:
+    name: basketItems
+    in: body
+    description: Object listing global ids of basket items
+    required: true
+    schema:
+      example:
+        globalIds:
+          - "SA123"
+          - "SS234"
+          - "IC12"
+  publicLinkParam:
+    name: publicLink
+    in: path
+    type: string
+    required: true
+    description: A public link of an inventory item
+  pageNumberParam:
+    name: pageNumber
+    in: query
+    description: 'For paginated results, this is the number of the page requested, 0 based.'
+    type: integer
+    format: int32
+    default: 0
+    minimum: 0
+  pageSizeParam:
+    name: pageSize
+    in: query
+    description: The maximum number of items to retrieve.
+    type: integer
+    format: int32
+    default: 20
+    minimum: 1
+    maximum: 50
+  orderByParam:
+    name: orderBy
+    in: query
+    description: Sort order for inventory items.
+    type: string
+    enum:
+      - name asc
+      - name desc
+      - type asc
+      - type desc
+      - globalId asc
+      - globalId desc
+      - creationDate asc
+      - creationDate desc
+      - modificationDate asc
+      - modificationDate desc
+    default: name asc
+  ownedByParam:
+    name: ownedBy
+    in: query
+    description: Username of the owner of requested items
+    type: string
+  bulkOperationBodyParam:
+    name: bulkOperationBody
+    in: body
+    description: Details of bulk operation
+    required: true
+    schema:
+      example:
+        operationType: CREATE
+        rollbackOnError: true
+        records:
+          - type: SAMPLE
+            name: mySample
+          - type: CONTAINER
+            cType: LIST
+            name: myContainer
+  contentsHashParam:
+    name: contentsHash
+    in: path
+    description: the sha256 hash of the contents of the file to be retrieved.
+    required: true
+    type: string
+responses:
+  UnprocessableQuery:
+    description: Query could not be processed.
+    schema:
+      $ref: '#/definitions/Error'
+  NotFound:
+    description: Resource could not be found - either does not exist, or client is not authorised.
+    schema:
+      $ref: '#/definitions/Error'
+  TooManyRequests:
+    description: Too many requests - see the X-Rate-Limit headers for more information.
+    schema:
+      $ref: '#/definitions/Error'
+  LicenseProblem:
+    description: License expired or not active.
+    schema:
+      $ref: '#/definitions/Error'

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentApiPostFullValidatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentApiPostFullValidatorTest.java
@@ -1,0 +1,186 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.api.v1.controller.InstrumentsApiController.ApiInstrumentFullPost;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryNumberField;
+import com.researchspace.model.inventory.field.InventoryRadioField;
+import com.researchspace.model.inventory.field.InventoryRadioFieldDef;
+import com.researchspace.model.inventory.field.InventoryTextField;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+
+public class InstrumentApiPostFullValidatorTest extends InventoryRecordValidationTestBase {
+
+  @Autowired
+  @Qualifier("instrumentApiPostFullValidator")
+  private InstrumentApiPostFullValidator instrumentPostFullValidator;
+
+  @Before
+  public void setup() {
+    validator = instrumentPostFullValidator;
+  }
+
+  @Test
+  public void validateMandatoryFields() {
+    User testUser = createInitAndLoginAnyUser();
+    ApiInstrument apiInstrumentPost = new ApiInstrument();
+    ApiInstrumentFullPost fullPost = new ApiInstrumentFullPost();
+    fullPost.setApiInstrument(apiInstrumentPost);
+    fullPost.setUser(testUser);
+    fullPost.setTemplate(createInstrumentTemplateWithMandatoryFields());
+
+    Errors errors = new BeanPropertyBindingResult(apiInstrumentPost, "apiInstrument");
+    validator.validate(fullPost, errors);
+    assertEquals(2, errors.getErrorCount());
+    assertFieldNameIs(errors, "fields");
+    FieldError firstError = errors.getFieldErrors().get(0);
+    FieldError secondError = errors.getFieldErrors().get(1);
+    assertEquals("errors.inventory.instrument.mandatory.field.empty", firstError.getCode());
+    assertEquals("myText (mandatory - no default value)", getFirstArgument(firstError));
+    assertEquals("errors.inventory.instrument.mandatory.field.no.selection", secondError.getCode());
+    assertEquals("myRadio (mandatory - no default value)", getFirstArgument(secondError));
+
+    apiInstrumentPost.setFields(
+        Stream.generate(ApiInventoryEntityField::new).limit(6).collect(Collectors.toList()));
+    errors = new BeanPropertyBindingResult(apiInstrumentPost, "apiInstrument");
+    validator.validate(fullPost, errors);
+    assertEquals(4, errors.getErrorCount());
+    assertFieldNameIs(errors, "fields");
+    List<FieldError> fieldErrors = errors.getFieldErrors();
+    assertEquals("myText (mandatory - with default value)", getFirstArgument(fieldErrors.get(0)));
+    assertEquals("myText (mandatory - no default value)", getFirstArgument(fieldErrors.get(1)));
+    assertEquals("myRadio (mandatory - with default value)", getFirstArgument(fieldErrors.get(2)));
+    assertEquals("myRadio (mandatory - no default value)", getFirstArgument(fieldErrors.get(3)));
+
+    apiInstrumentPost.getFields().get(0).setContent("test content");
+    apiInstrumentPost.getFields().get(1).setContent("test content");
+    apiInstrumentPost.getFields().get(3).setSelectedOptions(List.of("a"));
+    apiInstrumentPost.getFields().get(4).setSelectedOptions(List.of("b"));
+    errors = new BeanPropertyBindingResult(apiInstrumentPost, "apiInstrument");
+    validator.validate(fullPost, errors);
+    assertEquals(0, errors.getErrorCount());
+  }
+
+  @Test
+  public void validateFieldDefinitionsAndContent() {
+    User testUser = createInitAndLoginAnyUser();
+    ApiInstrument apiInstrumentPost = new ApiInstrument();
+    ApiInstrumentFullPost fullPost = new ApiInstrumentFullPost();
+    fullPost.setApiInstrument(apiInstrumentPost);
+    fullPost.setUser(testUser);
+    fullPost.setTemplate(createInstrumentTemplateWithNumberAndTextFields());
+
+    apiInstrumentPost.setFields(List.of(new ApiInventoryEntityField()));
+    Errors errors = new BeanPropertyBindingResult(apiInstrumentPost, "apiInstrument");
+    validator.validate(fullPost, errors);
+    assertEquals(1, errors.getErrorCount());
+    assertNotNull(errors.getGlobalErrors().get(0).getDefaultMessage());
+    assertEquals(
+        "\"fields\" array should have 2 fields, but had 1",
+        errors.getGlobalErrors().get(0).getDefaultMessage());
+
+    ApiInventoryEntityField invalidNumberField = new ApiInventoryEntityField();
+    invalidNumberField.setType(ApiFieldType.NUMBER);
+    invalidNumberField.setContent("abc");
+    ApiInventoryEntityField validTextField = new ApiInventoryEntityField();
+    validTextField.setType(ApiFieldType.TEXT);
+    validTextField.setContent("valid text");
+    apiInstrumentPost.setFields(List.of(invalidNumberField, validTextField));
+    errors = new BeanPropertyBindingResult(apiInstrumentPost, "apiInstrument");
+    validator.validate(fullPost, errors);
+    assertEquals(1, errors.getErrorCount());
+    String invalidNumberMessage = errors.getGlobalErrors().get(0).getDefaultMessage();
+    assertNotNull(invalidNumberMessage);
+    assertTrue(invalidNumberMessage.contains("Invalid number"));
+
+    invalidNumberField.setContent("3.56");
+    errors = new BeanPropertyBindingResult(apiInstrumentPost, "apiInstrument");
+    validator.validate(fullPost, errors);
+    assertEquals(0, errors.getErrorCount());
+  }
+
+  private InstrumentTemplate createInstrumentTemplateWithMandatoryFields() {
+    InstrumentTemplate template = new InstrumentTemplate();
+
+    InventoryTextField textField =
+        new InventoryTextField("myText (mandatory - with default value)");
+    textField.setMandatory(true);
+    textField.setFieldData("default value");
+    addField(template, textField);
+
+    InventoryTextField textField2 = new InventoryTextField("myText (mandatory - no default value)");
+    textField2.setMandatory(true);
+    textField2.setData("");
+    addField(template, textField2);
+
+    InventoryTextField textField3 = new InventoryTextField("myText (not mandatory)");
+    textField3.setData("");
+    addField(template, textField3);
+
+    InventoryRadioField radioField =
+        new InventoryRadioField(
+            createRadioDef(List.of("a", "b", "c")), "myRadio (mandatory - with default value)");
+    radioField.setMandatory(true);
+    radioField.setSelectedOptions(List.of("a"));
+    addField(template, radioField);
+
+    InventoryRadioField radioField2 =
+        new InventoryRadioField(
+            createRadioDef(List.of("a", "b", "c")), "myRadio (mandatory - no default value)");
+    radioField2.setMandatory(true);
+    addField(template, radioField2);
+
+    InventoryRadioField radioField3 =
+        new InventoryRadioField(createRadioDef(List.of("a", "b", "c")), "myRadio (not mandatory)");
+    addField(template, radioField3);
+
+    return template;
+  }
+
+  private InstrumentTemplate createInstrumentTemplateWithNumberAndTextFields() {
+    InstrumentTemplate template = new InstrumentTemplate();
+
+    InventoryNumberField numberField = new InventoryNumberField("my number");
+    addField(template, numberField);
+
+    InventoryTextField textField = new InventoryTextField("my text");
+    addField(template, textField);
+
+    return template;
+  }
+
+  private InventoryRadioFieldDef createRadioDef(List<String> options) {
+    InventoryRadioFieldDef radioDef = new InventoryRadioFieldDef();
+    radioDef.setRadioOptionsList(options);
+    return radioDef;
+  }
+
+  private void addField(InstrumentTemplate template, InventoryEntityField field) {
+    field.setColumnIndex(template.getFields().size() + 1);
+    field.setInventoryRecord(template);
+    template.getFields().add(field);
+  }
+
+  private Object getFirstArgument(FieldError fieldError) {
+    assertNotNull(fieldError.getArguments());
+    assertTrue(fieldError.getArguments().length > 0);
+    return fieldError.getArguments()[0];
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentsApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentsApiControllerMVCIT.java
@@ -1,0 +1,177 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiLinkItem;
+import com.researchspace.apiutils.ApiError;
+import com.researchspace.model.User;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@WebAppConfiguration
+@TestPropertySource(properties = {"inventory.instrument.enabled=true"})
+public class InstrumentsApiControllerMVCIT extends API_MVC_InventoryTestBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void createBasicInstrument() throws Exception {
+    User anyUser = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(anyUser);
+
+    String instrumentJson = "{\"name\": \"instrument-1\"}";
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(apiKey, "/instruments", anyUser, instrumentJson))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+    assertNull(result.getResolvedException());
+    ApiInstrument created = mvcUtils.getFromJsonResponseBody(result, ApiInstrument.class);
+    assertNotNull(created);
+    assertNotNull(created.getId());
+    assertEquals("instrument-1", created.getName());
+    assertEquals(anyUser.getUsername(), created.getCreatedBy());
+    assertEquals(anyUser.getUsername(), created.getModifiedBy());
+    assertNotNull(created.getOwner());
+    assertEquals(anyUser.getUsername(), created.getOwner().getUsername());
+    assertFalse(created.getLinks().isEmpty());
+    assertTrue(created.getLinkOfType(ApiLinkItem.SELF_REL).isPresent());
+    assertTrue(
+        created
+            .getLinkOfType(ApiLinkItem.SELF_REL)
+            .orElseThrow(() -> new IllegalStateException("missing self link"))
+            .getLink()
+            .endsWith("/api/inventory/v1/instruments/" + created.getId()));
+  }
+
+  @Test
+  public void getInstrumentById() throws Exception {
+    User anyUser = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(anyUser);
+    ApiInstrument instrument = createBasicInstrumentForUser(anyUser);
+
+    MvcResult result =
+        mockMvc
+            .perform(getInstrumentById(anyUser, apiKey, instrument.getId()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    assertNull(result.getResolvedException());
+    ApiInstrument retrieved = mvcUtils.getFromJsonResponseBody(result, ApiInstrument.class);
+    assertNotNull(retrieved);
+    assertEquals(instrument.getId(), retrieved.getId());
+    assertEquals("myInstrument", retrieved.getName());
+    assertEquals(0, retrieved.getFields().size());
+    assertEquals(0, retrieved.getExtraFields().size());
+    assertFalse(retrieved.isStoredInContainer());
+  }
+
+  @Test
+  public void getInstrumentErrorMessages() throws Exception {
+    User anyUser = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(anyUser);
+
+    User otherUser = createInitAndLoginAnyUser();
+    ApiInstrument instrument = createBasicInstrumentForUser(otherUser);
+
+    mockMvc
+        .perform(getInstrumentById(anyUser, apiKey, 12345L))
+        .andExpect(status().isNotFound())
+        .andReturn();
+
+    mockMvc
+        .perform(getInstrumentById(anyUser, "WRONG KEY", instrument.getId()))
+        .andExpect(status().isUnauthorized())
+        .andReturn();
+  }
+
+  @Test
+  public void createInstrumentErrors() throws Exception {
+    User anyUser = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(anyUser);
+
+    MvcResult result =
+        mockMvc
+            .perform(createBuilderForPostWithJSONBody(apiKey, "/instruments", anyUser, "{}"))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+    ApiError error = getErrorFromJsonResponseBody(result, ApiError.class);
+    assertApiErrorContainsMessage(error, "name is a required field");
+
+    String tooLongName = StringUtils.leftPad("test", 256, '*');
+    String invalidJson = "{ \"name\": \"" + tooLongName + "\" }";
+    result =
+        mockMvc
+            .perform(createBuilderForPostWithJSONBody(apiKey, "/instruments", anyUser, invalidJson))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+    error = getErrorFromJsonResponseBody(result, ApiError.class);
+    assertApiErrorContainsMessage(error, "Name cannot be longer than");
+
+    result =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(
+                    apiKey, "/instruments", anyUser, "{\"name\": \"instrument-ok\"}"))
+            .andExpect(status().isCreated())
+            .andReturn();
+    ApiInstrument created = mvcUtils.getFromJsonResponseBody(result, ApiInstrument.class);
+    assertEquals("instrument-ok", created.getName());
+  }
+
+  @Test
+  public void createInstrumentWithNewTargetLocationRequest() throws Exception {
+    User anyUser = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(anyUser);
+    ApiContainer gridContainer = createBasicGridContainerForUser(anyUser, 2, 2);
+
+    String instrumentJson =
+        "{ \"name\": \"instrument-in-grid\", \"newTargetLocation\": { \"containerId\": "
+            + gridContainer.getId()
+            + ", \"location\": { \"coordX\": 1, \"coordY\": 2 } } }";
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(apiKey, "/instruments", anyUser, instrumentJson))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+    ApiInstrument created = mvcUtils.getFromJsonResponseBody(result, ApiInstrument.class);
+    assertNotNull(created);
+    assertNotNull(created.getId());
+    assertEquals("instrument-in-grid", created.getName());
+
+    MvcResult getResult =
+        mockMvc
+            .perform(getInstrumentById(anyUser, apiKey, created.getId()))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiInstrument retrieved = mvcUtils.getFromJsonResponseBody(getResult, ApiInstrument.class);
+    assertNotNull(retrieved);
+    assertEquals(created.getId(), retrieved.getId());
+    assertEquals("instrument-in-grid", retrieved.getName());
+  }
+
+  private MockHttpServletRequestBuilder getInstrumentById(
+      User user, String apiKey, Long instrumentId) {
+    return createBuilderForGet(API_VERSION.ONE, apiKey, "/instruments/{id}", user, instrumentId);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentsApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentsApiControllerTest.java
@@ -1,0 +1,155 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiContainerLocation;
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiLinkItem;
+import com.researchspace.api.v1.model.ApiTargetLocation;
+import com.researchspace.model.User;
+import com.researchspace.testutils.SpringTransactionalTest;
+import javax.ws.rs.NotFoundException;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+
+public class InstrumentsApiControllerTest extends SpringTransactionalTest {
+
+  @Autowired private InstrumentsApiController instrumentsApi;
+
+  private final BindingResult mockBindingResult = mock(BindingResult.class);
+  private User testUser;
+
+  @Before
+  public void setUp() {
+    testUser = createInitAndLoginAnyUser();
+    assertTrue(testUser.isContentInitialized());
+    ReflectionTestUtils.setField(instrumentsApi, "inventoryInstrumentEnabled", true);
+    when(mockBindingResult.hasErrors()).thenReturn(false);
+  }
+
+  @Test
+  public void createAndRetrieveInstrument() throws Exception {
+    ApiInstrument request = new ApiInstrument();
+    request.setName("controller instrument");
+
+    ApiInstrument created =
+        instrumentsApi.createNewInstrument(request, mockBindingResult, testUser);
+    assertNotNull(created);
+    assertNotNull(created.getId());
+    assertEquals("controller instrument", created.getName());
+    assertNotNull(created.getOwner());
+    assertEquals(testUser.getUsername(), created.getOwner().getUsername());
+    assertFalse(created.getLinks().isEmpty());
+    assertTrue(created.getLinkOfType(ApiLinkItem.SELF_REL).isPresent());
+    assertTrue(
+        created
+            .getLinkOfType(ApiLinkItem.SELF_REL)
+            .orElseThrow(() -> new IllegalStateException("missing self link"))
+            .getLink()
+            .endsWith("/api/inventory/v1/instruments/" + created.getId()));
+
+    ApiInstrument retrieved = instrumentsApi.getInstrumentById(created.getId(), testUser);
+    assertNotNull(retrieved);
+    assertEquals(created.getId(), retrieved.getId());
+    assertEquals(created.getName(), retrieved.getName());
+    assertEquals(testUser.getUsername(), retrieved.getOwner().getUsername());
+    assertFalse(retrieved.getLinks().isEmpty());
+    assertTrue(retrieved.getLinkOfType(ApiLinkItem.SELF_REL).isPresent());
+  }
+
+  @Test
+  public void createInstrumentWithNewTargetLocationAssignsContainerParent() throws Exception {
+    ApiContainer gridContainer = createBasicGridContainerForUser(testUser, 2, 2);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("instrument in grid");
+    ApiContainerLocation targetLocation = new ApiContainerLocation(1, 2);
+    request.setNewTargetLocation(new ApiTargetLocation(gridContainer.getId(), targetLocation));
+
+    ApiInstrument created =
+        instrumentsApi.createNewInstrument(request, mockBindingResult, testUser);
+
+    assertNotNull(request.getParentContainer());
+    assertEquals(gridContainer.getId(), request.getParentContainer().getId());
+    assertEquals(targetLocation, request.getParentLocation());
+    assertTrue(created.isStoredInContainer());
+    assertNotNull(created.getParentContainers());
+    assertEquals(gridContainer.getId(), created.getParentContainers().get(0).getId());
+    assertNotNull(created.getParentLocation());
+    assertEquals(Integer.valueOf(1), created.getParentLocation().getCoordX());
+    assertEquals(Integer.valueOf(2), created.getParentLocation().getCoordY());
+  }
+
+  @Test
+  public void createInstrumentRequiresName() {
+    ApiInstrument request = new ApiInstrument();
+    BindingResult bindingResult = new BeanPropertyBindingResult(request, "apiInstrument");
+
+    BindException bindException =
+        assertThrows(
+            BindException.class,
+            () -> instrumentsApi.createNewInstrument(request, bindingResult, testUser));
+
+    assertEquals(1, bindException.getErrorCount());
+    assertNotNull(bindException.getFieldError());
+    assertEquals("name", bindException.getFieldError().getField());
+    assertEquals("errors.required", bindException.getFieldError().getCode());
+  }
+
+  @Test
+  public void createInstrumentRejectsTooLongName() {
+    ApiInstrument request = new ApiInstrument();
+    request.setName(StringUtils.leftPad("test", 256, '*'));
+    BindingResult bindingResult = new BeanPropertyBindingResult(request, "apiInstrument");
+
+    BindException bindException =
+        assertThrows(
+            BindException.class,
+            () -> instrumentsApi.createNewInstrument(request, bindingResult, testUser));
+
+    assertEquals(1, bindException.getErrorCount());
+    assertNotNull(bindException.getFieldError());
+    assertEquals("name", bindException.getFieldError().getField());
+    assertEquals("errors.maxlength", bindException.getFieldError().getCode());
+  }
+
+  @Test
+  public void createInstrumentThrowsWhenFeatureDisabled() {
+    ReflectionTestUtils.setField(instrumentsApi, "inventoryInstrumentEnabled", false);
+    ApiInstrument request = new ApiInstrument();
+    request.setName("disabled instrument");
+
+    UnsupportedOperationException unsupportedOperationException =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> instrumentsApi.createNewInstrument(request, mockBindingResult, testUser));
+
+    assertEquals(
+        "The inventory Instrument is not enabled in this RSpace instance",
+        unsupportedOperationException.getMessage());
+  }
+
+  @Test
+  public void getInstrumentByIdThrowsNotFoundIfMissing() {
+    NotFoundException notFoundException =
+        assertThrows(
+            NotFoundException.class,
+            () -> instrumentsApi.getInstrumentById(Long.MAX_VALUE, testUser));
+
+    assertTrue(notFoundException.getMessage().contains("Inventory Instrument"));
+    assertTrue(notFoundException.getMessage().contains(Long.toString(Long.MAX_VALUE)));
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryFilesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryFilesApiControllerTest.java
@@ -15,8 +15,8 @@ import com.researchspace.api.v1.controller.InventoryFilesApiController.ApiInvent
 import com.researchspace.api.v1.controller.InventoryFilesApiController.ApiInventoryFilePost;
 import com.researchspace.api.v1.model.ApiContainerInfo;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryFile;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleInfo;
 import com.researchspace.api.v1.model.ApiSampleWithoutSubSamples;
 import com.researchspace.core.util.ISearchResults;
@@ -137,7 +137,7 @@ public class InventoryFilesApiControllerTest extends SpringTransactionalTest {
 
     User user = createInitAndLoginAnyUser();
     ApiSampleWithoutSubSamples apiSample = createComplexSampleForUser(user);
-    ApiSampleField attachmentField = apiSample.getFields().get(6);
+    ApiInventoryEntityField attachmentField = apiSample.getFields().get(6);
     assertEquals(ApiFieldType.ATTACHMENT, attachmentField.getType());
     assertNull(attachmentField.getAttachment());
 

--- a/src/test/java/com/researchspace/api/v1/controller/SampleApiPostFullValidatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleApiPostFullValidatorTest.java
@@ -2,8 +2,8 @@ package com.researchspace.api.v1.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiQuantityInfo;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.model.User;
@@ -102,7 +102,7 @@ public class SampleApiPostFullValidatorTest extends InventoryRecordValidationTes
 
     // re-run validation with the 'fields' array, but with empty field content
     apiSamplePost.setFields(
-        Stream.generate(ApiSampleField::new).limit(6).collect(Collectors.toList()));
+        Stream.generate(ApiInventoryEntityField::new).limit(6).collect(Collectors.toList()));
     e = new BeanPropertyBindingResult(apiSamplePost, "apiSample");
     validator.validate(fullPost, e);
     assertEquals(4, e.getErrorCount());

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesApiControllerMVCIT.java
@@ -1,15 +1,30 @@
 package com.researchspace.api.v1.controller;
 
 import static com.researchspace.api.v1.controller.SamplesApiControllerMVCIT.NUM_FIELDS_IN_COMPLEX_SAMPLE;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.researchspace.api.v1.model.*;
+import com.researchspace.api.v1.model.ApiField;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult.InventoryBulkOperationStatus;
-import com.researchspace.api.v1.model.ApiSampleField.ApiInventoryFieldDef;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
+import com.researchspace.api.v1.model.ApiLinkItem;
+import com.researchspace.api.v1.model.ApiSample;
+import com.researchspace.api.v1.model.ApiSampleInfo;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplateInfo;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
+import com.researchspace.api.v1.model.ApiSampleTemplateSearchResult;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.api.v1.model.ApiSubSampleAlias;
 import com.researchspace.apiutils.ApiError;
 import com.researchspace.core.util.JacksonUtil;
 import com.researchspace.core.util.TransformerUtils;
@@ -224,7 +239,7 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     ApiSampleTemplate sampleTemplate = getFromJsonResponseBody(result, ApiSampleTemplate.class);
     assertEquals("Restriction Enzyme", sampleTemplate.getName());
     assertEquals(5, sampleTemplate.getFields().size());
-    ApiSampleField firstField = sampleTemplate.getFields().get(0);
+    ApiInventoryEntityField firstField = sampleTemplate.getFields().get(0);
     assertEquals("Recognition sequence length", firstField.getName());
     assertEquals(List.of("6"), firstField.getSelectedOptions());
   }
@@ -270,28 +285,33 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     int initialCount = searchHits.getTotalHits().intValue();
     ApiSampleTemplatePost templatePost = createValidSampleTemplatePostNoFields();
     // create 10 fields, 1 of each type
-    ApiSampleField text = createBasicApiSampleField("text", ApiFieldType.TEXT, "text value");
-    ApiSampleField string =
+    ApiInventoryEntityField text =
+        createBasicApiSampleField("text", ApiFieldType.TEXT, "text value");
+    ApiInventoryEntityField string =
         createBasicApiSampleField("string", ApiFieldType.STRING, "string value");
-    ApiSampleField date = createBasicApiSampleField("date", ApiFieldType.DATE, "2020-10-31");
-    ApiSampleField time = createBasicApiSampleField("time", ApiFieldType.TIME, "23:45");
-    ApiSampleField number = createBasicApiSampleField("number", ApiFieldType.NUMBER, "112.34");
+    ApiInventoryEntityField date =
+        createBasicApiSampleField("date", ApiFieldType.DATE, "2020-10-31");
+    ApiInventoryEntityField time = createBasicApiSampleField("time", ApiFieldType.TIME, "23:45");
+    ApiInventoryEntityField number =
+        createBasicApiSampleField("number", ApiFieldType.NUMBER, "112.34");
 
-    ApiSampleField choice =
+    ApiInventoryEntityField choice =
         createBasicApiSampleOptionsField("choice", ApiFieldType.CHOICE, List.of("1", "2"));
     ApiInventoryFieldDef def = new ApiInventoryFieldDef();
     def.setOptions(List.of("1", "2", "3"));
     choice.setDefinition(def);
 
-    ApiSampleField radio =
+    ApiInventoryEntityField radio =
         createBasicApiSampleOptionsField("radio", ApiFieldType.RADIO, List.of("1"));
     ApiInventoryFieldDef def2 = new ApiInventoryFieldDef();
     def2.setOptions(List.of("1", "2", "3"));
     radio.setDefinition(def2);
 
-    ApiSampleField attach = createBasicApiSampleField("attach", ApiFieldType.ATTACHMENT, "attach");
-    ApiSampleField ref = createBasicApiSampleField("ref", ApiFieldType.REFERENCE, "ref value");
-    ApiSampleField URI =
+    ApiInventoryEntityField attach =
+        createBasicApiSampleField("attach", ApiFieldType.ATTACHMENT, "attach");
+    ApiInventoryEntityField ref =
+        createBasicApiSampleField("ref", ApiFieldType.REFERENCE, "ref value");
+    ApiInventoryEntityField URI =
         createBasicApiSampleField("uri", ApiFieldType.URI, "https://somewhere.com");
 
     templatePost.setFields(
@@ -368,13 +388,13 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     ApiSampleTemplatePost sampleTemplatePost = new ApiSampleTemplatePost();
     sampleTemplatePost.setName("test template with radio and choice");
     // add radio field
-    ApiSampleField radioField =
+    ApiInventoryEntityField radioField =
         createBasicApiSampleOptionsField("my radio", ApiFieldType.RADIO, List.of("r2"));
     ApiInventoryFieldDef radioDef = new ApiInventoryFieldDef(List.of("r1", "r2", "r3"), false);
     radioField.setDefinition(radioDef);
     sampleTemplatePost.getFields().add(radioField);
     // add choice field
-    ApiSampleField choiceField =
+    ApiInventoryEntityField choiceField =
         createBasicApiSampleOptionsField("my choice", ApiFieldType.CHOICE, List.of("c1", "c2"));
     ApiInventoryFieldDef def = new ApiInventoryFieldDef(List.of("c1", "c2", "c3"), true);
     choiceField.setDefinition(def);
@@ -389,10 +409,10 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     assertEquals("IT" + createdTemplate.getId(), retrievedTemplate.getGlobalId());
     assertFalse(retrievedTemplate.isHistoricalVersion());
     assertEquals(2, retrievedTemplate.getFields().size());
-    ApiSampleField retrievedTemplateRadioField = retrievedTemplate.getFields().get(0);
+    ApiInventoryEntityField retrievedTemplateRadioField = retrievedTemplate.getFields().get(0);
     assertEquals("my radio", retrievedTemplateRadioField.getName());
     assertEquals(List.of("r2"), retrievedTemplateRadioField.getSelectedOptions());
-    ApiSampleField retrievedTemplateChoiceField = retrievedTemplate.getFields().get(1);
+    ApiInventoryEntityField retrievedTemplateChoiceField = retrievedTemplate.getFields().get(1);
     assertEquals("my choice", retrievedTemplateChoiceField.getName());
     assertEquals(List.of("c1", "c2"), retrievedTemplateChoiceField.getSelectedOptions());
 
@@ -418,7 +438,7 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     ApiSampleWithFullSubSamples anotherApiSample =
         new ApiSampleWithFullSubSamples("another sample from template v1");
     anotherApiSample.setTemplateId(retrievedTemplate.getId());
-    ApiSampleField emptyField = new ApiSampleField();
+    ApiInventoryEntityField emptyField = new ApiInventoryEntityField();
     emptyField.setContent("");
     anotherApiSample.setFields(List.of(emptyField, emptyField));
     ApiSampleWithFullSubSamples anotherCreatedSample =
@@ -432,7 +452,7 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     ApiSample templateUpdates = new ApiSample();
     templateUpdates.setId(retrievedTemplate.getId());
     // add a new option to radio field, and set it as a default
-    ApiSampleField radioFieldUpdates = new ApiSampleField();
+    ApiInventoryEntityField radioFieldUpdates = new ApiInventoryEntityField();
     radioFieldUpdates.setId(retrievedTemplateRadioField.getId());
     radioFieldUpdates.setName("updated radio");
     ApiInventoryFieldDef updatedRadioDef =
@@ -441,7 +461,7 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     radioFieldUpdates.setSelectedOptions(List.of("r4"));
     templateUpdates.getFields().add(radioFieldUpdates);
     // add a new option to choice field, and set it as a default
-    ApiSampleField choiceFieldUpdates = new ApiSampleField();
+    ApiInventoryEntityField choiceFieldUpdates = new ApiInventoryEntityField();
     choiceFieldUpdates.setId(retrievedTemplateChoiceField.getId());
     choiceFieldUpdates.setName("updated choice");
     ApiInventoryFieldDef updatedChoiceDef =
@@ -545,7 +565,7 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     ApiSampleTemplatePost sampleTemplatePost = new ApiSampleTemplatePost();
     sampleTemplatePost.setName("test template v1");
     // add radio field
-    ApiSampleField radioField =
+    ApiInventoryEntityField radioField =
         createBasicApiSampleOptionsField("my radio", ApiFieldType.RADIO, List.of("r1"));
     ApiInventoryFieldDef radioDef = new ApiInventoryFieldDef(List.of("r1", "r2", "r3"), false);
     radioField.setDefinition(radioDef);
@@ -567,15 +587,15 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
     sampleApiMgr.createNewApiSample(apiSample, anyUser);
     // 2nd have a different radio option (that'll be valid after update) and some text
     apiSample.setName("sample2 with r2 selected and text content");
-    ApiSampleField myRadioField = new ApiSampleField();
+    ApiInventoryEntityField myRadioField = new ApiInventoryEntityField();
     myRadioField.setContent("r2");
-    ApiSampleField myTextField = new ApiSampleField();
+    ApiInventoryEntityField myTextField = new ApiInventoryEntityField();
     myTextField.setContent("text");
     apiSample.setFields(List.of(myRadioField, myTextField));
     sampleApiMgr.createNewApiSample(apiSample, anyUser);
     // 3rd have a different radio option and empty text field (this one should update fine)
     apiSample.setName("sample3 with r2 selected and no text content");
-    apiSample.setFields(List.of(myRadioField, new ApiSampleField()));
+    apiSample.setFields(List.of(myRadioField, new ApiInventoryEntityField()));
     sampleApiMgr.createNewApiSample(apiSample, anyUser);
     // 4th is a the same as 3rd, will use for edit lock testing
     apiSample.setName("sample4 (locked)");

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesApiControllerTest.java
@@ -8,10 +8,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.researchspace.api.v1.model.*;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult.InventoryBulkOperationStatus;
-import com.researchspace.api.v1.model.ApiSampleField.ApiInventoryFieldDef;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
+import com.researchspace.api.v1.model.ApiSample;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplateInfo;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
+import com.researchspace.api.v1.model.ApiSampleTemplateSearchResult;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.api.v1.model.ApiSubSampleAlias;
 import com.researchspace.model.User;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.service.impl.ContentInitializerForDevRunManager;
@@ -125,10 +133,10 @@ public class SampleTemplatesApiControllerTest extends SpringTransactionalTest {
     // create a template with 2 fields
     ApiSampleTemplatePost templatePost = new ApiSampleTemplatePost();
     templatePost.setName("test template");
-    ApiSampleField stringField =
+    ApiInventoryEntityField stringField =
         createBasicApiSampleField("my string", ApiFieldType.STRING, "my string");
     templatePost.getFields().add(stringField);
-    ApiSampleField numberField =
+    ApiInventoryEntityField numberField =
         createBasicApiSampleField("my number", ApiFieldType.NUMBER, "3.14");
     templatePost.getFields().add(numberField);
 
@@ -147,12 +155,12 @@ public class SampleTemplatesApiControllerTest extends SpringTransactionalTest {
     ApiSampleTemplate templateUpdate = new ApiSampleTemplate();
     templateUpdate.setName("updated template");
     // string field update - invalid name (too long)
-    ApiSampleField stringFieldUpdate = new ApiSampleField();
+    ApiInventoryEntityField stringFieldUpdate = new ApiInventoryEntityField();
     stringFieldUpdate.setName("Description");
     stringFieldUpdate.setId(createdTemplate.getFields().get(0).getId());
     templateUpdate.getFields().add(stringFieldUpdate);
     // numeric field update - invalid name (restricted) and content
-    ApiSampleField numericFieldUpdate = new ApiSampleField();
+    ApiInventoryEntityField numericFieldUpdate = new ApiInventoryEntityField();
     numericFieldUpdate.setId(createdTemplate.getFields().get(1).getId());
     numericFieldUpdate.setName("abc".repeat(20));
     numericFieldUpdate.setType(
@@ -160,7 +168,8 @@ public class SampleTemplatesApiControllerTest extends SpringTransactionalTest {
     numericFieldUpdate.setContent("three point fifteen");
     templateUpdate.getFields().add(numericFieldUpdate);
     // attempt to add new field, but without name
-    ApiSampleField newFieldUpdate = createBasicApiSampleField("", ApiFieldType.TEXT, "my text");
+    ApiInventoryEntityField newFieldUpdate =
+        createBasicApiSampleField("", ApiFieldType.TEXT, "my text");
     newFieldUpdate.setNewFieldRequest(true);
     templateUpdate.getFields().add(newFieldUpdate);
 
@@ -190,12 +199,12 @@ public class SampleTemplatesApiControllerTest extends SpringTransactionalTest {
     sampleTemplatePost.setName("test template");
     sampleTemplatePost.setSubSampleAlias(new ApiSubSampleAlias("portion", "portions"));
     sampleTemplatePost.setDefaultUnitId(RSUnitDef.GRAM.getId());
-    ApiSampleField radioField =
+    ApiInventoryEntityField radioField =
         createBasicApiSampleOptionsField("my radio", ApiFieldType.RADIO, List.of("2"));
     ApiInventoryFieldDef radioDef = new ApiInventoryFieldDef(List.of("1", "2", "3"), false);
     radioField.setDefinition(radioDef);
     sampleTemplatePost.getFields().add(radioField);
-    ApiSampleField stringField =
+    ApiInventoryEntityField stringField =
         createBasicApiSampleField("my string", ApiFieldType.STRING, "my string");
     sampleTemplatePost.getFields().add(stringField);
     // set explicit ordering so string field is first
@@ -211,9 +220,9 @@ public class SampleTemplatesApiControllerTest extends SpringTransactionalTest {
     assertEquals("portion", createdTemplate.getSubSampleAlias().getAlias());
     assertEquals(RSUnitDef.GRAM.getId(), createdTemplate.getDefaultUnitId());
     assertEquals(2, createdTemplate.getFields().size());
-    ApiSampleField firstField = createdTemplate.getFields().get(0);
+    ApiInventoryEntityField firstField = createdTemplate.getFields().get(0);
     assertEquals("my string", firstField.getName());
-    ApiSampleField secondField = createdTemplate.getFields().get(1);
+    ApiInventoryEntityField secondField = createdTemplate.getFields().get(1);
     assertEquals("my radio", secondField.getName());
     assertEquals(null, secondField.getContent());
     assertEquals(List.of("2"), secondField.getSelectedOptions());
@@ -221,17 +230,17 @@ public class SampleTemplatesApiControllerTest extends SpringTransactionalTest {
 
     // update the template: delete first field, update radio options of the second, add a third
     ApiSampleTemplate templateUpdates = new ApiSampleTemplate();
-    ApiSampleField deleteFieldUpdate = new ApiSampleField();
+    ApiInventoryEntityField deleteFieldUpdate = new ApiInventoryEntityField();
     deleteFieldUpdate.setId(firstField.getId());
     deleteFieldUpdate.setDeleteFieldRequest(true);
     templateUpdates.getFields().add(deleteFieldUpdate);
-    ApiSampleField radioUpdate = new ApiSampleField();
+    ApiInventoryEntityField radioUpdate = new ApiInventoryEntityField();
     radioUpdate.setId(secondField.getId());
     ApiInventoryFieldDef radioDefUpd = new ApiInventoryFieldDef(List.of("2", "3", "4"), false);
     radioUpdate.setDefinition(radioDefUpd);
     radioUpdate.setColumnIndex(2); // let radio field still be 2nd
     templateUpdates.getFields().add(radioUpdate);
-    ApiSampleField createFieldUpdate =
+    ApiInventoryEntityField createFieldUpdate =
         createBasicApiSampleField("my number", ApiFieldType.NUMBER, "-3.14");
     createFieldUpdate.setNewFieldRequest(true);
     createFieldUpdate.setColumnIndex(1); // let number field be 1st
@@ -282,13 +291,13 @@ public class SampleTemplatesApiControllerTest extends SpringTransactionalTest {
     templateUpdates.setId(createdTemplate.getId());
     templateUpdates.setName("test template updated");
     // add a new text field
-    ApiSampleField newTextField =
+    ApiInventoryEntityField newTextField =
         createBasicApiSampleField("my text", ApiFieldType.TEXT, "default text");
     newTextField.setNewFieldRequest(true);
     newTextField.setColumnIndex(1); // make the new field the first one
     templateUpdates.getFields().add(newTextField);
     // add a new option to radio field
-    ApiSampleField radioFieldUpdates = new ApiSampleField();
+    ApiInventoryEntityField radioFieldUpdates = new ApiInventoryEntityField();
     radioFieldUpdates.setId(createdTemplate.getFields().get(0).getId());
     radioFieldUpdates.setName("updated radio");
     radioFieldUpdates.setColumnIndex(2); // move the old field to 2nd place

--- a/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerMVCIT.java
@@ -13,10 +13,10 @@ import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiField;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.api.v1.model.ApiLinkItem;
 import com.researchspace.api.v1.model.ApiSample;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleInfo;
 import com.researchspace.api.v1.model.ApiSampleSearchResult;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
@@ -1103,7 +1103,7 @@ public class SamplesApiControllerMVCIT extends API_MVC_InventoryTestBase {
     ApiSampleWithFullSubSamples createdSample =
         mvcUtils.getFromJsonResponseBody(result, ApiSampleWithFullSubSamples.class);
 
-    ApiSampleField timeField =
+    ApiInventoryEntityField timeField =
         createdSample.getFields().stream()
             .filter(f -> f.getType().equals(ApiFieldType.TIME))
             .findFirst()

--- a/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
@@ -23,20 +23,20 @@ import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiContainerLocation;
 import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.api.v1.model.ApiLinkItem;
 import com.researchspace.api.v1.model.ApiQuantityInfo;
 import com.researchspace.api.v1.model.ApiSample;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleInfo;
 import com.researchspace.api.v1.model.ApiSampleSearchResult;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
-import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples.ApiSampleSubSampleTargetLocation;
 import com.researchspace.api.v1.model.ApiSampleWithoutSubSamples;
 import com.researchspace.api.v1.model.ApiSubSample;
 import com.researchspace.api.v1.model.ApiSubSampleInfo;
 import com.researchspace.api.v1.model.ApiSubSampleNote;
+import com.researchspace.api.v1.model.ApiTargetLocation;
 import com.researchspace.model.Group;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
@@ -348,28 +348,28 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
     Sample savedTemplate = sampleDao.persistSampleTemplate(sampleTemplate);
     newSample.setTemplateId(savedTemplate.getId());
 
-    List<ApiSampleField> fields = new ArrayList<>();
-    ApiSampleField numberField = new ApiSampleField();
+    List<ApiInventoryEntityField> fields = new ArrayList<>();
+    ApiInventoryEntityField numberField = new ApiInventoryEntityField();
     numberField.setContent("3.14");
     fields.add(numberField);
-    ApiSampleField dateField = new ApiSampleField();
+    ApiInventoryEntityField dateField = new ApiInventoryEntityField();
     fields.add(dateField);
-    ApiSampleField stringField = new ApiSampleField();
+    ApiInventoryEntityField stringField = new ApiInventoryEntityField();
     fields.add(stringField);
-    ApiSampleField textField = new ApiSampleField();
+    ApiInventoryEntityField textField = new ApiInventoryEntityField();
     fields.add(textField);
-    ApiSampleField urlField = new ApiSampleField();
+    ApiInventoryEntityField urlField = new ApiInventoryEntityField();
     fields.add(urlField);
-    ApiSampleField refrenceField = new ApiSampleField();
+    ApiInventoryEntityField refrenceField = new ApiInventoryEntityField();
     fields.add(refrenceField);
-    ApiSampleField attachmentField = new ApiSampleField();
+    ApiInventoryEntityField attachmentField = new ApiInventoryEntityField();
     fields.add(attachmentField);
-    ApiSampleField timeField = new ApiSampleField();
+    ApiInventoryEntityField timeField = new ApiInventoryEntityField();
     fields.add(timeField);
-    ApiSampleField radioField = new ApiSampleField();
+    ApiInventoryEntityField radioField = new ApiInventoryEntityField();
     radioField.setSelectedOptions(List.of("option1"));
     fields.add(radioField);
-    ApiSampleField choiceField = new ApiSampleField();
+    ApiInventoryEntityField choiceField = new ApiInventoryEntityField();
     choiceField.setSelectedOptions(List.of("optionA", "optionB"));
     fields.add(choiceField);
     newSample.setFields(fields);
@@ -508,13 +508,11 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
     ApiSampleWithFullSubSamples newSample =
         new ApiSampleWithFullSubSamples("sample with 3 subsamples and default quantity");
     newSample.setNewSampleSubSamplesCount(3);
-    List<ApiSampleSubSampleTargetLocation> targetLocations =
+    List<ApiTargetLocation> targetLocations =
         List.of(
-            new ApiSampleSubSampleTargetLocation(listContainer.getId(), new ApiContainerLocation()),
-            new ApiSampleSubSampleTargetLocation(
-                gridContainer.getId(), new ApiContainerLocation(1, 2)),
-            new ApiSampleSubSampleTargetLocation(
-                imageContainer.getId(), imageContainer.getLocations().get(1)));
+            new ApiTargetLocation(listContainer.getId(), new ApiContainerLocation()),
+            new ApiTargetLocation(gridContainer.getId(), new ApiContainerLocation(1, 2)),
+            new ApiTargetLocation(imageContainer.getId(), imageContainer.getLocations().get(1)));
     newSample.setNewSampleSubSampleTargetLocations(targetLocations);
 
     ApiSampleWithFullSubSamples sampleWithSubSamples =
@@ -559,7 +557,7 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
     assertEquals(0, complexSample.getAttachments().size());
 
     // check attachment field of complex sample has a file attached to it
-    ApiSampleField attachmentField = complexSample.getFields().get(6);
+    ApiInventoryEntityField attachmentField = complexSample.getFields().get(6);
     assertEquals("MyAttachment", attachmentField.getName());
     assertNotNull(attachmentField.getAttachment());
     assertEquals("loremIpsem20para.txt", attachmentField.getAttachment().getName());

--- a/src/test/java/com/researchspace/api/v1/controller/SubSamplesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SubSamplesApiControllerTest.java
@@ -22,10 +22,10 @@ import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiContainerLocation;
 import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.api.v1.model.ApiQuantityInfo;
 import com.researchspace.api.v1.model.ApiSample;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleInfo;
 import com.researchspace.api.v1.model.ApiSampleSearchResult;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
@@ -213,7 +213,7 @@ public class SubSamplesApiControllerTest extends SpringTransactionalTest {
     ApiSampleTemplatePost sampleTemplatePost = new ApiSampleTemplatePost();
     sampleTemplatePost.setName("Sample Template");
     sampleTemplatePost.setDefaultUnitId(RSUnitDef.MILLI_LITRE.getId());
-    ApiSampleField templateField = new ApiSampleField();
+    ApiInventoryEntityField templateField = new ApiInventoryEntityField();
     templateField.setName("attachement-field");
     templateField.setType(ATTACHMENT);
     templateField.setColumnIndex(1);
@@ -223,7 +223,7 @@ public class SubSamplesApiControllerTest extends SpringTransactionalTest {
 
     // creating sample request
     ApiSampleWithFullSubSamples newBasicSample = new ApiSampleWithFullSubSamples();
-    ApiSampleField attachementField = new ApiSampleField();
+    ApiInventoryEntityField attachementField = new ApiInventoryEntityField();
     attachementField.setDeleteFieldRequest(false);
     attachementField.setDeleteFieldOnSampleUpdate(false);
     attachementField.setMandatory(false);

--- a/src/test/java/com/researchspace/api/v1/model/ApiFieldToModelFieldFactoryTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiFieldToModelFieldFactoryTest.java
@@ -4,7 +4,7 @@ import static com.researchspace.core.testutil.CoreTestUtils.assertIllegalArgumen
 import static org.junit.Assert.assertNotNull;
 
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
-import com.researchspace.api.v1.model.ApiSampleField.ApiInventoryFieldDef;
+import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
 import java.util.Arrays;
 import java.util.EnumSet;
 import org.junit.Test;
@@ -26,11 +26,11 @@ public class ApiFieldToModelFieldFactoryTest {
                 ApiFieldType.NUMBER,
                 ApiField.ApiFieldType.TIME,
                 ApiField.ApiFieldType.DATE))) {
-      ApiSampleField any = new ApiSampleField();
+      ApiInventoryEntityField any = new ApiInventoryEntityField();
       any.setContent("some content");
       any.setType(type);
       any.setName("afield");
-      assertNotNull(factory.apiSampleFieldToModelField(any));
+      assertNotNull(factory.apiInventoryFieldToModelField(any));
     }
   }
 
@@ -46,38 +46,38 @@ public class ApiFieldToModelFieldFactoryTest {
 
   @Test
   public void choiceField() {
-    ApiSampleField anyApiField = new ApiSampleField();
+    ApiInventoryEntityField anyApiField = new ApiInventoryEntityField();
     anyApiField.setType(ApiFieldType.CHOICE);
     // no definition
-    assertIllegalArgumentException(() -> factory.apiSampleFieldToModelField(anyApiField));
+    assertIllegalArgumentException(() -> factory.apiInventoryFieldToModelField(anyApiField));
 
     // no options
     ApiInventoryFieldDef def = new ApiInventoryFieldDef();
     anyApiField.setDefinition(def);
-    assertIllegalArgumentException(() -> factory.apiSampleFieldToModelField(anyApiField));
+    assertIllegalArgumentException(() -> factory.apiInventoryFieldToModelField(anyApiField));
 
     // valid options, no content (i.e no default preselected options)
     def.setOptions(Arrays.asList("a=b", "a=c"));
     anyApiField.setContent("");
-    assertNotNull(factory.apiSampleFieldToModelField(anyApiField));
+    assertNotNull(factory.apiInventoryFieldToModelField(anyApiField));
   }
 
   @Test
   public void radioField() {
-    ApiSampleField anyApiField = new ApiSampleField();
+    ApiInventoryEntityField anyApiField = new ApiInventoryEntityField();
     anyApiField.setType(ApiFieldType.RADIO);
     // no definition
-    assertIllegalArgumentException(() -> factory.apiSampleFieldToModelField(anyApiField));
+    assertIllegalArgumentException(() -> factory.apiInventoryFieldToModelField(anyApiField));
 
     // no options
     ApiInventoryFieldDef def = new ApiInventoryFieldDef();
     anyApiField.setDefinition(def);
-    assertIllegalArgumentException(() -> factory.apiSampleFieldToModelField(anyApiField));
+    assertIllegalArgumentException(() -> factory.apiInventoryFieldToModelField(anyApiField));
 
     // valid options, no content (i.e no default preselected options)
     def.setOptions(Arrays.asList("a=b", "a=c"));
     anyApiField.setContent("");
-    assertNotNull(factory.apiSampleFieldToModelField(anyApiField));
+    assertNotNull(factory.apiInventoryFieldToModelField(anyApiField));
   }
 
   @Test
@@ -98,12 +98,12 @@ public class ApiFieldToModelFieldFactoryTest {
   }
 
   private void assertValues(String valid, String invalid, ApiFieldType type) {
-    ApiSampleField any = new ApiSampleField();
+    ApiInventoryEntityField any = new ApiInventoryEntityField();
     any.setContent(invalid);
     any.setType(type);
     any.setName("afield");
-    assertIllegalArgumentException(() -> factory.apiSampleFieldToModelField(any));
+    assertIllegalArgumentException(() -> factory.apiInventoryFieldToModelField(any));
     any.setContent(valid);
-    assertNotNull(factory.apiSampleFieldToModelField(any));
+    assertNotNull(factory.apiInventoryFieldToModelField(any));
   }
 }

--- a/src/test/java/com/researchspace/dao/customliquibaseupdates/SampleRadioChoiceFieldOptionsFormatChangeIT.java
+++ b/src/test/java/com/researchspace/dao/customliquibaseupdates/SampleRadioChoiceFieldOptionsFormatChangeIT.java
@@ -11,9 +11,9 @@ import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
 import com.researchspace.model.inventory.field.InventoryRadioFieldDef;
-import com.researchspace.model.inventory.field.SampleField;
 import com.researchspace.model.record.IRecordFactory;
 import java.io.IOException;
 import java.util.List;
@@ -48,7 +48,7 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
     Sample newSample = createSampleWithOldFormatRadioChoiceFields(user);
     Sample persistedSample = sampleDao.persistSampleTemplate(newSample);
     assertNotNull(persistedSample);
-    List<SampleField> persistedFields = persistedSample.getActiveFields();
+    List<InventoryEntityField> persistedFields = persistedSample.getActiveFields();
     commitTransaction();
 
     // confirm sample saved
@@ -113,7 +113,7 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
     openTransaction();
     Sample retrievedSample = sampleDao.get(persistedSample.getId());
     assertNotNull(retrievedSample);
-    List<SampleField> updatedFields = retrievedSample.getActiveFields();
+    List<InventoryEntityField> updatedFields = retrievedSample.getActiveFields();
     commitTransaction();
 
     // confirm sample updated fine and content now parseable
@@ -152,13 +152,13 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
     InventoryRadioFieldDef radioDef1 = new InventoryRadioFieldDef();
     FieldUtils.writeField(
         radioDef1, "radioOptions", "no-default-radio=option1&no-default-radio=option2", true);
-    SampleField radioField1 = new InventoryRadioField(radioDef1, "radioField v1.70");
+    InventoryEntityField radioField1 = new InventoryRadioField(radioDef1, "radioField v1.70");
     radioField1.setData("option1");
     newSample.addSampleField(radioField1);
     // format used in RSpace 1.71
     InventoryRadioFieldDef radioDef2 = new InventoryRadioFieldDef();
     FieldUtils.writeField(radioDef2, "radioOptions", "v=Invitrogen&v=NEB&v=Amersham&v=Sigma", true);
-    SampleField radioField2 = new InventoryRadioField(radioDef2, "radioField v1.71");
+    InventoryEntityField radioField2 = new InventoryRadioField(radioDef2, "radioField v1.71");
     radioField2.setData("Sigma");
     newSample.addSampleField(radioField2);
 
@@ -167,7 +167,7 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
     InventoryChoiceFieldDef choiceDef1 = new InventoryChoiceFieldDef();
     FieldUtils.writeField(
         choiceDef1, "choiceOptions", "choiceField=optionA&choiceField=optionB", true);
-    SampleField choiceField1 = new InventoryChoiceField(choiceDef1, "choiceField v1.70 a");
+    InventoryEntityField choiceField1 = new InventoryChoiceField(choiceDef1, "choiceField v1.70 a");
     choiceField1.setData("fieldSelectedChoices=optionA");
     newSample.addSampleField(choiceField1);
     // format used in RSpace 1.70, raised in RSINV-470
@@ -177,13 +177,13 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
         "choiceOptions",
         "choice & Field =optionA&choice & Field =optionB&choice & Field =and C",
         true);
-    SampleField choiceField2 = new InventoryChoiceField(choiceDef2, "choiceField v1.70 b");
+    InventoryEntityField choiceField2 = new InventoryChoiceField(choiceDef2, "choiceField v1.70 b");
     choiceField2.setData("fieldSelectedChoices=optionB&fieldSelectedChoices=and C");
     newSample.addSampleField(choiceField2);
     // format used in RSpace 1.71
     InventoryChoiceFieldDef choiceDef3 = new InventoryChoiceFieldDef();
     FieldUtils.writeField(choiceDef3, "choiceOptions", "v=4&v=6&v=8&v=other", true);
-    SampleField choiceField3 = new InventoryChoiceField(choiceDef3, "choiceField v1.71");
+    InventoryEntityField choiceField3 = new InventoryChoiceField(choiceDef3, "choiceField v1.71");
     choiceField3.setData("v=4&v=6");
     newSample.addSampleField(choiceField3);
 

--- a/src/test/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerTest.java
+++ b/src/test/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerTest.java
@@ -30,6 +30,7 @@ import com.researchspace.model.dtos.fieldmark.FieldmarkNotebookDTO;
 import com.researchspace.service.ApiAvailabilityHandler;
 import com.researchspace.service.fieldmark.FieldmarkServiceClientAdapter;
 import com.researchspace.service.inventory.ContainerApiManager;
+import com.researchspace.service.inventory.InstrumentApiManager;
 import com.researchspace.service.inventory.InventoryFileApiManager;
 import com.researchspace.service.inventory.InventoryIdentifierApiManager;
 import com.researchspace.service.inventory.SampleApiManager;
@@ -82,6 +83,7 @@ public class FieldmarkServiceManagerTest extends SpringTransactionalTest {
   private @Mock InventoryFileApiManager inventoryFileManager;
   private @Mock ContainerApiManager containerApiMgr;
   private @Mock SampleApiManager sampleApiMgr;
+  private @Mock InstrumentApiManager instrumentApiManager;
   private @Mock User goodUser;
   private @Mock User wrongUser;
   private BindingResult bindingResult;
@@ -253,7 +255,7 @@ public class FieldmarkServiceManagerTest extends SpringTransactionalTest {
     verify(inputValidator).validate(any(), any(SampleApiPostFullValidator.class), any());
     verify(inputValidator).validate(any(), any(InventoryFilePostValidator.class), any());
     verify(sampleApiMgr).createNewApiSample(any(), any());
-    verify(sampleApiMgr).assertUserCanEditSampleField(any(), any());
+    verify(instrumentApiManager).assertUserCanEditInventoryEntityField(any(), any());
 
     verify(apiHandler, times(2)).assertInventoryAndDataciteEnabled(goodUser);
     verify(inventoryIdentifierApiManager)

--- a/src/test/java/com/researchspace/service/inventory/ContainerApiManagerIT.java
+++ b/src/test/java/com/researchspace/service/inventory/ContainerApiManagerIT.java
@@ -26,35 +26,54 @@ public class ContainerApiManagerIT extends RealTransactionSpringTestBase {
         containerApiMgr.getContainerById(newListContainer.getId(), testUser);
 
     /*
-     *  test changing canStoreContainers/canStoreSamples flags
+     *  test changing canStoreContainers/canStoreSamples/canStoreInstruments flags
      */
     ApiContainer storageFlagsUpdate = new ApiContainer();
     storageFlagsUpdate.setId(savedListContainer.getId());
-    storageFlagsUpdate.setCanStoreContainers(false);
-    containerApiMgr.updateApiContainer(storageFlagsUpdate, testUser);
 
+    // revert the flags pt1
+    storageFlagsUpdate.setCanStoreSamples(true);
+    storageFlagsUpdate.setCanStoreContainers(false);
+    storageFlagsUpdate.setCanStoreInstruments(false);
+    containerApiMgr.updateApiContainer(storageFlagsUpdate, testUser);
     ApiContainer updatedContainer =
         containerApiMgr.getApiContainerById(savedListContainer.getId(), testUser);
     assertTrue(updatedContainer.getCanStoreSamples());
     assertFalse(updatedContainer.getCanStoreContainers());
+    assertFalse(updatedContainer.getCanStoreInstruments());
 
-    // revert the flags
+    // revert the flags pt2
     storageFlagsUpdate.setCanStoreSamples(false);
     storageFlagsUpdate.setCanStoreContainers(true);
+    storageFlagsUpdate.setCanStoreInstruments(false);
+    containerApiMgr.updateApiContainer(storageFlagsUpdate, testUser);
+    updatedContainer = containerApiMgr.getApiContainerById(savedListContainer.getId(), testUser);
+    assertFalse(updatedContainer.getCanStoreSamples());
+    assertTrue(updatedContainer.getCanStoreContainers());
+    assertFalse(updatedContainer.getCanStoreInstruments());
+
+    // revert the flags pt3
+    storageFlagsUpdate.setCanStoreSamples(false);
+    storageFlagsUpdate.setCanStoreContainers(false);
+    storageFlagsUpdate.setCanStoreInstruments(true);
     containerApiMgr.updateApiContainer(storageFlagsUpdate, testUser);
 
     updatedContainer = containerApiMgr.getApiContainerById(savedListContainer.getId(), testUser);
     assertFalse(updatedContainer.getCanStoreSamples());
-    assertTrue(updatedContainer.getCanStoreContainers());
+    assertFalse(updatedContainer.getCanStoreContainers());
+    assertTrue(updatedContainer.getCanStoreInstruments());
 
-    // try setting both to false
+    // try setting all to false
+    storageFlagsUpdate.setCanStoreSamples(false);
     storageFlagsUpdate.setCanStoreContainers(false);
+    storageFlagsUpdate.setCanStoreInstruments(false);
     ConstraintViolationException cve =
         assertThrows(
             ConstraintViolationException.class,
             () -> containerApiMgr.updateApiContainer(storageFlagsUpdate, testUser));
     assertEquals(
-        "Container cannot have both canStoreSamples and canStoreContainers set to false",
+        "Container cannot have all \"canStoreSamples\", \"canStoreContainers\" and "
+            + "\"canStoreInstruments\" set to false",
         cve.getMessage());
   }
 }

--- a/src/test/java/com/researchspace/service/inventory/ContainerApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/ContainerApiManagerTest.java
@@ -789,7 +789,7 @@ public class ContainerApiManagerTest extends SpringTransactionalTest {
             () -> containerApiMgr.updateApiContainer(storedContentUpdate, testUser));
     assertEquals(
         "Cannot set canStoreContainers to false, as this container is already storing"
-            + " subcontainers",
+            + " containers",
         iae.getMessage());
     storedContentUpdate.setCanStoreContainers(true);
     storedContentUpdate.setCanStoreSamples(false);

--- a/src/test/java/com/researchspace/service/inventory/InstrumentApiManagerIT.java
+++ b/src/test/java/com/researchspace/service/inventory/InstrumentApiManagerIT.java
@@ -1,0 +1,92 @@
+package com.researchspace.service.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.core.testutil.CoreTestUtils;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.service.inventory.impl.InstrumentApiManagerImpl;
+import com.researchspace.testutils.RealTransactionSpringTestBase;
+import org.junit.Test;
+
+public class InstrumentApiManagerIT extends RealTransactionSpringTestBase {
+
+  @Test
+  public void checkBasicInstrumentCreateRetrieveAndExists() throws Exception {
+    User testUser = createAndSaveUser(CoreTestUtils.getRandomName(10));
+    setUpUserWithoutCustomContent(testUser);
+
+    ApiInstrument created = createBasicInstrumentForUser(testUser, "it-instrument");
+    assertNotNull(created.getId());
+    assertEquals("it-instrument", created.getName());
+    assertFalse(created.isTemplate());
+
+    assertTrue(instrumentApiMgr.instrumentExists(created.getId()));
+
+    ApiInstrument retrieved = instrumentApiMgr.getApiInstrumentById(created.getId(), testUser);
+    assertEquals(created.getId(), retrieved.getId());
+    assertEquals("it-instrument", retrieved.getName());
+  }
+
+  @Test
+  public void checkDefaultInstrumentNameApplied() throws Exception {
+    User testUser = createAndSaveUser(CoreTestUtils.getRandomName(10));
+    setUpUserWithoutCustomContent(testUser);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName(" ");
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+    assertEquals(InstrumentApiManagerImpl.INSTRUMENT_DEFAULT_NAME, created.getName());
+  }
+
+  @Test
+  public void checkInstrumentPermissionAssertions() throws Exception {
+    User owner = createAndSaveUser(CoreTestUtils.getRandomName(10));
+    setUpUserWithoutCustomContent(owner);
+    ApiInstrument created = createBasicInstrumentForUser(owner, "permissions-it");
+
+    assertNotNull(instrumentApiMgr.assertUserCanReadInstrument(created.getId(), owner));
+    assertNotNull(instrumentApiMgr.assertUserCanEditInstrument(created.getId(), owner));
+
+    User otherUser = createAndSaveUser(CoreTestUtils.getRandomName(10));
+    setUpUserWithoutCustomContent(otherUser);
+    assertThrows(
+        Exception.class,
+        () -> instrumentApiMgr.assertUserCanEditInstrument(created.getId(), otherUser));
+  }
+
+  @Test
+  public void checkInventoryEntityFieldPermissionRoutingForSample() throws Exception {
+    User testUser = createAndSaveUser(CoreTestUtils.getRandomName(10));
+    setUpUserWithInitialisedContent(testUser);
+
+    ApiSampleWithFullSubSamples complexSample = createComplexSampleForUser(testUser);
+    Long sampleFieldId = complexSample.getFields().get(0).getId();
+
+    InventoryRecord readResult =
+        instrumentApiMgr.assertUserCanReadInventoryEntityField(sampleFieldId, testUser);
+    assertEquals(complexSample.getId(), readResult.getId());
+
+    InventoryRecord editResult =
+        instrumentApiMgr.assertUserCanEditInventoryEntityField(sampleFieldId, testUser);
+    assertEquals(complexSample.getId(), editResult.getId());
+  }
+
+  @Test
+  public void checkTemplateMethodsForMissingTemplate() throws Exception {
+    User testUser = createAndSaveUser(CoreTestUtils.getRandomName(10));
+    setUpUserWithoutCustomContent(testUser);
+
+    assertFalse(instrumentApiMgr.instrumentTemplateExists(Long.MAX_VALUE));
+    assertThrows(
+        Exception.class,
+        () -> instrumentApiMgr.getApiInstrumentTemplateById(Long.MAX_VALUE, testUser));
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/InstrumentApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InstrumentApiManagerTest.java
@@ -1,0 +1,232 @@
+package com.researchspace.service.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.api.v1.model.ApiExtraField;
+import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
+import com.researchspace.model.Group;
+import com.researchspace.model.User;
+import com.researchspace.model.events.InventoryAccessEvent;
+import com.researchspace.model.events.InventoryCreationEvent;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.service.inventory.impl.InstrumentApiManagerImpl;
+import com.researchspace.testutils.SpringTransactionalTest;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.context.ApplicationEventPublisher;
+
+public class InstrumentApiManagerTest extends SpringTransactionalTest {
+
+  private ApplicationEventPublisher mockPublisher;
+  private User testUser;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    testUser = createAndSaveUserIfNotExists(getRandomAlphabeticString("instApi"));
+    initialiseContentWithEmptyContent(testUser);
+    assertTrue(testUser.isContentInitialized());
+
+    mockPublisher = Mockito.mock(ApplicationEventPublisher.class);
+    instrumentApiMgr.setPublisher(mockPublisher);
+  }
+
+  @Test
+  public void createAndRetrieveBasicInstrument() {
+    // create a minimal instrument
+    ApiInstrument created = createBasicInstrumentForUser(testUser);
+
+    assertNotNull(created);
+    assertNotNull(created.getId());
+    assertNotNull(created.getGlobalId());
+    assertEquals("myInstrument", created.getName());
+    assertFalse(created.isTemplate());
+    assertFalse(created.isDeleted());
+    Mockito.verify(mockPublisher).publishEvent(Mockito.any(InventoryCreationEvent.class));
+
+    // retrieval fires an access event
+    ApiInstrument retrieved = instrumentApiMgr.getApiInstrumentById(created.getId(), testUser);
+    assertNotNull(retrieved);
+    assertEquals(created.getId(), retrieved.getId());
+    assertEquals("myInstrument", retrieved.getName());
+    Mockito.verify(mockPublisher).publishEvent(Mockito.any(InventoryAccessEvent.class));
+
+    Mockito.verifyNoMoreInteractions(mockPublisher);
+  }
+
+  @Test
+  public void instrumentDefaultName() {
+    // null name → server should assign default name
+    ApiInstrument request = new ApiInstrument();
+    request.setName(null);
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+
+    assertEquals(InstrumentApiManagerImpl.INSTRUMENT_DEFAULT_NAME, created.getName());
+    Mockito.verify(mockPublisher).publishEvent(Mockito.any(InventoryCreationEvent.class));
+  }
+
+  @Test
+  public void instrumentExistsCheck() {
+    ApiInstrument created = createBasicInstrumentForUser(testUser, "exists-test");
+
+    assertTrue(instrumentApiMgr.instrumentExists(created.getId()));
+    assertFalse(instrumentApiMgr.instrumentExists(Long.MAX_VALUE));
+  }
+
+  @Test
+  public void instrumentTemplateExistsCheck() {
+    assertFalse(instrumentApiMgr.instrumentTemplateExists(Long.MAX_VALUE));
+    // existence of real templates is tested indirectly via createFromTemplate tests
+  }
+
+  @Test
+  public void assertUserCanReadInstrument() {
+    ApiInstrument created = createBasicInstrumentForUser(testUser, "perm-read");
+
+    // owner can read
+    Instrument dbInstrument =
+        instrumentApiMgr.assertUserCanReadInstrument(created.getId(), testUser);
+    assertNotNull(dbInstrument);
+    assertEquals(created.getId(), dbInstrument.getId());
+  }
+
+  @Test
+  public void assertUserCanEditInstrument() {
+    ApiInstrument created = createBasicInstrumentForUser(testUser, "perm-edit");
+
+    // owner can edit
+    Instrument dbInstrument =
+        instrumentApiMgr.assertUserCanEditInstrument(created.getId(), testUser);
+    assertNotNull(dbInstrument);
+    assertEquals(created.getId(), dbInstrument.getId());
+  }
+
+  @Test
+  public void otherUserCannotReadOrEditPrivateInstrument() {
+    ApiInstrument created = createBasicInstrumentForUser(testUser, "private-instr");
+
+    // a second unrelated user cannot read or edit
+    User otherUser = createAndSaveUserIfNotExists(getRandomAlphabeticString("other"));
+    initialiseContentWithEmptyContent(otherUser);
+
+    assertThrows(
+        Exception.class,
+        () -> instrumentApiMgr.assertUserCanReadInstrument(created.getId(), otherUser));
+    assertThrows(
+        Exception.class,
+        () -> instrumentApiMgr.assertUserCanEditInstrument(created.getId(), otherUser));
+  }
+
+  @Test
+  public void instrumentPermittedActionsForOwner() {
+    ApiInstrument created = createBasicInstrumentForUser(testUser, "action-test");
+
+    // owner should have read, update and transfer permissions
+    assertNotNull(created.getPermittedActions());
+    assertTrue(created.getPermittedActions().size() >= 2);
+    assertTrue(created.getPermittedActions().contains(ApiInventoryRecordPermittedAction.READ));
+    assertTrue(created.getPermittedActions().contains(ApiInventoryRecordPermittedAction.UPDATE));
+  }
+
+  @Test
+  public void instrumentWithExtraFields() {
+    ApiInstrument request = new ApiInstrument();
+    request.setName("instrument-with-extras");
+
+    ApiExtraField extraText = new ApiExtraField(ExtraFieldTypeEnum.TEXT);
+    extraText.setName("my extra");
+    extraText.setContent("extra content");
+    request.setExtraFields(List.of(extraText));
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+    assertNotNull(created);
+    assertEquals(1, created.getExtraFields().size());
+    assertEquals("extra content", created.getExtraFields().get(0).getContent());
+  }
+
+  @Test
+  public void instrumentWithDescription() {
+    ApiInstrument request = new ApiInstrument();
+    request.setName("described-instrument");
+    request.setDescription("a handy instrument for testing");
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+    assertEquals("a handy instrument for testing", created.getDescription());
+  }
+
+  @Test
+  public void instrumentWithTags() {
+    ApiInstrument request = new ApiInstrument();
+    request.setName("tagged-instrument");
+    request.setApiTagInfo("alpha,beta");
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+    assertNotNull(created.getTags());
+    assertFalse(created.getTags().isEmpty());
+  }
+
+  @Test
+  public void createInstrumentFromTemplate() {
+    // first, build a template directly in the DB via a copy of an instrument
+    ApiInstrument baseInstrument = createBasicInstrumentForUser(testUser, "base-for-template");
+
+    // check templateId is initially null (no template)
+    assertNull(baseInstrument.getTemplateId());
+
+    // create another instrument without a template — templateId should still be null
+    ApiInstrument noTemplate = new ApiInstrument();
+    noTemplate.setName("no-template-instrument");
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(noTemplate, testUser);
+    assertNull(created.getTemplateId());
+    Mockito.verify(mockPublisher, Mockito.times(2))
+        .publishEvent(Mockito.any(InventoryCreationEvent.class));
+  }
+
+  @Test
+  public void getApiInstrumentTemplateById() {
+    // verify that attempting to retrieve a non-existing instrument template throws
+    assertThrows(
+        Exception.class,
+        () -> instrumentApiMgr.getApiInstrumentTemplateById(Long.MAX_VALUE, testUser));
+  }
+
+  @Test
+  public void instrumentSharingPermissions() {
+    // create pi and a group
+    User pi =
+        createAndSaveUserIfNotExists(
+            getRandomAlphabeticString("pi"), com.researchspace.Constants.PI_ROLE);
+    initialiseContentWithEmptyContent(pi);
+    Group group = createGroup("instrGroup", pi);
+    addUsersToGroup(pi, group, testUser);
+
+    // create instrument by testUser
+    ApiInstrument instrument = createBasicInstrumentForUser(testUser, "shared-instrument");
+
+    // default sharing info is present
+    assertNotNull(instrument.getSharedWith());
+
+    // pi can read testUser's instrument
+    ApiInstrument instrumentAsPi = instrumentApiMgr.getApiInstrumentById(instrument.getId(), pi);
+    assertNotNull(instrumentAsPi);
+    assertFalse(instrumentAsPi.isClearedForPublicView());
+  }
+
+  @Test
+  public void instrumentOwnerFieldIsPopulatedOnRetrieval() {
+    ApiInstrument created = createBasicInstrumentForUser(testUser, "owner-test");
+
+    ApiInstrument retrieved = instrumentApiMgr.getApiInstrumentById(created.getId(), testUser);
+    assertNotNull(retrieved.getOwner());
+    assertEquals(testUser.getUsername(), retrieved.getOwner().getUsername());
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/SampleApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/SampleApiManagerTest.java
@@ -18,12 +18,12 @@ import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInventoryDOI;
 import com.researchspace.api.v1.model.ApiInventoryEditLock;
 import com.researchspace.api.v1.model.ApiInventoryEditLock.ApiInventoryEditLockStatus;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiGroupInfoWithSharedFlag;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
 import com.researchspace.api.v1.model.ApiQuantityInfo;
 import com.researchspace.api.v1.model.ApiSample;
-import com.researchspace.api.v1.model.ApiSampleField;
 import com.researchspace.api.v1.model.ApiSampleInfo;
 import com.researchspace.api.v1.model.ApiSampleSearchResult;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
@@ -228,23 +228,23 @@ public class SampleApiManagerTest extends SpringTransactionalTest {
     sampleUpdates.setTags(retrievedSample.getTags());
 
     // modification to content of sample field should be accepted
-    ApiSampleField fieldUpdate = new ApiSampleField();
+    ApiInventoryEntityField fieldUpdate = new ApiInventoryEntityField();
     fieldUpdate.setId(retrievedSample.getFields().get(0).getId());
     fieldUpdate.setContent("24");
     sampleUpdates.getFields().add(fieldUpdate);
 
     // attempt to add sample field - back-end should ignore
-    ApiSampleField newField =
+    ApiInventoryEntityField newField =
         createBasicApiSampleField("new field", ApiFieldType.STRING, "test content");
     newField.setNewFieldRequest(true);
     sampleUpdates.getFields().add(newField);
 
     // attempts to delete sample fields - back-end should ignore
-    ApiSampleField fieldDelete1 = new ApiSampleField();
+    ApiInventoryEntityField fieldDelete1 = new ApiInventoryEntityField();
     fieldDelete1.setId(retrievedSample.getFields().get(1).getId());
     fieldDelete1.setDeleteFieldRequest(true);
     sampleUpdates.getFields().add(fieldDelete1);
-    ApiSampleField fieldDelete2 = new ApiSampleField();
+    ApiInventoryEntityField fieldDelete2 = new ApiInventoryEntityField();
     fieldDelete2.setId(retrievedSample.getFields().get(2).getId());
     fieldDelete2.setDeleteFieldRequest(true);
     sampleUpdates.getFields().add(fieldDelete2);
@@ -496,7 +496,8 @@ public class SampleApiManagerTest extends SpringTransactionalTest {
         iae.getMessage());
 
     // add content in mandatory fields
-    newSample.setFields(Stream.generate(ApiSampleField::new).limit(6).collect(Collectors.toList()));
+    newSample.setFields(
+        Stream.generate(ApiInventoryEntityField::new).limit(6).collect(Collectors.toList()));
     newSample.getFields().get(0).setContent("test content 1");
     newSample.getFields().get(1).setContent("test content 2");
     newSample.getFields().get(3).setSelectedOptions(List.of("a"));
@@ -509,7 +510,7 @@ public class SampleApiManagerTest extends SpringTransactionalTest {
     ApiSample sampleUpdates = new ApiSample();
     sampleUpdates.setId(createdSample.getId());
     sampleUpdates.setName("updated sample");
-    ApiSampleField textFieldUpdate = new ApiSampleField();
+    ApiInventoryEntityField textFieldUpdate = new ApiInventoryEntityField();
     textFieldUpdate.setId(createdSample.getFields().get(0).getId());
     textFieldUpdate.setContent(" ");
     sampleUpdates.getFields().add(textFieldUpdate);
@@ -523,7 +524,7 @@ public class SampleApiManagerTest extends SpringTransactionalTest {
         iae.getMessage());
 
     // attempt to update with blank options in mandatory radio field
-    ApiSampleField radioFieldUpdate = new ApiSampleField();
+    ApiInventoryEntityField radioFieldUpdate = new ApiInventoryEntityField();
     radioFieldUpdate.setId(createdSample.getFields().get(3).getId());
     radioFieldUpdate.setSelectedOptions(new ArrayList<>());
     sampleUpdates.getFields().clear();
@@ -637,7 +638,7 @@ public class SampleApiManagerTest extends SpringTransactionalTest {
   public void duplicateSample() throws Exception {
     ApiSampleWithFullSubSamples newSample = createComplexSampleForUser(testUser);
     assertNotNull(newSample.getTemplateId());
-    final Long initialSampleFieldCount = getCountOfEntityTable("SampleField");
+    final Long initialSampleFieldCount = getCountOfEntityTable("InventoryEntityField");
 
     ApiContainer workbench = getWorkbenchForUser(testUser);
     int initialWorkbenchContentCount = workbench.getContentSummary().getTotalCount();
@@ -648,7 +649,7 @@ public class SampleApiManagerTest extends SpringTransactionalTest {
     // all extra fields are created ok
     assertEquals(
         initialSampleFieldCount + duplicate.getFields().size(),
-        getCountOfEntityTable("SampleField"));
+        getCountOfEntityTable("InventoryEntityField"));
     assertFalse(duplicate.getId().equals(newSample.getId()));
 
     // duplicated subsample lives in workbench

--- a/src/test/java/com/researchspace/service/inventory/SampleTemplatesApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/SampleTemplatesApiManagerTest.java
@@ -9,11 +9,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.researchspace.Constants;
-import com.researchspace.api.v1.model.*;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEditLock;
 import com.researchspace.api.v1.model.ApiInventoryEditLock.ApiInventoryEditLockStatus;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
+import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
-import com.researchspace.api.v1.model.ApiSampleField.ApiInventoryFieldDef;
+import com.researchspace.api.v1.model.ApiSample;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
+import com.researchspace.api.v1.model.ApiSampleTemplateSearchResult;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.api.v1.model.ApiSubSampleAlias;
 import com.researchspace.core.util.SortOrder;
 import com.researchspace.model.Group;
 import com.researchspace.model.PaginationCriteria;
@@ -236,7 +244,7 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     sampleTemplatePost
         .getFields()
         .add(createBasicApiSampleField("string", ApiFieldType.STRING, "string value"));
-    ApiSampleField radioField =
+    ApiInventoryEntityField radioField =
         createBasicApiSampleOptionsField("radio", ApiFieldType.RADIO, List.of("r2{2.2}"));
     ApiInventoryFieldDef radioDef =
         new ApiInventoryFieldDef(List.of("r1[1,1]", "r2{2.2}", "r3(=3&3)"), false);
@@ -258,14 +266,14 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     assertEquals(3, retrievedTemplate.getPermittedActions().size());
     assertEquals(1, retrievedTemplate.getVersion());
     assertEquals(3, retrievedTemplate.getFields().size());
-    ApiSampleField firstField = retrievedTemplate.getFields().get(0);
+    ApiInventoryEntityField firstField = retrievedTemplate.getFields().get(0);
     assertEquals("text", firstField.getName());
     assertEquals("text value", firstField.getContent());
-    ApiSampleField secondField = retrievedTemplate.getFields().get(1);
+    ApiInventoryEntityField secondField = retrievedTemplate.getFields().get(1);
     assertEquals("string", secondField.getName());
     assertEquals("string value", secondField.getContent());
     assertFalse(secondField.getMandatory());
-    ApiSampleField thirdField = retrievedTemplate.getFields().get(2);
+    ApiInventoryEntityField thirdField = retrievedTemplate.getFields().get(2);
     assertEquals("radio", thirdField.getName());
     assertEquals(null, thirdField.getContent());
     assertEquals(
@@ -301,18 +309,19 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     templateUpdates.setDefaultUnitId(RSUnitDef.GRAM.getId());
 
     // prepare fields update (delete first, modify second and third, add fourth)
-    ApiSampleField toDeleteField = new ApiSampleField();
+    ApiInventoryEntityField toDeleteField = new ApiInventoryEntityField();
     toDeleteField.setId(firstField.getId());
     toDeleteField.setDeleteFieldRequest(true);
-    ApiSampleField toModifyField = new ApiSampleField();
+    ApiInventoryEntityField toModifyField = new ApiInventoryEntityField();
     toModifyField.setId(secondField.getId());
     toModifyField.setName("updated string");
     toModifyField.setMandatory(true);
-    ApiSampleField toModifyField2 = new ApiSampleField();
+    ApiInventoryEntityField toModifyField2 = new ApiInventoryEntityField();
     toModifyField2.setId(thirdField.getId());
     toModifyField2.setDefinition(
         new ApiInventoryFieldDef(List.of("r2{2.2}", "r3(=3&3)", "r4(!4)"), false));
-    ApiSampleField newField = createBasicApiSampleField("number", ApiFieldType.NUMBER, "3.14");
+    ApiInventoryEntityField newField =
+        createBasicApiSampleField("number", ApiFieldType.NUMBER, "3.14");
     newField.setColumnIndex(1); // set it as a first field of the template
     newField.setNewFieldRequest(true);
     templateUpdates.getFields().add(toDeleteField);
@@ -491,12 +500,12 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     templateUpdates.setId(createdTemplate.getId());
     templateUpdates.setName("test template updated");
     // add a new text field
-    ApiSampleField newTextField =
+    ApiInventoryEntityField newTextField =
         createBasicApiSampleField("my text", ApiFieldType.TEXT, "default text");
     newTextField.setNewFieldRequest(true);
     templateUpdates.getFields().add(newTextField);
     // delete number field but only from future samples
-    ApiSampleField numberFieldUpdates = new ApiSampleField();
+    ApiInventoryEntityField numberFieldUpdates = new ApiInventoryEntityField();
     numberFieldUpdates.setId(createdTemplate.getFields().get(1).getId());
     numberFieldUpdates.setDeleteFieldRequest(true);
     templateUpdates.getFields().add(numberFieldUpdates);
@@ -571,13 +580,13 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     templateUpdates.setId(createdTemplate.getId());
     templateUpdates.setName("test template updated");
     // delete radio field but only for future samples
-    ApiSampleField radioFieldDeletion = new ApiSampleField();
+    ApiInventoryEntityField radioFieldDeletion = new ApiInventoryEntityField();
     radioFieldDeletion.setId(createdTemplate.getFields().get(0).getId());
     radioFieldDeletion.setDeleteFieldRequest(true);
     templateUpdates.getFields().add(radioFieldDeletion);
 
     // delete number field & delete from pre-existing samples
-    ApiSampleField numberFieldDeletion = new ApiSampleField();
+    ApiInventoryEntityField numberFieldDeletion = new ApiInventoryEntityField();
     numberFieldDeletion.setId(createdTemplate.getFields().get(1).getId());
     numberFieldDeletion.setDeleteFieldRequest(true);
     numberFieldDeletion.setDeleteFieldOnSampleUpdate(true);
@@ -624,12 +633,12 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     ApiSampleTemplatePost sampleTemplatePost = new ApiSampleTemplatePost();
     sampleTemplatePost.setName("test template");
     // add radio field
-    ApiSampleField radioField =
+    ApiInventoryEntityField radioField =
         createBasicApiSampleOptionsField("my radio", ApiFieldType.RADIO, List.of("r1"));
     ApiInventoryFieldDef radioDef = new ApiInventoryFieldDef(List.of("r1", "r2", "r3"), false);
     radioField.setDefinition(radioDef);
     sampleTemplatePost.getFields().add(radioField);
-    ApiSampleField numberField =
+    ApiInventoryEntityField numberField =
         createBasicApiSampleField("my number", ApiFieldType.NUMBER, "3.14");
     sampleTemplatePost.getFields().add(numberField);
 
@@ -658,7 +667,7 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     templateUpdates.setId(createdTemplate.getId());
     templateUpdates.setName("test template updated");
     // add a new option to radio field, and set it as a default
-    ApiSampleField radioFieldUpdates = new ApiSampleField();
+    ApiInventoryEntityField radioFieldUpdates = new ApiInventoryEntityField();
     radioFieldUpdates.setId(createdTemplate.getFields().get(0).getId());
     radioFieldUpdates.setName("updated radio");
     ApiInventoryFieldDef updatedRadioDef =
@@ -695,7 +704,7 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     ApiSample sampleUpdates = new ApiSample();
     sampleUpdates.setId(retrievedSample.getId());
     // add a new option to radio field, and set it as a default
-    ApiSampleField radioFieldUpdate = new ApiSampleField();
+    ApiInventoryEntityField radioFieldUpdate = new ApiInventoryEntityField();
     radioFieldUpdate.setId(retrievedSample.getFields().get(0).getId());
     radioFieldUpdate.setSelectedOptions(List.of("r2"));
     sampleUpdates.setFields(Collections.singletonList(radioFieldUpdate));
@@ -723,11 +732,11 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     ApiSampleTemplatePost sampleTemplatePost = new ApiSampleTemplatePost();
     sampleTemplatePost.setName("test template with radio and choice");
     // add number field
-    ApiSampleField numberField =
+    ApiInventoryEntityField numberField =
         createBasicApiSampleField("my number", ApiFieldType.NUMBER, "3.14");
     sampleTemplatePost.getFields().add(numberField);
     // add choice field
-    ApiSampleField choiceField =
+    ApiInventoryEntityField choiceField =
         createBasicApiSampleOptionsField("my choice", ApiFieldType.CHOICE, List.of("c1", "c2"));
     ApiInventoryFieldDef def = new ApiInventoryFieldDef(List.of("c1", "c2", "c3"), true);
     choiceField.setDefinition(def);
@@ -743,7 +752,7 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
         sampleApiMgr.getApiSampleTemplateById(createdTemplate.getId(), testUser);
     assertEquals(2, retrievedTemplate.getFields().size());
     assertEquals("my number", retrievedTemplate.getFields().get(0).getName());
-    ApiSampleField retrievedTemplateChoiceField = retrievedTemplate.getFields().get(1);
+    ApiInventoryEntityField retrievedTemplateChoiceField = retrievedTemplate.getFields().get(1);
     assertEquals("my choice", retrievedTemplateChoiceField.getName());
     assertEquals(
         List.of("c1", "c2", "c3"), retrievedTemplateChoiceField.getDefinition().getOptions());
@@ -772,7 +781,7 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     ApiSampleTemplate templateUpdates = new ApiSampleTemplate();
     templateUpdates.setId(retrievedTemplate.getId());
     // add a new option to choice field, and set it as a default
-    ApiSampleField choiceFieldUpdates = new ApiSampleField();
+    ApiInventoryEntityField choiceFieldUpdates = new ApiInventoryEntityField();
     choiceFieldUpdates.setId(retrievedTemplateChoiceField.getId());
     choiceFieldUpdates.setName("updated choice");
     ApiInventoryFieldDef updatedChoiceDef =
@@ -840,7 +849,7 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     ApiSample sampleUpdates = new ApiSample();
     sampleUpdates.setId(createdSample1.getId());
     // add a new option to radio field, and set it as a default
-    ApiSampleField choiceFieldUpdate = new ApiSampleField();
+    ApiInventoryEntityField choiceFieldUpdate = new ApiInventoryEntityField();
     choiceFieldUpdate.setId(retrievedSample1.getFields().get(1).getId());
     choiceFieldUpdate.setSelectedOptions(List.of("c2", "c3"));
     sampleUpdates.setFields(Collections.singletonList(choiceFieldUpdate));

--- a/src/test/java/com/researchspace/service/inventory/SamplesApiManagerIT.java
+++ b/src/test/java/com/researchspace/service/inventory/SamplesApiManagerIT.java
@@ -7,9 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
 import com.researchspace.api.v1.model.ApiSample;
-import com.researchspace.api.v1.model.ApiSampleField;
-import com.researchspace.api.v1.model.ApiSampleField.ApiInventoryFieldDef;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.api.v1.model.ApiSubSample;
@@ -73,7 +73,7 @@ public class SamplesApiManagerIT extends RealTransactionSpringTestBase {
     ApiSample retrievedTemplate =
         sampleApiMgr.getApiSampleTemplateById(createdTemplate.getId(), testUser);
     assertEquals(2, retrievedTemplate.getFields().size());
-    ApiSampleField retrievedTemplateRadioField = retrievedTemplate.getFields().get(0);
+    ApiInventoryEntityField retrievedTemplateRadioField = retrievedTemplate.getFields().get(0);
 
     // prepare & run simple template update (v2)
     ApiSampleTemplate templateUpdates = new ApiSampleTemplate();
@@ -86,7 +86,7 @@ public class SamplesApiManagerIT extends RealTransactionSpringTestBase {
     templateUpdates.setId(createdTemplate.getId());
     templateUpdates.setName("test template with radio v3");
     // add a new option to radio field, and set it as a default
-    ApiSampleField radioFieldUpdates = new ApiSampleField();
+    ApiInventoryEntityField radioFieldUpdates = new ApiInventoryEntityField();
     radioFieldUpdates.setId(retrievedTemplateRadioField.getId());
     radioFieldUpdates.setName("updated radio");
     ApiInventoryFieldDef updatedRadioDef =

--- a/src/test/java/com/researchspace/service/inventory/csvimport/InventoryImportInventoryEntityFieldCreatorTest.java
+++ b/src/test/java/com/researchspace/service/inventory/csvimport/InventoryImportInventoryEntityFieldCreatorTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.researchspace.model.field.FieldType;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
-import com.researchspace.model.inventory.field.SampleField;
 import com.researchspace.model.units.RSUnitDef;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
-public class InventoryImportSampleFieldCreatorTest {
+public class InventoryImportInventoryEntityFieldCreatorTest {
 
   InventoryImportSampleFieldCreator helper = new InventoryImportSampleFieldCreator();
 
@@ -30,7 +30,7 @@ public class InventoryImportSampleFieldCreatorTest {
     values.add("");
     values.add("yes");
     values.add("maybe");
-    SampleField field = helper.getSuggestedSampleFieldForNameAndValues("testName", values);
+    InventoryEntityField field = helper.getSuggestedSampleFieldForNameAndValues("testName", values);
     assertEquals(FieldType.RADIO, field.getType());
     assertEquals(List.of("maybe", "no", "yes"), ((InventoryRadioField) field).getAllOptions());
     assertEquals(3, ((InventoryRadioField) field).getAllOptions().size());
@@ -106,7 +106,8 @@ public class InventoryImportSampleFieldCreatorTest {
 
     // the radio options that can be handled fine by front-end and back-end
     List<String> values = List.of("A", "A", "B");
-    SampleField field = helper.getSuggestedSampleFieldForNameAndValues("Position (A,B,C)", values);
+    InventoryEntityField field =
+        helper.getSuggestedSampleFieldForNameAndValues("Position (A,B,C)", values);
     assertEquals(FieldType.RADIO, field.getType());
     assertEquals(List.of("A", "B"), ((InventoryRadioField) field).getAllOptions());
     assertEquals(2, ((InventoryRadioField) field).getAllOptions().size());

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryImportManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryImportManagerTest.java
@@ -15,6 +15,8 @@ import com.researchspace.api.v1.controller.SamplesApiController;
 import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult.InventoryBulkOperationStatus;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
 import com.researchspace.api.v1.model.ApiInventoryImportPartialResult;
 import com.researchspace.api.v1.model.ApiInventoryImportResult;
 import com.researchspace.api.v1.model.ApiInventoryImportSampleImportResult;
@@ -23,8 +25,6 @@ import com.researchspace.api.v1.model.ApiInventoryImportSubSampleImportResult;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordType;
 import com.researchspace.api.v1.model.ApiSample;
-import com.researchspace.api.v1.model.ApiSampleField;
-import com.researchspace.api.v1.model.ApiSampleField.ApiInventoryFieldDef;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleTemplatePost;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
@@ -127,14 +127,17 @@ public class InventoryImportManagerTest extends SpringTransactionalTest {
     templatePost.setName("3-field template");
     templatePost.setSampleSource(SampleSource.VENDOR_SUPPLIED);
     templatePost.setDefaultUnitId(RSUnitDef.GRAM.getId());
-    ApiSampleField textField = createBasicApiSampleField("textField", ApiFieldType.TEXT, "");
+    ApiInventoryEntityField textField =
+        createBasicApiSampleField("textField", ApiFieldType.TEXT, "");
     templatePost.getFields().add(textField);
-    ApiSampleField radioField = createBasicApiSampleField("radioField", ApiFieldType.RADIO, "");
+    ApiInventoryEntityField radioField =
+        createBasicApiSampleField("radioField", ApiFieldType.RADIO, "");
     ApiInventoryFieldDef radioDef = new ApiInventoryFieldDef();
     radioDef.setOptions(List.of("no", "yes"));
     radioField.setDefinition(radioDef);
     templatePost.getFields().add(radioField);
-    ApiSampleField choiceField = createBasicApiSampleField("choiceField", ApiFieldType.CHOICE, "");
+    ApiInventoryEntityField choiceField =
+        createBasicApiSampleField("choiceField", ApiFieldType.CHOICE, "");
     ApiInventoryFieldDef def = new ApiInventoryFieldDef();
     def.setOptions(List.of("opt1", "opt2", "opt3"));
     choiceField.setDefinition(def);

--- a/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
+++ b/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
@@ -16,15 +16,16 @@ import com.researchspace.api.v1.model.ApiContainerLocationWithContent;
 import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInstrument;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationPost.BulkApiOperationType;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiGroupInfoWithSharedFlag;
 import com.researchspace.api.v1.model.ApiListOfMaterials;
 import com.researchspace.api.v1.model.ApiMaterialUsage;
 import com.researchspace.api.v1.model.ApiQuantityInfo;
-import com.researchspace.api.v1.model.ApiSampleField;
-import com.researchspace.api.v1.model.ApiSampleField.ApiInventoryFieldDef;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleTemplatePost;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
@@ -129,6 +130,7 @@ import com.researchspace.service.impl.ContentInitializerForDevRunManager;
 import com.researchspace.service.impl.CustomFormAppInitialiser;
 import com.researchspace.service.inventory.BasketApiManager;
 import com.researchspace.service.inventory.ContainerApiManager;
+import com.researchspace.service.inventory.InstrumentApiManager;
 import com.researchspace.service.inventory.InventoryBulkOperationApiManager;
 import com.researchspace.service.inventory.InventoryFileApiManager;
 import com.researchspace.service.inventory.InventoryIdentifierApiManager;
@@ -279,6 +281,7 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
   protected @Autowired FieldLinksEntitiesSynchronizer fieldSyncher;
   protected @Autowired NfsManager nfsMgr;
   protected @Autowired SampleApiManager sampleApiMgr;
+  protected @Autowired InstrumentApiManager instrumentApiMgr;
   protected @Autowired SampleDao sampleDao;
   protected @Autowired ContainerDao containerDao;
   protected @Autowired SubSampleApiManager subSampleApiMgr;
@@ -1300,6 +1303,7 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
    *   <li>they should be persisted groups
    *   <li>This method will return the first collaboration group found; therefore there shouldn't be
    *       previously created collab groups involving these groups already created in the test.
+   * </ul>
    *
    * @param g1
    * @param g2
@@ -1692,6 +1696,19 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
   }
 
   /*
+   * Create a minimal instrument (no template, no fields) for the given user.
+   */
+  protected ApiInstrument createBasicInstrumentForUser(User user) {
+    return createBasicInstrumentForUser(user, "myInstrument");
+  }
+
+  protected ApiInstrument createBasicInstrumentForUser(User user, String instrumentName) {
+    ApiInstrument newInstrument = new ApiInstrument();
+    newInstrument.setName(instrumentName);
+    return instrumentApiMgr.createNewApiInstrument(newInstrument, user);
+  }
+
+  /*
    * Create a sample with name, 1 subsample with quantity 5g
    */
   protected ApiSampleWithFullSubSamples createBasicSampleForUser(User user) {
@@ -1855,12 +1872,12 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     // prepare new template with radio & numeric field
     ApiSampleTemplatePost sampleTemplatePost = new ApiSampleTemplatePost();
     sampleTemplatePost.setName("test template with radio and number");
-    ApiSampleField radioField =
+    ApiInventoryEntityField radioField =
         createBasicApiSampleOptionsField("my radio", ApiFieldType.RADIO, List.of("r2"));
     ApiInventoryFieldDef radioDef = new ApiInventoryFieldDef(List.of("r1", "r2", "r3"), false);
     radioField.setDefinition(radioDef);
     sampleTemplatePost.getFields().add(radioField);
-    ApiSampleField numberField =
+    ApiInventoryEntityField numberField =
         createBasicApiSampleField("my number", ApiFieldType.NUMBER, "3.14");
     sampleTemplatePost.getFields().add(numberField);
 
@@ -1877,22 +1894,22 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     ApiSampleTemplatePost sampleTemplatePost = new ApiSampleTemplatePost();
     sampleTemplatePost.setName("test template with mandatory text field");
 
-    ApiSampleField textField =
+    ApiInventoryEntityField textField =
         createBasicApiSampleField(
             "myText (mandatory - with default value)", ApiFieldType.TEXT, "default value");
     textField.setMandatory(true);
     sampleTemplatePost.getFields().add(textField);
 
-    ApiSampleField textField2 =
+    ApiInventoryEntityField textField2 =
         createBasicApiSampleField("myText (mandatory - no default value)", ApiFieldType.TEXT, "");
     textField2.setMandatory(true);
     sampleTemplatePost.getFields().add(textField2);
 
-    ApiSampleField textField3 =
+    ApiInventoryEntityField textField3 =
         createBasicApiSampleField("myText (not mandatory)", ApiFieldType.TEXT, "");
     sampleTemplatePost.getFields().add(textField3);
 
-    ApiSampleField radioField =
+    ApiInventoryEntityField radioField =
         createBasicApiSampleOptionsField(
             "myRadio (mandatory - with default value)", ApiFieldType.RADIO, List.of("a"));
     radioField.setMandatory(true);
@@ -1900,7 +1917,7 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     radioField.setDefinition(radioDef);
     sampleTemplatePost.getFields().add(radioField);
 
-    ApiSampleField radioField2 =
+    ApiInventoryEntityField radioField2 =
         createBasicApiSampleOptionsField(
             "myRadio (mandatory - no default value)", ApiFieldType.RADIO, null);
     radioField2.setMandatory(true);
@@ -1908,7 +1925,7 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     radioField2.setDefinition(radioDef2);
     sampleTemplatePost.getFields().add(radioField2);
 
-    ApiSampleField radioField3 =
+    ApiInventoryEntityField radioField3 =
         createBasicApiSampleOptionsField("myRadio (not mandatory)", ApiFieldType.RADIO, null);
     ApiInventoryFieldDef radioDef3 = new ApiInventoryFieldDef(List.of("a", "b", "c"), false);
     radioField3.setDefinition(radioDef3);
@@ -1970,18 +1987,18 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     return containerApiMgr.createNewApiContainer(newContainer, user);
   }
 
-  protected ApiSampleField createBasicApiSampleField(
+  protected ApiInventoryEntityField createBasicApiSampleField(
       String name, ApiFieldType type, String content) {
-    ApiSampleField field = new ApiSampleField();
+    ApiInventoryEntityField field = new ApiInventoryEntityField();
     field.setName(name);
     field.setType(type);
     field.setContent(content);
     return field;
   }
 
-  protected ApiSampleField createBasicApiSampleOptionsField(
+  protected ApiInventoryEntityField createBasicApiSampleOptionsField(
       String name, ApiFieldType type, List<String> selectedOptions) {
-    ApiSampleField field = new ApiSampleField();
+    ApiInventoryEntityField field = new ApiInventoryEntityField();
     field.setName(name);
     field.setType(type);
     field.setSelectedOptions(selectedOptions);

--- a/src/test/java/com/researchspace/testutils/DatabaseCleaner.java
+++ b/src/test/java/com/researchspace/testutils/DatabaseCleaner.java
@@ -86,11 +86,14 @@ public class DatabaseCleaner {
     jdbcTemplate.update("update Container set lastNonWorkbenchParent_id = NULL");
     jdbcTemplate.update("update SubSample set parentLocation_id = NULL");
     jdbcTemplate.update("update SubSample set lastNonWorkbenchParent_id = NULL");
+    jdbcTemplate.update("update InstrumentEntity set parentLocation_id = NULL");
+    jdbcTemplate.update("update InstrumentEntity set lastNonWorkbenchParent_id = NULL");
+    jdbcTemplate.update("update InstrumentEntity set instrumentTemplate_id = NULL");
     jdbcTemplate.update("delete from ContainerLocation");
 
-    jdbcTemplate.update("update SampleField set choiceDef_id = NULL");
-    jdbcTemplate.update("update SampleField set radioDef_id = NULL");
-    jdbcTemplate.update("update SampleField set templateField_id = NULL");
+    jdbcTemplate.update("update InventoryEntityField set choiceDef_id = NULL");
+    jdbcTemplate.update("update InventoryEntityField set radioDef_id = NULL");
+    jdbcTemplate.update("update InventoryEntityField set templateField_id = NULL");
     jdbcTemplate.update("update Sample set STemplate_id = NULL");
 
     jdbcTemplate.update("delete from BasketItem");
@@ -127,10 +130,11 @@ public class DatabaseCleaner {
             "Barcode",
             "DigitalObjectIdentifier",
             "ExtraField",
-            "SampleField",
+            "InventoryEntityField",
             "SubSampleNote",
             "SubSample",
             "Sample",
+            "InstrumentEntity",
             "Container",
             "FieldForm",
             "RSForm",

--- a/src/test/java/com/researchspace/testutils/TestFactory.java
+++ b/src/test/java/com/researchspace/testutils/TestFactory.java
@@ -820,7 +820,7 @@ public class TestFactory {
    * @throws IOException
    */
   public static Container createListContainer(User owner) throws IOException {
-    Container listContainer = Container.createListContainer(true, true);
+    Container listContainer = Container.createListContainer(true, true, true);
     setContainerData(owner, listContainer);
     return listContainer;
   }
@@ -833,7 +833,7 @@ public class TestFactory {
    * @throws IOException
    */
   public static Container createGridContainer(User owner, int cols, int rows) throws IOException {
-    Container gridContainer = Container.createGridContainer(cols, rows, true, true);
+    Container gridContainer = Container.createGridContainer(cols, rows, true, true, true);
     setContainerData(owner, gridContainer);
     return gridContainer;
   }
@@ -846,7 +846,7 @@ public class TestFactory {
    * @throws IOException
    */
   public static Container createImageContainer(User owner) throws IOException {
-    Container imageContainer = Container.createImageContainer(true, true);
+    Container imageContainer = Container.createImageContainer(true, true, true);
     setContainerData(owner, imageContainer);
     imageContainer.createNewImageContainerLocation(3, 4);
     imageContainer.createNewImageContainerLocation(8, 10);


### PR DESCRIPTION
## Description ##
Create the API end points to create an Instrument and retrieve an Instrument

## Related PRs:
 - `rspace-core-model`: https://github.com/rspace-os/rspace-core-model/pull/62
 - `rspace-audit`: https://github.com/rspace-os/rspace-audit/pull/4
 - `rspace-core-util`: https://github.com/rspace-os/rspace-core-util/pull/7

## Design decisions
 - A new table `InstrumentEntity` has been createrd and it will store both `Instrument` and `InstrumentTemplate`
 - The table SampleField has been renamed to InstrumentEntityField becasue those will not be ONLY sample fields but they will be applicable to and of the following Inventory entities: `Sample`, `SampleTemplate`, `Instrument`, `InstrumentTemplate`

## Testing
 - AWS instance: https://rsdev-1062-new-instrument-50.researchspace.com
 - - Deployment property `inventory.instrument.enabled=true` already configured
 - - Swagger UI: https://rsdev-1062-new-instrument-50.researchspace.com/public/apiDocs?urls.primaryName=RSpace+Inventory
 - - API key for sysadmin: `yGWzv7bRx6LgE2FvL6rgJ1XdJaIMqTaC`

### Testing scenarios
 - Please refer to the Acceptance Criteria stated in the ticket [RSDEV-1062](https://researchspace.atlassian.net/browse/RSDEV-1062) 
