### PR TITLE
Integration skill

### DIFF
--- a/.agents/skills/rspace-empty-integration/REFERENCE.md
+++ b/.agents/skills/rspace-empty-integration/REFERENCE.md
@@ -259,7 +259,21 @@ Add an entry in alphabetical position:
 <NAME>_AVAILABLE("<name>.available"),
 ```
 
-### `IntegrationsHandlerImpl.java`
+### `IntegrationController.java`
+
+Add a `rc.put(...)` entry inside `getAll(User)`, in alphabetical order alongside the existing entries:
+
+```java
+rc.put(<NAME>_APP_NAME, integrationsHandler.getIntegration(user, <NAME>_APP_NAME));
+```
+
+Also add the corresponding static import at the top of the file:
+
+```java
+import static com.researchspace.service.IntegrationsHandler.<NAME>_APP_NAME;
+```
+
+### `system.properties`
 
 Add a line in the `system.property.description.*.available` group:
 
@@ -472,8 +486,11 @@ tinymce<Name>: "./src/tinyMCE/<name>/index.tsx",
 ## Anti-patterns (things never to do for an empty integration)
 
 - Adding `<NAME>` to `IntegrationsHandlerImpl.postProcessInfo`,
-  `setNewIntegrationInfo`, or `isSingleOptionSetAppConfigIntegration` switches.
-  (Adding to `isAppConfigIntegration` IS required — see above.)
+  `setNewIntegrationInfo`, `isAppConfigIntegration`, or
+  `isSingleOptionSetAppConfigIntegration` switches. These are only needed for
+  integrations with per-user credentials or app-level config options (OAuth
+  tokens, API keys, server URLs). A truly empty integration (no per-user
+  options) does not appear in any of these switches.
 - Adding `<NAME>_APIKEY` (or any other) `PropertyDescriptor` and
   `AppConfigElementDescriptor` to the changeset.
 - Adding deployment URL properties to `PropertyHolder.java` or

--- a/.agents/skills/rspace-empty-integration/REFERENCE.md
+++ b/.agents/skills/rspace-empty-integration/REFERENCE.md
@@ -1,0 +1,494 @@
+# RSpace Empty Integration Skill — Reference
+
+Detailed templates and edit recipes. Substitute `<Name>`, `<NAME>`, `<name>`,
+`<ticket>`, and `<DATE>` throughout.
+
+> **Hashing the LOGO_COLOR hue.** Compute hue as a deterministic hash of the
+> integration's lowercase name, modulo 360. A simple djb2-style hash works:
+> `let h = 5381; for (const c of "<name>") h = ((h << 5) + h + c.charCodeAt(0)) | 0;
+> hue = ((h % 360) + 360) % 360;`. This guarantees distinct but stable defaults.
+
+---
+
+## Files to create
+
+### 1. `src/main/resources/sqlUpdates/changeLog-<ticket>.xml`
+
+```xml
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <!-- <Name> integration -->
+    <changeSet id="<DATE>a" context="run" author="agent">
+        <comment>Create a new app - <Name></comment>
+        <insert tableName="App">
+            <column name="id" type="NUMERIC" value="NULL"/>
+            <column name="label" type="STRING" value="<Name>"/>
+            <column name="name" type="STRING" value="app.<name>"/>
+            <column name="defaultEnabled" type="BOOLEAN" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="<DATE>b" context="run" author="agent">
+        <comment>Create a new system property for <Name></comment>
+        <insert tableName="PropertyDescriptor">
+            <column name="id" type="NUMERIC" value="NULL"/>
+            <column name="defaultValue" type="STRING" value="DENIED"/>
+            <column name="name" type="STRING" value="<name>.available"/>
+            <column name="type" type="NUMERIC" value="3"/>
+        </insert>
+        <insert tableName="SystemProperty">
+            <column name="id" type="NUMERIC" value="NULL"/>
+            <column name="dependent_id" type="NUMERIC" value="NULL"/>
+            <column name="descriptor_id" type="NUMERIC"
+                    valueComputed="(select id from PropertyDescriptor where name ='<name>.available')"/>
+        </insert>
+        <insert tableName="SystemPropertyValue">
+            <column name="id" type="NUMERIC" value="NULL"/>
+            <column name="value" type="String" value="DENIED"/>
+            <column name="property_id" type="NUMERIC"
+                    valueComputed="(select sp.id from SystemProperty sp inner join PropertyDescriptor pd on sp.descriptor_id=pd.id where pd.name='<name>.available')"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>
+```
+
+### 2. `src/main/webapp/ui/src/assets/branding/<name>/index.ts`
+
+```ts
+/**
+ * The colour used in the background of the logo. Hand-tune to match the
+ * service's real brand colour.
+ */
+export const LOGO_COLOR = {
+  hue: <HASHED_HUE>,
+  saturation: 50,
+  lightness: 40,
+};
+```
+
+### 3. `src/main/webapp/ui/src/assets/branding/<name>/logo.svg`
+
+100×100 placeholder. `<INITIALS>` is the first one or two letters of `<Name>`.
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="hsl(<HASHED_HUE>, 50%, 40%)"/>
+  <text x="50" y="62" text-anchor="middle"
+        font-family="Helvetica, Arial, sans-serif" font-size="42"
+        font-weight="700" fill="#ffffff"><INITIALS></text>
+</svg>
+```
+
+### 4. `src/main/webapp/ui/src/eln/apps/integrations/<Name>.tsx`
+
+```tsx
+import Grid from "@mui/material/Grid";
+import React from "react";
+import IntegrationCard from "../IntegrationCard";
+import { type IntegrationStates } from "../useIntegrationsEndpoint";
+import <Name>Icon from "../../../assets/branding/<name>/logo.svg";
+import { LOGO_COLOR } from "../../../assets/branding/<name>";
+
+type <Name>Args = {
+  integrationState: IntegrationStates["<NAME>"];
+  update: (newIntegrationState: IntegrationStates["<NAME>"]) => void;
+};
+
+/*
+ * <Name> integration — empty scaffold. Replace placeholder text below.
+ */
+function <Name>({ integrationState, update }: <Name>Args): React.ReactNode {
+  return (
+    <Grid item sm={6} xs={12} sx={{ display: "flex" }}>
+      <IntegrationCard
+        name="<Name>"
+        integrationState={integrationState}
+        // TODO: replace placeholder explanatoryText with a real description.
+        explanatoryText="<Name> integration. TODO: replace this placeholder."
+        image={<Name>Icon}
+        color={LOGO_COLOR}
+        update={(newMode) => update({ mode: newMode, credentials: {} })}
+        // TODO: replace placeholder usageText.
+        usageText="TODO: describe how this integration is used inside RSpace."
+        // TODO: replace placeholder helpLinkText.
+        helpLinkText="<Name> integration docs"
+        // TODO: replace placeholder website.
+        website="example.com"
+        docLink="<name>"
+        setupSection={
+          <ol>
+            <li>Enable the integration.</li>
+            <li>
+              When editing a document, click the <Name> icon in the text editor
+              toolbar to open the dialog.
+            </li>
+          </ol>
+        }
+      />
+    </Grid>
+  );
+}
+
+export default React.memo(<Name>);
+```
+
+### 5. `src/main/webapp/scripts/externalTinymcePlugins/<name>/plugin.min.js`
+
+```js
+tinymce.PluginManager.add('<name>', function (editor, url) {
+
+  editor.addCommand("cmd<Name>", function () {
+    editor.windowManager.openUrl({
+      title: "<Name>",
+      url: url + "/dialog.html",
+      width: 1000,
+      height: 600,
+      buttons: [
+        { type: "cancel", id: "close", name: "close", text: "Close" }
+      ]
+    });
+  });
+
+  editor.ui.registry.addButton('<name>', {
+    icon: '<name>',
+    tooltip: '<Name>',
+    onAction: function () {
+      editor.execCommand("cmd<Name>");
+    }
+  });
+});
+```
+
+### 6. `src/main/webapp/scripts/externalTinymcePlugins/<name>/dialog.html`
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title><Name></title>
+  <script src="/ui/dist/runtime.js"></script>
+  <script src="/ui/dist/tinymce<Name>.js"></script>
+</head>
+<body>
+  <div id="tinymce-<name>"></div>
+</body>
+</html>
+```
+
+### 7. `src/main/webapp/ui/src/tinyMCE/<name>/index.tsx`
+
+```tsx
+import React from "react";
+import { createRoot } from "react-dom/client";
+import <Name> from "./<Name>";
+
+document.addEventListener("DOMContentLoaded", function () {
+  const domContainer = document.getElementById("tinymce-<name>");
+  if (domContainer) {
+    const root = createRoot(domContainer);
+    root.render(<<Name> />);
+  }
+});
+```
+
+### 8. `src/main/webapp/ui/src/tinyMCE/<name>/<Name>.tsx`
+
+```tsx
+import React from "react";
+
+/**
+ * Empty <Name> dialog body. The dialog title chrome (provided by TinyMCE
+ * via `windowManager.openUrl({ title: "<Name>", … })`) supplies the heading.
+ */
+function <Name>(): React.ReactNode {
+  return <></>;
+}
+
+export default <Name>;
+```
+
+### 9. `src/main/webapp/ui/src/tinyMCE/<name>/__tests__/<Name>.test.tsx`
+
+```tsx
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render } from "@/__tests__/customQueries";
+import <Name> from "../<Name>";
+
+describe("<Name> dialog body", () => {
+  it("renders without crashing", () => {
+    const { container } = render(<<Name> />);
+    expect(container).toBeTruthy();
+  });
+});
+```
+
+---
+
+## Files to modify
+
+> **General rule**: insert each new line/block in the correct alphabetical
+> position relative to the existing entries, and bail out if a matching entry
+> already exists.
+
+### `IntegrationsHandler.java`
+
+Insert in the constants block, alphabetically:
+
+```java
+String <NAME>_APP_NAME = "<NAME>";
+```
+
+### `SystemPropertyName.java`
+
+`SystemPropertyManagerImpl` caches `findByName` results with a SpEL key
+`"#name.propertyName"`, where `name` is a `SystemPropertyName` enum value. If
+`SystemPropertyName.valueOfPropertyName("<name>.available")` returns `null`,
+the SpEL evaluation throws `EL1007E: Property or field 'propertyName' cannot
+be found on null` and `/integration/allIntegrations` returns a 500-ish error
+that crashes the React Apps page on first load.
+
+Add an entry in alphabetical position:
+
+```java
+<NAME>_AVAILABLE("<name>.available"),
+```
+
+### `IntegrationsHandlerImpl.java`
+
+Add a line in the `system.property.description.*.available` group:
+
+```properties
+system.property.description.<name>.available=Makes <Name> integration available.
+```
+
+### `sqlUpdates/liquibase-master.xml`
+
+Append (or insert at the appropriate position) inside `<databaseChangeLog>`:
+
+```xml
+<include file="changeLog-<ticket>.xml" relativeToChangelogFile="true"/>
+```
+
+### `eln/apps/CardListing.tsx`
+
+Three insertions (alphabetical within each group):
+
+1. Import:
+   ```ts
+   import <Name> from "./integrations/<Name>";
+   ```
+
+2. `useCallback`:
+   ```ts
+   const <name>Update = React.useCallback(
+     (newState: IntegrationStates["<NAME>"]) => {
+       void runInAction(async () => {
+         integrationStates.<NAME> = await update("<NAME>", newState);
+       });
+     },
+     [update, integrationStates.<NAME>],
+   );
+   ```
+
+3. Conditional render:
+   ```tsx
+   {integrationStates.<NAME>.mode === mode && (
+     <<Name>
+       integrationState={integrationStates.<NAME>}
+       update={<name>Update}
+     />
+   )}
+   ```
+
+### `eln/apps/useIntegrationsEndpoint.ts`
+
+Five insertions:
+
+1. In the `IntegrationStates` type:
+   ```ts
+   <NAME>: IntegrationState<emptyObject>;
+   ```
+
+   `emptyObject` is the codebase's local type alias for the empty-credentials
+   case (already imported at the top of `useIntegrationsEndpoint.ts` from
+   `../../util/types`). Match the existing convention rather than emitting
+   `Record<string, never>`.
+
+2. A decoder function near the others:
+   ```ts
+   function decode<Name>(data: FetchedState): IntegrationStates["<NAME>"] {
+     return {
+       mode: parseState(data),
+       credentials: {},
+     };
+   }
+   ```
+
+3. In `decodeIntegrationStates`:
+   ```ts
+   <NAME>: decode<Name>(data.<NAME>),
+   ```
+
+4. In `encodeIntegrationState`:
+   ```ts
+   if (integration === "<NAME>") {
+     return {
+       name: "<NAME>",
+       available: data.mode !== "UNAVAILABLE",
+       enabled: data.mode === "ENABLED",
+       options: {},
+     };
+   }
+   ```
+
+5. In **both** trailing `switch (integration)` statements (the `useIntegrationsEndpoint`
+   hook has two of these — search for `case "GITHUB":`):
+   ```ts
+   case "<NAME>":
+     return decode<Name>(responseData.data) as IntegrationStates[I];
+   // …and in the second switch:
+   case "<NAME>":
+     return decode<Name>(response.data.data) as IntegrationStates[I];
+   ```
+
+### `eln/apps/__tests__/allIntegrationsAreDisabled.json`
+
+Insert object alphabetically:
+
+```json
+"<NAME>": {
+  "name": "<NAME>",
+  "displayName": "<Name>",
+  "available": false,
+  "enabled": false,
+  "oauthConnected": false,
+  "options": {}
+}
+```
+
+### `assets/DocLinks.ts`
+
+Insert alphabetically inside `docLinks`:
+
+```ts
+<name>: mkDocLink("TODO_<NAME>_DOC_ID"),
+```
+
+### `WEB-INF/pages/system/settings_ajax.jsp`
+
+Add inside the block of `<div id="*.available.description">` siblings:
+
+```jsp
+<div id="<name>.available.description"><spring:message code="system.property.description.<name>.available"/></div>
+```
+
+### `scripts/pages/system/settings_mod.js`
+
+Add under an existing `_printCategory(...)` block (default to `'Other'` and let
+the developer move it):
+
+```js
+_printSettings(['<name>.available']);
+```
+
+### `scripts/pages/workspace/editor/tinymce5_configuration.js`
+
+Two insertions inside `initTinyMCE`:
+
+1. Next to other `*Enabled` const declarations:
+   ```js
+   const <name>Enabled = integrations.<NAME>.enabled && integrations.<NAME>.available;
+   ```
+
+2. Next to other `if (*Enabled) { ... external_plugins ... }` blocks. The
+   block has TWO lines: registering the plugin script, then registering the
+   toolbar button name (without this second line, the plugin loads but no
+   button appears in the editor toolbar):
+   ```js
+   if (<name>Enabled) {
+     localTinymcesetup.external_plugins["<name>"] = "/scripts/externalTinymcePlugins/<name>/plugin.min.js";
+     addToToolbarIfNotPresent(localTinymcesetup, " | <name>");
+   }
+   ```
+
+> **Do not** add `enabledFileRepositories += " <name>"`,
+> `fileRepositoriesMenu += " opt<Name>"`, or `addToMenuIfNotPresent` lines.
+> Those wire the integration into the "Insert from…" dropdown menu, which the
+> empty integration omits in favour of a top-level toolbar button.
+
+### `scripts/tinymce/tinymce5109/icons/custom_icons/icons.js`
+
+Add a new entry inside `tinymce.IconManager.add('custom_icons', { … })`:
+
+```js
+'<name>': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><circle cx="12" cy="12" r="10" fill="none" stroke="#151515" stroke-width="2"/><text x="12" y="16" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#151515"><INITIALS></text></svg>',
+```
+
+### `build-resources/resources_to_MD5_rename.txt`
+
+Two additions in their respective alphabetical groups:
+
+```
+scripts/externalTinymcePlugins/<name>/plugin.min.js
+ui/dist/tinymce<Name>.js
+```
+
+> **Do not** add `ui/dist/externalWorkFlows.js`. That bundle is Galaxy-specific.
+
+### `src/main/webapp/ui/webpack.config.mjs`
+
+In the `entry: { … }` block, alongside the other `tinymce*` entries:
+
+```js
+tinymce<Name>: "./src/tinyMCE/<name>/index.tsx",
+```
+
+> **Do not** add an `externalWorkFlows` entry.
+
+---
+
+## Manual follow-up checklist (print after running)
+
+1. Replace placeholder strings in `<Name>.tsx`: `explanatoryText`,
+   `usageText`, `helpLinkText`, `website`.
+2. Replace `TODO_<NAME>_DOC_ID` in `DocLinks.ts` with the real helpdocs short ID.
+3. Hand-tune `LOGO_COLOR` in `branding/<name>/index.ts` to match the real brand.
+4. Replace the placeholder `branding/<name>/logo.svg` with a real
+   100×100 logo per the conventions in
+   `src/main/webapp/ui/src/eln/apps/README.md`.
+5. Replace the TinyMCE icon SVG in `icons.js` with a properly-designed icon.
+6. Move the `_printSettings(['<name>.available']);` line in `settings_mod.js`
+   under the correct sysadmin-settings category (default placement is `'Other'`).
+7. Run a clean rebuild and confirm the integration appears in the Apps page,
+   the sysadmin settings page, and the TinyMCE toolbar of a structured
+   document.
+
+## Anti-patterns (things never to do for an empty integration)
+
+- Adding `<NAME>` to `IntegrationsHandlerImpl.postProcessInfo`,
+  `setNewIntegrationInfo`, or `isSingleOptionSetAppConfigIntegration` switches.
+  (Adding to `isAppConfigIntegration` IS required — see above.)
+- Adding `<NAME>_APIKEY` (or any other) `PropertyDescriptor` and
+  `AppConfigElementDescriptor` to the changeset.
+- Adding deployment URL properties to `PropertyHolder.java` or
+  `defaultDeployment.properties`.
+- Editing `notebookEditor.jsp`, `structuredDocument.jsp`, `textField.jsp`, or
+  `journal.js`.
+- Adding an `externalWorkFlows`-shaped webpack entry or `ui/dist` bundle.
+- Adding `addMenuItem('opt<Name>', …)` or `window.insertActions.set(…)` blocks
+  in `plugin.min.js`.
+- Adding `enabledFileRepositories += " <name>"` or
+  `fileRepositoriesMenu += " opt<Name>"` in `tinymce5_configuration.js`.
+- Setting `localTinymcesetup.<name>_url` / `<name>_web_url` in
+  `tinymce5_configuration.js`.
+
+
+
+
+

--- a/.agents/skills/rspace-empty-integration/REFERENCE.md
+++ b/.agents/skills/rspace-empty-integration/REFERENCE.md
@@ -273,6 +273,45 @@ Also add the corresponding static import at the top of the file:
 import static com.researchspace.service.IntegrationsHandler.<NAME>_APP_NAME;
 ```
 
