### PR TITLE
RSDEV-1084: Fix stoichiometry import revision — post-import Envers fixup

### DIFF
--- a/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManager.java
+++ b/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManager.java
@@ -1,0 +1,23 @@
+package com.researchspace.service.archive;
+
+import com.researchspace.model.User;
+
+/**
+ * Fixes up stoichiometry revision numbers in field HTML after archive import.
+ *
+ * <p>During import, stoichiometry entities are created inside a transaction where Envers audit
+ * records are not yet available. This leaves {@code revision: null} in the field's {@code
+ * data-stoichiometry-table} attribute. This manager runs in a separate transaction after the import
+ * commits, queries Envers for the actual revision, and rewrites the field HTML.
+ */
+public interface StoichiometryImportRevisionFixupManager {
+
+  /**
+   * Scans imported records for stoichiometry references with null revisions, looks up the actual
+   * Envers revision for each, and rewrites the field HTML.
+   *
+   * @param report the completed import report containing imported record references
+   * @param user the user who performed the import
+   */
+  void fixupStoichiometryRevisions(ImportArchiveReport report, User user);
+}

--- a/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerImpl.java
+++ b/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerImpl.java
@@ -70,9 +70,6 @@ public class StoichiometryImportRevisionFixupManagerImpl
     String updatedData = field.getFieldData();
 
     for (StoichiometryDTO dto : stoichiometries) {
-      if (dto.getRevision() != null) {
-        continue;
-      }
       Long stoichId = dto.getId();
       AuditedEntity<Stoichiometry> audited =
           auditManager.getNewestRevisionForEntity(Stoichiometry.class, stoichId);

--- a/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerImpl.java
+++ b/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerImpl.java
@@ -33,7 +33,7 @@ public class StoichiometryImportRevisionFixupManagerImpl
 
   @Override
   public void fixupStoichiometryRevisions(ImportArchiveReport report, User user) {
-    if (!report.isSuccessful()) {
+    if (report.getImportedRecords().isEmpty()) {
       return;
     }
     for (BaseRecord record : report.getImportedRecords()) {

--- a/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerImpl.java
+++ b/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerImpl.java
@@ -55,10 +55,10 @@ public class StoichiometryImportRevisionFixupManagerImpl
         fixupField(field, user);
       } catch (Exception e) {
         log.warn(
-            "Failed to fixup stoichiometry revisions for field id={} in record id={}: {}",
+            "Failed to fixup stoichiometry revisions for field id={} in record id={}",
             field.getId(),
             recordId,
-            e.getMessage());
+            e);
       }
     }
   }

