### PR TITLE
Harden Jenkins branch-name normalization for sandbox compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -466,13 +466,17 @@ def branchToDbName (String name) {
 }
 
 // Replaces characters that are unsafe in filesystem paths or AWS/host resource names (notably '/') with '-',
-// keeping dots, underscores and hyphens. Used so branches like 'feature/foo' don't break path/name construction.
+// keeping dots, underscores and hyphens, and appends a short hash of the original name so that distinct
+// branches that would otherwise collide (e.g. 'feature/foo' and 'feature-foo') stay unique.
 def branchToSafeName (String name) {
+    String hash = name.md5().take(8)
     String newname = name.replaceAll('[^A-Za-z0-9._-]', '-')
-    if (newname.length() > 63) {
-        newname = newname.substring(0, 63)
+    String candidate = "${newname}-${hash}"
+    if (candidate.length() > 63) {
+        newname = newname.substring(0, 63 - 1 - hash.length())
+        candidate = "${newname}-${hash}"
     }
-    return newname
+    return candidate
 }
 
 def notifySlack(String buildStatus = 'STARTED', String info = '') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -468,7 +468,11 @@ def branchToDbName (String name) {
 // Replaces characters that are unsafe in filesystem paths or AWS/host resource names (notably '/') with '-',
 // keeping dots, underscores and hyphens. Used so branches like 'feature/foo' don't break path/name construction.
 def branchToSafeName (String name) {
-    return name.replaceAll('[^A-Za-z0-9._-]', '-')
+    String newname = name.replaceAll('[^A-Za-z0-9._-]', '-')
+    if (newname.length() > 63) {
+        newname = newname.substring(0, 63)
+    }
+    return newname
 }
 
 def notifySlack(String buildStatus = 'STARTED', String info = '') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -473,7 +473,7 @@ def branchNameHash (String name) {
         .digest(name.getBytes(java.nio.charset.StandardCharsets.UTF_8))
     StringBuilder hash = new StringBuilder()
     for (byte b : digest) {
-        hash.append(Integer.toHexString((b & 0xff) | 0x100).substring(1))
+        hash.append(String.format('%02x', b & 0xff))
     }
     return hash.substring(0, 8)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,9 @@ pipeline {
     environment {
         BUILD_FAILURE_EMAIL_LIST = 'dev@researchspace.com'
         CI = 'true'
-        RS_FILE_BASE = "/var/lib/jenkins/userContent/${BRANCH_NAME}-filestore"
+        // BRANCH_NAME may contain '/' (e.g. feature/foo); sanitise before using it in filesystem paths or resource names
+        SAFE_BRANCH_NAME = branchToSafeName("${BRANCH_NAME}")
+        RS_FILE_BASE = "/var/lib/jenkins/userContent/${SAFE_BRANCH_NAME}-filestore"
         SANITIZED_DBNAME = branchToDbName("${BRANCH_NAME}")
         AWS_TOMCAT_AMI = 'ami-0ccb4189a68a02c7d'
         APP_VERSION = readMavenPom().getVersion()
@@ -63,7 +65,7 @@ pipeline {
                 '''
                 echo 'Cleaning out filestore'
                 sh "rm -rf $RS_FILE_BASE"
-                sh "mkdir $RS_FILE_BASE"
+                sh "mkdir -p $RS_FILE_BASE"
                 echo "Workspace jenkins var is $WORKSPACE"
             }
         }
@@ -347,7 +349,7 @@ pipeline {
                                 [
                                         $class: 'StringParameterValue',
                                         name: 'SERVER_NAME',
-                                        value: "$BRANCH_NAME-$BUILD_ID"
+                                        value: "$SAFE_BRANCH_NAME-$BUILD_ID"
                                 ],
                                 [
                                         $class: 'StringParameterValue',
@@ -362,7 +364,7 @@ pipeline {
                                 [
                                         $class: 'StringParameterValue',
                                         name: 'DEPLOYMENT_PROPERTY_OVERRIDE',
-                                        value: "$WORKSPACE/${BRANCH_NAME}.properties"
+                                        value: "$WORKSPACE/${SAFE_BRANCH_NAME}.properties"
                                 ]
                         ],
                         wait: false
@@ -461,6 +463,12 @@ def branchToDbName (String name) {
         newname = newname.substring(0, 63)
     }
     return newname
+}
+
+// Replaces characters that are unsafe in filesystem paths or AWS/host resource names (notably '/') with '-',
+// keeping dots, underscores and hyphens. Used so branches like 'feature/foo' don't break path/name construction.
+def branchToSafeName (String name) {
+    return name.replaceAll('[^A-Za-z0-9._-]', '-')
 }
 
 def notifySlack(String buildStatus = 'STARTED', String info = '') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -468,8 +468,14 @@ def branchToDbName (String name) {
 // Replaces characters that are unsafe in filesystem paths or AWS/host resource names (notably '/') with '-',
 // keeping dots, underscores and hyphens, and appends a short hash of the original name so that distinct
 // branches that would otherwise collide (e.g. 'feature/foo' and 'feature-foo') stay unique.
+def branchNameHash (String name) {
+    byte[] digest = java.security.MessageDigest.getInstance('MD5')
+        .digest(name.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    return digest.collect { String.format('%02x', it & 0xff) }.join().take(8)
+}
+
 def branchToSafeName (String name) {
-    String hash = name.md5().take(8)
+    String hash = branchNameHash(name)
     String newname = name.replaceAll('[^A-Za-z0-9._-]', '-')
     String candidate = "${newname}-${hash}"
     if (candidate.length() > 63) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -471,7 +471,11 @@ def branchToDbName (String name) {
 def branchNameHash (String name) {
     byte[] digest = java.security.MessageDigest.getInstance('MD5')
         .digest(name.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-    return digest.collect { String.format('%02x', it & 0xff) }.join().take(8)
+    StringBuilder hash = new StringBuilder()
+    for (byte b : digest) {
+        hash.append(Integer.toHexString((b & 0xff) | 0x100).substring(1))
+    }
+    return hash.substring(0, 8)
 }
 
 def branchToSafeName (String name) {


### PR DESCRIPTION
## Description ##
- Normalizes branch names for Jenkins path/host usage without collisions, while avoiding Groovy helpers that are not available in the Jenkins sandbox.
- **Branch naming**
  - keeps the existing character sanitization for filesystem/resource-safe names
  - appends an 8-character MD5 suffix derived from the original branch name so branches like `feature/foo` and `feature-foo` remain distinct
  - preserves the 63-character cap by truncating only the sanitized prefix
- **Jenkins compatibility**
  - replaces unsupported Groovy extension calls (`String.md5()`, zero-arg `List.join()`) with standard Java/Groovy constructs allowed in the pipeline runtime

```groovy
def branchNameHash (String name) {
    byte[] digest = java.security.MessageDigest.getInstance('MD5')
        .digest(name.getBytes(java.nio.charset.StandardCharsets.UTF_8))
    StringBuilder hash = new StringBuilder()
    for (byte b : digest) {
        hash.append(String.format('%02x', b & 0xff))
    }
    return hash.substring(0, 8)
}
```

## Design decisions
- Use a short deterministic hash suffix rather than pure sanitization to avoid branch-name collisions across shared Jenkins resources.
- Use `MessageDigest` + `StringBuilder` instead of Groovy convenience methods so the helper works under Jenkins script-security constraints.

## Testing notes
- No special manual testing notes.