+### `IntegrationsHandlerImpl.java`
+
+Without this change, `IntegrationsHandlerImpl.isValidIntegration()` returns
+`false` for the new name, causing `checkValidIntegration()` to throw, which
+makes `/integration/allIntegrations` return an error and crashes the React Apps
+page on first load.
+
+Two edits are required:
+
+**1.** Add a new private method (e.g. after `isSingleOptionSetAppConfigIntegration`):
+
+```java
+private boolean isValidEmptyIntegration(String integrationName) {
+  switch (integrationName) {
+    case <NAME>_APP_NAME:
+      return true;
+  }
+  return false;
+}
+```
+
+**2.** Find the last line of `isAppConfigIntegration()`:
+
+```java
+return isSingleOptionSetAppConfigIntegration(integrationName);
+```
+
+Replace it with:
+
+```java
+return isValidEmptyIntegration(integrationName)
+    || isSingleOptionSetAppConfigIntegration(integrationName);
+```
+
+> **Why a separate method?** `isSingleOptionSetAppConfigIntegration` is for
+> integrations with exactly one stored credential (e.g. Egnyte domain, Zenodo
+> token). An empty integration has no per-user options, so it must not appear
+> there. `isValidEmptyIntegration` is the correct home.
+
 ### `system.properties`
 
 Add a line in the `system.property.description.*.available` group:
