### PR TITLE
RSDEV-1130-delete-user-stoichiometry-link: 1st cut

### DIFF
--- a/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
@@ -171,6 +171,69 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
             + " :id");
     execute(userId, session, "delete from Basket where owner_id = :id");
 
+    // Delete StoichiometryInventoryLink rows targeting this user's inventory items.
+    // The link's FKs to Sample/SubSample/Container/InstrumentEntity have no
+    // ON DELETE CASCADE, so we must remove them before the inventory rows.
+    // Order: _AUD first, then main (matches the file convention).
+
+    // sample_id targets
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink_AUD sil"
+            + " left join Sample s on sil.sample_id = s.id"
+            + " where s.owner_id = :id");
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink sil"
+            + " left join Sample s on sil.sample_id = s.id"
+            + " where s.owner_id = :id");
+
+    // subSample_id targets (SubSample has no owner_id; resolve via parent Sample)
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink_AUD sil"
+            + " left join SubSample ss on sil.subSample_id = ss.id"
+            + " left join Sample s on ss.sample_id = s.id"
+            + " where s.owner_id = :id");
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink sil"
+            + " left join SubSample ss on sil.subSample_id = ss.id"
+            + " left join Sample s on ss.sample_id = s.id"
+            + " where s.owner_id = :id");
+
+    // container_id targets
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink_AUD sil"
+            + " left join Container c on sil.container_id = c.id"
+            + " where c.owner_id = :id");
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink sil"
+            + " left join Container c on sil.container_id = c.id"
+            + " where c.owner_id = :id");
+
+    // instrumentEntity_id targets
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink_AUD sil"
+            + " left join InstrumentEntity ins on sil.instrumentEntity_id = ins.id"
+            + " where ins.owner_id = :id");
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink sil"
+            + " left join InstrumentEntity ins on sil.instrumentEntity_id = ins.id"
+            + " where ins.owner_id = :id");
+
     /* start sample/subsample deletion */
 
     // first delete subsample-connected entities
@@ -476,6 +539,27 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
     executeDeleteByRecordOwner(userId, session, "ecatImageAnnotation", RECORD_ID);
     executeDeleteByRecordOwner(
         userId, session, "ecatImageAnnotation_AUD", "id", "ecatImageAnnotation", "id", RECORD_ID);
+
+    // Delete StoichiometryInventoryLink rows joined via the user's stoichiometry
+    // chain BEFORE deleting StoichiometryMolecule. The FK fk_stoichiometry_molecule
+    // has no ON DELETE CASCADE; the ORM cascade on StoichiometryMolecule.inventoryLink
+    // is bypassed because we use native SQL bulk deletes here.
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink_AUD sil"
+            + " left join StoichiometryMolecule sm on sil.stoichiometry_molecule_id = sm.id"
+            + " left join Stoichiometry s on sm.stoichiometry_id = s.id"
+            + " left join BaseRecord br on s.record_id = br.id"
+            + " where br.owner_id=:id");
+    execute(
+        userId,
+        session,
+        "delete sil from StoichiometryInventoryLink sil"
+            + " left join StoichiometryMolecule sm on sil.stoichiometry_molecule_id = sm.id"
+            + " left join Stoichiometry s on sm.stoichiometry_id = s.id"
+            + " left join BaseRecord br on s.record_id = br.id"
+            + " where br.owner_id=:id");
 
     // Delete StoichiometryMolecule first, then Stoichiometry, joined via
     // Stoichiometry.record_id → BaseRecord. record_id is NOT NULL

