### PR TITLE
Set npm minimum release age

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,8 +116,8 @@ pipeline {
                 dir('src/main/webapp/ui') {
                     echo 'Installing npm packages'
                     sh 'node -v'
-                    sh 'npx -y npm@11.11.1 -v'
-                    sh 'npx -y npm@11.11.1 ci --force'
+                    sh 'npx -y npm@11.14.1 -v'
+                    sh 'npx -y npm@11.14.1 ci --force'
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -2473,7 +2473,7 @@
             <version>1.15.1</version>
             <configuration>
               <nodeVersion>v24.13.1</nodeVersion>
-              <npmVersion>11.11.1</npmVersion>
+              <npmVersion>11.14.1</npmVersion>
               <workingDirectory>src/main/webapp/ui</workingDirectory>
             </configuration>
             <executions>

--- a/src/main/webapp/ui/.npmrc
+++ b/src/main/webapp/ui/.npmrc
@@ -1,3 +1,3 @@
 # uncomment for extra logging
 loglevel=verbose
-minimum-release-age=1440
+minimum-release-age=7

--- a/src/main/webapp/ui/.npmrc
+++ b/src/main/webapp/ui/.npmrc
@@ -1,3 +1,3 @@
 # uncomment for extra logging
 loglevel=verbose
-minimum-release-age=7
+min-release-age=7

--- a/src/main/webapp/ui/.npmrc
+++ b/src/main/webapp/ui/.npmrc
@@ -1,2 +1,3 @@
 # uncomment for extra logging
 loglevel=verbose
+minimum-release-age=1440

--- a/src/main/webapp/ui/package.json
+++ b/src/main/webapp/ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "private": true,
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@11.14.1",
   "scripts": {
     "test": "cross-env NODE_OPTIONS=\"--conditions=require\" vitest run",
     "test:ui": "cross-env NODE_OPTIONS=\"--conditions=require\" vitest --ui",


### PR DESCRIPTION
## Description ##
Sets the minimum release age of npm package installs to 7 days to mitigate most supply chain attacks.