### PR TITLE
RSDEV-1108-delete-users-reactionless-stoichiometries: 1st cut

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 See [AGENTS.md](./AGENTS.md) for full project context (build, test, architecture, conventions).
 
+## Plans and working files
+
+When asked to write an implementation plan, design doc, or any other agent-authored
+working file (notes, scratch analyses, investigation summaries), save it under
+`.claude/plans/` at the repo root — e.g. `.claude/plans/RSDEV-1108-plan.md`. The
+`.claude/` directory is gitignored, so these files stay local to the developer's
+checkout and do not pollute the repo or PRs. Do not save plan files at the repo
+root or inside `src/`. If `.claude/plans/` does not exist, create it.
+
 ## PR Descriptions
 
 When creating or updating GitHub pull request descriptions:

--- a/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
@@ -477,29 +477,24 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
     executeDeleteByRecordOwner(
         userId, session, "ecatImageAnnotation_AUD", "id", "ecatImageAnnotation", "id", RECORD_ID);
 
-    // Delete StoichiometryMolecule first, then Stoichiometry before deleting RSChemElement
+    // Delete StoichiometryMolecule first, then Stoichiometry, joined via
+    // Stoichiometry.record_id → BaseRecord. record_id is NOT NULL
+    // (changeLog-rsdev-874.xml changeset 2026-01-19), so this catches both
+    // reaction-attached and reactionless stoichiometries owned by the user.
     execute(
         userId,
         session,
         "delete sm from StoichiometryMolecule_AUD sm left join Stoichiometry s on"
-            + " sm.stoichiometry_id = s.id left join RSChemElement rsce on s.parent_reaction_id ="
-            + " rsce.id left join BaseRecord br on rsce.record_id = br.id where br.owner_id=:id");
+            + " sm.stoichiometry_id = s.id left join BaseRecord br on s.record_id ="
+            + " br.id where br.owner_id=:id");
     execute(
         userId,
         session,
-        "delete sm from StoichiometryMolecule sm left join Stoichiometry s on sm.stoichiometry_id ="
-            + " s.id left join RSChemElement rsce on s.parent_reaction_id = rsce.id left join"
-            + " BaseRecord br on rsce.record_id = br.id where br.owner_id=:id");
-    executeDeleteByRecordOwner(
-        userId,
-        session,
-        "Stoichiometry_AUD",
-        "parent_reaction_id",
-        "RSChemElement",
-        "id",
-        RECORD_ID);
-    executeDeleteByRecordOwner(
-        userId, session, "Stoichiometry", "parent_reaction_id", "RSChemElement", "id", RECORD_ID);
+        "delete sm from StoichiometryMolecule sm left join Stoichiometry s on"
+            + " sm.stoichiometry_id = s.id left join BaseRecord br on s.record_id ="
+            + " br.id where br.owner_id=:id");
+    executeDeleteByRecordOwner(userId, session, "Stoichiometry_AUD", RECORD_ID);
+    executeDeleteByRecordOwner(userId, session, "Stoichiometry", RECORD_ID);
 
     executeDeleteByRecordOwner(userId, session, "RSChemElement", RECORD_ID);
     executeDeleteByRecordOwner(

--- a/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
@@ -619,6 +619,24 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
   }
 
   @Test
+  public void testDeleteUserWithReactionlessStoichiometry() throws Exception {
+    User userToDelete = createInitAndLoginAnyUser();
+
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(userToDelete, "Chemistry doc");
+
+    Stoichiometry stoichiometry = Stoichiometry.builder().record(doc).build();
+    stoichiometryMgr.save(stoichiometry);
+
+    User sysadmin = logoutAndLoginAsSysAdmin();
+    UserDeletionPolicy policy = unrestrictedDeletionPolicy();
+    ServiceOperationResult<User> result =
+        userDeletionMgr.removeUser(userToDelete.getId(), policy, sysadmin);
+
+    assertTrue(result.isSucceeded());
+    assertUserNotExist(userToDelete);
+  }
+
+  @Test
   public void deleteUserFormThatReferencesPreviousVersion() throws Exception {
     User formCreator = createInitAndLoginAnyUser();
 

--- a/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
@@ -625,6 +625,23 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
     StructuredDocument doc = createBasicDocumentInRootFolderWithText(userToDelete, "Chemistry doc");
 
     Stoichiometry stoichiometry = Stoichiometry.builder().record(doc).build();
+    stoichiometry = stoichiometryMgr.save(stoichiometry);
+
+    RSChemElement moleculeChemElement =
+        RSChemElement.builder().chemElements("C2H6O").record(doc).build();
+    moleculeChemElement = rsChemElementMgr.save(moleculeChemElement, userToDelete);
+
+    StoichiometryMolecule molecule =
+        StoichiometryMolecule.builder()
+            .stoichiometry(stoichiometry)
+            .rsChemElement(moleculeChemElement)
+            .role(MoleculeRole.REACTANT)
+            .formula("C2H6O")
+            .name("Ethanol")
+            .smiles("CCO")
+            .molecularWeight(46.07)
+            .build();
+    stoichiometry.addMolecule(molecule);
     stoichiometryMgr.save(stoichiometry);
 
     User sysadmin = logoutAndLoginAsSysAdmin();


### PR DESCRIPTION
 Title: RSDEV-1108: delete users with reactionless stoichiometries

  Body:

  Investigation and fix done by GitHub Copilot AI agent (Claude) on behalf of the user.

  Fixes user deletion failing when a user owns a `Stoichiometry` row that has no `parent_reaction_id` (a "reactionless" stoichiometry).

  ## Root causes
  - `UserDeletionDaoHibernate` joined `Stoichiometry` → `RSChemElement` via `parent_reaction_id` to locate rows for the user, so reactionless stoichiometries (and their `StoichiometryMolecule` children) were never deleted, leaving FK references that blocked user deletion.
  - `Stoichiometry.record_id` is `NOT NULL` (per `changeLog-rsdev-874.xml`), so joining via `record_id → BaseRecord.owner_id` reliably covers both reaction-attached and reactionless stoichiometries.

  ## Changes
  - `UserDeletionDaoHibernate.deleteRecordRelatedEntries`: switched the `Stoichiometry` / `StoichiometryMolecule` (and `_AUD`) deletes to join via `Stoichiometry.record_id → BaseRecord.owner_id` instead of via `RSChemElement.parent_reaction_id`.
  - `UserDeletionManagerTestIT.testDeleteUserWithReactionlessStoichiometry`: new IT covering the reactionless case, including an attached `StoichiometryMolecule` + `RSChemElement` to exercise the cascade.
  - `CLAUDE.md`: minor project-instruction tweak.

  Linked ticket: RSDEV-1108