### PR TITLE
RSDEV-1081: fix I/O error when exporting to figshare

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1490,7 +1490,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-figshare-adapter</artifactId>
-      <version>c7d2ba38e8</version>
+      <version>1.1.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1490,7 +1490,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-figshare-adapter</artifactId>
-      <version>da590b025f</version>
+      <version>c7d2ba38e8</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1490,13 +1490,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-figshare-adapter</artifactId>
-      <version>1.1.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.github.rspace-os</groupId>
-          <artifactId>rspace-repository-spi</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>da590b025f</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>


### PR DESCRIPTION
PR fixes the I/O error when exporting to figshare, by switching to latest rspace-figshare-adapter (and latest figshare-java-client).

Connected PRs:
https://github.com/rspace-os/rspace-figshare-adapter/pull/5
https://github.com/rspace-os/figshare-client-java/pull/8