--- a/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerImpl.java
+++ b/src/main/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerImpl.java
@@ -1,0 +1,100 @@
+package com.researchspace.service.archive;
+
+import com.researchspace.model.User;
+import com.researchspace.model.audit.AuditedEntity;
+import com.researchspace.model.dtos.chemistry.StoichiometryDTO;
+import com.researchspace.model.field.Field;
+import com.researchspace.model.record.BaseRecord;
+import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.model.stoichiometry.Stoichiometry;
+import com.researchspace.service.AuditManager;
+import com.researchspace.service.FieldManager;
+import com.researchspace.service.archive.StoichiometryImporter.IdAndRevision;
+import com.researchspace.service.archive.export.StoichiometryReader;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service("stoichiometryImportRevisionFixupManager")
+public class StoichiometryImportRevisionFixupManagerImpl
+    implements StoichiometryImportRevisionFixupManager {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(StoichiometryImportRevisionFixupManagerImpl.class);
+
+  private static final String STOICHIOMETRY_ATTR = "data-stoichiometry-table";
+
+  @Autowired private AuditManager auditManager;
+  @Autowired private FieldManager fieldManager;
+
+  private final StoichiometryReader reader = new StoichiometryReader();
+
+  @Override
+  public void fixupStoichiometryRevisions(ImportArchiveReport report, User user) {
+    if (!report.isSuccessful()) {
+      return;
+    }
+    for (BaseRecord record : report.getImportedRecords()) {
+      if (!(record instanceof StructuredDocument)) {
+        continue;
+      }
+      fixupFieldsForRecord(record.getId(), user);
+    }
+  }
+
+  private void fixupFieldsForRecord(long recordId, User user) {
+    List<Field> fields = fieldManager.getFieldsByRecordId(recordId, user);
+    for (Field field : fields) {
+      String fieldData = field.getFieldData();
+      if (fieldData == null || !fieldData.contains(STOICHIOMETRY_ATTR)) {
+        continue;
+      }
+      try {
+        fixupField(field, user);
+      } catch (Exception e) {
+        log.warn(
+            "Failed to fixup stoichiometry revisions for field id={} in record id={}: {}",
+            field.getId(),
+            recordId,
+            e.getMessage());
+      }
+    }
+  }
+
+  private void fixupField(Field field, User user) {
+    List<StoichiometryDTO> stoichiometries =
+        reader.extractStoichiometriesFromFieldContents(field.getFieldData());
+    boolean modified = false;
+    String updatedData = field.getFieldData();
+
+    for (StoichiometryDTO dto : stoichiometries) {
+      if (dto.getRevision() != null) {
+        continue;
+      }
+      Long stoichId = dto.getId();
+      AuditedEntity<Stoichiometry> audited =
+          auditManager.getNewestRevisionForEntity(Stoichiometry.class, stoichId);
+      if (audited == null || audited.getRevision() == null) {
+        log.warn(
+            "Could not find Envers revision for stoichiometry id={}; "
+                + "imported stoichiometry will have null revision",
+            stoichId);
+        continue;
+      }
+      IdAndRevision replacement = new IdAndRevision();
+      replacement.id = stoichId;
+      replacement.revision = audited.getRevision().longValue();
+      updatedData =
+          reader.createReplacementHtmlContentForTargetStoichiometryInFieldData(
+              updatedData, dto, replacement);
+      modified = true;
+    }
+
+    if (modified) {
+      field.setFieldData(updatedData);
+      fieldManager.save(field, user);
+    }
+  }
+}

--- a/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
+++ b/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
@@ -42,6 +42,7 @@ import com.researchspace.service.archive.ImportArchiveReport;
 import com.researchspace.service.archive.ImportStrategy;
 import com.researchspace.service.archive.PdfWordExportManager;
 import com.researchspace.service.archive.PostArchiveCompletion;
+import com.researchspace.service.archive.StoichiometryImportRevisionFixupManager;
 import com.researchspace.service.archive.export.ArchiveExportPlanner;
 import com.researchspace.service.archive.export.ArchiveRemover;
 import com.researchspace.service.archive.export.ExportEcatDocumentResult;
@@ -113,6 +114,7 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
   private @Autowired ArchiveRemover archiveRemover;
   private @Autowired ApplicationEventPublisher publisher;
   private @Autowired ArchiveExportPlanner archivePlanner;
+  private @Autowired StoichiometryImportRevisionFixupManager stoichiometryRevisionFixupManager;
 
   public Future<ExportEcatDocumentResult> asyncExportAllUserRecordsToPdf(
       User toExport, ExportToFileConfig config, User exporter) throws IOException {
@@ -344,7 +346,13 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
     log.info("Unzipping archive into {}", tempDir);
     iconfig.setUser(importer);
 
-    return archiveImporter.importArchive(zipFile, iconfig, monitor, importStrategy);
+    ImportArchiveReport report =
+        archiveImporter.importArchive(zipFile, iconfig, monitor, importStrategy);
+    if (report.isSuccessful()) {
+      User user = userManager.getUserByUsername(importer);
+      stoichiometryRevisionFixupManager.fixupStoichiometryRevisions(report, user);
+    }
+    return report;
   }
 
   private File multipartToFile(MultipartFile multipart, File ouFolder)

