### PR TITLE
a few tweaks to feat-remove-old-gallery branch

### DIFF
--- a/build-resources/resources_to_MD5_rename.txt
+++ b/build-resources/resources_to_MD5_rename.txt
@@ -62,8 +62,6 @@ scripts/pages/workspace/editor/formlist.js
 scripts/pages/workspace/editor/tinymce5_configuration.js
 scripts/pages/workspace/editor/tinymceRS_pasteHandler.js
 scripts/pages/workspace/editor/tinymceRS_scrollHandler.js
-scripts/pages/workspace/GalleriesCrudops.js
-scripts/pages/workspace/mediaGalleryManager.js
 scripts/segment.js
 scripts/tags/createFromTemplateDlg.js
 scripts/tags/export.js
@@ -79,9 +77,7 @@ scripts/tinymceDialogUtils.js
 styles/authentication/login.css
 styles/displaytag.css
 styles/forms.css
-styles/gallery.css
 styles/journal.css
-styles/mediaGallery.css
 styles/messages.css
 styles/pages/groups/viewGroup.css
 styles/pages/searchableRecordPicker.css
@@ -120,7 +116,6 @@ ui/dist/fileTreeToolbar.js
 ui/dist/groupActivity.js
 ui/dist/groupEditBar.js
 ui/dist/groupUserActivity.js
-ui/dist/imageEditor.js
 ui/dist/InternalLink.js
 ui/dist/inventoryEntry.js
 ui/dist/inventoryRecordIdentifierPublicPage.js
@@ -132,6 +127,7 @@ ui/dist/myLabGroups.js
 ui/dist/newLabGroup.js
 ui/dist/notebookToolbar.js
 ui/dist/oAuth.js
+ui/dist/pdfPreviewDialog.js
 ui/dist/PreviewInfo.js
 ui/dist/raidConnections.js
 ui/dist/rorIntegration.js

--- a/src/main/java/com/researchspace/webapp/controller/ImageController.java
+++ b/src/main/java/com/researchspace/webapp/controller/ImageController.java
@@ -27,7 +27,6 @@ import com.researchspace.service.FieldManager;
 import com.researchspace.service.IMediaFactory;
 import com.researchspace.service.IconImageManager;
 import com.researchspace.service.MediaManager;
-import com.researchspace.service.RSChemElementManager;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/com/researchspace/webapp/controller/NfsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsController.java
@@ -2,29 +2,21 @@ package com.researchspace.webapp.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.researchspace.core.util.LoggingUtils;
 import com.researchspace.model.DeploymentPropertyType;
 import com.researchspace.model.User;
-import com.researchspace.model.UserKeyPair;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileStoreInfo;
-import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.model.netfiles.NfsFileSystemInfo;
-import com.researchspace.model.netfiles.NfsFileSystemOption;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.netfiles.NfsFileDetails;
-import com.researchspace.netfiles.NfsFileTreeNode;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.netfiles.NfsViewProperty;
 import com.researchspace.service.NfsFileHandler;
 import com.researchspace.service.NfsManager;
-import com.researchspace.service.UserKeyManager;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.List;
@@ -49,8 +41,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
- * Controller handling client-side actions on Filestores Gallery page, also handles single file
- * streaming after clicking on a download link.
+ * Controller serving the filestore login dialog and handling per-link filestore actions (current
+ * path lookup and single-file download) triggered from filestore links inside documents/notebooks.
  */
 @DeploymentProperty(DeploymentPropertyType.NET_FILE_STORES_ENABLED)
 @Controller