@@ -431,6 +470,12 @@ Two insertions inside `initTinyMCE`:
    }
    ```
 
+> **⚠️ CRITICAL — the ` | ` separator is mandatory.** The argument to
+> `addToToolbarIfNotPresent` MUST be `" | <name>"` (space, pipe, space, then
+> the name). Passing only `"<name>"` concatenates it directly onto the last
+> toolbar token (e.g. `"fullscreennew_test"`), which TinyMCE cannot parse, and
+> **no toolbar button will appear** even though the plugin loads successfully.
+
 > **Do not** add `enabledFileRepositories += " <name>"`,
 > `fileRepositoriesMenu += " opt<Name>"`, or `addToMenuIfNotPresent` lines.
 > Those wire the integration into the "Insert from…" dropdown menu, which the
@@ -479,18 +524,23 @@ tinymce<Name>: "./src/tinyMCE/<name>/index.tsx",
 5. Replace the TinyMCE icon SVG in `icons.js` with a properly-designed icon.
 6. Move the `_printSettings(['<name>.available']);` line in `settings_mod.js`
    under the correct sysadmin-settings category (default placement is `'Other'`).
-7. Run a clean rebuild and confirm the integration appears in the Apps page,
+7. Run `cd src/main/webapp/ui && npm run build` to produce the
+   `ui/dist/tinymce<Name>.js` bundle. Without this, the TinyMCE dialog opens
+   blank (the React component fails to load). This was already done in step 5
+   of the skill workflow; include it here as a reminder for manual runs.
+8. Run a clean rebuild and confirm the integration appears in the Apps page,
    the sysadmin settings page, and the TinyMCE toolbar of a structured
    document.
 
 ## Anti-patterns (things never to do for an empty integration)
 
 - Adding `<NAME>` to `IntegrationsHandlerImpl.postProcessInfo`,
-  `setNewIntegrationInfo`, `isAppConfigIntegration`, or
-  `isSingleOptionSetAppConfigIntegration` switches. These are only needed for
-  integrations with per-user credentials or app-level config options (OAuth
-  tokens, API keys, server URLs). A truly empty integration (no per-user
-  options) does not appear in any of these switches.
+  `setNewIntegrationInfo`, or `isSingleOptionSetAppConfigIntegration` switches.
+  These are only needed for integrations with per-user credentials or
+  app-level config options (OAuth tokens, API keys, server URLs). An empty
+  integration has no per-user options, so it must not appear in any of these.
+  Use the dedicated `isValidEmptyIntegration()` method instead (see recipe
+  above).
 - Adding `<NAME>_APIKEY` (or any other) `PropertyDescriptor` and
   `AppConfigElementDescriptor` to the changeset.
 - Adding deployment URL properties to `PropertyHolder.java` or

--- a/.agents/skills/rspace-empty-integration/SKILL.md
+++ b/.agents/skills/rspace-empty-integration/SKILL.md
@@ -20,7 +20,7 @@ Inputs to gather from the user:
 Derived: `<NAME>` = uppercase, `<name>` = lowercase, `<DATE>` = today's date in
 `YYYY-MM-DD`.
 
-Workspace root: `rspace-web/` (a Java/Spring + React/TypeScript monorepo).
+Workspace root: the repo root (the directory containing `pom.xml` and `mvnw`).
 
 ## Workflow
 
@@ -34,7 +34,7 @@ on what is and isn't in scope, and re-read it before each ambiguous decision.
 
 ### 2. Verify prerequisites
 
-- Confirm `rspace-web/pom.xml` exists at the workspace root.
+- Confirm `pom.xml` exists at the workspace root.
 - Confirm `<NAME>` is not already a key in
   `src/main/webapp/ui/src/eln/apps/useIntegrationsEndpoint.ts` `IntegrationStates`
   type. If it is, abort with a clear message — the integration already exists.
@@ -53,14 +53,13 @@ For exact file contents and templates, see [REFERENCE.md](REFERENCE.md):
 - [ ] `src/main/webapp/ui/src/tinyMCE/<name>/<Name>.tsx`
 - [ ] `src/main/webapp/ui/src/tinyMCE/<name>/__tests__/<Name>.test.tsx`
 
-### 4. Modify existing files (13)
+### 4. Modify existing files (15)
 
 Each edit must preserve existing alphabetical ordering. See
 [REFERENCE.md](REFERENCE.md) for the exact insertion patterns.
 
 - [ ] `src/main/java/com/researchspace/service/IntegrationsHandler.java`
 - [ ] `src/main/java/com/researchspace/service/SystemPropertyName.java`
-- [ ] `src/main/java/com/researchspace/service/impl/IntegrationsHandlerImpl.java`
 - [ ] `src/main/java/com/researchspace/webapp/controller/IntegrationController.java`
 - [ ] `src/main/resources/bundles/system/system.properties`
 - [ ] `src/main/resources/sqlUpdates/liquibase-master.xml`
@@ -94,6 +93,18 @@ Optionally run the smoke test for the new TinyMCE component:
 
 ```bash
 cd src/main/webapp/ui && npx vitest run src/tinyMCE/<name>/__tests__/<Name>.test.tsx
