### PR TITLE
Do not create new stoichiometry table from toolbar if there is focus on an existing one

### DIFF
--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/index.test.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/index.test.tsx
@@ -300,6 +300,7 @@ function getLastRenderedDialogProps(): DialogProps | null {
 
 describe("TinyMCE stoichiometry plugin", () => {
   beforeEach(() => {
+    fetchMock.resetMocks();
     vi.resetModules();
     vi.clearAllMocks();
     rootRenderCalls.length = 0;
@@ -462,6 +463,7 @@ describe("TinyMCE stoichiometry plugin", () => {
     expect(
       editorDocument.querySelectorAll('[data-stoichiometry-table-only="true"]'),
     ).toHaveLength(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("removes a newly inserted tableOnly div when its stoichiometry table is deleted", async () => {

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/index.test.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/index.test.tsx
@@ -425,6 +425,45 @@ describe("TinyMCE stoichiometry plugin", () => {
     ).not.toBeNull();
   });
 
+  it("reopens the selected stoichiometry table from the toolbar button instead of inserting a new one", async () => {
+    const registeredPlugins = registerTinymcePlugins();
+    const editorDocument = document.implementation.createHTMLDocument("editor");
+    const tableOnlyNode = createTableOnlyNode(editorDocument, {
+      id: "stoichiometry-1",
+      stoichiometry: { id: 12, revision: 4 },
+    });
+    const { buttons, editor, selectionState } = createEditorHarness({
+      editorDocument,
+      initialSelectionNode: tableOnlyNode,
+    });
+
+    await instantiateStoichiometryPlugin();
+    const StoichiometryPlugin = getRegisteredStoichiometryPlugin(registeredPlugins);
+    new StoichiometryPlugin(editor);
+
+    tableOnlyNode.innerHTML =
+      '<span data-stoichiometry-preview="true"><div><button type="button">Edit</button></div></span>';
+    selectionState.current = tableOnlyNode.querySelector("button") as HTMLElement;
+
+    buttons.get("stoichiometryInsertButton")?.onAction();
+
+    await waitFor(() => {
+      expect(getLastRenderedDialogProps()).toEqual(
+        expect.objectContaining({
+          open: true,
+          chemId: null,
+          stoichiometryId: 12,
+          stoichiometryRevision: 4,
+          autoCreateTableOnOpen: false,
+        }),
+      );
+    });
+
+    expect(
+      editorDocument.querySelectorAll('[data-stoichiometry-table-only="true"]'),
+    ).toHaveLength(1);
+  });
+
   it("removes a newly inserted tableOnly div when its stoichiometry table is deleted", async () => {
     const registeredPlugins = registerTinymcePlugins();
     const editorDocument = document.implementation.createHTMLDocument("editor");
@@ -579,6 +618,9 @@ describe("TinyMCE stoichiometry plugin", () => {
     const StoichiometryPlugin = getRegisteredStoichiometryPlugin(registeredPlugins);
     new StoichiometryPlugin(editor);
 
+    expect(document.importNode(tableOnlyNode, true)).toHaveTextContent(
+      "Empty Stoichiometry Table",
+    );
     expectToHaveTextContent(tableOnlyNode, "Empty Stoichiometry Table");
   });
 
@@ -697,7 +739,3 @@ describe("TinyMCE stoichiometry plugin", () => {
     expect(editor.focus).not.toHaveBeenCalled();
   });
 });
-
-
-
-

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/index.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/index.tsx
@@ -488,20 +488,20 @@ class StoichiometryPlugin {
     };
 
 
-    const openCreateStoichiometryDialog = () => {
-      editor.execCommand("cmdCreateStoichiometry", false);
+    const openStoichiometryDialogFromSelection = () => {
+      editor.execCommand("cmdStoichiometry", false);
     };
 
     editor.ui.registry.addButton("stoichiometryInsertButton", {
       tooltip: "Insert reaction table",
       icon: "stoichiometry",
-      onAction: openCreateStoichiometryDialog,
+      onAction: openStoichiometryDialogFromSelection,
     });
 
     editor.ui.registry.addMenuItem("stoichiometryMenuItem", {
       text: "Reaction Table",
       icon: "stoichiometry",
-      onAction: openCreateStoichiometryDialog,
+      onAction: openStoichiometryDialogFromSelection,
     });
 
     if (!window.insertActions) {
@@ -511,7 +511,7 @@ class StoichiometryPlugin {
       text: "Stoichiometry Table",
       icon: "stoichiometry",
       aliases: ["Stoichiometry"],
-      action: openCreateStoichiometryDialog,
+      action: openStoichiometryDialogFromSelection,
     });
 
     editor.addCommand("cmdCreateStoichiometry", function () {


### PR DESCRIPTION
## Description ##
Do not create new stoichiometry table from toolbar if there is focus on an existing one.

Fixes PRT-1072

## Replication Steps ##
1. Create a new stoichiometry table.
2. Click on the stoichiometry table in the UI, then click on the "Reaction Table" button in the toolbar.
3. It should open the existing table instead of creating a new one.