### PR TITLE
Update AboutRSpaceDialog.tsx to stop using hardcoded year and use .getFullYear instead

### DIFF
--- a/src/main/webapp/ui/src/components/AppBar/AboutRSpaceDialog.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/AboutRSpaceDialog.tsx
@@ -119,7 +119,7 @@ export function AboutRSpaceContent(): React.ReactElement {
         RSpace is licensed under AGPL.
       </Typography>
       <Typography variant="caption" align="center" color="textSecondary">
-        © 2025 ResearchSpace
+        © {new Date().getFullYear()} ResearchSpace
       </Typography>
 
       <Box mt={2} mb={3}>

--- a/src/main/webapp/ui/src/components/AppBar/AboutRSpaceDialog.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/AboutRSpaceDialog.tsx
@@ -119,7 +119,7 @@ export function AboutRSpaceContent(): React.ReactElement {
         RSpace is licensed under AGPL.
       </Typography>
       <Typography variant="caption" align="center" color="textSecondary">
-        © {new Date().getFullYear()} ResearchSpace
+        © 2026 ResearchSpace
       </Typography>
 
       <Box mt={2} mb={3}>


### PR DESCRIPTION
## Description ##
Noticed that the about page has the year 2025 hardcoded into it (see screenshot). I have changed it to use getFullYear so that the year will always stay the current one

## Design decisions
N/A

## Testing notes
N/A

Screenshot:
<img width="674" height="200" alt="image" src="https://github.com/user-attachments/assets/47bffa57-25d4-4874-bbca-361bff83a54c" />