@@ -60,49 +52,16 @@ public class NfsController extends BaseController {
   protected static final String SUCCESS_MSG = "ok";
   protected static final String NEED_LOG_IN_MSG = "need.log.in";
 
-  protected static final String MODEL_TREE_NODE = "nfsTreeNode";
-  protected static final String MODEL_DIR = "dir";
-  protected static final String MODEL_ADDING_FILE_STORE_FLAG = "addingFileStore";
-  protected static final String MODEL_SHOW_EXTRA_DIRS_FLAG = "showExtraDirs";
-  protected static final String MODEL_SHOW_CURRENT_DIR_FLAG = "showCurrentDir";
-  protected static final String MODEL_FILESYSTEM_TYPE = "fileSystemType";
-  public static final String PROBLEM_LOADING_FILES = "PROBLEM_LOADING_FILES";
-
   protected static final String SESSION_NFS_CLIENTS = "SESSION_NFS_CLIENTS";
   protected static final String SESSION_NFS_DOWNLOAD_PATH = "SESSION_NFS_DOWNLOAD_PATH";
 
   private static final String NO_FILE_PATHS_IN_DIR_NAME =
       "netfilestores.login.no.file.paths.in.dir";
   private static final int DOWNLOAD_BUFFER_SIZE = 1024;
-  private static final String ERRORID = "errorId";
 
   @Autowired private NfsManager nfsManager;
 
   @Autowired private NfsFileHandler nfsFileHandler;
-
-  @Autowired private UserKeyManager userKeyManager;
-
-  /*
-   * =========================
-   * net files gallery navigation methods
-   * =========================
-   */
-
-  /**
-   * @return a view of Gallery->Filestores page
-   */
-  @GetMapping("/netFilesGalleryView")
-  public ModelAndView getNetFilesGalleryView(Model model, Principal p) {
-    addFileStoresAndFileSystemsToView(model, p);
-
-    UserKeyPair userKeyPair = userKeyManager.getUserKeyPair(getPrincipalUser(p));
-    if (userKeyPair != null) {
-      model.addAttribute(
-          NfsViewProperty.PUBLIC_KEY.toString(),
-          StringEscapeUtils.escapeEcmaScript(userKeyPair.getPublicKey()));
-    }
-    return new ModelAndView("netfiles/netFiles");
-  }
 
   /**
    * @return a view of login dialog for file system
@@ -132,132 +91,6 @@ public class NfsController extends BaseController {
     String escapedFileSystemsJson =
         StringEscapeUtils.escapeEcmaScript(activeSystemsJson); // RSPAC-2360
     model.addAttribute(NfsViewProperty.FILE_SYSTEMS_JSON.toString(), escapedFileSystemsJson);
-  }
-
-  /**
-   * @return "logged.as.username" when successfully connected, "need.log.in" if not logged in, or
-   *     error msg for other problems
-   */
-  @PostMapping("/tryConnectToFileSystemRoot")
-  @ResponseBody
-  public String tryConnectToFileSystemRoot(
-      @RequestParam(value = "fileSystemId") Long fileSystemId,
-      @RequestParam(value = "targetDir", required = false) String targetDir,
-      HttpServletRequest request,
-      Principal p) {
-
-    User user = getPrincipalUser(p);
-    Map<Long, NfsClient> nfsClients = retrieveNfsClientsMapFromSession(request);
-
-    if (!nfsManager.checkIfUserLoggedIn(fileSystemId, nfsClients, user)) {
-      return NEED_LOG_IN_MSG;
-    }
-    return testConnectionToTarget(targetDir != null ? targetDir : "", fileSystemId, nfsClients);
-  }
-
-  /**
-   * @return "logged.as.-username-" when successfully connected, "need.log.in" if not logged in, or
-   *     error msg for other problems
-   */
-  @GetMapping("/tryConnectToFileStore")
-  @ResponseBody
-  public String tryConnectToFileStore(
-      @RequestParam("fileStoreId") Long fileStoreId, HttpServletRequest request, Principal p) {
-
-    User user = getPrincipalUser(p);
-    Map<Long, NfsClient> nfsClients = retrieveNfsClientsMapFromSession(request);
-
-    NfsFileStore fileStore = getUserFileStoreFromId(fileStoreId, user);
-    Long fileSystemId = fileStore.getFileSystem().getId();
-
-    if (!nfsManager.checkIfUserLoggedIn(fileSystemId, nfsClients, user)) {
-      return NEED_LOG_IN_MSG;
-    }
-
-    String path = NfsFileStore.validateTargetPath(fileStore.getPath());
-    return testConnectionToTarget(path, fileSystemId, nfsClients);
-  }
-
-  private String testConnectionToTarget(
-      String target, Long fileSystemId, Map<Long, NfsClient> nfsClients) {
-    NfsClient nfsClient = getNfsClientFromMap(fileSystemId, nfsClients);
-    String result = nfsManager.testConnectionToTarget(target, fileSystemId, nfsClient);
-    if (!result.startsWith(NfsManager.LOGGED_AS_MSG)) {
-      // translate error code
-      result = getText(result);
-    }
-    return result;
-  }
-
-  /**
-   * retrieves a jsp with tree structure for jquery.fileTree used on Gallery->Filestores page
-   *
-   * @param fileSystemId if provided returns tree starting at file system root, for adding a
-   *     filestore
-   * @param fileStoreId if provided returns tree starting at file store location, for browsing a
-   *     filestore
-   * @param dirPath returns branch starting at particular path (called after expanding a tree node)
-   * @param nfsOrder decides about tree nodes order, accepts "byname" or "bydate" values
-   */
-  @PostMapping("/nfsFileTree")
-  public String retrieveNfsFileTree(
-      @RequestParam(value = "fileSystemId", required = false) Long fileSystemId,
-      @RequestParam(value = "fileStoreId", required = false) Long fileStoreId,
-      @RequestParam("dir") String dirPath,
-      @RequestParam(value = "order", defaultValue = "byname") String nfsOrder,
-      HttpServletRequest request,
-      Model model,
-      Principal p) {
-
-    if (fileSystemId == null && fileStoreId == null) {
-      throw new IllegalArgumentException(
-          "either file system id or file store id have to be provided");
-    }
-
-    User user = getPrincipalUser(p);
-    Map<Long, NfsClient> nfsClients = retrieveNfsClientsMapFromSession(request);
-
-    boolean browsingUserFileStore = fileStoreId != null;
-    NfsFileStore userFileStore = null;
-    if (browsingUserFileStore) {
-      userFileStore = getUserFileStoreFromId(fileStoreId, user);
-      fileSystemId = userFileStore.getFileSystem().getId();
-    }
-    assertUserLoggedIn(fileSystemId, request, user);
-
-    if (browsingUserFileStore && "".equals(dirPath)) {
-      dirPath = userFileStore.getPath();
-    }
-    dirPath = URLDecoder.decode(dirPath, StandardCharsets.UTF_8);
-    dirPath = dirPath.replaceAll("//", "/");
-
-    try {
-      NfsClient nfsClient = getNfsClientFromMap(fileSystemId, nfsClients);
-      NfsFileTreeNode nodeTree = nfsClient.createFileTree(dirPath, nfsOrder, userFileStore);
-      NfsFileSystem targetFileSystem = nfsManager.getFileSystem(fileSystemId);
-      model.addAttribute(MODEL_DIR, dirPath);
-      model.addAttribute(MODEL_TREE_NODE, nodeTree);
-      model.addAttribute(MODEL_ADDING_FILE_STORE_FLAG, !browsingUserFileStore);
-      model.addAttribute(
-          MODEL_SHOW_EXTRA_DIRS_FLAG,
-          nfsClient.supportsExtraDirs() && !targetFileSystem.fileSystemRequiresUserRootDirs());
-      model.addAttribute(MODEL_SHOW_CURRENT_DIR_FLAG, nfsClient.supportsCurrentDir());
-      model.addAttribute(MODEL_FILESYSTEM_TYPE, targetFileSystem.getClientType());
-    } catch (IOException ex) {
-      String errorID = LoggingUtils.generateLogId();
-      String rmsg =
-          "errorId-"
-              + errorID
-              + " Retrieve Failed: cannot retrieve file from "
-              + dirPath
-              + ": "
-              + ex.getMessage();
-      log.error(rmsg, ex);
-      model.addAttribute(PROBLEM_LOADING_FILES, true);
-      model.addAttribute(ERRORID, errorID);
-    }
-
-    return "netfiles/netFiles_fileTree";
   }
 
   @Data
@@ -317,106 +150,6 @@ public class NfsController extends BaseController {
       return loginResult; // logged in fine
     }
     return getText(loginResult); // error code, let's translate
-  }
-
-  @PostMapping("/nfsLogout")
-  @ResponseBody
-  public String logoutFromNfs(
-      @RequestParam(value = "fileSystemId") Long fileSystemId, HttpServletRequest request) {
-    nfsManager.logoutFromNfs(fileSystemId, retrieveNfsClientsMapFromSession(request));
-    return SUCCESS_MSG;
-  }
-
-  /*
-   * ==========================
-   * public key authentication managing methods
-   * ==========================
-   *
-   */
-  @PostMapping("/nfsRegisterKey")
-  @ResponseBody
-  public String registerNewKeyForNfs(Principal principal) {
-    UserKeyPair registerNewKey = userKeyManager.createNewUserKeyPair(getPrincipalUser(principal));
-    return registerNewKey.getPublicKey();
-  }
-
-  /**
-   * This method is not called from front-end, but URL can be called by anyone who want to test
-   * registration workflow.
-   *
-   * @param principal
-   * @return
-   */
-  @GetMapping("/nfsRemoveKey")
-  @ResponseBody
-  public String removeKeyForNfs(Principal principal) {
-    userKeyManager.removeUserKeyPair(getPrincipalUser(principal));
-    return SUCCESS_MSG;
-  }
-
-  @GetMapping("/nfsPublicKeyRegistrationUrl")
-  @ResponseBody
-  public String getNfsPublicKeyRegistrationUrl(
-      @RequestParam(value = "fileSystemId") Long fileSystemId) {
-    return nfsManager
-        .getFileSystem(fileSystemId)
-        .getAuthOption(NfsFileSystemOption.PUBLIC_KEY_REGISTRATION_DIALOG_URL);
-  }
-
-  /*
-   * ==========================
-   * file store managing methods
-   * ==========================
-   */
-  @PostMapping("/saveFileStore")
-  @ResponseBody
-  public AjaxReturnObject<String> saveFileStore(
-      @RequestParam("fileSystemId") Long fileSystemId,
-      @RequestParam("nfsname") String fileStoreName,
-      @RequestParam("nfspath") String fileStorePath,
-      HttpServletRequest request,
-      Principal p) {
-
-    User user = getPrincipalUser(p);
-    assertUserLoggedIn(fileSystemId, request, user);
-
-    if (StringUtils.isEmpty(fileStoreName)) {
-      return new AjaxReturnObject<>(
-          null,
-          getErrorListFromMessageCode(getText("net.filestores.validation.userfolder.name.empty")));
-    }
-
-    boolean filestoreNameUnique = nfsManager.verifyFileStoreNameUniqueForUser(fileStoreName, user);
-    if (!filestoreNameUnique) {
-      return new AjaxReturnObject<>(
-          null,
-          getErrorListFromMessageCode(
-              getText(
-                  "net.filestores.validation.userfolder.name.not.unique",
-                  new String[] {fileStoreName})));
-    }
-
-    NfsFileStore userStore =
-        nfsManager.createAndSaveNewFileStore(fileSystemId, fileStoreName, fileStorePath, user);
-
-    String userStoreJson = null;
-    try {
-      userStoreJson = (new ObjectMapper()).writeValueAsString(userStore.toFileStoreInfo());
-    } catch (JsonProcessingException e) {
-      log.warn("couldn't serialize created filestore", e);
-    }
-
-    return new AjaxReturnObject<>(userStoreJson, null);
-  }
-
-  @PostMapping("/deleteFileStore")
-  @ResponseBody
-  public String deleteFileStore(@RequestParam("fileStoreId") Long fileStoreId, Principal p) {
-
-    User user = getPrincipalUser(p);
-    NfsFileStore userFolder = getUserFileStoreFromId(fileStoreId, user);
-    nfsManager.markFileStoreAsDeleted(userFolder);
-    return SUCCESS_MSG;
   }
 
   @PostMapping("/getCurrentPath")
