### PR TITLE
Rsdev 1091 export reactionless stoichiometries xml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,67 @@
 # CLAUDE.md
 
 See [AGENTS.md](./AGENTS.md) for full project context (build, test, architecture, conventions).
+
+## PR Descriptions
+
+When creating or updating GitHub pull request descriptions:
+- Start by stating the investigation/fix was done by GitHub Copilot AI agent on behalf of the user
+- Follow with a one-sentence summary of what the PR fixes or adds
+- Keep the description concise — avoid exhaustive detail
+- Include a **Root causes** section (brief bullet points) when it's a bug fix
+- Include a **Changes** section listing the key files/methods touched
+- Reference any linked Jira ticket (e.g. RSDEV-1081)
+- Do not exceed ~15 lines total
+
+## Pull Requests
+
+- **Branch naming:** `<TICKET-ID>-<short-description>` e.g. `RSDEV-967-fullname-sort`
+- **PR source:** branch on `ResearchSpace-ELN/rspace-web`
+- **PR target:** `main` on `rspace-os/rspace-web` (the upstream OSS repo)
+
+## Jira Comments
+
+When adding comments to Jira tickets:
+- Start by stating the investigation/fix was done by GitHub Copilot AI agent on behalf of the user
+- Keep comments brief — aim for under 10 lines
+- Cover: root cause (1-2 sentences), fix (1-2 sentences), links to PRs or commits
+- Use **bold** for section labels (Root cause, Fix, PRs)
+- Do not repeat information already in the ticket description
+
+## Tech Stack (RSpace)
+
+**Backend:** Java 11 source level on JDK 17 runtime, Spring Framework (MVC, Security, WebSocket), Maven, MariaDB + Hibernate ORM, Liquibase migrations, Jetty (dev).
+**Frontend:** TypeScript + React, Material-UI v5, Webpack, MobX (legacy) + React Query (new work), Vitest, Playwright.
+
+### Java / Backend conventions
+- **Do NOT use Java 17+ language features** (no records, sealed classes, text blocks, pattern matching) — source level is Java 11
+- Do NOT use Spring Boot; Spring context is configured via `applicationContext-*.xml` files
+- Follow the layering: `Controller → Service (Manager) → DAO → Hibernate/DB`
+    - Controllers: input validation only — never call DAOs directly
+    - Services: must be named ending in `Manager` for AOP transaction proxying
+    - DAOs: assume an active transaction; use `sessionFactory.getCurrentSession()`
+- Prefer constructor injection; avoid `@Autowired` on fields
+- Security is **Apache Shiro** (not Spring Security); check permissions via `PermissionUtils.isPermitted()`
+- Use soft deletes — never hard-delete records
+- All schema changes via **Liquibase** changesets in `src/main/resources/sqlUpdates/`
+- Code style: **Google Java Style Guide** enforced by Spotless (`mvn spotless:apply`)
+- Lombok is used; Javadoc required on service interface methods and non-trivial entity methods
+- Log caught exceptions at WARN or ERROR; no empty catch blocks; never log sensitive data
+
+### Testing (backend)
+Three tiers — run in order:
+1. **Pure unit** (`*Test.java`, `-Dfast=true`): plain JUnit 5 + Mockito, no Spring context
+2. **Spring transactional** (`*Test.java`): Spring context, auto-rolled-back; extend `SpringTransactionalTest`
+3. **Integration/MVC** (`*IT.java`): real DB commits; extend `RealTransactionSpringTestBase` or `MVCTestBase`; runs in `mvn verify`
+
+Use JUnit 5 for new test classes. Do not mix assertion styles within a class.
+
+### Frontend conventions
+- Functional components with hooks only; use React Query for new state management
+- Import `render`/`within` from `@/__tests__/customQueries`, not directly from `@testing-library/react`
+- Axios for API calls; DOMPurify for any user-generated HTML
+- Run `npm run lint` and `npm run tsc` before committing
+
+### General
+- Keep PRs focused; prefer small, reviewable changes
+- Reference the linked Jira ticket in commits and PRs

--- a/DevDocs/DeveloperNotes/ExportAndImport.md
+++ b/DevDocs/DeveloperNotes/ExportAndImport.md
@@ -24,6 +24,10 @@ Galaxy export: d8cb04959c12bfe5feb49334450b0c26efa2ad17 RSDEV-910
 
 Stoichiometries: RSDEV-948 https://github.com/rspace-os/rspace-web/pull/642
 
+Reaction-less Stoichiometries (no parent reaction drawing): RSDEV-1091 — completes the round-trip
+for the reaction-less Stoichiometry tables introduced by RSDEV-874 by populating molecules from the
+archive on import.
+
 ## Export
 
  - ExportObjectGenerator add a call in `createAssociateFiles` to explicitly import new data. See for example 