--- a/src/main/java/com/researchspace/service/GroupManager.java
+++ b/src/main/java/com/researchspace/service/GroupManager.java
@@ -102,8 +102,9 @@ public interface GroupManager {
    * Disbands and removes the group only if no member of the group has logged in within the last
    * year. Members with a null {@code lastLogin} are treated as never-logged-in (allowed).
    *
-   * <p>This method is intended for use by sysadmins to remove groups that are no longer active, without risking deleting groups
-   * that are still in use. It is not intended for regular use by non-sysadmin users
+   * <p>This method is intended for use by sysadmins to remove groups that are no longer active,
+   * without risking deleting groups that are still in use. It is not intended for regular use by
+   * non-sysadmin users
    *
    * @param groupId id of the group to delete
    * @param subject the subject performing the deletion (must already be authorised by the caller)

--- a/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
@@ -12,6 +12,7 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTable;
 import com.researchspace.api.v1.model.ApiMaterialUsage;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.core.util.TransformerUtils;
+import com.researchspace.dao.StoichiometryInventoryLinkDao;
 import com.researchspace.model.Community;
 import com.researchspace.model.EcatMediaFile;
 import com.researchspace.model.FileProperty;
@@ -27,6 +28,8 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.events.AccountEventType;
 import com.researchspace.model.events.UserAccountEvent;
 import com.researchspace.model.field.Field;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.model.oauth.UserConnection;
@@ -37,6 +40,7 @@ import com.researchspace.model.record.Record;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.model.stoichiometry.MoleculeRole;
 import com.researchspace.model.stoichiometry.Stoichiometry;
+import com.researchspace.model.stoichiometry.StoichiometryInventoryLink;
 import com.researchspace.model.stoichiometry.StoichiometryMolecule;
 import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.service.UserDeletionPolicy.UserTypeRestriction;
@@ -81,6 +85,7 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
   private @Autowired JdbcTemplate jdbcTemplate;
   private @Autowired StoichiometryManager stoichiometryMgr;
   private @Autowired RSChemElementManager rsChemElementMgr;
+  private @Autowired StoichiometryInventoryLinkDao stoichiometryInventoryLinkDao;
 
   @Before
   public void setUp() throws Exception {
@@ -651,6 +656,105 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
 
     assertTrue(result.isSucceeded());
     assertUserNotExist(userToDelete);
+  }
+
+  @Test
+  public void testDeleteUserWithStoichiometryAndInventoryLink() throws Exception {
+    User userToDelete = createInitAndLoginAnyUser();
+
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(userToDelete, "Chemistry doc");
+
+    RSChemElement chemElement = RSChemElement.builder().chemElements("CCO").record(doc).build();
+    chemElement = rsChemElementMgr.save(chemElement, userToDelete);
+
+    Stoichiometry stoichiometry =
+        Stoichiometry.builder().parentReaction(chemElement).record(doc).build();
+    stoichiometry = stoichiometryMgr.save(stoichiometry);
+
+    RSChemElement moleculeChemElement =
+        RSChemElement.builder().chemElements("C2H6O").record(doc).build();
+    moleculeChemElement = rsChemElementMgr.save(moleculeChemElement, userToDelete);
+
+    StoichiometryMolecule molecule =
+        StoichiometryMolecule.builder()
+            .stoichiometry(stoichiometry)
+            .rsChemElement(moleculeChemElement)
+            .role(MoleculeRole.REACTANT)
+            .formula("C2H6O")
+            .name("Ethanol")
+            .smiles("CCO")
+            .molecularWeight(46.07)
+            .build();
+    stoichiometry.addMolecule(molecule);
+    stoichiometry = stoichiometryMgr.save(stoichiometry);
+    StoichiometryMolecule savedMolecule = stoichiometry.getMolecules().get(0);
+
+    ApiSampleWithFullSubSamples apiSample = createBasicSampleForUser(userToDelete);
+    Sample sample = sampleDao.get(apiSample.getId());
+    SubSample subSample = sample.getSubSamples().get(0);
+
+    StoichiometryInventoryLink link = new StoichiometryInventoryLink();
+    link.setStoichiometryMolecule(savedMolecule);
+    link.setInventoryRecord(subSample);
+    stoichiometryInventoryLinkDao.save(link);
+
+    User sysadmin = logoutAndLoginAsSysAdmin();
+    UserDeletionPolicy policy = unrestrictedDeletionPolicy();
+    ServiceOperationResult<User> result =
+        userDeletionMgr.removeUser(userToDelete.getId(), policy, sysadmin);
+
+    assertTrue(result.isSucceeded());
+    assertUserNotExist(userToDelete);
+  }
+
+  @Test
+  public void testDeleteUserOwningInventoryLinkedFromOtherUsersStoichiometry() throws Exception {
+    User stoichOwner = createInitAndLoginAnyUser();
+
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(stoichOwner, "Chemistry doc");
+
+    RSChemElement chemElement = RSChemElement.builder().chemElements("CCO").record(doc).build();
+    chemElement = rsChemElementMgr.save(chemElement, stoichOwner);
+
+    Stoichiometry stoichiometry =
+        Stoichiometry.builder().parentReaction(chemElement).record(doc).build();
+    stoichiometry = stoichiometryMgr.save(stoichiometry);
+
+    RSChemElement moleculeChemElement =
+        RSChemElement.builder().chemElements("C2H6O").record(doc).build();
+    moleculeChemElement = rsChemElementMgr.save(moleculeChemElement, stoichOwner);
+
+    StoichiometryMolecule molecule =
+        StoichiometryMolecule.builder()
+            .stoichiometry(stoichiometry)
+            .rsChemElement(moleculeChemElement)
+            .role(MoleculeRole.REACTANT)
+            .formula("C2H6O")
+            .name("Ethanol")
+            .smiles("CCO")
+            .molecularWeight(46.07)
+            .build();
+    stoichiometry.addMolecule(molecule);
+    stoichiometry = stoichiometryMgr.save(stoichiometry);
+    StoichiometryMolecule savedMolecule = stoichiometry.getMolecules().get(0);
+
+    RSpaceTestUtils.logout();
+    User inventoryOwner = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples apiSample = createBasicSampleForUser(inventoryOwner);
+    Sample sample = sampleDao.get(apiSample.getId());
+
+    StoichiometryInventoryLink link = new StoichiometryInventoryLink();
+    link.setStoichiometryMolecule(savedMolecule);
+    link.setInventoryRecord(sample);
+    stoichiometryInventoryLinkDao.save(link);
+
+    User sysadmin = logoutAndLoginAsSysAdmin();
+    UserDeletionPolicy policy = unrestrictedDeletionPolicy();
+    ServiceOperationResult<User> result =
+        userDeletionMgr.removeUser(inventoryOwner.getId(), policy, sysadmin);
+
+    assertTrue(result.isSucceeded());
+    assertUserNotExist(inventoryOwner);
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
+++ b/src/test/java/com/researchspace/service/UserDeletionManagerTestIT.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTable;
+import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
 
 import com.researchspace.api.v1.model.ApiMaterialUsage;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
@@ -696,7 +697,7 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
     StoichiometryInventoryLink link = new StoichiometryInventoryLink();
     link.setStoichiometryMolecule(savedMolecule);
     link.setInventoryRecord(subSample);
-    stoichiometryInventoryLinkDao.save(link);
+    Long linkId = stoichiometryInventoryLinkDao.save(link).getId();
 
     User sysadmin = logoutAndLoginAsSysAdmin();
     UserDeletionPolicy policy = unrestrictedDeletionPolicy();
@@ -705,6 +706,62 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
 
     assertTrue(result.isSucceeded());
     assertUserNotExist(userToDelete);
+    assertStoichiometryInventoryLinkAndAuditDeleted(linkId);
+  }
+
+  @Test
+  public void testDeleteUserOwningStoichiometryLinkedToOtherUsersInventory() throws Exception {
+    // Inventory belongs to a different user from the one being deleted, so
+    // deleteInventoryItems cannot clean up the link row — the SQL in
+    // deleteRecords (joined via BaseRecord.owner_id) is the only thing that
+    // can remove it before the StoichiometryMolecule delete runs.
+    User inventoryOwner = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples apiSample = createBasicSampleForUser(inventoryOwner);
+    Sample sample = sampleDao.get(apiSample.getId());
+
+    RSpaceTestUtils.logout();
+    User userToDelete = createInitAndLoginAnyUser();
+
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(userToDelete, "Chemistry doc");
+
+    RSChemElement chemElement = RSChemElement.builder().chemElements("CCO").record(doc).build();
+    chemElement = rsChemElementMgr.save(chemElement, userToDelete);
+
+    Stoichiometry stoichiometry =
+        Stoichiometry.builder().parentReaction(chemElement).record(doc).build();
+    stoichiometry = stoichiometryMgr.save(stoichiometry);
+
+    RSChemElement moleculeChemElement =
+        RSChemElement.builder().chemElements("C2H6O").record(doc).build();
+    moleculeChemElement = rsChemElementMgr.save(moleculeChemElement, userToDelete);
+
+    StoichiometryMolecule molecule =
+        StoichiometryMolecule.builder()
+            .stoichiometry(stoichiometry)
+            .rsChemElement(moleculeChemElement)
+            .role(MoleculeRole.REACTANT)
+            .formula("C2H6O")
+            .name("Ethanol")
+            .smiles("CCO")
+            .molecularWeight(46.07)
+            .build();
+    stoichiometry.addMolecule(molecule);
+    stoichiometry = stoichiometryMgr.save(stoichiometry);
+    StoichiometryMolecule savedMolecule = stoichiometry.getMolecules().get(0);
+
+    StoichiometryInventoryLink link = new StoichiometryInventoryLink();
+    link.setStoichiometryMolecule(savedMolecule);
+    link.setInventoryRecord(sample);
+    Long linkId = stoichiometryInventoryLinkDao.save(link).getId();
+
+    User sysadmin = logoutAndLoginAsSysAdmin();
+    UserDeletionPolicy policy = unrestrictedDeletionPolicy();
+    ServiceOperationResult<User> result =
+        userDeletionMgr.removeUser(userToDelete.getId(), policy, sysadmin);
+
+    assertTrue(result.isSucceeded());
+    assertUserNotExist(userToDelete);
+    assertStoichiometryInventoryLinkAndAuditDeleted(linkId);
   }
 
   @Test
@@ -746,7 +803,7 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
     StoichiometryInventoryLink link = new StoichiometryInventoryLink();
     link.setStoichiometryMolecule(savedMolecule);
     link.setInventoryRecord(sample);
-    stoichiometryInventoryLinkDao.save(link);
+    Long linkId = stoichiometryInventoryLinkDao.save(link).getId();
 
     User sysadmin = logoutAndLoginAsSysAdmin();
     UserDeletionPolicy policy = unrestrictedDeletionPolicy();
@@ -755,6 +812,19 @@ public class UserDeletionManagerTestIT extends RealTransactionSpringTestBase {
 
     assertTrue(result.isSucceeded());
     assertUserNotExist(inventoryOwner);
+    assertStoichiometryInventoryLinkAndAuditDeleted(linkId);
+  }
+
+  private void assertStoichiometryInventoryLinkAndAuditDeleted(Long linkId) {
+    String where = "id = " + linkId;
+    assertEquals(
+        "StoichiometryInventoryLink row should have been deleted",
+        0,
+        countRowsInTableWhere(jdbcTemplate, "StoichiometryInventoryLink", where));
+    assertEquals(
+        "StoichiometryInventoryLink_AUD rows should have been deleted",
+        0,
+        countRowsInTableWhere(jdbcTemplate, "StoichiometryInventoryLink_AUD", where));
   }
 
   @Test


### PR DESCRIPTION
Title: RSDEV-1130: delete user with stoichiometry inventory link

  Body:

  ## Description
  Jira: [RSDEV-1130](https://researchspace.atlassian.net/browse/RSDEV-1130)

  Fixes sysadmin user deletion failing with a foreign-key error when the user
  has created a stoichiometry that has an inventory link, or owns an inventory
  item that another user's stoichiometry links to.

  Failure observed in the ticket:

  Cannot delete or update a parent row: a foreign key constraint fails
  (rspace.StoichiometryInventoryLink,
   CONSTRAINT fk_stoichiometry_molecule FOREIGN KEY (stoichiometry_molecule_id)
   REFERENCES StoichiometryMolecule (id))

  `UserDeletionDaoHibernate.deleteRecords` uses native bulk SQL to delete
  `StoichiometryMolecule`, which bypasses the ORM cascade declared on
  `StoichiometryMolecule.inventoryLink`. The DB-level FK has no
  `ON DELETE CASCADE`, so the molecule delete is rejected whenever a
  `StoichiometryInventoryLink` row exists. The same class of failure is
  reachable from `deleteInventoryItems` for the four inventory target columns of
  `StoichiometryInventoryLink` (`sample_id`, `subSample_id`, `container_id`,
  `instrumentEntity_id`).

  ## Design decisions
  - **Code-only fix, no Liquibase change.** Mirrors the file's existing pattern
    of explicit ordered raw-SQL deletes (`_AUD` first, then main) rather than
    introducing DB-level cascades. Keeps deletion order auditable in one Java file
    and consistent with the surrounding `StoichiometryMolecule_AUD` /
    `RecordAttachment_AUD` blocks.
  - `deleteRecords` cleans up link rows joined via the user's stoichiometry chain
    (covers the single-user ticket reproducer).
  - `deleteInventoryItems` cleans up link rows that target the user's inventory
    regardless of who owns the linking stoichiometry (covers the cross-user case
    reachable when a collaborator with WRITE permission links to the deleted
    user's inventory).
  - Two new ITs in `UserDeletionManagerTestIT`: one for the single-user
    reproducer and one for the cross-user inventory-target path. IT variants for
    Container and InstrumentEntity targets are intentionally omitted — the SQL
    is structurally identical to the Sample/SubSample variant; covered by review.

  ## Testing notes
  New integration tests run under `mvn verify` (or directly):

  mvn test -Dtest=UserDeletionManagerTestIT#testDeleteUserWithStoichiometryAndInventoryLink
  mvn test -Dtest=UserDeletionManagerTestIT#testDeleteUserOwningInventoryLinkedFromOtherUsersStoichiometry

  Manual repro (sanity check): create user → enable chemistry → create inventory
  sample → create doc with a stoichiometry → link an inventory subsample to a
  molecule → log out → log in as sysadmin → delete the user → confirm no FK
  error and the user is removed.

Second sanity check: do the same as above but cross-user. One user shares their inventory items with another giving write access. The other user then links their stoichiometry to those items. The inventory owning user is then deleted - it should be a success with no FK constraint errors.

  ---
  Per Drata, please follow the AI and Third Party code policy when opening this PR.