@@ -578,27 +311,6 @@ public class NfsController extends BaseController {
    * helper methods
    * ==========================
    */
-
-  /** throws exception if fileStoreId doesn't exist or doesn't belong to current user */
-  private NfsFileStore getUserFileStoreFromId(Long fileStoreId, User user) {
-
-    NfsFileStore fileStore = nfsManager.getNfsFileStore(fileStoreId);
-    if (fileStore == null) {
-      throw new IllegalArgumentException("could not find user folder with id: " + fileStoreId);
-    }
-    if (!user.getUsername().equals(fileStore.getUser().getUsername())) {
-      throw new IllegalArgumentException(
-          user.getUsername() + " asked for someone else's filestore: " + fileStore);
-    }
-    return fileStore;
-  }
-
-  private void assertUserLoggedIn(Long fileSystemId, HttpServletRequest request, User user) {
-    Map<Long, NfsClient> nfsClients = retrieveNfsClientsMapFromSession(request);
-    if (!nfsManager.checkIfUserLoggedIn(fileSystemId, nfsClients, user)) {
-      throw new IllegalStateException("user not logged into filesystem " + fileSystemId);
-    }
-  }
 
   private NfsClient getNfsClientFromMap(Long fileSystemId, Map<Long, NfsClient> nfsClients) {
     return nfsClients.get(fileSystemId);

--- a/src/main/java/com/researchspace/webapp/controller/NfsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsController.java
@@ -4,15 +4,18 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.researchspace.model.DeploymentPropertyType;
 import com.researchspace.model.User;
+import com.researchspace.model.UserKeyPair;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileStoreInfo;
 import com.researchspace.model.netfiles.NfsFileSystemInfo;
+import com.researchspace.model.netfiles.NfsFileSystemOption;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.netfiles.NfsFileDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.netfiles.NfsViewProperty;
 import com.researchspace.service.NfsFileHandler;
 import com.researchspace.service.NfsManager;
+import com.researchspace.service.UserKeyManager;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -62,6 +65,8 @@ public class NfsController extends BaseController {
   @Autowired private NfsManager nfsManager;
 
   @Autowired private NfsFileHandler nfsFileHandler;
+
+  @Autowired private UserKeyManager userKeyManager;
 
   /**
    * @return a view of login dialog for file system
@@ -150,6 +155,41 @@ public class NfsController extends BaseController {
       return loginResult; // logged in fine
     }
     return getText(loginResult); // error code, let's translate
+  }
+
+  /*
+   * ==========================
+   * public key authentication managing methods
+   *
+   * No longer triggered from the RSpace UI after the old Gallery removal, but the URLs
+   * are kept so external scripts / integrations relying on them continue to work.
+   * ==========================
+   */
+
+  /** Kept for URL stability — no longer called from the RSpace UI. */
+  @PostMapping("/nfsRegisterKey")
+  @ResponseBody
+  public String registerNewKeyForNfs(Principal principal) {
+    UserKeyPair registerNewKey = userKeyManager.createNewUserKeyPair(getPrincipalUser(principal));
+    return registerNewKey.getPublicKey();
+  }
+
+  /** Kept for URL stability — no longer called from the RSpace UI. */
+  @GetMapping("/nfsRemoveKey")
+  @ResponseBody
+  public String removeKeyForNfs(Principal principal) {
+    userKeyManager.removeUserKeyPair(getPrincipalUser(principal));
+    return SUCCESS_MSG;
+  }
+
+  /** Kept for URL stability — no longer called from the RSpace UI. */
+  @GetMapping("/nfsPublicKeyRegistrationUrl")
+  @ResponseBody
+  public String getNfsPublicKeyRegistrationUrl(
+      @RequestParam(value = "fileSystemId") Long fileSystemId) {
+    return nfsManager
+        .getFileSystem(fileSystemId)
+        .getAuthOption(NfsFileSystemOption.PUBLIC_KEY_REGISTRATION_DIALOG_URL);
   }
 
   @PostMapping("/getCurrentPath")

--- a/src/main/java/com/researchspace/webapp/controller/SnippetController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SnippetController.java
@@ -5,19 +5,13 @@ import com.researchspace.model.audittrail.AuditAction;
 import com.researchspace.model.field.ErrorList;
 import com.researchspace.model.record.Snippet;
 import java.security.Principal;
-import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-@Deprecated // GET content endpoint also implemented in SnippetsApiController REST API. Existing
-// method left here while old gallery code is still using it. Other endpoints will be
-// migrated when the document editor is migrated to react.
 @Controller
 @BrowserCacheAdvice(cacheTime = BrowserCacheAdvice.DEFAULT)
 @RequestMapping("/snippet")
@@ -63,13 +57,5 @@ public class SnippetController extends BaseController {
     User user = userManager.getUserByUsername(principal.getName());
     String updatedSnippetContent = recordManager.copySnippetIntoField(snippetId, fieldId, user);
     return updatedSnippetContent;
-  }
-
-  @ResponseBody
-  @GetMapping("/content/{id}")
-  public String getSnippetContent(
-      @PathVariable("id") Long id, Principal principal, HttpServletResponse response) {
-    Snippet snippet = recordManager.getAsSubclass(id, Snippet.class);
-    return snippet.getContent();
   }
 }

--- a/src/main/resources/bundles/gallery/netfiles.properties
+++ b/src/main/resources/bundles/gallery/netfiles.properties
@@ -1,6 +1,15 @@
+netfilestores.login.dialog.title=Login Required
+netfilestores.login.dialog.intro=Please authenticate to File System:
+netfilestores.login.username.label=Username:
+netfilestores.login.password.label=Password:
+netfilestores.login.user.dir.label=Directory:
 netfilestores.login.no.file.paths.in.dir=No paths in directory name
+
+net.filestores.error.invalidUrl=Invalid connection URL. Try connecting to another Filestore or contact your System Admin
 net.filestores.error.auth.password=Authentication problem, check your username and password or contact your System Admin
 net.filestores.error.auth.publicKey=Authentication problem, verify that your public key is properly registered or contact your System Admin
+net.filestores.error.connection=Connection problem, please try again or contact your System Admin
+net.filestores.error.download=Couldn't retrieve the file, please try again or contact your System Admin
 
 net.filestores.validation.no.username=Please provide the username
 net.filestores.validation.no.password=Please provide the password

--- a/src/main/webapp/WEB-INF/pages/netfiles/netFiles_login.jsp
+++ b/src/main/webapp/WEB-INF/pages/netfiles/netFiles_login.jsp
@@ -1,0 +1,33 @@
+<%@ include file="/common/taglibs.jsp"%>
+
+<script type="text/javascript">
+    var USER_FILESTORES_JSON_STRING = '${FILE_STORES_JSON}';
+    var FILESYSTEMS_JSON_STRING = '${FILE_SYSTEMS_JSON}';
+</script>
+
+<div id="nfsUserPasswordLoginPanel" style="display:none" title='<spring:message code="netfilestores.login.dialog.title"/>'>
+
+    <p id="nfsUserPasswordLoginInfo" style="margin: 10px;">
+        <spring:message code="netfilestores.login.dialog.intro"/>
+        <br/>"<span class="nfsFileSystemName"></span>"
+    </p>
+
+    <table style="margin:0px 0px 2px 0px; width: 100%;">
+        <tr>
+            <td style="padding-left:8px;"><spring:message code="netfilestores.login.username.label"/></td>
+            <td><input type='text' id='nfsUsername'></input></td>
+        </tr>
+        <tr>
+            <td style="padding-left:8px;"><spring:message code="netfilestores.login.password.label"/></td>
+            <td><input type='password' id='nfsPassword'></input></td>
+        </tr>
+        <rst:hasDeploymentProperty name="loginDirectoryOption" value="true">
+        <tr id="userDirectoriesRequired">
+            <td style="padding-left:8px;"><spring:message code="netfilestores.login.user.dir.label"/></td>
+            <td><input  id='nfsUserDir'></input></td>
+        </tr>
+        </rst:hasDeploymentProperty>
+    </table>
+
+    <div class="nfsError" style="margin-left:10px; margin-top: 5px; color:red;"></div>
+</div>

--- a/src/main/webapp/scripts/global.js
+++ b/src/main/webapp/scripts/global.js
@@ -2238,8 +2238,7 @@ RS.showNetFileLoginDialog = function (fileSystemId, fileStoreId, afterLoginCallb
       showUsernamePasswordDialog(fileSystem, afterLoginCallback);
     } else {
       apprise('Sorry, there is some problem with logging you into ' + fileSystem.name +
-        ' please go to <a href="/gallery/netfiles" target="_blank">Gallery Filestores</a>' +
-        ' and try login there');
+        '. Please ask your administrator for help.');
     }
 
   });

