### PR TITLE
Fix sorting by Full Name column in sysadmin users table (RSDEV-967)

### DIFF
--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.tsx
@@ -1956,7 +1956,7 @@ export const UsersPage = (): React.ReactNode => {
                                 recordCount: "recordCount()",
                                 lastLogin: "lastLogin",
                                 created: "creationDate",
-                                name: "lastName",
+                                fullName: "lastName",
                                 firstName: "firstName",
                                 lastName: "lastName",
                                 email: "email",


### PR DESCRIPTION
## Summary

Sorting the Users table by the **Full Name** column threw `Uncaught Error: Invalid order by: fullName` because the `apiOrderBy` lookup map in `onSortModelChange` had a key `name` which never matched any column field. The Full Name column uses `field: "fullName"`, so the entry was simply never found.

## Fix

Rename `name: "lastName"` → `fullName: "lastName"` in the `apiOrderBy` map.

Sorting by Full Name now sends `orderBy=lastName` to the backend, consistent with the existing default sort order.

Fixes [RSDEV-967](https://researchspace.atlassian.net/browse/RSDEV-967)