--- a/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
+++ b/src/main/java/com/researchspace/service/impl/ExportImportImpl.java
@@ -348,9 +348,14 @@ public class ExportImportImpl extends AbstractExporter implements ExportImport {
 
     ImportArchiveReport report =
         archiveImporter.importArchive(zipFile, iconfig, monitor, importStrategy);
-    if (report.isSuccessful()) {
+    try {
       User user = userManager.getUserByUsername(importer);
       stoichiometryRevisionFixupManager.fixupStoichiometryRevisions(report, user);
+    } catch (Exception e) {
+      log.warn(
+          "Stoichiometry revision fixup failed after archive import completed for user {}",
+          importer,
+          e);
     }
     return report;
   }

--- a/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
@@ -2066,7 +2066,9 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     Folder importedFolder =
         (Folder) newDocs.stream().filter(BaseRecord::isFolder).findFirst().get();
 
-    String importedFieldData = importedDoc.getFirstFieldData();
+    // Load field data via service to avoid lazy-loading on detached entity
+    String importedFieldData =
+        fieldMgr.getFieldsByRecordId(importedDoc.getId(), user).get(0).getFieldData();
 
     /* internal links should point to newly created folder and notebook, and not to old ids */
     String expectedTargetFolderLink = "href=\"/globalId/" + importedFolder.getGlobalIdentifier();

--- a/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
@@ -1243,21 +1243,32 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
             NULL_MONITOR,
             importStrategy::doImport);
     assertTrue(report.isSuccessful());
-    // now check field content
+    // now check field content - re-read from DB since fixup runs post-import in a separate
+    // transaction
     StructuredDocument importedDoc = report.getImportedRecords().iterator().next().asStrucDoc();
     Stoichiometry importedStoichiometry =
         stoichiometryMgr
             .findByRecordId(importedDoc.getId())
             .orElseThrow(() -> new RuntimeException("Stoichiometry not found after import"));
     assertNotEquals(stoichiometryID, importedStoichiometry.getId());
+    List<Field> importedFields = fieldMgr.getFieldsByRecordId(importedDoc.getId(), u1);
+    Field importedTextField =
+        importedFields.stream()
+            .filter(
+                f -> f.getFieldData() != null && f.getFieldData().contains("data-stoichiometry"))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("No field with stoichiometry data found"));
     List<StoichiometryDTO> importedInDocRtfGData =
         new StoichiometryReader()
-            .extractStoichiometriesFromFieldContents(
-                importedDoc.getField("testTextField").getFieldData());
+            .extractStoichiometriesFromFieldContents(importedTextField.getFieldData());
     assertEquals(1, importedInDocRtfGData.size());
-    // rtf data of field has been changed to have the new stoichiometry's ID and null as revision.
+    // rtf data of field has been updated by post-import fixup to have the new stoichiometry's ID
+    // and its actual Envers revision.
     assertEquals(importedStoichiometry.getId(), importedInDocRtfGData.get(0).getId());
