### PR TITLE
 Displays the user's LabGroup affiliations in bullet point form

### DIFF
--- a/src/main/webapp/WEB-INF/pages/admin/directory/user_list_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/admin/directory/user_list_ajax.jsp
@@ -61,7 +61,7 @@
 						<ul style="margin: 0; padding: 0;">
 							<c:forEach items="${user.groups}" var="group">
 							  <c:if test="${!(group.privateProfile and applicationScope['RS_DEPLOY_PROPS']['profileHidingEnabled'] and not subject.isConnectedToGroup(group))}">
-								<li><a href="/groups/view/${group.id}">${group.displayName}</a></li>
+								<li><a href="/groups/view/${group.id}">${group.displayName}</a><br />(${group.groupType.label})</li>
 							  </c:if>
 							</c:forEach>
 						</ul>

--- a/src/main/webapp/WEB-INF/pages/admin/directory/user_list_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/admin/directory/user_list_ajax.jsp
@@ -58,11 +58,13 @@
 					</td>
 					</rst:hasDeploymentProperty>
 					<td>
-						<c:forEach items="${user.groups}" var="group">
-              <c:if test="${!(group.privateProfile and applicationScope['RS_DEPLOY_PROPS']['profileHidingEnabled'] and not subject.isConnectedToGroup(group))}">
-              	<a href="/groups/view/${group.id}"> ${group.displayName} </a>
-              </c:if>
-						</c:forEach>
+						<ul style="margin: 0; padding: 0;">
+							<c:forEach items="${user.groups}" var="group">
+							  <c:if test="${!(group.privateProfile and applicationScope['RS_DEPLOY_PROPS']['profileHidingEnabled'] and not subject.isConnectedToGroup(group))}">
+								<li><a href="/groups/view/${group.id}"> ${group.displayName}</a></li>
+							  </c:if>
+							</c:forEach>
+						</ul>
 					</td>
 					<td style="word-wrap: break-word;">
 						${user.userInfo.email}

--- a/src/main/webapp/WEB-INF/pages/admin/directory/user_list_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/admin/directory/user_list_ajax.jsp
@@ -71,9 +71,9 @@
 					</td>
 					<td>
 						<c:if test="${not empty user.orcidId}">
-							<a class="orcidIdLink" target="_blank" href="http://orcid.org/${user.orcidId}">
-								<img class="orcidIdImg" src="/images/integrations/orcid-small.png" style="vertical-align: text-bottom;" />
-								http://orcid.org/${user.orcidId}
+							<a class="orcidIdLink" target="_blank" href="https://orcid.org/${user.orcidId}">
+								<img class="orcidIdImg" src="/images/integrations/orcid-small.png" style="vertical-align: text-bottom;" alt="ORCiD Logo" />
+								https://orcid.org/${user.orcidId}
 							</a>
 							<br />
 						</c:if> 

--- a/src/main/webapp/WEB-INF/pages/admin/directory/user_list_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/admin/directory/user_list_ajax.jsp
@@ -61,7 +61,7 @@
 						<ul style="margin: 0; padding: 0;">
 							<c:forEach items="${user.groups}" var="group">
 							  <c:if test="${!(group.privateProfile and applicationScope['RS_DEPLOY_PROPS']['profileHidingEnabled'] and not subject.isConnectedToGroup(group))}">
-								<li><a href="/groups/view/${group.id}"> ${group.displayName}</a></li>
+								<li><a href="/groups/view/${group.id}">${group.displayName}</a></li>
 							  </c:if>
 							</c:forEach>
 						</ul>

--- a/src/main/webapp/WEB-INF/pages/signup.jsp
+++ b/src/main/webapp/WEB-INF/pages/signup.jsp
@@ -240,7 +240,7 @@
             <form:hidden path="token"/>
             <label>
               <input type="checkbox" value="remember-me" required/>
-              <span class="rs-field__text rs-field__text--normal">I agree to these <a href='<c:url value="http://researchspace.com/terms-conditions/" />' target='_blank'>Terms and Conditions</a></span>
+              <span class="rs-field__text rs-field__text--normal">I agree to these <a href='<c:url value="https://researchspace.com/terms-conditions/" />' target='_blank'>Terms and Conditions</a></span>
             </label>
           </div>
         </rst:hasDeploymentProperty>


### PR DESCRIPTION
## Description ##
Displays the user's LabGroup affiliations in bullet point form so that it is more readable.

Also replaces the remaining 2 `http://` references to `https://`.

Fixes RSDEV-1127