+```
+
+To verify the backend changes (Liquibase changeset applied, `SystemPropertyName` enum correct, integration visible in the API), run the existing MVC integration test against a running database:
+
+```bash
+mvn test -Dtest=IntegrationControllerMVCIT#getAllIntegrations
+```
+
+Alternatively, start the app and confirm `<NAME>` appears as a key in the response from:
+
+```
+GET http://localhost:8080/integration/allIntegrations
 ```
 
 ### 6. Report manual follow-ups

--- a/.agents/skills/rspace-empty-integration/SKILL.md
+++ b/.agents/skills/rspace-empty-integration/SKILL.md
@@ -53,7 +53,7 @@ For exact file contents and templates, see [REFERENCE.md](REFERENCE.md):
 - [ ] `src/main/webapp/ui/src/tinyMCE/<name>/<Name>.tsx`
 - [ ] `src/main/webapp/ui/src/tinyMCE/<name>/__tests__/<Name>.test.tsx`
 
-### 4. Modify existing files (15)
+### 4. Modify existing files (16)
 
 Each edit must preserve existing alphabetical ordering. See
 [REFERENCE.md](REFERENCE.md) for the exact insertion patterns.
@@ -61,6 +61,7 @@ Each edit must preserve existing alphabetical ordering. See
 - [ ] `src/main/java/com/researchspace/service/IntegrationsHandler.java`
 - [ ] `src/main/java/com/researchspace/service/SystemPropertyName.java`
 - [ ] `src/main/java/com/researchspace/webapp/controller/IntegrationController.java`
+- [ ] `src/main/java/com/researchspace/service/impl/IntegrationsHandlerImpl.java`
 - [ ] `src/main/resources/bundles/system/system.properties`
 - [ ] `src/main/resources/sqlUpdates/liquibase-master.xml`
 - [ ] `src/main/webapp/ui/src/eln/apps/CardListing.tsx`
@@ -81,7 +82,22 @@ Each edit must preserve existing alphabetical ordering. See
 > (`content.replace(needle, replacement, 1)`) rather than retrying the same
 > tool call.
 
-### 5. Verify
+### 5. Build the frontend bundles
+
+The TinyMCE dialog body (`dialog.html`) loads a Webpack bundle that does not
+exist until the UI is built. Run the build now so the integration is fully
+functional immediately after the scaffold is applied:
+
+```bash
+cd src/main/webapp/ui && npm run build
+```
+
+> **⚠️ This step is mandatory.** Without it, clicking the toolbar button opens
+> a blank dialog with a console error (`Failed to load resource:
+> tinymce<Name>.js`). The Apps-page card and sysadmin toggle work without the
+> build, but the TinyMCE dialog will not load.
+
+### 6. Verify
 
 Run the frontend type-check and lint to catch typos in the generated edits:
 
@@ -107,7 +123,7 @@ Alternatively, start the app and confirm `<NAME>` appears as a key in the respon
 GET http://localhost:8080/integration/allIntegrations
 ```
 
-### 6. Report manual follow-ups
+### 7. Report manual follow-ups
 
 After the scaffold is in place, output a checklist of work the developer must
 complete by hand: replace placeholder card strings, replace