--- a/src/test/java/com/researchspace/service/aws/impl/S3UtilitiesRealConnectionTest.java
+++ b/src/test/java/com/researchspace/service/aws/impl/S3UtilitiesRealConnectionTest.java
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.annotation.Value;
  * The tests running a real connection to AWS and Cloudflare S3 buckets, require bucket details and
  * iam authentication secrets in deployment properties.
  *
- * <p>Test buckets need to contain expected files/folders structure for tests to pass.
+ * Test buckets need to contain expected files/folders structure for tests to pass.
  */
 @RunWith(ConditionalTestRunner.class)
 @Slf4j

--- a/src/test/java/com/researchspace/service/aws/impl/S3UtilitiesRealConnectionTest.java
+++ b/src/test/java/com/researchspace/service/aws/impl/S3UtilitiesRealConnectionTest.java
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.annotation.Value;
  * The tests running a real connection to AWS and Cloudflare S3 buckets, require bucket details and
  * iam authentication secrets in deployment properties.
  *
- * Test buckets need to contain expected files/folders structure for tests to pass.
+ * <p>Test buckets need to contain expected files/folders structure for tests to pass.
  */
 @RunWith(ConditionalTestRunner.class)
 @Slf4j

--- a/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
@@ -1,7 +1,6 @@
 package com.researchspace.webapp.controller;
 
 import static com.researchspace.model.netfiles.NfsFileSystemOption.USER_DIRS_REQUIRED;
