### PR TITLE
RSDEV-1139: shim process in Vite config so Ketcher loads

### DIFF
--- a/src/main/webapp/ui/vite.config.ts
+++ b/src/main/webapp/ui/vite.config.ts
@@ -97,6 +97,13 @@ export default defineConfig(async ({ mode }) => {
     base: "/ui/dist/",
     define: {
       global: "globalThis",
+      process: JSON.stringify({
+        env: { NODE_ENV: mode },
+        browser: true,
+        version: "",
+        versions: {},
+        platform: "browser",
+      }),
     },
     plugins,
     resolve: {

--- a/src/main/webapp/ui/vite.config.ts
+++ b/src/main/webapp/ui/vite.config.ts
@@ -4,6 +4,7 @@ import bundleEntries from "./bundleEntries.json";
 import { defineConfig } from "vitest/config";
 import type { Alias, PluginOption, UserConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
 import browserslist from "browserslist";
 import browserslistToEsbuild from "browserslist-to-esbuild";
 import { browserslistToTargets } from "lightningcss";
@@ -78,7 +79,13 @@ const resolvedBundleEntries = Object.fromEntries(
 export default defineConfig(async ({ mode }) => {
   const isVitest = mode === "test" || process.env.VITEST === "true";
 
-  const plugins: PluginOption[] = [react()];
+  const plugins: PluginOption[] = [
+    react(),
+    nodePolyfills({
+      globals: { process: true, Buffer: true, global: true },
+      protocolImports: false,
+    }),
+  ];
 
   if (shouldGenerateBuildStats) {
     const { visualizer } = await import("rollup-plugin-visualizer");
@@ -97,13 +104,6 @@ export default defineConfig(async ({ mode }) => {
     base: "/ui/dist/",
     define: {
       global: "globalThis",
-      process: JSON.stringify({
-        env: { NODE_ENV: mode },
-        browser: true,
-        version: "",
-        versions: {},
-        platform: "browser",
-      }),
     },
     plugins,
     resolve: {


### PR DESCRIPTION
## Description ##
- Wires `vite-plugin-node-polyfills` (already a `devDependency` at `0.26.0`, previously unused) into `src/main/webapp/ui/vite.config.ts` to shim `process`, `Buffer`, and `global` for the browser bundle, so Ketcher's pre-bundled CJS polyfills (`assert` → `util`) can initialise without throwing.
- Fixes the post-Vite-migration regression tracked in [RSDEV-1139](https://researchspace.atlassian.net/browse/RSDEV-1139): opening Ketcher from the TinyMCE toolbar threw `ReferenceError: process is not defined` and the lazy chunk never rendered.

## Design decisions
- **First attempt** was a narrower inline `process` literal in Vite's `define` block (commit `0a9ee61e`). That only covers the `process` reference and would leave us playing whack-a-mole the next time a CJS dependency reads `Buffer` or another Node global at module init.
- **Switched to the plugin** per review feedback so the shim is structural rather than ad-hoc. `protocolImports: false` keeps the surface minimal: we polyfill the globals, but not `node:fs`-style imports.
- No new dependency: the plugin was already in `package.json`. No `package.json` / `package-lock.json` changes in this PR.

## Testing notes
- Clear the optimizer cache before retesting so pre-bundled CJS deps get retransformed with the new globals:
  `rm -rf src/main/webapp/ui/node_modules/.vite && npm run serve`
- Open an ELN document, click the Ketcher toolbar button, confirm the editor renders and no `process is not defined` error appears in the console.
- Sanity-check other lazy-loaded TinyMCE plugins (Snapgene, chemistry viewer) still load.
- `npm run tsc` passes; `npm run build` produces a working `KetcherDialog` chunk.

## Known build-time warning (not a regression)
`npm run build` now logs:

```
[EVAL] Warning: Use of direct `eval` function is strongly discouraged
       node_modules/vm-browserify/index.js:110:12
```

- `vm-browserify` is pulled in transitively by the plugin's `node-stdlib-browser` backend. Attempting to exclude it via the plugin's `modules: { vm: false }` option does not drop it from the bundle (node-stdlib-browser's index still references it, so rolldown bundles it anyway).
- Webpack auto-polyfilled `vm` the same way before the migration, so this is not new runtime behaviour — just newly visible because rolldown's reporter warns where webpack stayed silent.
- **CSP implication:** if RSpace's production CSP forbids `unsafe-eval` and any runtime path inside Ketcher reaches the `vm` shim, that call will be blocked. The likely follow-up is to alias-stub `vm-browserify` to an empty module via `resolve.alias` as a targeted fix. Leaving that for a separate ticket unless it surfaces in staging.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>