@@ -58,8 +62,28 @@ called `recordFolder.getName() + "_externalWorkflows.xml"` is written by the `XM
 
  - Key class in `AbstractImporterStrategyImpl`. Imports that have a global component (and hence need `ArchivalDocumentParserRef`)
 can be called from `insertToDatabase`. See `importExternalWorkFlows`. Imports that are purely field based and need GalleryItems etc to have already been imported
-go in `setFieldAssociates`. See `importChemElementsAndStoichiometries` or `importEmptyStoichiometries`. These imports use a map
+go in `setFieldAssociates`. See `importChemElementsAndStoichiometries`. These imports use a map
 of the IDs of GalleryItems from the Archive and the new IDs as they are imported into the DB, see `Map<String, EcatMediaFile> oldIdToNewGalleryItem`
+
+### Stoichiometries (reaction-linked vs reaction-less)
+
+The frontend renders Stoichiometry tables in two flavours, both with a JSON `data-stoichiometry-table` attribute:
+
+- **Reaction-linked**: the JSON sits on a chem `<img>` element. `parentReactionId` in the archived `StoichiometryDTO` references the chem element's id.
+- **Reaction-less** (RSDEV-874): rendered as `<div data-stoichiometry-table-only="true" data-stoichiometry-table='{...}'>`. `parentReactionId` is `null`. Created in the UI via the `/stoichiometry` slash command or the toolbar icon.
+
+Both flavours are extracted by the same JSoup selector in `StoichiometryReader` (`getElementsByAttribute("data-stoichiometry-table")`), so export needs no special-casing.
+
+Import (in `StoichiometryImporter`) splits cleanly:
+
+- `importStoichiometries(ArchivalGalleryMetadata, RSChemElement)` is called once per archived chem element from inside the chem-element loop in `AbstractImporterStrategyImpl.importChemElementsAndStoichiometries`. It matches archived stoichiometries by `parentReactionId == oldChemElement.getId()`.
+- `importReactionlessStoichiometries(Set<Long> archivedChemElementIds)` is called once after the chem-element loop. It handles every archived stoichiometry with `parentReactionId == null`, creating a new `Stoichiometry` bound to the importing field's structured document. It also emits a `log.warn` for orphan stoichs whose non-null `parentReactionId` doesn't match any chem element in the archive (otherwise silently dropped, like the reaction-linked branch).
+
+Molecule persistence is identical for both flavours: each `StoichiometryMolecule` row gets a fresh `RSChemElement` created from the DTO's SMILES — the `rs_chem_id` column is NOT NULL in the schema. See `StoichiometryManagerImpl.createReactionlessFromArchive(...)` and `createNewFromDataWithoutInventoryLinks(...)`. Inventory links are stripped at export time (`StoichiometryExporter.java:39`); the importer trusts the contract.
+
+Field HTML rewriting is shared via `StoichiometryReader.createReplacementHtmlContentForTargetStoichiometryInFieldData(...)`, which rewrites only the `data-stoichiometry-table` attribute value, leaving every other attribute (including `data-stoichiometry-table-only`) untouched.
+
+Revision (`StoichiometryDTO.revision`) is left as `null` in the rewritten HTML during import; `StoichiometryImportRevisionFixupManager` (RSDEV-1084) runs post-commit to query Envers and patch in the real revision number using the same generic `data-stoichiometry-table` selector — so the reaction-less branch is fixed up automatically.
 
 - `ArchiveParserImpl` needs to be modified if new import documents (eg ExternalWorkFlows) are to be imported and read into the
   `ArchivalDocumentParserRef` class.

--- a/src/main/java/com/researchspace/export/stoichiometry/StoichiometryHtmlGenerator.java
+++ b/src/main/java/com/researchspace/export/stoichiometry/StoichiometryHtmlGenerator.java
@@ -49,6 +49,10 @@ public class StoichiometryHtmlGenerator {
       if (header.isEmpty()) {
         header = " the chemical reaction above.";
       }
+      boolean isReactionLess = stoichiometryElement.attr("data-stoichiometry-table-only").equals("true");
+      if(isReactionLess){
+        header = " this reactionless stoichiometry.";
+      }
       context.put("header", header);
       String stoichiometryTableHtml =
           VelocityEngineUtils.mergeTemplateIntoString(

--- a/src/main/java/com/researchspace/export/stoichiometry/StoichiometryHtmlGenerator.java
+++ b/src/main/java/com/researchspace/export/stoichiometry/StoichiometryHtmlGenerator.java
@@ -49,8 +49,9 @@ public class StoichiometryHtmlGenerator {
       if (header.isEmpty()) {
         header = " the chemical reaction above.";
       }
-      boolean isReactionLess = stoichiometryElement.attr("data-stoichiometry-table-only").equals("true");
-      if(isReactionLess){
+      boolean isReactionLess =
+          stoichiometryElement.attr("data-stoichiometry-table-only").equals("true");
+      if (isReactionLess) {
         header = " this reactionless stoichiometry.";
       }
       context.put("header", header);

--- a/src/main/java/com/researchspace/service/StoichiometryManager.java
+++ b/src/main/java/com/researchspace/service/StoichiometryManager.java
@@ -8,6 +8,7 @@ import com.researchspace.model.dtos.chemistry.StoichiometryDTO;
 import com.researchspace.model.dtos.chemistry.StoichiometryUpdateDTO;
 import com.researchspace.model.record.Record;
 import com.researchspace.model.stoichiometry.Stoichiometry;
+import com.researchspace.model.stoichiometry.StoichiometryMolecule;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -31,4 +32,18 @@ public interface StoichiometryManager extends GenericManager<Stoichiometry, Long
 
   Stoichiometry createNewFromDataWithoutInventoryLinks(
       StoichiometryDTO stoichiometryDTO, RSChemElement chemElement, User user);
+
+  /**
+   * Recreates a reaction-less stoichiometry (no parent {@link RSChemElement}) from an archive DTO.
+   *
+   * <p>Mirrors the DB shape produced by {@link #createEmpty(Record, User)} followed by user edits:
+   * {@code parentReaction} is {@code null}; for each molecule a fresh {@link RSChemElement} is
+   * created from the DTO's SMILES (the {@code rs_chem_id} column on {@link StoichiometryMolecule}
+   * is NOT NULL). Used by the archive importer for stoichiometries with {@code parentReactionId ==
+   * null}.
+   *
+   * <p>Inventory links on the DTO molecules are ignored (the exporter strips them).
+   */
+  Stoichiometry createReactionlessFromArchive(
+      StoichiometryDTO stoichiometryDTO, Record record, User user);
 }

--- a/src/main/java/com/researchspace/service/StoichiometryService.java
+++ b/src/main/java/com/researchspace/service/StoichiometryService.java
@@ -4,6 +4,7 @@ import com.researchspace.model.RSChemElement;
 import com.researchspace.model.User;
 import com.researchspace.model.dtos.chemistry.StoichiometryDTO;
 import com.researchspace.model.dtos.chemistry.StoichiometryUpdateDTO;
+import com.researchspace.model.record.Record;
 import com.researchspace.model.stoichiometry.Stoichiometry;
 import com.researchspace.model.stoichiometry.StoichiometryMolecule;
 
@@ -24,4 +25,18 @@ public interface StoichiometryService {
 
   Stoichiometry createNewFromDataWithoutInventoryLinks(
       StoichiometryDTO stoichiometryDTO, RSChemElement chemElement, User user);
+
+  /**
+   * Recreates a reaction-less stoichiometry (no parent reaction) from an archive DTO.
+   *
+   * <p>Used only by the XML archive importer. Mirrors the DB shape user-created reaction-less
+   * stoichiometries produce: {@code parentReaction = null}; each {@link StoichiometryMolecule} gets
+   * a fresh {@link RSChemElement} created from the DTO's SMILES (the {@code rs_chem_id} column is
+   * NOT NULL).
+   *
+   * <p>Intentionally skips the permission check applied by other entry points; the archive importer
+   * is the authoritative authorisation gate for this code path.
+   */
+  Stoichiometry createReactionlessFromArchive(
+      StoichiometryDTO stoichiometryDTO, Record record, User user);
 }

--- a/src/main/java/com/researchspace/service/archive/AbstractImporterStrategyImpl.java
+++ b/src/main/java/com/researchspace/service/archive/AbstractImporterStrategyImpl.java
@@ -44,14 +44,12 @@ import com.researchspace.model.RSMath;
 import com.researchspace.model.User;
 import com.researchspace.model.Version;
 import com.researchspace.model.core.RecordType;
-import com.researchspace.model.dtos.chemistry.StoichiometryDTO;
 import com.researchspace.model.field.Field;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.ImportOverride;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.RecordInformation;
 import com.researchspace.model.record.StructuredDocument;
-import com.researchspace.model.stoichiometry.Stoichiometry;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.EcatCommentManager;
 import com.researchspace.service.ExternalWorkFlowDataManager;
@@ -62,19 +60,21 @@ import com.researchspace.service.RSChemElementManager;
 import com.researchspace.service.RecordContext;
 import com.researchspace.service.RecordManager;
 import com.researchspace.service.StoichiometryService;
-import com.researchspace.service.archive.StoichiometryImporter.IdAndRevision;
 import com.researchspace.service.archive.export.StoichiometryReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -494,7 +494,6 @@ abstract class AbstractImporterStrategyImpl {
     fld =
         importChemElementsAndStoichiometries(
             fld, archiveFld, user, recordFolder, oldIdToNewGalleryItem);
-    fld = importEmptyStoichiometries(archiveFld, fld, user);
     fld = importMath(fld, archiveFld, recordFolder);
     fld = importImageAnnotation(fld, archiveFld, recordFolder, oldIdToNewGalleryItem);
     importLinkedRecords(fld, archiveFld, recordFolder, linkRecord);
@@ -854,25 +853,6 @@ abstract class AbstractImporterStrategyImpl {
       "xsi:schemaLocation=\"http://www.chemaxon.com"
           + " http://www.chemaxon.com/marvin/schema/mrvSchema";
 
-  private Field importEmptyStoichiometries(ArchivalField archiveFld, Field newField, User user) {
-    List<StoichiometryDTO> stoichiometries = archiveFld.getStoichiometries();
-    for (StoichiometryDTO aStoichiometry : stoichiometries) {
-      if (aStoichiometry.getParentReactionId() == null) {
-        Stoichiometry created =
-            stoichiometryService.createEmpty(newField.getStructuredDocument().getId(), user);
-        IdAndRevision newDTO = new IdAndRevision();
-        newDTO.id = created.getId();
-        String updatedStoichiometriesFieldContent =
-            new StoichiometryReader()
-                .createReplacementHtmlContentForTargetStoichiometryInFieldData(
-                    newField.getFieldData(), aStoichiometry, newDTO);
-        newField.setFieldData(updatedStoichiometriesFieldContent);
-        fieldManager.save(newField, user);
-      }
-    }
-    return newField;
-  }
-
   private Field importChemElementsAndStoichiometries(
       Field fld,
       ArchivalField archiveFld,
@@ -944,6 +924,11 @@ abstract class AbstractImporterStrategyImpl {
         }
       }
     }
+    Set<Long> archivedChemElementIds =
+        chemMeta == null
+            ? Collections.emptySet()
+            : chemMeta.stream().map(ArchivalGalleryMetadata::getId).collect(Collectors.toSet());
+    stoichiometryImporter.importReactionlessStoichiometries(archivedChemElementIds);
     return fld;
   }
 

--- a/src/main/java/com/researchspace/service/archive/AbstractImporterStrategyImpl.java
+++ b/src/main/java/com/researchspace/service/archive/AbstractImporterStrategyImpl.java
@@ -861,8 +861,7 @@ abstract class AbstractImporterStrategyImpl {
       Map<String, EcatMediaFile> oldIdToNewGalleryItem)
       throws IOException {
     List<ArchivalGalleryMetadata> chemMeta = archiveFld.getChemElementMeta();
-    StoichiometryImporter stoichiometryImporter = null;
-    stoichiometryImporter =
+    StoichiometryImporter stoichiometryImporter =
         new StoichiometryImporter(
             stoichiometryService, new StoichiometryReader(), archiveFld, fld, fieldManager, user);
     if (chemMeta != null && !chemMeta.isEmpty()) {

--- a/src/main/java/com/researchspace/service/archive/StoichiometryImporter.java
+++ b/src/main/java/com/researchspace/service/archive/StoichiometryImporter.java
@@ -10,8 +10,11 @@ import com.researchspace.model.stoichiometry.Stoichiometry;
 import com.researchspace.service.FieldManager;
 import com.researchspace.service.StoichiometryService;
 import com.researchspace.service.archive.export.StoichiometryReader;
+import java.util.Set;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class StoichiometryImporter {
 
   private final StoichiometryService service;
@@ -62,6 +65,44 @@ public class StoichiometryImporter {
               newField.getFieldData(), matching, newDTO);
       newField.setFieldData(updatedStoichiometriesFieldContent);
       fieldManager.save(newField, user);
+    }
+  }
+
+  /**
+   * Imports stoichiometries with no parent reaction (RSDEV-874 reaction-less tables) and logs a
+   * warning for orphan stoichiometries whose {@code parentReactionId} does not match any chem
+   * element in the archive.
+   *
+   * <p>For each archive stoichiometry with {@code parentReactionId == null}, creates a new
+   * stoichiometry on the importing instance bound to {@code newField}'s structured document, copies
+   * every molecule (with {@code rsChemElement = null}), rewrites the field's {@code
+   * data-stoichiometry-table} JSON to reference the new id, and saves the field.
+   *
+   * @param archivedChemElementIds the set of chem element IDs present in the archive (from {@code
+   *     ArchivalField.getChemElementMeta()}); used to detect orphan stoichiometries.
+   */
+  public void importReactionlessStoichiometries(Set<Long> archivedChemElementIds) {
+    if (oldField.getStoichiometries() == null) {
+      return;
+    }
+    for (StoichiometryDTO archived : oldField.getStoichiometries()) {
+      if (archived.getParentReactionId() == null) {
+        Stoichiometry created =
+            service.createReactionlessFromArchive(archived, newField.getStructuredDocument(), user);
+        IdAndRevision newDTO = new IdAndRevision();
+        newDTO.id = created.getId();
+        String updatedFieldData =
+            reader.createReplacementHtmlContentForTargetStoichiometryInFieldData(
+                newField.getFieldData(), archived, newDTO);
+        newField.setFieldData(updatedFieldData);
+        fieldManager.save(newField, user);
+      } else if (!archivedChemElementIds.contains(archived.getParentReactionId())) {
+        log.warn(
+            "Archive stoichiometry id={} references parentReactionId={} which is not present "
+                + "in the imported chem elements; molecules will not be imported.",
+            archived.getId(),
+            archived.getParentReactionId());
+      }
     }
   }
 }

--- a/src/main/java/com/researchspace/service/archive/StoichiometryImporter.java
+++ b/src/main/java/com/researchspace/service/archive/StoichiometryImporter.java
@@ -52,7 +52,7 @@ public class StoichiometryImporter {
             .filter(
                 s ->
                     s.getParentReactionId() != null
-                        && s.getParentReactionId() == oldChemElement.getId())
+                        && s.getParentReactionId().equals(oldChemElement.getId()))
             .findFirst()
             .orElse(null);
     if (matching != null) {
@@ -75,16 +75,14 @@ public class StoichiometryImporter {
    *
    * <p>For each archive stoichiometry with {@code parentReactionId == null}, creates a new
    * stoichiometry on the importing instance bound to {@code newField}'s structured document, copies
-   * every molecule (with {@code rsChemElement = null}), rewrites the field's {@code
-   * data-stoichiometry-table} JSON to reference the new id, and saves the field.
+   * every molecule (each backed by a fresh {@link RSChemElement} — {@code rs_chem_id} is NOT NULL
+   * on {@code StoichiometryMolecule}), rewrites the field's {@code data-stoichiometry-table} JSON
+   * to reference the new id, and saves the field.
    *
    * @param archivedChemElementIds the set of chem element IDs present in the archive (from {@code
    *     ArchivalField.getChemElementMeta()}); used to detect orphan stoichiometries.
    */
   public void importReactionlessStoichiometries(Set<Long> archivedChemElementIds) {
-    if (oldField.getStoichiometries() == null) {
-      return;
-    }
     for (StoichiometryDTO archived : oldField.getStoichiometries()) {
       if (archived.getParentReactionId() == null) {
         Stoichiometry created =

--- a/src/main/java/com/researchspace/service/impl/StoichiometryManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/StoichiometryManagerImpl.java
@@ -163,6 +163,21 @@ public class StoichiometryManagerImpl extends GenericManagerImpl<Stoichiometry, 
   }
 
   @Override
+  public Stoichiometry createReactionlessFromArchive(
+      StoichiometryDTO existing, Record record, User user) {
+    Stoichiometry stoichiometry = Stoichiometry.builder().record(record).build();
+    stoichiometry = save(stoichiometry);
+    if (existing.getMolecules() != null) {
+      for (StoichiometryMoleculeDTO moleculeDTO : existing.getMolecules()) {
+        RSChemElement chemElement = createNewRsChemElement(user, moleculeDTO);
+        StoichiometryMolecule molecule = buildMolecule(moleculeDTO, stoichiometry, chemElement);
+        stoichiometry.addMolecule(molecule);
+      }
+    }
+    return save(stoichiometry);
+  }
+
+  @Override
   public Stoichiometry update(StoichiometryUpdateDTO stoichiometryUpdate, User user) {
     Stoichiometry stoichiometry = get(stoichiometryUpdate.getId());
     if (stoichiometry == null) {

--- a/src/main/java/com/researchspace/service/impl/StoichiometryManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/StoichiometryManagerImpl.java
@@ -165,8 +165,7 @@ public class StoichiometryManagerImpl extends GenericManagerImpl<Stoichiometry, 
   @Override
   public Stoichiometry createReactionlessFromArchive(
       StoichiometryDTO existing, Record record, User user) {
-    Stoichiometry stoichiometry = Stoichiometry.builder().record(record).build();
-    stoichiometry = save(stoichiometry);
+    Stoichiometry stoichiometry = createEmpty(record, user);
     if (existing.getMolecules() != null) {
       for (StoichiometryMoleculeDTO moleculeDTO : existing.getMolecules()) {
         RSChemElement chemElement = createNewRsChemElement(user, moleculeDTO);

--- a/src/main/java/com/researchspace/service/impl/StoichiometryServiceImpl.java
+++ b/src/main/java/com/researchspace/service/impl/StoichiometryServiceImpl.java
@@ -176,6 +176,17 @@ public class StoichiometryServiceImpl implements StoichiometryService {
         stoichiometryDTO, chemElement, user);
   }
 
+  /**
+   * Pass-through to the manager. Intentionally does <strong>not</strong> apply the permission check
+   * used by {@link #createEmpty(long, User)}; called only from the archive importer, which is the
+   * authoritative authorisation gate for archive-driven writes.
+   */
+  @Override
+  public Stoichiometry createReactionlessFromArchive(
+      StoichiometryDTO stoichiometryDTO, Record record, User user) {
+    return stoichiometryManager.createReactionlessFromArchive(stoichiometryDTO, record, user);
+  }
+
   private static boolean analysisExists(Optional<ElementalAnalysisDTO> analysis) {
     return analysis.isPresent()
         && analysis.get().getMoleculeInfo() != null

--- a/src/test/java/com/researchspace/export/stoichiometry/StoichiometryHtmlGeneratorTest.java
+++ b/src/test/java/com/researchspace/export/stoichiometry/StoichiometryHtmlGeneratorTest.java
@@ -1,0 +1,123 @@
+package com.researchspace.export.stoichiometry;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.model.User;
+import com.researchspace.model.dtos.chemistry.StoichiometryDTO;
+import com.researchspace.model.dtos.chemistry.StoichiometryMoleculeDTO;
+import com.researchspace.model.stoichiometry.MoleculeRole;
+import com.researchspace.service.StoichiometryService;
+import com.researchspace.testutils.RSpaceTestUtils;
+import java.util.List;
+import org.apache.velocity.app.VelocityEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Integration test for {@link StoichiometryHtmlGenerator} that exercises the real Velocity engine
+ * with the production {@code stoichiometry-table.vm} template. Verifies header generation for
+ * reaction-less stoichiometries (RSDEV-1091, commit 905507a4) and for the existing reaction-linked
+ * paths.
+ */
+public class StoichiometryHtmlGeneratorTest {
+
+  private static final String REACTIONLESS_HEADER = " this reactionless stoichiometry.";
+  private static final String DEFAULT_REACTION_HEADER = " the chemical reaction above.";
+
+  private StoichiometryHtmlGenerator generator;
+  private StoichiometryService stoichiometryService;
+  private User exporter;
+
+  @BeforeEach
+  public void setUp() {
+    VelocityEngine velocityEngine =
+        RSpaceTestUtils.setupVelocity("src/main/resources/velocityTemplates");
+    stoichiometryService = Mockito.mock(StoichiometryService.class);
+    generator = new StoichiometryHtmlGenerator();
+    ReflectionTestUtils.setField(generator, "velocityEngine", velocityEngine);
+    ReflectionTestUtils.setField(generator, "stoichiometryService", stoichiometryService);
+    ReflectionTestUtils.setField(generator, "urlPrefix", "https://test.researchspace.com");
+
+    exporter = new User();
+    exporter.setUsername("exporter");
+
+    when(stoichiometryService.getById(eq(1L), any(), any()))
+        .thenReturn(stoichiometryDtoWithMolecule());
+  }
+
+  @Test
+  public void addStoichiometryLinks_reactionlessStoichiometry_rendersReactionlessHeader() {
+    String html =
+        "<html><body>"
+            + "<div data-stoichiometry-table-only=\"true\" "
+            + "data-stoichiometry-table=\"{&quot;id&quot;:1,&quot;revision&quot;:null}\"></div>"
+            + "</body></html>";
+
+    String result = generator.addStoichiometryLinks(html, exporter);
+
+    assertTrue(
+        result.contains("Stoichiometry Information for" + REACTIONLESS_HEADER),
+        () -> "expected reaction-less header but got:\n" + result);
+    assertFalse(
+        result.contains(DEFAULT_REACTION_HEADER),
+        "default reaction-linked header must not appear when"
+            + " data-stoichiometry-table-only=\"true\"");
+  }
+
+  @Test
+  public void addStoichiometryLinks_reactionLinkedWithAltText_rendersAltAsHeader() {
+    String alt = " my custom reaction context.";
+    String html =
+        "<html><body>"
+            + "<img alt=\""
+            + alt
+            + "\" "
+            + "data-stoichiometry-table=\"{&quot;id&quot;:1,&quot;revision&quot;:null}\">"
+            + "</body></html>";
+
+    String result = generator.addStoichiometryLinks(html, exporter);
+
+    assertTrue(
+        result.contains("Stoichiometry Information for" + alt),
+        () -> "expected alt-derived header but got:\n" + result);
+    assertFalse(
+        result.contains(REACTIONLESS_HEADER),
+        "reaction-less header must not appear when data-stoichiometry-table-only is absent");
+  }
+
+  @Test
+  public void addStoichiometryLinks_reactionLinkedWithoutAltText_rendersDefaultHeader() {
+    String html =
+        "<html><body>"
+            + "<img data-stoichiometry-table=\"{&quot;id&quot;:1,&quot;revision&quot;:null}\">"
+            + "</body></html>";
+
+    String result = generator.addStoichiometryLinks(html, exporter);
+
+    assertTrue(
+        result.contains("Stoichiometry Information for" + DEFAULT_REACTION_HEADER),
+        () -> "expected default reaction-linked header but got:\n" + result);
+    assertFalse(
+        result.contains(REACTIONLESS_HEADER),
+        "reaction-less header must not appear when data-stoichiometry-table-only is absent");
+  }
+
+  private StoichiometryDTO stoichiometryDtoWithMolecule() {
+    StoichiometryMoleculeDTO mol =
+        StoichiometryMoleculeDTO.builder()
+            .role(MoleculeRole.REACTANT)
+            .formula("C2H6O")
+            .name("Ethanol")
+            .smiles("CCO")
+            .molecularWeight(46.07)
+            .coefficient(1.0)
+            .build();
+    return StoichiometryDTO.builder().id(1L).revision(null).molecules(List.of(mol)).build();
+  }
+}

--- a/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
@@ -74,6 +74,8 @@ import com.researchspace.model.core.RecordType;
 import com.researchspace.model.dtos.ExportSelection;
 import com.researchspace.model.dtos.WorkspaceListingConfig;
 import com.researchspace.model.dtos.chemistry.StoichiometryDTO;
+import com.researchspace.model.dtos.chemistry.StoichiometryMoleculeUpdateDTO;
+import com.researchspace.model.dtos.chemistry.StoichiometryUpdateDTO;
 import com.researchspace.model.externalWorkflows.ExternalWorkFlowData;
 import com.researchspace.model.externalWorkflows.ExternalWorkFlowData.ExternalService;
 import com.researchspace.model.externalWorkflows.ExternalWorkFlowData.ExternalWorkFlowDataBuilder;
@@ -89,7 +91,9 @@ import com.researchspace.model.record.IconEntity;
 import com.researchspace.model.record.Notebook;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.model.stoichiometry.MoleculeRole;
 import com.researchspace.model.stoichiometry.Stoichiometry;
+import com.researchspace.model.stoichiometry.StoichiometryMolecule;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.netfiles.NfsFileDetails;
 import com.researchspace.netfiles.NfsFolderDetails;
@@ -1287,6 +1291,140 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
     TriFunction<Long, Long, User, Stoichiometry> creator =
         (a, b, user) -> stoichiometryService.createFromReaction(b, a, user);
     testExportImportStoichiometriesWithChemOrEmpty(creator);
+  }
+
+  /**
+   * RSDEV-1091: reaction-less Stoichiometry with molecules round-trips through XML archive.
+   * Verifies that the molecules survive export/import (the bug this ticket fixes was that they were
+   * silently dropped) and that no phantom RSChemElement rows are created during import.
+   */
+  @Test
+  public void testExportImportReactionlessStoichiometryWithMolecules() throws Exception {
+    User u1 = createInitAndLoginAnyUser();
+    StructuredDocument sdoc = createBasicDocumentInRootFolderWithText(u1, "source");
+    Field textField = sdoc.getFields().get(0);
+    textField.setName("testTextField");
+
+    // Create reaction-less stoichiometry (no parent reaction) and populate molecules
+    Stoichiometry stoichiometry = stoichiometryService.createEmpty(sdoc.getId(), u1);
+
+    StoichiometryMoleculeUpdateDTO ethanol =
+        StoichiometryMoleculeUpdateDTO.builder()
+            .smiles("CCO")
+            .name("Ethanol")
+            .formula("C2H6O")
+            .role(MoleculeRole.REACTANT)
+            .coefficient(1.0)
+            .molecularWeight(46.07)
+            .mass(46.07)
+            .limitingReagent(true)
+            .build();
+    StoichiometryMoleculeUpdateDTO acetaldehyde =
+        StoichiometryMoleculeUpdateDTO.builder()
+            .smiles("CC=O")
+            .name("Acetaldehyde")
+            .formula("C2H4O")
+            .role(MoleculeRole.PRODUCT)
+            .coefficient(1.0)
+            .molecularWeight(44.05)
+            .build();
+
+    StoichiometryUpdateDTO updateDTO =
+        StoichiometryUpdateDTO.builder()
+            .id(stoichiometry.getId())
+            .molecules(List.of(ethanol, acetaldehyde))
+            .build();
+    stoichiometryService.update(stoichiometry.getId(), updateDTO, u1);
+
+    Long stoichiometryId = stoichiometry.getId();
+    Long stoichiometryRevision =
+        stoichiometryService.getById(stoichiometryId, null, u1).getRevision();
+
+    // Set the field HTML to the reaction-less marker DOM (RSDEV-874 frontend output)
+    textField.setFieldData(
+        "<div data-stoichiometry-table-only=\"true\" "
+            + "data-stoichiometry-table=\"{&quot;id&quot;:"
+            + stoichiometryId
+            + ",&quot;revision&quot;:"
+            + stoichiometryRevision
+            + "}\"></div>");
+    fieldMgr.save(textField, u1);
+
+    int rsChemElementsBeforeImport = countRowsInTable(jdbcTemplate, "RSChemElement");
+
+    final ArchiveExportConfig cfg = createDefaultArchiveConfig(u1, tempExportFolder.getRoot());
+    ArchiveResult result =
+        exportImportMgr
+            .asyncExportSelectionToArchive(
+                getSingleRecordExportSelection(sdoc.getId(), RecordType.NORMAL.toString()),
+                cfg,
+                u1,
+                anyURI(),
+                standardPostExport)
+            .get();
+
+    ArchivalImportConfig importCfg =
+        createDefaultArchiveImportConfig(u1, tempImportFolder2.getRoot());
+    ImportArchiveReport report =
+        exportImportMgr.importArchive(
+            fileToMultipartfile(result.getExportFile().getName(), result.getExportFile()),
+            u1.getUsername(),
+            importCfg,
+            NULL_MONITOR,
+            importStrategy::doImport);
+    assertTrue(report.isSuccessful());
+
+    StructuredDocument importedDoc = report.getImportedRecords().iterator().next().asStrucDoc();
+    Stoichiometry importedStoichiometry =
+        stoichiometryMgr
+            .findByRecordId(importedDoc.getId())
+            .orElseThrow(() -> new RuntimeException("Stoichiometry not found after import"));
+
+    // New stoichiometry row with no parent reaction
+    assertNotEquals(stoichiometryId, importedStoichiometry.getId());
+    assertNull(
+        "Imported reaction-less stoichiometry must not have a parent reaction",
+        importedStoichiometry.getParentReaction());
+
+    // Molecules survived the round-trip — this is the bug RSDEV-1091 fixes
+    assertEquals(2, importedStoichiometry.getMolecules().size());
+
+    StoichiometryMolecule importedEthanol =
+        importedStoichiometry.getMolecules().stream()
+            .filter(m -> "Ethanol".equals(m.getName()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Ethanol molecule missing after import"));
+    assertEquals("CCO", importedEthanol.getSmiles());
+    assertEquals("C2H6O", importedEthanol.getFormula());
+    assertEquals(MoleculeRole.REACTANT, importedEthanol.getRole());
+    assertEquals(46.07, importedEthanol.getMolecularWeight(), 0.001);
+    assertTrue(importedEthanol.getLimitingReagent());
+    assertNotNull(
+        "rs_chem_id is NOT NULL; reaction-less import must create RSChemElement rows",
+        importedEthanol.getRsChemElement());
+
+    StoichiometryMolecule importedAcetaldehyde =
+        importedStoichiometry.getMolecules().stream()
+            .filter(m -> "Acetaldehyde".equals(m.getName()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Acetaldehyde molecule missing after import"));
+    assertEquals(MoleculeRole.PRODUCT, importedAcetaldehyde.getRole());
+    assertNotNull(importedAcetaldehyde.getRsChemElement());
+
+    // One RSChemElement row created per imported molecule (mirrors user-creation path)
+    int rsChemElementsAfterImport = countRowsInTable(jdbcTemplate, "RSChemElement");
+    assertEquals(
+        "Reaction-less import must create one RSChemElement per molecule",
+        rsChemElementsBeforeImport + 2,
+        rsChemElementsAfterImport);
+
+    // Field HTML rewritten to reference the new id
+    List<StoichiometryDTO> importedRtfData =
+        new StoichiometryReader()
+            .extractStoichiometriesFromFieldContents(
+                importedDoc.getField("testTextField").getFieldData());
+    assertEquals(1, importedRtfData.size());
+    assertEquals(importedStoichiometry.getId(), importedRtfData.get(0).getId());
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/ExportImportManagerTestIT.java
@@ -1296,7 +1296,8 @@ public class ExportImportManagerTestIT extends RealTransactionSpringTestBase {
   /**
    * RSDEV-1091: reaction-less Stoichiometry with molecules round-trips through XML archive.
    * Verifies that the molecules survive export/import (the bug this ticket fixes was that they were
-   * silently dropped) and that no phantom RSChemElement rows are created during import.
+   * silently dropped) and that one fresh RSChemElement row is created per molecule on import,
+   * matching the user-creation path (the {@code rs_chem_id} column is NOT NULL).
    */
   @Test
   public void testExportImportReactionlessStoichiometryWithMolecules() throws Exception {

--- a/src/test/java/com/researchspace/service/StoichiometryManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/StoichiometryManagerImplTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -745,6 +746,81 @@ public class StoichiometryManagerImplTest {
     stoichiometryManager.update(updateDTO, user);
 
     assertNull(mol.getInventoryLink());
+  }
+
+  @Test
+  public void whenCreateReactionlessFromArchive_thenStoichiometryHasNoParentReactionAndMolecules()
+      throws Exception {
+    StoichiometryDTO archived = new StoichiometryDTO();
+    StoichiometryMoleculeDTO mol1 =
+        StoichiometryMoleculeDTO.builder()
+            .role(MoleculeRole.REACTANT)
+            .formula("C2H6O")
+            .name("Ethanol")
+            .smiles("CCO")
+            .molecularWeight(46.07)
+            .coefficient(1.0)
+            .mass(46.07)
+            .limitingReagent(true)
+            .build();
+    StoichiometryMoleculeDTO mol2 =
+        StoichiometryMoleculeDTO.builder()
+            .role(MoleculeRole.PRODUCT)
+            .formula("C2H4O")
+            .name("Acetaldehyde")
+            .smiles("CC=O")
+            .molecularWeight(44.05)
+            .coefficient(1.0)
+            .build();
+    archived.setMolecules(List.of(mol1, mol2));
+
+    when(rsChemElementManager.save(any(RSChemElement.class), any(User.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0, RSChemElement.class));
+
+    Stoichiometry result =
+        stoichiometryManager.createReactionlessFromArchive(archived, record, user);
+
+    assertNull(
+        "Imported reaction-less stoichiometry must not link to a parent reaction",
+        result.getParentReaction());
+    assertEquals(record, result.getRecord());
+    assertEquals(2, result.getMolecules().size());
+
+    StoichiometryMolecule firstMol = result.getMolecules().get(0);
+    assertEquals(MoleculeRole.REACTANT, firstMol.getRole());
+    assertEquals("CCO", firstMol.getSmiles());
+    assertEquals("Ethanol", firstMol.getName());
+    assertEquals("C2H6O", firstMol.getFormula());
+    assertEquals(46.07, firstMol.getMolecularWeight(), 0.001);
+    assertTrue(firstMol.getLimitingReagent());
+    assertNotNull(
+        "rs_chem_id is NOT NULL in the DB; reaction-less import must create an RSChemElement"
+            + " per molecule",
+        firstMol.getRsChemElement());
+
+    StoichiometryMolecule secondMol = result.getMolecules().get(1);
+    assertEquals(MoleculeRole.PRODUCT, secondMol.getRole());
+    assertNotNull(secondMol.getRsChemElement());
+
+    // One RSChemElement saved per molecule
+    verify(rsChemElementManager, times(2)).save(any(RSChemElement.class), any(User.class));
+  }
+
+  @Test
+  public void whenCreateReactionlessFromArchive_withNoMolecules_thenCreatesEmptyStoichiometry()
+      throws Exception {
+    StoichiometryDTO archived = new StoichiometryDTO();
+    archived.setMolecules(null);
+
+    Stoichiometry result =
+        stoichiometryManager.createReactionlessFromArchive(archived, record, user);
+
+    assertNull(result.getParentReaction());
+    assertEquals(record, result.getRecord());
+    assertTrue(
+        "Empty molecule list should produce an empty molecules collection",
+        result.getMolecules() == null || result.getMolecules().isEmpty());
+    verify(rsChemElementManager, never()).save(any(RSChemElement.class), any(User.class));
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
+++ b/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -39,7 +38,6 @@ public class StoichiometryImportRevisionFixupManagerTest {
   @Mock private ImportArchiveReport report;
 
   @InjectMocks private StoichiometryImportRevisionFixupManagerImpl testee;
-
 
   private StructuredDocument mockStructuredDocument(long id) {
     StructuredDocument doc = Mockito.mock(StructuredDocument.class);

--- a/src/test/java/com/researchspace/service/archive/StoichiometryImporterTest.java
+++ b/src/test/java/com/researchspace/service/archive/StoichiometryImporterTest.java
@@ -119,13 +119,6 @@ public class StoichiometryImporterTest {
   // --- importReactionlessStoichiometries (RSDEV-1091) ---
 
   @Test
-  public void testReactionlessImport_whenNoStoichiometries_doesNothing() {
-    when(oldField.getStoichiometries()).thenReturn(null);
-    testee.importReactionlessStoichiometries(Collections.emptySet());
-    verifyZeroInteractions(service);
-  }
-
-  @Test
   public void testReactionlessImport_whenEmptyStoichiometriesList_doesNothing() {
     when(oldField.getStoichiometries()).thenReturn(new ArrayList<>());
     testee.importReactionlessStoichiometries(Collections.emptySet());
@@ -141,7 +134,8 @@ public class StoichiometryImporterTest {
   }
 
   @Test
-  public void testReactionlessImport_whenStoichHasNullParentReaction_isImportedWithMolecules() {
+  public void
+      testReactionlessImport_whenStoichHasNullParentReaction_callsServiceAndRewritesFieldHtml() {
     Stoichiometry created = new Stoichiometry();
     created.setId(77L);
     when(oldField.getStoichiometries()).thenReturn(List.of(existingStoich));
@@ -161,8 +155,11 @@ public class StoichiometryImporterTest {
   }
 
   @Test
-  public void testReactionlessImport_whenOrphanReactionLinkedStoich_logsWarnAndDoesNotImport() {
-    // existingStoich has a parentReactionId that is NOT in the imported chem element set
+  public void testReactionlessImport_whenOrphanReactionLinkedStoich_doesNotImport() {
+    // existingStoich has a parentReactionId that is NOT in the imported chem element set.
+    // The production code emits a log.warn for this case (see StoichiometryImporter); we only
+    // assert the user-facing behaviour here (no import) — the log line is best-effort
+    // observability.
     when(oldField.getStoichiometries()).thenReturn(List.of(existingStoich));
     when(existingStoich.getParentReactionId()).thenReturn(99999L);
 

--- a/src/test/java/com/researchspace/service/archive/StoichiometryImporterTest.java
+++ b/src/test/java/com/researchspace/service/archive/StoichiometryImporterTest.java
@@ -1,6 +1,8 @@
 package com.researchspace.service.archive;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -19,7 +21,9 @@ import com.researchspace.service.StoichiometryService;
 import com.researchspace.service.archive.StoichiometryImporter.IdAndRevision;
 import com.researchspace.service.archive.export.StoichiometryReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -110,5 +114,61 @@ public class StoichiometryImporterTest {
     verify(newField)
         .setFieldData(
             "<img data-stoichiometry-table=\"{&quot;id&quot;:33,&quot;revision&quot;:null}\">");
+  }
+
+  // --- importReactionlessStoichiometries (RSDEV-1091) ---
+
+  @Test
+  public void testReactionlessImport_whenNoStoichiometries_doesNothing() {
+    when(oldField.getStoichiometries()).thenReturn(null);
+    testee.importReactionlessStoichiometries(Collections.emptySet());
+    verifyZeroInteractions(service);
+  }
+
+  @Test
+  public void testReactionlessImport_whenEmptyStoichiometriesList_doesNothing() {
+    when(oldField.getStoichiometries()).thenReturn(new ArrayList<>());
+    testee.importReactionlessStoichiometries(Collections.emptySet());
+    verifyZeroInteractions(service);
+  }
+
+  @Test
+  public void testReactionlessImport_whenAllStoichsAreReactionLinked_doesNothing() {
+    when(oldField.getStoichiometries()).thenReturn(List.of(existingStoich));
+    when(existingStoich.getParentReactionId()).thenReturn(1L);
+    testee.importReactionlessStoichiometries(Set.of(1L));
+    verify(service, never()).createReactionlessFromArchive(any(), any(), any());
+  }
+
+  @Test
+  public void testReactionlessImport_whenStoichHasNullParentReaction_isImportedWithMolecules() {
+    Stoichiometry created = new Stoichiometry();
+    created.setId(77L);
+    when(oldField.getStoichiometries()).thenReturn(List.of(existingStoich));
+    when(existingStoich.getParentReactionId()).thenReturn(null);
+    when(service.createReactionlessFromArchive(eq(existingStoich), eq(strucDoc), eq(user)))
+        .thenReturn(created);
+
+    testee.importReactionlessStoichiometries(Collections.emptySet());
+
+    verify(service).createReactionlessFromArchive(eq(existingStoich), eq(strucDoc), eq(user));
+    StoichiometryImporter.IdAndRevision expected = new StoichiometryImporter.IdAndRevision();
+    expected.id = 77L;
+    verify(reader)
+        .createReplacementHtmlContentForTargetStoichiometryInFieldData(
+            eq(NEW_FIELD_FIELDDATA), eq(existingStoich), eq(expected));
+    verify(fieldManager).save(eq(newField), eq(user));
+  }
+
+  @Test
+  public void testReactionlessImport_whenOrphanReactionLinkedStoich_logsWarnAndDoesNotImport() {
+    // existingStoich has a parentReactionId that is NOT in the imported chem element set
+    when(oldField.getStoichiometries()).thenReturn(List.of(existingStoich));
+    when(existingStoich.getParentReactionId()).thenReturn(99999L);
+
+    testee.importReactionlessStoichiometries(Set.of(1L, 2L));
+
+    verify(service, never()).createReactionlessFromArchive(any(), any(), any());
+    verify(fieldManager, never()).save(any(), any());
   }
 }


### PR DESCRIPTION
## Description ##
This PR was investigated and implemented by Claude AI agent on behalf of the user. Completes the XML archive round-trip for reaction-less Stoichiometries (follow-up to RSDEV-874 and RSDEV-948).

Root causes
- AbstractImporterStrategyImpl.importEmptyStoichiometries called createEmpty(...), silently dropping molecules from the archived DTO on import.
- StoichiometryHtmlGenerator emitted the reaction-linked header (the chemical reaction above) for reaction-less tables in PDF/HTML/Word exports.

Changes
- New StoichiometryManager.createReactionlessFromArchive(DTO, Record, User) populates molecules with fresh RSChemElement rows (rs_chem_id is NOT NULL).
- New StoichiometryImporter.importReactionlessStoichiometries(Set<Long>) replaces the lossy inline twin in AbstractImporterStrategyImpl and logs orphan stoichs.
- StoichiometryHtmlGenerator emits this reactionless stoichiometry. header when data-stoichiometry-table-only="true".
- Tests: round-trip IT (ExportImportManagerTestIT), unit tests for manager and importer, and StoichiometryHtmlGeneratorTest covering all three header branches.
- DevDocs ExportAndImport.md documents the reaction-linked vs reaction-less import split.

Linked: https://researchspace.atlassian.net/browse/RSDEV-1091

## Design decisions
***OPTIONAL***
- ***if there were any particular design decisions made, list them here***

## Testing notes
***OPTIONAL***
- ***if there are any particular pre-requisites or instructions for manual testing, list them here***
