### PR TITLE
RSDEV-1129-clustermaket-branding: fixed leftover clustermarket text

### DIFF
--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -348,7 +348,7 @@ system.property.description.pyrat.available=Makes PyRAT integration available. A
   users can link to animals in the PyRAT database.
 system.property.description.clustermarket.available=Makes Calira (formerly Clustermarket) integration available. After enabling the integration, \
   users can link to data regarding laboratory equipment.
-system.property.label.clustermarket.available=calira.available
+system.property.label.clustermarket.available=clustermarket.available
 system.property.description.omero.available=Makes Omero integration available. After enabling the integration, \
   users can link to Omero image data.
 system.property.description.dryad.available=Makes Dryad integration available. User can create new dryad submission\

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -348,6 +348,7 @@ system.property.description.pyrat.available=Makes PyRAT integration available. A
   users can link to animals in the PyRAT database.
 system.property.description.clustermarket.available=Makes Calira integration available. After enabling the integration, \
   users can link to data regarding laboratory equipment.
+system.property.label.clustermarket.available=calira.available
 system.property.description.omero.available=Makes Omero integration available. After enabling the integration, \
   users can link to Omero image data.
 system.property.description.dryad.available=Makes Dryad integration available. User can create new dryad submission\

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -346,7 +346,7 @@ system.property.description.repo.available=Makes {0} repository integration avai
   users can submit exports to a {0} repository.
 system.property.description.pyrat.available=Makes PyRAT integration available. After enabling the integration, \
   users can link to animals in the PyRAT database.
-system.property.description.clustermarket.available=Makes Calira integration available. After enabling the integration, \
+system.property.description.clustermarket.available=Makes Calira (formerly Clustermarket) integration available. After enabling the integration, \
   users can link to data regarding laboratory equipment.
 system.property.label.clustermarket.available=calira.available
 system.property.description.omero.available=Makes Omero integration available. After enabling the integration, \

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -440,6 +440,8 @@ inventory.import.subSamplesLimit=2000
 ## AWS configuration properties
 aws.s3.hasS3Access=false
 
+
+#Clustermarket is now rebranded as Calira.
 #clustermarket.client.id=
 #clustermarket.secret=
 clustermarket.api.url=https://api.clustermarket.com/v1/

--- a/src/main/resources/deployments/dev/deployment.properties
+++ b/src/main/resources/deployments/dev/deployment.properties
@@ -71,7 +71,7 @@ egnyte.client.id=
 egnyte.internal.app.client.id=
 
 
-# clustermarket
+# clustermarket - now rebranded as Calira
 clustermarket.client.id=
 clustermarket.secret=
 clustermarket.api.url=https://api.clustermarket.dev/v1/

--- a/src/main/webapp/WEB-INF/pages/system/community_settings_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/community_settings_ajax.jsp
@@ -24,7 +24,7 @@
     <script type="html/text" id="systemSettingRowTemplate" style="display:none">
         <div class="settingRow" data-name="{{setting.name}}">
             <div class="settingName bootstrap-custom-flat">
-                 <a data-content="{{setting.description}}">{{setting.name}}</a>
+                 <a data-content="{{setting.description}}">{{setting.label}}</a>
             </div>
             <div class="settingViewDiv">
                 <div class="settingValue">{{{setting.value}}}</div>
@@ -78,6 +78,10 @@
         <div id="group_autosharing.available.description"><spring:message code="system.property.description.group_autosharing.available" /></div>
         <div id="public_sharing.description"><spring:message code="system.property.description.public_sharing" /></div>
         <div id="publicdocs_allow_seo.description"><spring:message code="system.property.description.publicdocs_allow_seo" /></div>
+    </div>
+
+    <div id="systemSettingsLabels" style="display:none">
+        <div id="clustermarket.available.label"><spring:message code="system.property.label.clustermarket.available" /></div>
     </div>
 
 </div>

