### PR TITLE
RSDEV-1077: Fix internal link search by including blockUI template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,7 @@ STOMP over WebSocket at `/ws` endpoint with SockJS fallback. Spring's `@EnableWe
 5. **Form data size:** Local Jetty limits form data to 200KB (Tomcat: 2MB). Override with `-Dorg.eclipse.jetty.server.Request.maxFormContentSize=2000000`.
 6. **Liquibase context:** Use `-Dliquibase.context=run` when running migrations locally.
 7. **Service naming:** Service beans must end in `Manager` for AOP transaction proxying (configured in `applicationContext-service.xml`).
+8. **TinyMCE plugin iframes:** Plugin dialogs (e.g., `internalLink.jsp`) load in iframes and don't inherit the main page decorator. If they use `global.js` functions that depend on DOM templates (e.g., `blockUI.html` for `RS.blockPage()`), those templates must be explicitly `<jsp:include>`d.
 
 ## Key Conventions
 

--- a/src/main/webapp/WEB-INF/pages/connect/msteams/msTeamsTabConfig.jsp
+++ b/src/main/webapp/WEB-INF/pages/connect/msteams/msTeamsTabConfig.jsp
@@ -27,6 +27,7 @@
   <script src="/scripts/pages/workspace/clientUISettings.js"></script>
 
 </head>
+<jsp:include page="/scripts/templates/blockUI.html"/>
 
 <jsp:include page="../../searchableRecordPicker.jsp">
   <jsp:param name="onlyDocuments" value="true"/>

--- a/src/main/webapp/WEB-INF/pages/externalTinymcePlugins/internalLink.jsp
+++ b/src/main/webapp/WEB-INF/pages/externalTinymcePlugins/internalLink.jsp
@@ -29,6 +29,7 @@
         }
     </style>
 </head>
+<jsp:include page="/scripts/templates/blockUI.html"/>
 
 <jsp:include page="../searchableRecordPicker.jsp">
   <jsp:param name="onlyDocuments" value="false"/>

--- a/src/test/java/com/researchspace/service/GroupManagerTest.java
+++ b/src/test/java/com/researchspace/service/GroupManagerTest.java
@@ -42,11 +42,9 @@ import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.model.system.SystemProperty;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.impl.UserContentUpdater;
-import com.researchspace.testutils.RSpaceTestUtils;
 import com.researchspace.testutils.SpringTransactionalTest;
 import com.researchspace.testutils.TestFactory;
 import com.researchspace.testutils.TestGroup;
-import com.researchspace.webapp.controller.FolderManagerStub;
 import java.util.Arrays;
 import java.util.Set;
 import org.apache.shiro.authz.AuthorizationException;
@@ -62,21 +60,19 @@ public class GroupManagerTest extends SpringTransactionalTest {
 
   @Autowired SystemPropertyManager systemPropertyManager;
   @Autowired SharingHandler sharingHandler;
-  @Mock
-  private UserContentUpdater userContentUpdaterMock;
-  @Autowired
-  private UserContentUpdater userContentUpdaterBean;
+  @Mock private UserContentUpdater userContentUpdaterMock;
+  @Autowired private UserContentUpdater userContentUpdaterBean;
+
   @Before
   public void setUp() throws Exception {
     super.setUp();
     openMocks(this);
-    ReflectionTestUtils.setField(
-        grpMgr, "userContentUpdater", userContentUpdaterMock);
+    ReflectionTestUtils.setField(grpMgr, "userContentUpdater", userContentUpdaterMock);
   }
+
   @After
   public void tearDown() throws Exception {
-    ReflectionTestUtils.setField(
-        grpMgr, "userContentUpdater", userContentUpdaterBean);
+    ReflectionTestUtils.setField(grpMgr, "userContentUpdater", userContentUpdaterBean);
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
@@ -54,8 +54,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
   private final String TEST_DATA_RECORD_NAME = "RECORD NAME ";
   private final String TEST_DATA_FOLDER_NAME = "FOLDER NAME ";
   @Mock private UserContentUpdater userContentUpdaterMock;
-  @Autowired
-  private UserContentUpdater userContentUpdaterBean;
+  @Autowired private UserContentUpdater userContentUpdaterBean;
 
   @Autowired private NotebookEditorController notebookEditorController;
 
@@ -96,16 +95,14 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
     notebookEditorController.setRecordManager(recordManagerStub);
     notebookEditorController.setPermissionUtils(permissionUtils);
     notebookEditorController.setServletContext(servletContext);
-    ReflectionTestUtils.setField(
-        grpMgr, "userContentUpdater", userContentUpdaterMock);
+    ReflectionTestUtils.setField(grpMgr, "userContentUpdater", userContentUpdaterMock);
   }
 
   @After
   public void tearDown() throws Exception {
     RSpaceTestUtils.logout();
     FolderManagerStub.noteBooksArePublished = false;
-    ReflectionTestUtils.setField(
-        grpMgr, "userContentUpdater", userContentUpdaterBean);
+    ReflectionTestUtils.setField(grpMgr, "userContentUpdater", userContentUpdaterBean);
   }
 
   @Test(expected = AuthorizationException.class)


### PR DESCRIPTION
## Description ##
The internal link dialog's search has been broken since PRT-1016 (cf1bdfe45) upgraded Mustache.js to v4.2.0. The `RS.blockPage()` function renders a `#blockUIContentTemplate` Mustache template, but that template (from `blockUI.html`) was never included in the TinyMCE iframe's `internalLink.jsp`. Mustache 4.2.0 throws on undefined templates, silently crashing the search handler before the AJAX call executes.

Also fixes the same latent issue in the MS Teams tab config page. The pint to tab feature on Teams is deprecated https://documentation.researchspace.com/l/en/article/i95u9itfgu, but I've added the import so that if it's resurrected at any point then we aren't tripped up by this issue. 

## Design decisions
Fixed by including the missing template rather than making `RS.blockPage()` defensive — the template *should* be present wherever `global.js` is loaded.

## Testing notes
AWS build: https://rsdev-1077-internal-links-3.researchspace.com/
Open a document
Click the internal link button on the toolbar, or Insert → Internal Link from the menu
Enter the global ID of a document 
Click Search