### PR TITLE
Fix prt 1070 omero

### DIFF
--- a/src/test/java/com/researchspace/integrations/omero/service/OmeroServiceTest.java
+++ b/src/test/java/com/researchspace/integrations/omero/service/OmeroServiceTest.java
@@ -20,6 +20,7 @@ import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.si
 import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.tokenJson;
 import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.urlsJson;
 import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.versionJson;
+import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.wellsForPlateJson;
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -326,7 +327,7 @@ public class OmeroServiceTest {
                 .withMethod("GET")
                 .withPath("/api/v0/m/plates/422/wellsampleindex/0/wells/")
                 .withQueryStringParameter("offset", "0"))
-        .respond(response().withBody(imagesForDatasetJson));
+        .respond(response().withBody(wellsForPlateJson));
     client
         .when(
             request()

--- a/src/test/java/com/researchspace/webapp/integrations/omero/JSONClientTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/omero/JSONClientTest.java
@@ -15,6 +15,7 @@ import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.sc
 import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.screensJson;
 import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.urlsJson;
 import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.versionJson;
+import static com.researchspace.webapp.integrations.omero.OmeroJsonTestMother.wellsForPlateJson;
 import static org.junit.Assert.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -151,7 +152,7 @@ public class JSONClientTest {
                 .withMethod("GET")
                 .withPath("/api/v0/m/plates/422/wellsampleindex/0/wells/")
                 .withQueryStringParameter("offset", "0"))
-        .respond(response().withBody(imagesForDatasetJson));
+        .respond(response().withBody(wellsForPlateJson));
     JsonObject plate = jsonClient.getPlateWithId("422");
     Collection<JsonObject> wells = jsonClient.listWellsForPlateAcquisition(plate, 422L, 0);
     assertEquals(96, wells.size());

--- a/src/test/java/com/researchspace/webapp/integrations/omero/OmeroJsonTestMother.java
+++ b/src/test/java/com/researchspace/webapp/integrations/omero/OmeroJsonTestMother.java
@@ -73,6 +73,10 @@ public class OmeroJsonTestMother {
   public static String screensJsonResource = "TestResources/omero_json_responses/screens.json";
   public static String screensJson = makeDataJson(screensJsonResource);
 
+  public static String wellsForPlateJsonResource =
+      "TestResources/omero_json_responses/wells_for_plate.json";
+  public static String wellsForPlateJson = makeDataJson(wellsForPlateJsonResource);
+
   @SneakyThrows
   private static String makeDataJson(String resource) {
     ClassLoader classLoader = OmeroJsonTestMother.class.getClassLoader();

--- a/src/test/resources/TestResources/omero_json_responses/dataset.json
+++ b/src/test/resources/TestResources/omero_json_responses/dataset.json
@@ -73,7 +73,7 @@
     },
     "Name": "CDK5RAP2-C",
     "omero:childCount": 33,
-    "url:images": "https://localhost:8080/api/v0/m/datasets/51/images/",
-    "url:projects": "https://localhost:8080/api/v0/m/datasets/51/projects/"
+    "url:images": "http://localhost:1080/api/v0/m/datasets/51/images/",
+    "url:projects": "http://localhost:1080/api/v0/m/datasets/51/projects/"
   }
 }

--- a/src/test/resources/TestResources/omero_json_responses/dataset.json
+++ b/src/test/resources/TestResources/omero_json_responses/dataset.json
@@ -73,7 +73,7 @@
     },
     "Name": "CDK5RAP2-C",
     "omero:childCount": 33,
-    "url:images": "https://idr.openmicroscopy.org/api/v0/m/datasets/51/images/",
-    "url:projects": "https://idr.openmicroscopy.org/api/v0/m/datasets/51/projects/"
+    "url:images": "https://localhost:8080/api/v0/m/datasets/51/images/",
+    "url:projects": "https://localhost:8080/api/v0/m/datasets/51/projects/"
   }
 }

--- a/src/test/resources/TestResources/omero_json_responses/plate.json
+++ b/src/test/resources/TestResources/omero_json_responses/plate.json
@@ -76,15 +76,15 @@
     "RowNamingConvention": "letter",
     "Columns": 12,
     "Rows": 8,
-    "url:screens": "https://idr.openmicroscopy.org/api/v0/m/plates/422/screens/",
-    "url:wells": "https://idr.openmicroscopy.org/api/v0/m/plates/422/wells/",
-    "url:plateacquisitions": "https://idr.openmicroscopy.org/api/v0/m/plates/422/plateacquisitions/",
+    "url:screens": "http://localhost:1080/api/v0/m/plates/422/screens/",
+    "url:wells": "http://localhost:1080/api/v0/m/plates/422/wells/",
+    "url:plateacquisitions": "http://localhost:1080/api/v0/m/plates/422/plateacquisitions/",
     "omero:wellsampleIndex": [
       0,
       0
     ],
     "url:wellsampleindex_wells": [
-      "https://idr.openmicroscopy.org/api/v0/m/plates/422/wellsampleindex/0/wells/"
+      "http://localhost:1080/api/v0/m/plates/422/wellsampleindex/0/wells/"
     ]
   }
 }


### PR DESCRIPTION
## Description ##
Omero unit tests started failing because the sample.jsons being used (eg plate.json) had real omero urls in them. 