--- a/src/main/webapp/WEB-INF/pages/system/community_settings_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/community_settings_ajax.jsp
@@ -22,7 +22,7 @@
     </div>
 
     <script type="html/text" id="systemSettingRowTemplate" style="display:none">
-        <div class="settingRow" data-name="{{setting.name}}">
+        <div class="settingRow" data-name="{{setting.name}}" data-label="{{setting.label}}">
             <div class="settingName bootstrap-custom-flat">
                  <a data-content="{{setting.description}}">{{setting.label}}</a>
             </div>

--- a/src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp
@@ -26,7 +26,7 @@
     <div id="systemSettingRowTemplate" style="display:none">
         <div class="settingRow" data-name="{{setting.name}}">
             <div class="settingName bootstrap-custom-flat">
-                <a data-content="{{setting.description}}">{{setting.name}}</a>
+                <a data-content="{{setting.description}}">{{setting.label}}</a>
             </div>
             <div class="settingViewDiv">
                 <div class="settingValue">{{{setting.value}}}</div>
@@ -94,6 +94,10 @@
         <div id="pi_can_edit_all_work_in_labgroup.description"><spring:message code="system.property.description.pi_can_edit_all_work_in_labgroup" /></div>
         <div id="msteams.available.description"><spring:message code="system.property.description.msteams.available" /></div>
         <div id="protocols_io.available.description"><spring:message code="system.property.description.protocols_io.available" /></div>
+    </div>
+
+    <div id="systemSettingsLabels" style="display:none">
+        <div id="clustermarket.available.label"><spring:message code="system.property.label.clustermarket.available" /></div>
     </div>
 
 </div>

--- a/src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/settings_ajax.jsp
@@ -24,7 +24,7 @@
         </div>
     </div>
     <div id="systemSettingRowTemplate" style="display:none">
-        <div class="settingRow" data-name="{{setting.name}}">
+        <div class="settingRow" data-name="{{setting.name}}" data-label="{{setting.label}}">
             <div class="settingName bootstrap-custom-flat">
                 <a data-content="{{setting.description}}">{{setting.label}}</a>
             </div>

