### PR TITLE
RSDEV-1096-sortby-lastname-firstname: 1st cut

### DIFF
--- a/src/main/java/com/researchspace/dao/hibernate/UserDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDaoHibernate.java
@@ -453,12 +453,12 @@ public class UserDaoHibernate extends GenericDaoHibernate<User, Long> implements
     if (SortOrder.ASC.equals(pgCrit.getSortOrder())) {
       query.addOrder(Order.asc(pgCrit.getOrderBy()));
       if (pgCrit.getOrderBy().equalsIgnoreCase(LAST_NAME)) {
-        query.addOrder(Order.asc(LAST_NAME));
+        query.addOrder(Order.asc(FIRST_NAME));
       }
     } else {
       query.addOrder(Order.desc(pgCrit.getOrderBy()));
       if (pgCrit.getOrderBy().equalsIgnoreCase(LAST_NAME)) {
-        query.addOrder(Order.desc(LAST_NAME));
+        query.addOrder(Order.desc(FIRST_NAME));
       }
     }
   }

--- a/src/main/java/com/researchspace/dao/hibernate/UserDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDaoHibernate.java
@@ -454,11 +454,13 @@ public class UserDaoHibernate extends GenericDaoHibernate<User, Long> implements
       query.addOrder(Order.asc(pgCrit.getOrderBy()));
       if (pgCrit.getOrderBy().equalsIgnoreCase(LAST_NAME)) {
         query.addOrder(Order.asc(FIRST_NAME));
+        query.addOrder(Order.asc(USERNAME));
       }
     } else {
       query.addOrder(Order.desc(pgCrit.getOrderBy()));
       if (pgCrit.getOrderBy().equalsIgnoreCase(LAST_NAME)) {
         query.addOrder(Order.desc(FIRST_NAME));
+        query.addOrder(Order.desc(USERNAME));
       }
     }
   }

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.tsx
@@ -1516,8 +1516,8 @@ export const UsersPage = (): React.ReactNode => {
 
   const columns = [
     DataGridColumn.newColumnWithValueMapper(
-      "fullName",
-      (fullName) => fullName,
+      "fullNameSurnameFirst",
+      (v) => v,
       {
         headerName: "Full Name",
         flex: 1,
@@ -1956,7 +1956,7 @@ export const UsersPage = (): React.ReactNode => {
                                 recordCount: "recordCount()",
                                 lastLogin: "lastLogin",
                                 created: "creationDate",
-                                fullName: "lastName",
+                                fullNameSurnameFirst: "lastName",
                                 firstName: "firstName",
                                 lastName: "lastName",
                                 email: "email",

--- a/src/main/webapp/ui/src/hooks/api/useUserListing.ts
+++ b/src/main/webapp/ui/src/hooks/api/useUserListing.ts
@@ -13,6 +13,7 @@ type FetchedUser = {
   userInfo: {
     id: UserId;
     fullName: string;
+    fullNameSurnameFirst: string;
     firstName: string;
     lastName: string;
     email: string;
@@ -67,6 +68,7 @@ export type User = {
   id: UserId;
   url: string;
   fullName: string;
+  fullNameSurnameFirst: string;
   firstName: string;
   lastName: string;
   email: string;
@@ -342,6 +344,7 @@ export function useUserListing(): {
         id,
         url: `/userform?userId=${id}`,
         fullName: fetchedUser.userInfo.fullName,
+        fullNameSurnameFirst: fetchedUser.userInfo.fullNameSurnameFirst,
         firstName: fetchedUser.userInfo.firstName,
         lastName: fetchedUser.userInfo.lastName,
         email: fetchedUser.userInfo.email,

--- a/src/test/java/com/researchspace/dao/UserDaoTest.java
+++ b/src/test/java/com/researchspace/dao/UserDaoTest.java
@@ -264,6 +264,46 @@ public class UserDaoTest extends BaseDaoTestCase {
   }
 
   @Test
+  public void testApplyOrderTiebreaksByFirstNameThenUsername() {
+    // Unique surname per run isolates these three users from the rest of the DB.
+    String sharedSurname = getRandomAlphabeticString("RSDEV1096");
+
+    // aliceLow and aliceHigh collide on both lastName and firstName — only the
+    // tertiary (username) sort can order them deterministically.
+    User aliceLow = createAndSaveUserIfNotExists(getRandomAlphabeticString("zzaaa"));
+    aliceLow.setFirstName("Alice");
+    aliceLow.setLastName(sharedSurname);
+    userDao.save(aliceLow);
+
+    User aliceHigh = createAndSaveUserIfNotExists(getRandomAlphabeticString("zzzzz"));
+    aliceHigh.setFirstName("Alice");
+    aliceHigh.setLastName(sharedSurname);
+    userDao.save(aliceHigh);
+
+    // bob shares only the lastName — the secondary (firstName) sort places him
+    // relative to the Alices.
+    User bob = createAndSaveUserIfNotExists(getRandomAlphabeticString("zzbob"));
+    bob.setFirstName("Bob");
+    bob.setLastName(sharedSurname);
+    userDao.save(bob);
+    flush();
+
+    PaginationCriteria<User> pgCrit = PaginationCriteria.createDefaultForClass(User.class);
+    pgCrit.setOrderBy("lastName");
+    UserSearchCriteria criteria = new UserSearchCriteria();
+    criteria.setAllFields(sharedSurname);
+    pgCrit.setSearchCriteria(criteria);
+
+    pgCrit.setSortOrder(SortOrder.ASC);
+    List<User> asc = userDao.searchUsers(pgCrit).getResults();
+    assertEquals(Arrays.asList(aliceLow, aliceHigh, bob), asc);
+
+    pgCrit.setSortOrder(SortOrder.DESC);
+    List<User> desc = userDao.searchUsers(pgCrit).getResults();
+    assertEquals(Arrays.asList(bob, aliceHigh, aliceLow), desc);
+  }
+
+  @Test
   public void testSaveRetrieveUserPasswordToken() throws Exception {
     TokenBasedVerification upc =
         new TokenBasedVerification("a@b.com", null, TokenBasedVerificationType.PASSWORD_CHANGE);


### PR DESCRIPTION
Investigation and fix performed by Claude Code AI agent on behalf of the user.

  Switches the System > Users "Full Name" column to render `Lastname, Firstname` so the visual order matches the underlying server-side sort, and fixes a latent secondary-sort bug
   in the same query path. Linked: [RSDEV-1096](https://researchspace.atlassian.net/browse/RSDEV-1096).

  ## Root causes
  - `UserDaoHibernate.applyOrder` typo'd the secondary sort column as `LAST_NAME` instead of `FIRST_NAME`, so the intended `lastName, firstName` compound sort collapsed to a
  single-column sort with non-deterministic ordering among users sharing a surname.
  - The frontend Full Name column read `firstName lastName` while the backend sorted on `lastName`, confusing sysadmins scanning the listing.

  ## Changes
  - `UserDaoHibernate.applyOrder` — secondary sort now `FIRST_NAME`; added tertiary `USERNAME` for fully deterministic ordering when both names match.
  - `UserDaoTest.testApplyOrderTiebreaksByFirstNameThenUsername` — new transactional test covering the ASC/DESC tiebreak behaviour.
  - `useUserListing.ts` — added `fullNameSurnameFirst` to the fetched user type, the `User` type, and the constructor.
  - `eln/sysadmin/users/index.tsx` — Full Name column and sort mapping switched to `fullNameSurnameFirst`; confirmation dialogs still use `fullName` (first-first reads naturally
  in prose).

  Reminder per org policy: please follow the AI and Third Party code policy in Drata when merging.