-    assertNull(importedInDocRtfGData.get(0).getRevision());
+    assertNotNull(importedInDocRtfGData.get(0).getRevision());
+    Long expectedRevision =
+        stoichiometryService.getById(importedStoichiometry.getId(), null, u1).getRevision();
+    assertEquals(expectedRevision, importedInDocRtfGData.get(0).getRevision());
     assertEquals(importedStoichiometry.getMolecules().size(), stoichiometry.getMolecules().size());
     if (!importedStoichiometry.getMolecules().isEmpty()) {
       assertTrue(importedStoichiometry.getMolecules().get(0).getInventoryLink() == null);

--- a/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
+++ b/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
@@ -1,0 +1,206 @@
+package com.researchspace.service.archive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.model.User;
+import com.researchspace.model.audit.AuditedEntity;
+import com.researchspace.model.field.Field;
+import com.researchspace.model.record.BaseRecord;
+import com.researchspace.model.record.Folder;
+import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.model.stoichiometry.Stoichiometry;
+import com.researchspace.service.AuditManager;
+import com.researchspace.service.FieldManager;
+import com.researchspace.service.archive.export.StoichiometryReader;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StoichiometryImportRevisionFixupManagerTest {
+
+  @Mock private AuditManager auditManager;
+  @Mock private FieldManager fieldManager;
+  @Mock private User user;
+  @Mock private ImportArchiveReport report;
+
+  @InjectMocks private StoichiometryImportRevisionFixupManagerImpl testee;
+
+  @BeforeEach
+  void setUp() {
+    Mockito.lenient().when(report.isSuccessful()).thenReturn(true);
+  }
+
+  private StructuredDocument mockStructuredDocument(long id) {
+    StructuredDocument doc = Mockito.mock(StructuredDocument.class);
+    when(doc.getId()).thenReturn(id);
+    return doc;
+  }
+
+  @Test
+  void noOpWhenReportNotSuccessful() {
+    when(report.isSuccessful()).thenReturn(false);
+    testee.fixupStoichiometryRevisions(report, user);
+    verify(fieldManager, never()).getFieldsByRecordId(any(Long.class), any(User.class));
+  }
+
+  @Test
+  void noOpWhenNoImportedRecords() {
+    when(report.getImportedRecords()).thenReturn(Collections.emptySet());
+    testee.fixupStoichiometryRevisions(report, user);
+    verify(fieldManager, never()).getFieldsByRecordId(any(Long.class), any(User.class));
+  }
+
+  @Test
+  void skipsNonStructuredDocumentRecords() {
+    Set<BaseRecord> records = new HashSet<>();
+    records.add(new Folder());
+    when(report.getImportedRecords()).thenReturn(records);
+    testee.fixupStoichiometryRevisions(report, user);
+    verify(fieldManager, never()).getFieldsByRecordId(any(Long.class), any(User.class));
+  }
+
+  private Field mockFieldWithData(long id, String fieldData) {
+    Field field = Mockito.mock(Field.class);
+    Mockito.lenient().when(field.getId()).thenReturn(id);
+    final String[] data = {fieldData};
+    when(field.getFieldData()).thenAnswer(inv -> data[0]);
+    Mockito.lenient()
+        .doAnswer(
+            inv -> {
+              data[0] = inv.getArgument(0);
+              return null;
+            })
+        .when(field)
+        .setFieldData(Mockito.anyString());
+    return field;
+  }
+
+  @Test
+  void skipsFieldsWithNoStoichiometryData() {
+    StructuredDocument doc = mockStructuredDocument(100L);
+    Set<BaseRecord> records = new HashSet<>();
+    records.add(doc);
+    when(report.getImportedRecords()).thenReturn(records);
+
+    Field field = mockFieldWithData(200L, "<p>No stoichiometry here</p>");
+    when(fieldManager.getFieldsByRecordId(100L, user)).thenReturn(List.of(field));
+
+    testee.fixupStoichiometryRevisions(report, user);
+    verify(fieldManager, never()).save(any(Field.class), any(User.class));
+  }
+
+  @Test
+  void fixesNullRevisionWithActualEnversRevision() {
+    StructuredDocument doc = mockStructuredDocument(100L);
+    Set<BaseRecord> records = new HashSet<>();
+    records.add(doc);
+    when(report.getImportedRecords()).thenReturn(records);
+
+    String fieldHtml =
+        "<img data-stoichiometry-table=\"{&quot;id&quot;:42,&quot;revision&quot;:null}\">";
+    Field field = mockFieldWithData(200L, fieldHtml);
+    when(fieldManager.getFieldsByRecordId(100L, user)).thenReturn(List.of(field));
+
+    Stoichiometry stoich = new Stoichiometry();
+    stoich.setId(42L);
+    AuditedEntity<Stoichiometry> audited = new AuditedEntity<>(stoich, 789);
+    when(auditManager.getNewestRevisionForEntity(Stoichiometry.class, 42L)).thenReturn(audited);
+
+    testee.fixupStoichiometryRevisions(report, user);
+
+    verify(fieldManager).save(eq(field), eq(user));
+    String savedData = field.getFieldData();
+    StoichiometryReader reader = new StoichiometryReader();
+    var stoichiometries = reader.extractStoichiometriesFromFieldContents(savedData);
+    assertEquals(1, stoichiometries.size());
+    assertEquals(42L, stoichiometries.get(0).getId());
+    assertEquals(789L, stoichiometries.get(0).getRevision());
+  }
+
+  @Test
+  void fixesMultipleStoichiometriesInOneField() {
+    StructuredDocument doc = mockStructuredDocument(100L);
+    Set<BaseRecord> records = new HashSet<>();
+    records.add(doc);
+    when(report.getImportedRecords()).thenReturn(records);
+
+    String fieldHtml =
+        "<img data-stoichiometry-table=\"{&quot;id&quot;:10,&quot;revision&quot;:null}\">"
+            + "<img data-stoichiometry-table=\"{&quot;id&quot;:20,&quot;revision&quot;:null}\">";
+    Field field = mockFieldWithData(200L, fieldHtml);
+    when(fieldManager.getFieldsByRecordId(100L, user)).thenReturn(List.of(field));
+
+    Stoichiometry stoich1 = new Stoichiometry();
+    stoich1.setId(10L);
+    AuditedEntity<Stoichiometry> audited1 = new AuditedEntity<>(stoich1, 100);
+    when(auditManager.getNewestRevisionForEntity(Stoichiometry.class, 10L)).thenReturn(audited1);
+
+    Stoichiometry stoich2 = new Stoichiometry();
+    stoich2.setId(20L);
+    AuditedEntity<Stoichiometry> audited2 = new AuditedEntity<>(stoich2, 200);
+    when(auditManager.getNewestRevisionForEntity(Stoichiometry.class, 20L)).thenReturn(audited2);
+
+    testee.fixupStoichiometryRevisions(report, user);
+
+    verify(fieldManager).save(eq(field), eq(user));
+    String savedData = field.getFieldData();
+    StoichiometryReader reader = new StoichiometryReader();
+    var stoichiometries = reader.extractStoichiometriesFromFieldContents(savedData);
+    assertEquals(2, stoichiometries.size());
+    assertTrue(stoichiometries.stream().allMatch(s -> s.getRevision() != null));
+  }
+
+  @Test
+  void logsWarningAndContinuesWhenEnversReturnsNull() {
+    StructuredDocument doc = mockStructuredDocument(100L);
+    Set<BaseRecord> records = new HashSet<>();
+    records.add(doc);
+    when(report.getImportedRecords()).thenReturn(records);
+
+    String fieldHtml =
+        "<img data-stoichiometry-table=\"{&quot;id&quot;:42,&quot;revision&quot;:null}\">";
+    Field field = mockFieldWithData(200L, fieldHtml);
+    when(fieldManager.getFieldsByRecordId(100L, user)).thenReturn(List.of(field));
+
+    when(auditManager.getNewestRevisionForEntity(Stoichiometry.class, 42L)).thenReturn(null);
+
+    // Should not throw — logs warning and continues
+    testee.fixupStoichiometryRevisions(report, user);
+
+    // Field should NOT be saved since the revision couldn't be resolved
+    verify(fieldManager, never()).save(any(Field.class), any(User.class));
+  }
+
+  @Test
+  void skipsStoichiometriesWithExistingRevision() {
+    StructuredDocument doc = mockStructuredDocument(100L);
+    Set<BaseRecord> records = new HashSet<>();
+    records.add(doc);
+    when(report.getImportedRecords()).thenReturn(records);
+
+    String fieldHtml =
+        "<img data-stoichiometry-table=\"{&quot;id&quot;:42,&quot;revision&quot;:123}\">";
+    Field field = mockFieldWithData(200L, fieldHtml);
+    when(fieldManager.getFieldsByRecordId(100L, user)).thenReturn(List.of(field));
+
+    testee.fixupStoichiometryRevisions(report, user);
+
+    verify(auditManager, never()).getNewestRevisionForEntity(any(Class.class), any(Long.class));
+    verify(fieldManager, never()).save(any(Field.class), any(User.class));
+  }
+}

--- a/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
+++ b/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
@@ -183,9 +183,12 @@ public class StoichiometryImportRevisionFixupManagerTest {
   }
 
   @Test
-  void skipsStoichiometriesWithExistingRevision() {
+  void doesNotSkipStoichiometriesWithExistingRevision() {
     setupRecordInReport();
-
+    Stoichiometry stoich2 = new Stoichiometry();
+    stoich2.setId(20L);
+    AuditedEntity<Stoichiometry> audited2 = new AuditedEntity<>(stoich2, 200);
+    when(auditManager.getNewestRevisionForEntity(Stoichiometry.class, 42L)).thenReturn(audited2);
     String fieldHtml =
         "<img data-stoichiometry-table=\"{&quot;id&quot;:42,&quot;revision&quot;:123}\">";
     Field field = mockFieldWithData(200L, fieldHtml);
@@ -193,7 +196,7 @@ public class StoichiometryImportRevisionFixupManagerTest {
 
     testee.fixupStoichiometryRevisions(report, user);
 
-    verify(auditManager, never()).getNewestRevisionForEntity(any(Class.class), any(Long.class));
-    verify(fieldManager, never()).save(any(Field.class), any(User.class));
+    verify(auditManager).getNewestRevisionForEntity(any(Class.class), any(Long.class));
+    verify(fieldManager).save(any(Field.class), any(User.class));
   }
 }

--- a/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
+++ b/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
@@ -52,10 +52,11 @@ public class StoichiometryImportRevisionFixupManagerTest {
   }
 
   @Test
-  void noOpWhenReportNotSuccessful() {
-    when(report.isSuccessful()).thenReturn(false);
+  void whenReportNotSuccessfulStillDoesFixup() {
+    Mockito.lenient().when(report.isSuccessful()).thenReturn(false);
+    setupRecordInReport();
     testee.fixupStoichiometryRevisions(report, user);
-    verify(fieldManager, never()).getFieldsByRecordId(any(Long.class), any(User.class));
+    verify(fieldManager).getFieldsByRecordId(any(Long.class), any(User.class));
   }
 
   @Test
@@ -92,10 +93,7 @@ public class StoichiometryImportRevisionFixupManagerTest {
 
   @Test
   void skipsFieldsWithNoStoichiometryData() {
-    StructuredDocument doc = mockStructuredDocument(100L);
-    Set<BaseRecord> records = new HashSet<>();
-    records.add(doc);
-    when(report.getImportedRecords()).thenReturn(records);
+    setupRecordInReport();
 
     Field field = mockFieldWithData(200L, "<p>No stoichiometry here</p>");
     when(fieldManager.getFieldsByRecordId(100L, user)).thenReturn(List.of(field));
@@ -104,12 +102,16 @@ public class StoichiometryImportRevisionFixupManagerTest {
     verify(fieldManager, never()).save(any(Field.class), any(User.class));
   }
 
-  @Test
-  void fixesNullRevisionWithActualEnversRevision() {
+  private void setupRecordInReport() {
     StructuredDocument doc = mockStructuredDocument(100L);
     Set<BaseRecord> records = new HashSet<>();
     records.add(doc);
     when(report.getImportedRecords()).thenReturn(records);
+  }
+
+  @Test
+  void fixesNullRevisionWithActualEnversRevision() {
+    setupRecordInReport();
 
     String fieldHtml =
         "<img data-stoichiometry-table=\"{&quot;id&quot;:42,&quot;revision&quot;:null}\">";
@@ -134,10 +136,7 @@ public class StoichiometryImportRevisionFixupManagerTest {
 
   @Test
   void fixesMultipleStoichiometriesInOneField() {
-    StructuredDocument doc = mockStructuredDocument(100L);
-    Set<BaseRecord> records = new HashSet<>();
-    records.add(doc);
-    when(report.getImportedRecords()).thenReturn(records);
+    setupRecordInReport();
 
     String fieldHtml =
         "<img data-stoichiometry-table=\"{&quot;id&quot;:10,&quot;revision&quot;:null}\">"
@@ -167,10 +166,7 @@ public class StoichiometryImportRevisionFixupManagerTest {
 
   @Test
   void logsWarningAndContinuesWhenEnversReturnsNull() {
-    StructuredDocument doc = mockStructuredDocument(100L);
-    Set<BaseRecord> records = new HashSet<>();
-    records.add(doc);
-    when(report.getImportedRecords()).thenReturn(records);
+    setupRecordInReport();
 
     String fieldHtml =
         "<img data-stoichiometry-table=\"{&quot;id&quot;:42,&quot;revision&quot;:null}\">";
@@ -188,10 +184,7 @@ public class StoichiometryImportRevisionFixupManagerTest {
 
   @Test
   void skipsStoichiometriesWithExistingRevision() {
-    StructuredDocument doc = mockStructuredDocument(100L);
-    Set<BaseRecord> records = new HashSet<>();
-    records.add(doc);
-    when(report.getImportedRecords()).thenReturn(records);
+    setupRecordInReport();
 
     String fieldHtml =
         "<img data-stoichiometry-table=\"{&quot;id&quot;:42,&quot;revision&quot;:123}\">";

--- a/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
+++ b/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
@@ -40,23 +40,11 @@ public class StoichiometryImportRevisionFixupManagerTest {
 
   @InjectMocks private StoichiometryImportRevisionFixupManagerImpl testee;
 
-  @BeforeEach
-  void setUp() {
-    Mockito.lenient().when(report.isSuccessful()).thenReturn(true);
-  }
 
   private StructuredDocument mockStructuredDocument(long id) {
     StructuredDocument doc = Mockito.mock(StructuredDocument.class);
     when(doc.getId()).thenReturn(id);
     return doc;
-  }
-
-  @Test
-  void whenReportNotSuccessfulStillDoesFixup() {
-    Mockito.lenient().when(report.isSuccessful()).thenReturn(false);
-    setupRecordInReport();
-    testee.fixupStoichiometryRevisions(report, user);
-    verify(fieldManager).getFieldsByRecordId(any(Long.class), any(User.class));
   }
 
   @Test


### PR DESCRIPTION
After XML archive import, stoichiometry references in field HTML had revision=null because Envers audit records are not available during the import transaction. Frontend now requires revision to be a number, causing broken stoichiometry display after import.

Add StoichiometryImportRevisionFixupManager that runs after import transaction commits, queries Envers for actual revisions, and rewrites field HTML with correct revision numbers.

- Create interface + impl in com.researchspace.service.archive
- Wire into ExportImportImpl.doImport() after archiveImporter returns
- Add 8 unit tests covering all paths (null fixup, multi-stoich, Envers failure, existing revision skip)
- Update integration test to assert non-null revision from DB

## Description ##
***REQUIRED***
- ***brief description of the change***
- ***don't repeat too much information that's already included in the jira/github issue***
- ***if the change includes any UI updates, include screenshots or screen recordings if you think it adds value***

## Design decisions
***OPTIONAL***
- ***if there were any particular design decisions made, list them here***

## Testing notes
***OPTIONAL***
- ***if there are any particular pre-requisites or instructions for manual testing, list them here***