--- a/src/main/webapp/scripts/pages/system/community_settings_mod.js
+++ b/src/main/webapp/scripts/pages/system/community_settings_mod.js
@@ -193,8 +193,10 @@ function _printSettings(settingsToPrint) {
         else
             value = values[0]; // show community setting value if it is available
 
+        var labelOverride = $('#systemSettingsLabels').find('div[id="' + name + '.label"]').text();
         var templateData = {
                 "name": name,
+                "label": labelOverride || name,
                 "value": RS.escapeHtml(value) || '&nbsp;',
                 "description": $('#systemSettingsDescriptions').find('div[id="' + name + '.description"]').text(),
                 "disabled": values[1] === "DENIED"

--- a/src/main/webapp/scripts/pages/system/community_settings_mod.js
+++ b/src/main/webapp/scripts/pages/system/community_settings_mod.js
@@ -133,6 +133,7 @@ function editSetting($settingRow) {
 
 function saveSetting($settingRow) {
     var settingName = $settingRow.data('name');
+    var settingLabel = $settingRow.data('label') || settingName;
     var newValue = _get$InputFieldForRow($settingRow).val();
 
     RS.blockPage("Saving...");
@@ -145,10 +146,10 @@ function saveSetting($settingRow) {
     var jqxhr = $.post("/community/admin/ajax/updateProperty", data);
     jqxhr.done(function(result) {
         if (result.errorMsg) {
-            apprise('Community App Setting \'' + settingName + '\' couldn\'t be updated.');
+            apprise('Community App Setting \'' + settingLabel + '\' couldn\'t be updated.');
         } else {
             var safeResult = RS.escapeHtml(result.data);
-            $().toastmessage('showSuccessToast', 'Community App Setting \'' + settingName + '\' updated to \'' + safeResult + '\'');
+            $().toastmessage('showSuccessToast', 'Community App Setting \'' + settingLabel + '\' updated to \'' + safeResult + '\'');
             settings[settingName] = result.data;
             $settingRow.find('.settingViewDiv .settingValue').html(safeResult || '&nbsp;');
             toggleSettingMode($settingRow);

--- a/src/main/webapp/scripts/pages/system/settings_mod.js
+++ b/src/main/webapp/scripts/pages/system/settings_mod.js
@@ -141,6 +141,7 @@ define(function() {
     function saveSetting($settingRow) {
 
         var settingName = $settingRow.data('name');
+        var settingLabel = $settingRow.data('label') || settingName;
         var newValue = _get$InputFieldForRow($settingRow).val();
 
         RS.blockPage("Saving...");
@@ -152,10 +153,10 @@ define(function() {
         var jqxhr = $.post("/deploymentproperties/ajax/updateProperty", data);
         jqxhr.done(function(result) {
             if (result.errorMsg) {
-                apprise('System Setting \'' + settingName + '\' couldn\'t be updated.');
+                apprise('System Setting \'' + settingLabel + '\' couldn\'t be updated.');
             } else {
                 var safeResult = RS.escapeHtml(result.data);
-                $().toastmessage('showSuccessToast', 'System Setting \'' + settingName + '\' updated to \'' + safeResult + '\'');
+                $().toastmessage('showSuccessToast', 'System Setting \'' + settingLabel + '\' updated to \'' + safeResult + '\'');
                 settings[settingName] = result.data;
                 $settingRow.find('.settingViewDiv .settingValue').html(safeResult || '&nbsp;');
                 toggleSettingMode($settingRow);

--- a/src/main/webapp/scripts/pages/system/settings_mod.js
+++ b/src/main/webapp/scripts/pages/system/settings_mod.js
@@ -194,8 +194,10 @@ define(function() {
         var settingRowTemplate = $('#systemSettingRowTemplate').html();
 
         $.each(settingsToPrint, function(i, name) {
+            var labelOverride = $('#systemSettingsLabels').find('div[id="' + name + '.label"]').text();
             var templateData = {
                     "name": name,
+                    "label": labelOverride || name,
                     "value": RS.escapeHtml(settings[name]) || '&nbsp;',
                     "description": $('#systemSettingsDescriptions').find('div[id="' + name + '.description"]').text()
             };

--- a/src/main/webapp/ui/src/eln/apps/integrations/Clustermarket.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Clustermarket.tsx
@@ -75,7 +75,7 @@ function Clustermarket({
           update({ mode: newMode, credentials: integrationState.credentials })
         }
         helpLinkText="Calira integration docs"
-        website="clustermarket.com"
+        website="calira.co"
         docLink="clustermarket"
         usageText="You can view and insert your equipment bookings from Calira into RSpace documents, as data tables. These tables will contain direct links back to the bookings in Calira."
         setupSection={


### PR DESCRIPTION
## Description

  Extends the Clustermarket → Calira rebrand from #763 (commit 6f5a0f0) into two
  spots that still leaked the old internal key to end-users: the system-settings
  admin page, which rendered the raw PropertyDescriptor name
  (`clustermarket.available`) as the row label, and the Clustermarket integration
  card's `website` link in the Apps page.

  Per the design decision in #763, the underlying identifier (`clustermarket.available`
  PropertyDescriptor name, `SystemPropertyName.CLUSTER_MARKET_AVAILABLE`, etc.) is
  intentionally **not** renamed — this is a presentation-only change, so no
  Liquibase migration is required and existing permission checks / REST API
  calls / Java references all continue to resolve as before.

  ## Changes

  - `bundles/system/system.properties`: new key
    `system.property.label.clustermarket.available=calira.available` for the
    display label.
  - `WEB-INF/pages/system/settings_ajax.jsp` +
    `WEB-INF/pages/system/community_settings_ajax.jsp`:
    - Mustache `systemSettingRowTemplate` now renders `{{setting.label}}` instead
      of `{{setting.name}}` inside the link, and emits an additional
      `data-label="{{setting.label}}"` attribute on the `.settingRow` element
      (the existing `data-name` attribute, used by the save handler to identify
      the property server-side, is unchanged).
    - New hidden `systemSettingsLabels` block mirrors the existing
      `systemSettingsDescriptions` block and holds the localized override for
      `clustermarket.available`.
  - `scripts/pages/system/settings_mod.js` +
    `scripts/pages/system/community_settings_mod.js`:
    - `_printSettings` looks up the override from `#systemSettingsLabels` and
      falls back to the raw property name when no override is defined, so every
      other row continues to render exactly as before.
    - `saveSetting` reads `$settingRow.data('label')` (falling back to
      `settingName`) and uses it in the success toast and failure apprise
      messages, so users no longer see `clustermarket.available` after saving.
      The POST payload and `settings[]` cache keys still use the internal name.
  - `ui/src/eln/apps/integrations/Clustermarket.tsx`: updated the integration
    card's `website` prop from `clustermarket.com` to `calira.co`.

  ## Design decisions
  
  - **Presentation-only.** No DB migration, no rename of
    `SystemPropertyName.CLUSTER_MARKET_AVAILABLE`, no change to the
    `PropertyDescriptor.name` value, no change to bundle keys' suffixes
    (`...clustermarket.available`). This keeps the change minimal and
    consistent with the boundary established in #763.
  - **Generic mechanism, single consumer.** The label-override lookup is
    implemented as a generic mechanism (mirrors the existing
    `systemSettingsDescriptions` pattern) but only `clustermarket.available`
    has an override entry today. Future rebrands can drop a new
    `<div id="<key>.label">` block in the JSP + a corresponding bundle key
    without touching the JS.
  - **`data-label` attribute** over a duplicate JS lookup: the lookup happens
    once at row render time and the result is cached on the DOM, so the save
    handler doesn't need to re-query `#systemSettingsLabels`.

  ## Testing notes

  Manual:
  1. Log in as a sysadmin and open `/system/config#systemsettings`.
  2. Under *Scientific Tools and Specialized Data*, confirm the row now reads
     `calira.available` (not `clustermarket.available`); hover the label and
     confirm the description popover still mentions Calira.
  3. Toggle the value (Allowed / Denied / Denied by default) and confirm the
     success toast reads `System Setting 'calira.available' updated to '<value>'`.
  4. Repeat under `/community/admin/.../settings` (community-admin view) to
     confirm the community settings page picks up the same label.
  5. Confirm every other integration row still renders its existing
    `systemSettingsDescriptions` pattern) but only `clustermarket.available`
    has an override entry today. Future rebrands can drop a new
    `<div id="<key>.label">` block in the JSP + a corresponding bundle key
    without touching the JS.
  - **`data-label` attribute** over a duplicate JS lookup: the lookup happens
    once at row render time and the result is cached on the DOM, so the save
    handler doesn't need to re-query `#systemSettingsLabels`.

  ## Testing notes

  Manual:
  1. Log in as a sysadmin and open `/system/config#systemsettings`.
  2. Under *Scientific Tools and Specialized Data*, confirm the row now reads
     `calira.available` (not `clustermarket.available`); hover the label and
     confirm the description popover still mentions Calira.
  3. Toggle the value (Allowed / Denied / Denied by default) and confirm the
     success toast reads `System Setting 'calira.available' updated to '<value>'`.
  4. Repeat under `/community/admin/.../settings` (community-admin view) to
     confirm the community settings page picks up the same label.
  5. Confirm every other integration row still renders its existing
     `<integration>.available` key unchanged (label fallback).

  > AI & Third Party code policy: changes in this PR were AI-assisted; please
  > review per the AI and Third Party code policy in Drata before merging.

  Note: there's also a GroupManager.java modification still uncommitted in the working tree that doesn't appear related to this rebrand — worth deciding whether to revert it or move
   it to a separate branch before pushing.