-import static com.researchspace.webapp.controller.NfsController.MODEL_SHOW_EXTRA_DIRS_FLAG;
 import static com.researchspace.webapp.controller.NfsController.NEED_LOG_IN_MSG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -10,14 +9,11 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyObject;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.model.User;
-import com.researchspace.model.UserKeyPair;
 import com.researchspace.model.netfiles.NfsAuthenticationType;
 import com.researchspace.model.netfiles.NfsClientType;
 import com.researchspace.model.netfiles.NfsFileStore;
@@ -25,14 +21,11 @@ import com.researchspace.model.netfiles.NfsFileStoreInfo;
 import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.model.netfiles.NfsFileSystemInfo;
 import com.researchspace.model.record.IllegalAddChildOperation;
-import com.researchspace.netfiles.NfsAuthentication;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.netfiles.NfsFileDetails;
-import com.researchspace.netfiles.NfsFileTreeNode;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.netfiles.NfsViewProperty;
 import com.researchspace.service.NfsManager;
-import com.researchspace.service.UserKeyManager;
 import com.researchspace.testutils.SpringTransactionalTest;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -54,8 +47,6 @@ import org.springframework.ui.Model;
 public class NfsControllerTest extends SpringTransactionalTest {
 
   @Autowired private NfsController controller;
-
-  @Autowired private UserKeyManager userKeyManager;
 
   private User testUser;
   private String testUsername;
@@ -81,7 +72,6 @@ public class NfsControllerTest extends SpringTransactionalTest {
 
   private NfsManager nfsManagerMock;
   private NfsClient nfsClientMock;
-  private NfsAuthentication nfsAuthenticationMock;
 
   @Before
   public void setUp() throws IllegalAddChildOperation {
@@ -121,72 +111,11 @@ public class NfsControllerTest extends SpringTransactionalTest {
     when(nfsClientMock.isUserLoggedIn()).thenReturn(true);
     when(nfsClientMock.getUsername()).thenReturn(testUsername);
 
-    nfsAuthenticationMock = mock(NfsAuthentication.class);
-    when(nfsAuthenticationMock.validateCredentials(null, null, testUser))
-        .thenReturn("testUsername.required");
-    when(nfsAuthenticationMock.login(
-            eq(testUsername), anyString(), eq(testNfsFileSystem), eq(testUser)))
-        .thenReturn(nfsClientMock);
-
     nfsManagerMock = mock(NfsManager.class);
     when(nfsManagerMock.getNfsFileStore(TEST_FILE_STORE_ID)).thenReturn(testNfsFileStore);
     when(nfsManagerMock.getFileSystem(TEST_FILE_SYSTEM_ID)).thenReturn(testNfsFileSystem);
 
     controller.setNfsManager(nfsManagerMock);
-  }
-
-  @Test
-  public void getNetFilesViewTest() {
-
-    controller.getNetFilesGalleryView(model, principalStub);
-    assertEquals("[]", model.asMap().get(NfsViewProperty.FILE_SYSTEMS_JSON.toString()));
-    assertEquals("[]", model.asMap().get(NfsViewProperty.FILE_STORES_JSON.toString()));
-    assertEquals(null, model.asMap().get(NfsViewProperty.PUBLIC_KEY.toString()));
-
-    when(nfsManagerMock.getFileStoreInfosForUser(testUser)).thenReturn(testNfsFileStoreInfoList);
-    when(nfsManagerMock.getActiveFileSystemInfos()).thenReturn(testNfsFileSystemInfoList);
-    controller.getNetFilesGalleryView(model, principalStub);
-
-    // filesystem json double-escaped (RSPAC-2360)
-    String filesystemJson =
-        "{\"id\":11,\"name\":\"testFileSystem\",\"url\":\"smb://test.com\","
-            + "\"clientType\":\"SAMBA\",\"authType\":\"PASSWORD\",\"options\":{},\"loggedAs\":null}";
-    String expectedFilesystemJson = StringEscapeUtils.escapeEcmaScript(filesystemJson);
-    assertEquals(
-        "[" + expectedFilesystemJson + "]",
-        model.asMap().get(NfsViewProperty.FILE_SYSTEMS_JSON.toString()));
-
-    // filestores json double-escaped (RSPAC-2090)
-    String filestoreJson =
-        "{\"id\":10,\"name\":\"testFileStoreName\",\"path\":\"testFileStorePath\","
-            + "\"fileSystem\":"
-            + filesystemJson
-            + "}";
-    String expectedFilestoreJson = StringEscapeUtils.escapeEcmaScript(filestoreJson);
-    assertEquals(
-        "[" + expectedFilestoreJson + "]",
-        model.asMap().get(NfsViewProperty.FILE_STORES_JSON.toString()));
-    assertEquals(null, model.asMap().get(NfsViewProperty.PUBLIC_KEY.toString()));
-  }
-
-  @Test
-  public void getNetFilesViewUserDirsRequiredTest() {
-    testNfsFileSystem.setClientOptions(USER_DIRS_REQUIRED + "=true");
-    testNfsFileSystemInfoList.clear();
-    testNfsFileSystemInfoList.add(testNfsFileSystem.toFileSystemInfo());
-
-    when(nfsManagerMock.getFileStoreInfosForUser(testUser)).thenReturn(testNfsFileStoreInfoList);
-    when(nfsManagerMock.getActiveFileSystemInfos()).thenReturn(testNfsFileSystemInfoList);
-    controller.getNetFilesGalleryView(model, principalStub);
-
-    // filesystem json double-escaped (RSPAC-2360)
-    String filesystemJson =
-        "{\"id\":11,\"name\":\"testFileSystem\",\"url\":\"smb://test.com\","
-            + "\"clientType\":\"SAMBA\",\"authType\":\"PASSWORD\",\"options\":{\"USER_DIRS_REQUIRED\":\"true\"},\"loggedAs\":null}";
-    String expectedFilesystemJson = StringEscapeUtils.escapeEcmaScript(filesystemJson);
-    assertEquals(
-        "[" + expectedFilesystemJson + "]",
-        model.asMap().get(NfsViewProperty.FILE_SYSTEMS_JSON.toString()));
   }
 
   @Test
@@ -207,92 +136,6 @@ public class NfsControllerTest extends SpringTransactionalTest {
     assertEquals(
         "[" + expectedFilesystemJson + "]",
         model.asMap().get(NfsViewProperty.FILE_SYSTEMS_JSON.toString()));
-  }
-
-  @Test
-  public void testLoginToFileSystem() {
-
-    String unloggedMsg =
-        controller.tryConnectToFileSystemRoot(TEST_FILE_SYSTEM_ID, null, request, principalStub);
-    assertEquals(NEED_LOG_IN_MSG, unloggedMsg);
-
-    loginTestUserToTestFileSystem();
-
-    String msg =
-        controller.tryConnectToFileSystemRoot(TEST_FILE_SYSTEM_ID, null, request, principalStub);
-    assertEquals(NfsManager.LOGGED_AS_MSG + testUsername, msg);
-  }
-
-  @Test
-  public void testLoginToFileSystemUserDirSpecified() {
-    loginTestUserToTestFileSystem("USER_NAME");
-
-    String msg =
-        controller.tryConnectToFileSystemRoot(
-            TEST_FILE_SYSTEM_ID, "USER_NAME", request, principalStub);
-    assertEquals(NfsManager.LOGGED_AS_MSG + testUsername, msg);
-  }
-
-  @Test
-  public void testConnectToUserFileStore() {
-
-    String unloggedMsg =
-        controller.tryConnectToFileStore(TEST_FILE_STORE_ID, request, principalStub);
-    assertEquals(NEED_LOG_IN_MSG, unloggedMsg);
-
-    loginTestUserToTestFileSystem(testNfsFileStore.getPath());
-
-    String msg = controller.tryConnectToFileStore(TEST_FILE_STORE_ID, request, principalStub);
-    assertEquals(NfsManager.LOGGED_AS_MSG + testUsername, msg);
-  }
-
-  @Test
-  public void testDeleteFileStore() {
-
-    loginTestUserToTestFileSystem();
-
-    String result = controller.deleteFileStore(TEST_FILE_STORE_ID, principalStub);
-    assertEquals(NfsController.SUCCESS_MSG, result);
-    verify(nfsManagerMock).markFileStoreAsDeleted(testNfsFileStore);
-  }
-
-  @Test
-  public void testGetSimpleNfsFileTree() throws IOException {
-
-    loginTestUserToTestFileSystem();
-
-    NfsFileTreeNode node = new NfsFileTreeNode();
-    node.calculateFileName("testTreeNodeName");
-    when(nfsClientMock.createFileTree(anyString(), anyString(), eq(testNfsFileStore)))
-        .thenReturn(node);
-    when(nfsClientMock.supportsExtraDirs()).thenReturn(true);
-    controller.retrieveNfsFileTree(
-        null, TEST_FILE_STORE_ID, "", "byname", request, model, principalStub);
-    verify(nfsClientMock).createFileTree("" + TEST_FILE_STORE_PATH, "byname", testNfsFileStore);
-
-    NfsFileTreeNode retrievedRootNode =
-        (NfsFileTreeNode) model.asMap().get(NfsController.MODEL_TREE_NODE);
-    assertNotNull(retrievedRootNode);
-    assertEquals(node.getFileName(), retrievedRootNode.getFileName());
-
-    assertTrue((Boolean) model.getAttribute(MODEL_SHOW_EXTRA_DIRS_FLAG));
-
-    assertEquals(0, retrievedRootNode.getNodes().size());
-  }
-
-  @Test
-  public void testGetSimpleNfsFileTreeUserDirsRequired() throws IOException {
-
-    loginTestUserToTestFileSystem();
-    testNfsFileSystem.setClientOptions(USER_DIRS_REQUIRED.toString() + "=true");
-    NfsFileTreeNode node = new NfsFileTreeNode();
-    node.calculateFileName("testTreeNodeName");
-    when(nfsClientMock.createFileTree(anyString(), anyString(), eq(testNfsFileStore)))
-        .thenReturn(node);
-    when(nfsClientMock.supportsExtraDirs()).thenReturn(true);
-    controller.retrieveNfsFileTree(
-        null, TEST_FILE_STORE_ID, "", "byname", request, model, principalStub);
-    assertFalse((Boolean) model.getAttribute(MODEL_SHOW_EXTRA_DIRS_FLAG));
   }
 
   @Test
@@ -320,24 +163,6 @@ public class NfsControllerTest extends SpringTransactionalTest {
         controller.loginToNfs(
             TEST_FILE_SYSTEM_ID, "username", "password", "\\target_dir", request, principalStub);
     assertEquals("No paths in directory name", loginResult);
-  }
-
-  @Test
-  public void testTreeListingWithNonAsciiCharsEncodedInDirParam() throws IOException {
-
-    loginTestUserToTestFileSystem();
-
-    NfsFileTreeNode node = new NfsFileTreeNode();
-    node.calculateFileName("testTreeNodeName");
-    when(nfsClientMock.createFileTree(anyString(), anyString(), eq(testNfsFileStore)))
-        .thenReturn(node);
-
-    String dirParam = "samba-folder%2F%2FBio%20Multi%20Me%C3%9Fsystem%2F";
-    String expectedDir = "samba-folder/Bio Multi Meßsystem/";
-
-    controller.retrieveNfsFileTree(
-        null, TEST_FILE_STORE_ID, dirParam, "byname", request, model, principalStub);
-    verify(nfsClientMock).createFileTree(eq(expectedDir), anyString(), eq(testNfsFileStore));
   }
 
   @Test
@@ -383,30 +208,6 @@ public class NfsControllerTest extends SpringTransactionalTest {
   }
 
   @Test
-  public void registerSshKeyForNewUserIT() {
-
-    /* this test uses real (autowired) userKeyManager */
-
-    controller.getNetFilesGalleryView(model, principalStub);
-    assertEquals(null, model.asMap().get(NfsViewProperty.PUBLIC_KEY.toString()));
-
-    // generating the key
-    String returnedKey = controller.registerNewKeyForNfs(principalStub);
-
-    // checking that key is in the db
-    UserKeyPair registeredKeyPair = userKeyManager.getUserKeyPair(testUser);
-    assertNotNull(
-        "controller should register new key for testUser, but is null", registeredKeyPair);
-    assertEquals(returnedKey, registeredKeyPair.getPublicKey());
-
-    // reloaded view should contain new public key
-    controller.getNetFilesGalleryView(model, principalStub);
-    assertEquals(
-        StringEscapeUtils.escapeEcmaScript(returnedKey),
-        model.asMap().get(NfsViewProperty.PUBLIC_KEY.toString()));
-  }
-
-  @Test
   public void getNfsFileStoreInfo() {
     AjaxReturnObject<NfsFileStoreInfo> fileStoreResp =
         controller.getNfsFileStoreInfo(TEST_FILE_STORE_ID);
@@ -420,7 +221,7 @@ public class NfsControllerTest extends SpringTransactionalTest {
     assertEquals(TEST_FILE_SYSTEM_URL, fileStoreInfo.getFileSystem().getUrl());
   }
 
-  private void loginTestUserToTestFileSystem(String target) {
+  private void loginTestUserToTestFileSystem() {
     // mock session and manager as if user logged in
     Map<Long, NfsClient> nfsClients = new HashMap<>();
     nfsClients.put(TEST_FILE_SYSTEM_ID, nfsClientMock);
@@ -428,12 +229,5 @@ public class NfsControllerTest extends SpringTransactionalTest {
 
     when(nfsManagerMock.checkIfUserLoggedIn(TEST_FILE_SYSTEM_ID, nfsClients, testUser))
         .thenReturn(true);
-    when(nfsManagerMock.testConnectionToTarget(
-            eq(target), eq(TEST_FILE_SYSTEM_ID), eq(nfsClientMock)))
-        .thenReturn("logged.as." + testUsername);
-  }
-
-  private void loginTestUserToTestFileSystem() {
-    loginTestUserToTestFileSystem("");
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/SnippetControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SnippetControllerTest.java
@@ -6,26 +6,15 @@ import static org.junit.Assert.assertTrue;
 
 import com.researchspace.model.User;
 import com.researchspace.model.record.IllegalAddChildOperation;
-import com.researchspace.model.record.Snippet;
-import com.researchspace.service.RecordManager;
-import com.researchspace.service.UserManager;
 import com.researchspace.testutils.SpringTransactionalTest;
 import java.security.Principal;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.orm.ObjectRetrievalFailureException;
 
 public class SnippetControllerTest extends SpringTransactionalTest {
 
   @Autowired private SnippetController snippetController;
-
-  @Autowired private RecordManager recordManager;
-
-  @Autowired private UserManager userManager;
-
-  private MockHttpServletResponse response;
 
   private User user;
   private Principal principalTestUserStub = null;
@@ -52,26 +41,5 @@ public class SnippetControllerTest extends SpringTransactionalTest {
     assertEquals(
         response.getErrorMsg().getAllErrorMessagesAsStringsSeparatedBy(""),
         messages.getMessage("errors.invalidchars", new String[] {"/,> or <", "name"}));
-  }
-
-  private static final Long NON_EXISTENT_SNIPPET_ID = -501L;
-
-  @Test
-  public void testGetSnippetContent() {
-
-    final String testContent = "test snippet content";
-
-    User user = userManager.getUserByUsername(principalTestUserStub.getName());
-    Snippet snippet = recordManager.createSnippet("a", testContent, user);
-
-    String snippetContent =
-        snippetController.getSnippetContent(snippet.getId(), principalTestUserStub, response);
-
-    assertEquals(testContent, snippetContent);
-  }
-
-  @Test(expected = ObjectRetrievalFailureException.class)
-  public void testExceptionOnGettingNonExistentSnippetContent() {
-    snippetController.getSnippetContent(NON_EXISTENT_SNIPPET_ID, principalTestUserStub, response);
   }
 }


### PR DESCRIPTION
Summary (from Claude Code agent doing the changes):
  - Restored WEB-INF/pages/netfiles/netFiles_login.jsp and keys in bundles/gallery/netfiles.properties to fix filestore-link login dialog
  - Reworded the non-PASSWORD-auth fallback in global.js to drop the dead /gallery/netfiles link.
  - Removed SnippetController.getSnippetContent + its test cases.
  - Removed 7 orphaned NfsController endpoints + helpers + dead constants, with matching test deletions; kept the 3 SSH-key endpoints with comments noting they're retained for URL stability.
  - Updated build-resources/resources_to_MD5_rename.txt: dropped 5 deleted assets, added ui/dist/pdfPreviewDialog.js.