--- a/.agents/skills/rspace-empty-integration/SKILL.md
+++ b/.agents/skills/rspace-empty-integration/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: rspace-empty-integration
+description: Scaffold a new "empty" RSpace integration end-to-end (Liquibase migration, sysadmin/user toggles, Apps-page card, TinyMCE toolbar icon opening a blank-bodied dialog with the integration's name as the chrome title). Use when a user asks to add, scaffold, create, or generate a new integration in the rspace-web codebase, mentions an integration name (e.g. "add a Galaxy/Foo/Bar integration"), or refers to "empty integration", "integration skeleton", or "new App". Do not use this skill when the request requires authentication (OAuth/API key), per-user configuration, deployment URLs, or backend Java services — those layers must be added by hand on top of the empty scaffold.
+---
+
+# RSpace Empty Integration Skill
+
+Scaffold a new RSpace integration with the minimum surface area: database
+toggles, an Apps-page card, and a TinyMCE toolbar icon that opens a blank
+dialog whose title chrome is the integration name. Authentication, deployment
+URLs, and domain logic are out of scope.
+
+## Quick start
+
+Inputs to gather from the user:
+
+- `<Name>` — PascalCase (e.g. `Galaxy`)
+- `<ticket>` — Liquibase changeset suffix (e.g. `rsdev-1234`)
+
+Derived: `<NAME>` = uppercase, `<name>` = lowercase, `<DATE>` = today's date in
+`YYYY-MM-DD`.
+
+Workspace root: `rspace-web/` (a Java/Spring + React/TypeScript monorepo).
+
+## Workflow
+
+Work through this checklist in order. **Do not skip steps.** All edits must be
+idempotent: detect existing entries and refuse to overwrite.
+
+### 1. Read the spec
+
+Read `DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md` for full context
+on what is and isn't in scope, and re-read it before each ambiguous decision.
+
+### 2. Verify prerequisites
+
+- Confirm `rspace-web/pom.xml` exists at the workspace root.
+- Confirm `<NAME>` is not already a key in
+  `src/main/webapp/ui/src/eln/apps/useIntegrationsEndpoint.ts` `IntegrationStates`
+  type. If it is, abort with a clear message — the integration already exists.
+
+### 3. Create new files (9)
+
+For exact file contents and templates, see [REFERENCE.md](REFERENCE.md):
+
+- [ ] `src/main/resources/sqlUpdates/changeLog-<ticket>.xml`
+- [ ] `src/main/webapp/ui/src/assets/branding/<name>/index.ts`
+- [ ] `src/main/webapp/ui/src/assets/branding/<name>/logo.svg`
+- [ ] `src/main/webapp/ui/src/eln/apps/integrations/<Name>.tsx`
+- [ ] `src/main/webapp/scripts/externalTinymcePlugins/<name>/plugin.min.js`
+- [ ] `src/main/webapp/scripts/externalTinymcePlugins/<name>/dialog.html`
+- [ ] `src/main/webapp/ui/src/tinyMCE/<name>/index.tsx`
+- [ ] `src/main/webapp/ui/src/tinyMCE/<name>/<Name>.tsx`
+- [ ] `src/main/webapp/ui/src/tinyMCE/<name>/__tests__/<Name>.test.tsx`
+
+### 4. Modify existing files (13)
+
+Each edit must preserve existing alphabetical ordering. See
+[REFERENCE.md](REFERENCE.md) for the exact insertion patterns.
+
+- [ ] `src/main/java/com/researchspace/service/IntegrationsHandler.java`
+- [ ] `src/main/java/com/researchspace/service/SystemPropertyName.java`
+- [ ] `src/main/java/com/researchspace/service/impl/IntegrationsHandlerImpl.java`
+- [ ] `src/main/java/com/researchspace/webapp/controller/IntegrationController.java`
+- [ ] `src/main/resources/bundles/system/system.properties`
+- [ ] `src/main/resources/sqlUpdates/liquibase-master.xml`
+- [ ] `src/main/webapp/ui/src/eln/apps/CardListing.tsx`
+- [ ] `src/main/webapp/ui/src/eln/apps/useIntegrationsEndpoint.ts`
+- [ ] `src/main/webapp/ui/src/eln/apps/__tests__/allIntegrationsAreDisabled.json`
+- [ ] `src/main/webapp/ui/src/assets/DocLinks.ts`
+- [ ] `src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp`
+- [ ] `src/main/webapp/scripts/pages/system/settings_mod.js`
+- [ ] `src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js`
+- [ ] `src/main/webapp/scripts/tinymce/tinymce5109/icons/custom_icons/icons.js`
+- [ ] `build-resources/resources_to_MD5_rename.txt`
+- [ ] `src/main/webapp/ui/webpack.config.mjs`
+
+> **Verify every edit takes effect.** Some edit tools may report success
+> without actually applying the change. After each modification, run a quick
+> `grep` for the inserted string in the target file. If it isn't present,
+> re-apply the edit using a deterministic Python script
+> (`content.replace(needle, replacement, 1)`) rather than retrying the same
+> tool call.
+
+### 5. Verify
+
+Run the frontend type-check and lint to catch typos in the generated edits:
+
+```bash
+cd src/main/webapp/ui && npm run tsc && npm run lint
+```
+
+Optionally run the smoke test for the new TinyMCE component:
+
+```bash
+cd src/main/webapp/ui && npx vitest run src/tinyMCE/<name>/__tests__/<Name>.test.tsx
+```
+
+### 6. Report manual follow-ups
+
+After the scaffold is in place, output a checklist of work the developer must
+complete by hand: replace placeholder card strings, replace
+`TODO_<NAME>_DOC_ID` in `DocLinks.ts`, hand-tune `LOGO_COLOR`, replace the
+placeholder logo and TinyMCE icon SVGs, and pick the right category in
+`settings_mod.js`.
+
+## Out of scope
+
+This skill does **not** handle: OAuth, API-key auth, per-user options,
+deployment URLs, backend services/controllers/DAOs, archive export,
+per-text-field React components (the `externalWorkFlows` bundle pattern), or
+the `enabledFileRepositories` / `fileRepositoriesMenu` / "Insert from…" menu
+plumbing. If any of these are needed, scaffold the empty integration first,
+then add those layers by hand following
+`DevDocs/DeveloperNotes/CreatingNewIntegration.md` and
+`src/main/webapp/ui/src/eln/apps/AddingANewIntegration.md`.
+
+
+
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,7 +306,7 @@ Currently available:
 
 - `.agents/skills/rspace-empty-integration/` — scaffolds a new "empty" RSpace
   integration (Liquibase migration, sysadmin/user toggles, Apps-page card,
-  TinyMCE toolbar icon opening a blank-titled dialog).
+  TinyMCE toolbar icon opening a dialog whose chrome title is the integration's name).
 
 **Discovery:** `.agents/skills/` is the cross-agent convention (used by
 agents-md-aware tools, Cursor, Codex CLI, and others that follow the AGENTS.md
@@ -317,6 +317,6 @@ Either way, every agent can read these files directly — no install step needed
 to use them in this repo.
 
 **To add a new skill:** create `.agents/skills/<skill-name>/SKILL.md` with
-frontmatter, keep it under ~100 lines, and put bulky templates/recipes in a
+frontmatter, keep it under ~150 lines, and put bulky templates/recipes in a
 sibling `REFERENCE.md`. List it above so the team can discover it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,3 +295,28 @@ DevDocs/                           # Developer documentation
 - **AGENTS.md** (this file): Primary instructions for all AI agents
 - **CLAUDE.md**: Points to AGENTS.md — for Claude Code / Anthropic agents
 - **.github/copilot-instructions.md**: Quick-reference for GitHub Copilot — points to AGENTS.md
+
+## Repo-Local Agent Skills
+
+Reusable agent skills (executable playbooks) live under `.agents/skills/`. Each
+skill is a directory containing a `SKILL.md` (with YAML frontmatter `name` +
+`description`) plus optional `REFERENCE.md` and bundled resources.
+
+Currently available:
+
+- `.agents/skills/rspace-empty-integration/` — scaffolds a new "empty" RSpace
+  integration (Liquibase migration, sysadmin/user toggles, Apps-page card,
+  TinyMCE toolbar icon opening a blank-titled dialog).
+
+**Discovery:** `.agents/skills/` is the cross-agent convention (used by
+agents-md-aware tools, Cursor, Codex CLI, and others that follow the AGENTS.md
+spec). Claude Code users who want auto-discovery can either (a) symlink
+`.claude/skills -> ../.agents/skills` locally (not committed), or (b) point
+Claude at the skill explicitly: "use the skill at `.agents/skills/<name>`".
+Either way, every agent can read these files directly — no install step needed
+to use them in this repo.
+
+**To add a new skill:** create `.agents/skills/<skill-name>/SKILL.md` with
+frontmatter, keep it under ~100 lines, and put bulky templates/recipes in a
+sibling `REFERENCE.md`. List it above so the team can discover it.
+

--- a/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
+++ b/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
@@ -19,7 +19,7 @@ The plan is derived from a detailed analysis of the seven Galaxy commits
 work.
 
 It is intended to be implemented as an agent skill (see
-`~/.agents/skills/rspace-empty-integration/`) and read by humans adding
+`.agents/skills/rspace-empty-integration/`) and read by humans adding
 integrations by hand. See also:
 
 - `DevDocs/DeveloperNotes/CreatingNewIntegration.md`

--- a/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
+++ b/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
@@ -1,0 +1,142 @@
+# Empty Integration Skill — Plan
+
+This document specifies the canonical scaffolding required to add a new
+"empty" integration to RSpace: an integration whose only behaviour is
+
+1. registering a sysadmin-level on/off toggle and a per-user on/off toggle in
+   the database,
+2. appearing as a card on the **Apps** page,
+3. registering a TinyMCE toolbar icon that, when clicked, opens an
+   otherwise-blank dialog whose title chrome shows the integration's name.
+
+It does **not** cover authentication (OAuth, API keys), per-user configuration
+options, deployment-level URLs, backend Java services/controllers/DAOs, or any
+domain logic. Those layers are added on top once an empty integration exists.
+
+The plan is derived from a detailed analysis of the seven Galaxy commits
+(`e0b2ab0e`, `33b42970`, `8a4c9719`, `3916c38b`, `e6c82abd`, `60021385`,
+`d8cb0495`), separating generic-integration scaffolding from Galaxy-specific
+work.
+
+It is intended to be implemented as an agent skill (see
+`~/.agents/skills/rspace-empty-integration/`) and read by humans adding
+integrations by hand. See also:
+
+- `DevDocs/DeveloperNotes/CreatingNewIntegration.md`
+- `src/main/webapp/ui/src/eln/apps/AddingANewIntegration.md`
+- `src/main/webapp/ui/src/eln/apps/README.md`
+
+## Inputs
+
+The skill / human implementer needs four pieces of data:
+
+| Variable        | Example         | Notes                                              |
+| --------------- | --------------- | -------------------------------------------------- |
+| `<Name>`        | `Galaxy`        | PascalCase. Used in display names and class names. |
+| `<NAME>`        | `GALAXY`        | UPPERCASE. Used in Java constants and TS keys.     |
+| `<name>`        | `galaxy`        | lowercase. Used in URLs, file paths, JSON keys.    |
+| `<ticket>`      | `rsdev-1234`    | Liquibase changeset filename suffix.               |
+| `<DATE>`        | `2026-04-28`    | Liquibase changeset id prefix (today's date).      |
+
+## Files created (9)
+
+| Path                                                                                | Purpose                                                                 |
+| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `src/main/resources/sqlUpdates/changeLog-<ticket>.xml`                               | Liquibase: App row + sysadmin PropertyDescriptor / SystemProperty.      |
+| `src/main/webapp/ui/src/assets/branding/<name>/index.ts`                             | Exports `LOGO_COLOR` HSL.                                               |
+| `src/main/webapp/ui/src/assets/branding/<name>/logo.svg`                             | 100×100 placeholder logo.                                               |
+| `src/main/webapp/ui/src/eln/apps/integrations/<Name>.tsx`                            | Apps-page card (Chemistry-style simple toggle).                         |
+| `src/main/webapp/scripts/externalTinymcePlugins/<name>/plugin.min.js`                | TinyMCE plugin: registers icon + toolbar button + dialog opener.        |
+| `src/main/webapp/scripts/externalTinymcePlugins/<name>/dialog.html`                  | Dialog body host that loads the React bundle.                           |
+| `src/main/webapp/ui/src/tinyMCE/<name>/index.tsx`                                    | Mounts React component into `#tinymce-<name>`.                          |
+| `src/main/webapp/ui/src/tinyMCE/<name>/<Name>.tsx`                                   | Empty React component.                                                  |
+| `src/main/webapp/ui/src/tinyMCE/<name>/__tests__/<Name>.test.tsx`                    | Vitest smoke test.                                                      |
+
+## Files modified (13)
+
+| Path                                                                                       | Edit                                                                                                                  |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `src/main/java/com/researchspace/service/IntegrationsHandler.java`                         | Insert `String <NAME>_APP_NAME = "<NAME>";` constant in alphabetical order.                                           |
+| `src/main/resources/bundles/system/system.properties`                                      | Add `system.property.description.<name>.available=Makes <Name> integration available.`                                |
+| `src/main/resources/sqlUpdates/liquibase-master.xml`                                       | Register the new changeset.                                                                                            |
+| `src/main/webapp/ui/src/eln/apps/CardListing.tsx`                                          | Add import, `<name>Update` `useCallback`, and conditional render block (alphabetical).                                |
+| `src/main/webapp/ui/src/eln/apps/useIntegrationsEndpoint.ts`                               | Add `IntegrationStates` entry, decoder, encoder branch, two switch arms.                                              |
+| `src/main/webapp/ui/src/eln/apps/__tests__/allIntegrationsAreDisabled.json`                | Insert `"<NAME>": { … }` fixture object.                                                                              |
+| `src/main/webapp/ui/src/assets/DocLinks.ts`                                                | Add `<name>: mkDocLink("TODO_<NAME>_DOC_ID"),`.                                                                       |
+| `src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp`                                   | Add `<div id="<name>.available.description">…</div>`.                                                                 |
+| `src/main/webapp/scripts/pages/system/settings_mod.js`                                     | Add `_printSettings(['<name>.available']);` under an existing category.                                               |
+| `src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js`                 | Add `<name>Enabled` const + `if (<name>Enabled) localTinymcesetup.external_plugins["<name>"] = "..."` block.          |
+| `src/main/webapp/scripts/tinymce/tinymce516/icons/custom_icons/icons.js`                   | Register a `<name>` SVG icon entry.                                                                                   |
+| `build-resources/resources_to_MD5_rename.txt`                                              | Add `scripts/externalTinymcePlugins/<name>/plugin.min.js` and `ui/dist/tinymce<Name>.js` lines.                       |
+| `src/main/webapp/ui/webpack.config.js`                                                     | Add `tinymce<Name>: "./src/tinyMCE/<name>/index.tsx",` entry.                                                         |
+
+## Out of scope (explicitly NOT touched)
+
+The empty-integration skill **does not** modify any of:
+
+- `IntegrationsHandlerImpl.java` — only needed when there are per-user options
+  (OAuth tokens or API keys saved via `UserConnectionManager`).
+- `IPropertyHolder.java`, `PropertyHolder.java`, `defaultDeployment.properties`
+  — only needed for deployment-level URLs.
+- `IntegrationController.java`.
+- `WEB-INF/pages/notebookEditor/notebookEditor.jsp`,
+  `WEB-INF/pages/workspace/editor/structuredDocument.jsp`,
+  `WEB-INF/pages/workspace/editor/include/textField.jsp`,
+  `scripts/pages/journal.js` — these are only modified by integrations that
+  mount per-text-field React components (e.g. Galaxy's
+  `ext-workflows-textfield`).
+- The `externalWorkFlows` webpack entry — Galaxy-specific workflow tracking
+  bundle.
+- `BaseController`, `ControllerExceptionHandler`,
+  `IControllerExceptionHandler`, `NotFoundLoggedAsErrorExceptionHandlerVisitor`,
+  `JournalController`, `StructuredDocumentController`,
+  `DeploymentPropertiesController` — Galaxy-PR-specific exception-handling
+  refactors, not generic.
+- The `enabledFileRepositories` / `fileRepositoriesMenu` strings and the
+  `localTinymcesetup.recordId = recordId` line in `tinymce5_configuration.js`.
+- The `addMenuItem('opt<Name>', …)` registration and `window.insertActions`
+  population in `plugin.min.js` — those wire the integration into the
+  "Insert from…" dropdown menu, which the empty integration omits.
+
+## Conventions
+
+- **Liquibase**: each `<changeSet>` uses `context="run"` and an id of the form
+  `<DATE>a`, `<DATE>b`, …
+- **`PropertyDescriptor.defaultValue`** = `DENIED`. **`SystemPropertyValue.value`**
+  = `DENIED`. (The Galaxy commit used `ALLOWED` for the descriptor; that is an
+  outlier and not the convention.)
+- **TypeScript credentials** for an empty integration: `Record<string, never>`.
+  The encoder emits `options: {}`; the decoder emits `credentials: {}`.
+- **Apps-page card**: follows the **Chemistry** simple-toggle pattern. No
+  `useState`, no auth form, `update={(newMode) => update({ mode: newMode,
+  credentials: {} })}`. Setup section is a two-step `<ol>`. Placeholder strings
+  for `explanatoryText`, `usageText`, `helpLinkText`, `website`. Each placeholder
+  carries a `// TODO:` comment.
+- **TinyMCE dialog**: dialog title comes from
+  `windowManager.openUrl({ title: "<Name>", … })`. The React bundle mounts
+  into `#tinymce-<name>` but renders an empty fragment.
+- **Icon**: 20×20-ish monochrome SVG using `#151515` for the strokes/fills,
+  matching the existing custom icon style.
+- **Branding logo**: 100×100 SVG. Background is the `LOGO_COLOR` hue at high
+  saturation; foreground is white initials of the integration name.
+- **Idempotency**: every edit must detect existing entries (e.g.
+  `<NAME>:` already in `IntegrationStates`) and refuse to overwrite, so
+  re-running on the same name is safe.
+- **Insertion order**: insertions into existing files should preserve
+  alphabetical ordering wherever the surrounding file is alphabetised.
+
+## Manual follow-up after running the skill
+
+1. Replace placeholder strings in `<Name>.tsx`
+   (`explanatoryText`, `usageText`, `helpLinkText`, `website`).
+2. Replace `TODO_<NAME>_DOC_ID` in `DocLinks.ts` with the real helpdocs short
+   ID once the help page exists.
+3. Hand-tune `LOGO_COLOR` in `branding/<name>/index.ts` to match the real
+   service's brand.
+4. Replace the placeholder `branding/<name>/logo.svg` with the real
+   100×100 logo per the conventions in
+   `src/main/webapp/ui/src/eln/apps/README.md`.
+5. Replace the TinyMCE icon SVG in `icons.js` with a properly-designed icon.
+6. Choose the appropriate sysadmin-settings category in `settings_mod.js`
+   (the skill defaults to `'Other'`).
+

--- a/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
+++ b/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
@@ -52,7 +52,7 @@ The skill / human implementer needs four pieces of data:
 | `src/main/webapp/ui/src/tinyMCE/<name>/<Name>.tsx`                                   | Empty React component.                                                  |
 | `src/main/webapp/ui/src/tinyMCE/<name>/__tests__/<Name>.test.tsx`                    | Vitest smoke test.                                                      |
 
-## Files modified (16)
+## Files modified (15)
 
 | Path                                                                                       | Edit                                                                                                                  |
 | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
@@ -67,20 +67,27 @@ The skill / human implementer needs four pieces of data:
 | `src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp`                                   | Add `<div id="<name>.available.description">…</div>`.                                                                 |
 | `src/main/webapp/scripts/pages/system/settings_mod.js`                                     | Add `_printSettings(['<name>.available']);` under an existing category.                                               |
 | `src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js`                 | Add `<name>Enabled` const, plus an `if (<name>Enabled) { ... }` block containing both `localTinymcesetup.external_plugins["<name>"] = "..."` AND `addToToolbarIfNotPresent(localTinymcesetup, " | <name>")` (the second line is required for the toolbar button to appear). |
-| `src/main/webapp/scripts/tinymce/tinymce516/icons/custom_icons/icons.js`                   | Register a `<name>` SVG icon entry.                                                                                   |
+| `src/main/java/com/researchspace/webapp/controller/IntegrationController.java`       | Add `rc.put(<NAME>_APP_NAME, ...)` in `getAll(User)` and the corresponding static import.                             |
+| `src/main/webapp/scripts/tinymce/tinymce5109/icons/custom_icons/icons.js`            | Register a `<name>` SVG icon entry.                                                                                   |
 | `build-resources/resources_to_MD5_rename.txt`                                              | Add `scripts/externalTinymcePlugins/<name>/plugin.min.js` and `ui/dist/tinymce<Name>.js` lines.                       |
-| `src/main/webapp/ui/webpack.config.js`                                                     | Add `tinymce<Name>: "./src/tinyMCE/<name>/index.tsx",` entry.                                                         |
+| `src/main/webapp/ui/webpack.config.mjs`                                                    | Add `tinymce<Name>: "./src/tinyMCE/<name>/index.tsx",` entry.                                                         |
 
 ## Out of scope (explicitly NOT touched)
 
 The empty-integration skill **does not** modify any of:
 
 - `IntegrationsHandlerImpl.java` — only needed when there are per-user options
-  (OAuth tokens or API keys saved via `UserConnectionManager`).
+  (OAuth tokens or API keys saved via `UserConnectionManager`) or when the
+  integration requires app-level configuration (deployment URLs). A simple
+  toggle integration with no per-user options does not appear in any of the
+  `isAppConfigIntegration`, `postProcessInfo`, or `setNewIntegrationInfo`
+  switches.
 - `IPropertyHolder.java`, `PropertyHolder.java`, `defaultDeployment.properties`
   — only needed for deployment-level URLs.
-- `IntegrationController.java`'s endpoint methods — except for the new
-  `rc.put(<NAME>_APP_NAME, ...)` in `getAll(User)` (which IS required).
+- `IntegrationController.java`'s endpoint methods other than `getAll(User)` —
+  no separate create/update/delete endpoints are needed for a simple toggle.
+  (The `rc.put(<NAME>_APP_NAME, ...)` insertion in `getAll(User)` IS required
+  and is listed in "Files modified" above.)
 - `WEB-INF/pages/notebookEditor/notebookEditor.jsp`,
   `WEB-INF/pages/workspace/editor/structuredDocument.jsp`,
   `WEB-INF/pages/workspace/editor/include/textField.jsp`,
@@ -107,7 +114,9 @@ The empty-integration skill **does not** modify any of:
 - **`PropertyDescriptor.defaultValue`** = `DENIED`. **`SystemPropertyValue.value`**
   = `DENIED`. (The Galaxy commit used `ALLOWED` for the descriptor; that is an
   outlier and not the convention.)
-- **TypeScript credentials** for an empty integration: `Record<string, never>`.
+- **TypeScript credentials** for an empty integration: use the `emptyObject`
+  type alias (imported from `../../util/types` in `useIntegrationsEndpoint.ts`),
+  matching the convention used by all existing empty-credential integrations.
   The encoder emits `options: {}`; the decoder emits `credentials: {}`.
 - **Apps-page card**: follows the **Chemistry** simple-toggle pattern. No
   `useState`, no auth form, `update={(newMode) => update({ mode: newMode,

--- a/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
+++ b/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
@@ -52,12 +52,13 @@ The skill / human implementer needs four pieces of data:
 | `src/main/webapp/ui/src/tinyMCE/<name>/<Name>.tsx`                                   | Empty React component.                                                  |
 | `src/main/webapp/ui/src/tinyMCE/<name>/__tests__/<Name>.test.tsx`                    | Vitest smoke test.                                                      |
 
-## Files modified (15)
+## Files modified (16)
 
 | Path                                                                                       | Edit                                                                                                                  |
 | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | `src/main/java/com/researchspace/service/IntegrationsHandler.java`                         | Insert `String <NAME>_APP_NAME = "<NAME>";` constant in alphabetical order.                                           |
 | `src/main/java/com/researchspace/service/SystemPropertyName.java`                          | Add `<NAME>_AVAILABLE("<name>.available"),` enum entry. Without this, `SystemPropertyManagerImpl`'s `@Cacheable(key = "#name.propertyName")` resolves on a null and throws `EL1007E: Property or field 'propertyName' cannot be found on null`, breaking `/integration/allIntegrations`. |
+| `src/main/java/com/researchspace/service/impl/IntegrationsHandlerImpl.java`                | Add a new `isValidEmptyIntegration()` private method with `case <NAME>_APP_NAME: return true;`, and update `isAppConfigIntegration()` to delegate to it. Without this, `isValidIntegration()` returns false and the Apps page crashes. |
 | `src/main/resources/bundles/system/system.properties`                                      | Add `system.property.description.<name>.available=Makes <Name> integration available.`                                |
 | `src/main/resources/sqlUpdates/liquibase-master.xml`                                       | Register the new changeset.                                                                                            |
 | `src/main/webapp/ui/src/eln/apps/CardListing.tsx`                                          | Add import, `<name>Update` `useCallback`, and conditional render block (alphabetical).                                |
@@ -76,12 +77,12 @@ The skill / human implementer needs four pieces of data:
 
 The empty-integration skill **does not** modify any of:
 
-- `IntegrationsHandlerImpl.java` — only needed when there are per-user options
-  (OAuth tokens or API keys saved via `UserConnectionManager`) or when the
-  integration requires app-level configuration (deployment URLs). A simple
-  toggle integration with no per-user options does not appear in any of the
-  `isAppConfigIntegration`, `postProcessInfo`, or `setNewIntegrationInfo`
-  switches.
+- `IntegrationsHandlerImpl.java`'s `postProcessInfo`, `setNewIntegrationInfo`,
+  or `isSingleOptionSetAppConfigIntegration` switches — only needed for
+  integrations with per-user options (OAuth tokens, API keys). Note that
+  `IntegrationsHandlerImpl.java` itself IS modified — a dedicated
+  `isValidEmptyIntegration()` method is added and `isAppConfigIntegration()`
+  delegates to it (see Files modified table above).
 - `IPropertyHolder.java`, `PropertyHolder.java`, `defaultDeployment.properties`
   — only needed for deployment-level URLs.
 - `IntegrationController.java`'s endpoint methods other than `getAll(User)` —

--- a/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
+++ b/DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md
@@ -52,11 +52,12 @@ The skill / human implementer needs four pieces of data:
 | `src/main/webapp/ui/src/tinyMCE/<name>/<Name>.tsx`                                   | Empty React component.                                                  |
 | `src/main/webapp/ui/src/tinyMCE/<name>/__tests__/<Name>.test.tsx`                    | Vitest smoke test.                                                      |
 
-## Files modified (13)
+## Files modified (16)
 
 | Path                                                                                       | Edit                                                                                                                  |
 | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | `src/main/java/com/researchspace/service/IntegrationsHandler.java`                         | Insert `String <NAME>_APP_NAME = "<NAME>";` constant in alphabetical order.                                           |
+| `src/main/java/com/researchspace/service/SystemPropertyName.java`                          | Add `<NAME>_AVAILABLE("<name>.available"),` enum entry. Without this, `SystemPropertyManagerImpl`'s `@Cacheable(key = "#name.propertyName")` resolves on a null and throws `EL1007E: Property or field 'propertyName' cannot be found on null`, breaking `/integration/allIntegrations`. |
 | `src/main/resources/bundles/system/system.properties`                                      | Add `system.property.description.<name>.available=Makes <Name> integration available.`                                |
 | `src/main/resources/sqlUpdates/liquibase-master.xml`                                       | Register the new changeset.                                                                                            |
 | `src/main/webapp/ui/src/eln/apps/CardListing.tsx`                                          | Add import, `<name>Update` `useCallback`, and conditional render block (alphabetical).                                |
@@ -65,7 +66,7 @@ The skill / human implementer needs four pieces of data:
 | `src/main/webapp/ui/src/assets/DocLinks.ts`                                                | Add `<name>: mkDocLink("TODO_<NAME>_DOC_ID"),`.                                                                       |
 | `src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp`                                   | Add `<div id="<name>.available.description">…</div>`.                                                                 |
 | `src/main/webapp/scripts/pages/system/settings_mod.js`                                     | Add `_printSettings(['<name>.available']);` under an existing category.                                               |
-| `src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js`                 | Add `<name>Enabled` const + `if (<name>Enabled) localTinymcesetup.external_plugins["<name>"] = "..."` block.          |
+| `src/main/webapp/scripts/pages/workspace/editor/tinymce5_configuration.js`                 | Add `<name>Enabled` const, plus an `if (<name>Enabled) { ... }` block containing both `localTinymcesetup.external_plugins["<name>"] = "..."` AND `addToToolbarIfNotPresent(localTinymcesetup, " | <name>")` (the second line is required for the toolbar button to appear). |
 | `src/main/webapp/scripts/tinymce/tinymce516/icons/custom_icons/icons.js`                   | Register a `<name>` SVG icon entry.                                                                                   |
 | `build-resources/resources_to_MD5_rename.txt`                                              | Add `scripts/externalTinymcePlugins/<name>/plugin.min.js` and `ui/dist/tinymce<Name>.js` lines.                       |
 | `src/main/webapp/ui/webpack.config.js`                                                     | Add `tinymce<Name>: "./src/tinyMCE/<name>/index.tsx",` entry.                                                         |
@@ -78,7 +79,8 @@ The empty-integration skill **does not** modify any of:
   (OAuth tokens or API keys saved via `UserConnectionManager`).
 - `IPropertyHolder.java`, `PropertyHolder.java`, `defaultDeployment.properties`
   — only needed for deployment-level URLs.
-- `IntegrationController.java`.
+- `IntegrationController.java`'s endpoint methods — except for the new
+  `rc.put(<NAME>_APP_NAME, ...)` in `getAll(User)` (which IS required).
 - `WEB-INF/pages/notebookEditor/notebookEditor.jsp`,
   `WEB-INF/pages/workspace/editor/structuredDocument.jsp`,
   `WEB-INF/pages/workspace/editor/include/textField.jsp`,


### PR DESCRIPTION
 ## Description

 This PR was created by GitHub Copilot AI agent on behalf of @nhanlon2.

 Adds a reusable agent skill and canonical plan document for scaffolding a new "empty" RSpace integration — the minimum required surface area (database toggles, Apps-page card, TinyMCE toolbar icon opening a dialog) without authentication, per-user config, or
domain logic.

 **Changes**
 - `.agents/skills/rspace-empty-integration/SKILL.md` — executable checklist for agents/developers
 - `.agents/skills/rspace-empty-integration/REFERENCE.md` — file templates and edit recipes (Liquibase XML, TSX, Java constants, JS plugin, etc.)
 - `DevDocs/DeveloperNotes/EmptyIntegrationSkillPlan.md` — canonical spec derived from analysis of Galaxy integration commits
 - `AGENTS.md` — documents the `.agents/skills/` convention and lists the new skill

 ## Design decisions

 - Scope is deliberately minimal; OAuth, API keys, per-user options, and deployment URLs must be added on top by hand.
 - Derived from Galaxy integration commits, stripping Galaxy-specific work to isolate the generic scaffold.
 - `IntegrationsHandlerImpl` switches (`isAppConfigIntegration` etc.) are out of scope — a simple toggle integration does not need them (consistent with JOVE).

 ## Testing notes

 Frontend: `npm run tsc && npm run lint` in `src/main/webapp/ui`.
 Backend: `mvn test -Dtest=IntegrationControllerMVCIT#getAllIntegrations` confirms the new integration key appears in the API response.