### PR TITLE
RSDEV-1111: allowlist controlling s3 file systems usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1493,7 +1493,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>2.23.2</version>
+      <version>c54b58e4e2</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1493,7 +1493,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>4173c60e13</version>
+      <version>e354feb3e2</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1493,7 +1493,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>c54b58e4e2</version>
+      <version>2.23.3</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1493,7 +1493,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>2.23.0</version>
+      <version>4173c60e13</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
@@ -183,7 +183,7 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
   @Override
   public List<NfsFileSystemInfo> getFilesystems(@RequestAttribute(name = "user") User user) {
     assertFilestoresApiEnabled(user);
-    return nfsManager.getActiveFileSystemInfos();
+    return nfsManager.getActiveFileSystemInfos(user);
   }
 
   @Override

--- a/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
@@ -74,6 +74,7 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
     assertFilestoresApiEnabled(user);
     NfsFileStore filestore = nfsManager.getNfsFileStore(filestoreId);
     NfsFileSystem filesystem = filestore.getFileSystem();
+    aclChecker.assertCanRead(user, filesystem);
     NfsClient nfsClient = getNfsClientForUserAndFilesystem(user, filesystem);
 
     String combinedPath = filestore.getPath();
@@ -119,6 +120,7 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
 
     NfsFileStore filestore = nfsManager.getNfsFileStore(filestoreId);
     NfsFileSystem filesystem = filestore.getFileSystem();
+    aclChecker.assertCanRead(user, filesystem);
     NfsClient nfsClient = getNfsClientForUserAndFilesystem(user, filesystem);
 
     String fullPath = filestore.getAbsolutePath(remotePath);
@@ -145,6 +147,8 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
       @RequestAttribute(name = "user") User user) {
 
     assertFilestoresApiEnabled(user);
+    NfsFileSystem filesystem = nfsManager.getFileSystem(filesystemId);
+    aclChecker.assertCanRead(user, filesystem);
     boolean filestoreNameUnique = nfsManager.verifyFileStoreNameUniqueForUser(filestoreName, user);
     if (!filestoreNameUnique) {
       throw new IllegalArgumentException(
@@ -191,6 +195,7 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
 
     assertFilestoresApiEnabled(user);
     NfsFileSystem filesystem = nfsManager.getFileSystem(filesystemId);
+    aclChecker.assertCanRead(user, filesystem);
     NfsClient nfsClient = getNfsClientForUserAndFilesystem(user, filesystem);
 
     NfsFileTreeNode fileTree = nfsClient.createFileTree(browsePath, null, null);

--- a/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
@@ -74,7 +74,6 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
     assertFilestoresApiEnabled(user);
     NfsFileStore filestore = nfsManager.getNfsFileStore(filestoreId);
     NfsFileSystem filesystem = filestore.getFileSystem();
-    aclChecker.assertCanRead(user, filesystem);
     NfsClient nfsClient = getNfsClientForUserAndFilesystem(user, filesystem);
 
     String combinedPath = filestore.getPath();
@@ -86,7 +85,14 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
     return getRemotePathBrowseResult(filesystem, nfsClient, fileTree);
   }
 
+  /**
+   * Returns an NfsClient for the given user and filesystem after asserting the user has read
+   * access. Throws {@link org.apache.shiro.authz.AuthorizationException} (mapped to 403) if not.
+   * All read paths on this controller (browse, download) route through here so the assertion cannot
+   * be forgotten.
+   */
   private NfsClient getNfsClientForUserAndFilesystem(User user, NfsFileSystem filesystem) {
+    aclChecker.assertCanRead(user, filesystem);
     if (NfsAuthenticationType.NONE.equals(filesystem.getAuthType())) {
       return nfsFactory.getNfsClient(user.getUsername(), null, filesystem);
     }
@@ -120,7 +126,6 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
 
     NfsFileStore filestore = nfsManager.getNfsFileStore(filestoreId);
     NfsFileSystem filesystem = filestore.getFileSystem();
-    aclChecker.assertCanRead(user, filesystem);
     NfsClient nfsClient = getNfsClientForUserAndFilesystem(user, filesystem);
 
     String fullPath = filestore.getAbsolutePath(remotePath);
@@ -195,7 +200,6 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
 
     assertFilestoresApiEnabled(user);
     NfsFileSystem filesystem = nfsManager.getFileSystem(filesystemId);
-    aclChecker.assertCanRead(user, filesystem);
     NfsClient nfsClient = getNfsClientForUserAndFilesystem(user, filesystem);
 
     NfsFileTreeNode fileTree = nfsClient.createFileTree(browsePath, null, null);

--- a/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
@@ -87,9 +87,7 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
 
   /**
    * Returns an NfsClient for the given user and filesystem after asserting the user has read
-   * access. Throws {@link org.apache.shiro.authz.AuthorizationException} (mapped to 403) if not.
-   * All read paths on this controller (browse, download) route through here so the assertion cannot
-   * be forgotten.
+   * access.
    */
   private NfsClient getNfsClientForUserAndFilesystem(User user, NfsFileSystem filesystem) {
     aclChecker.assertCanRead(user, filesystem);

--- a/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresApiController.java
@@ -215,6 +215,7 @@ public class GalleryFilestoresApiController extends GalleryFilestoresBaseApiCont
 
     assertFilestoresApiEnabled(user);
     NfsFileSystem filesystem = nfsManager.getFileSystem(filesystemId);
+    aclChecker.assertCanRead(user, filesystem);
     NfsClient nfsClient =
         credentialsStore.validateCredentialsAndLoginNfs(credentials, errors, user, filesystem);
     try {

--- a/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresBaseApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/GalleryFilestoresBaseApiController.java
@@ -1,6 +1,7 @@
 package com.researchspace.api.v1.controller;
 
 import com.researchspace.model.User;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsManager;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -9,6 +10,8 @@ public class GalleryFilestoresBaseApiController extends BaseApiController {
   @Autowired protected NfsManager nfsManager;
 
   @Autowired protected GalleryFilestoresCredentialsStore credentialsStore;
+
+  @Autowired protected FilestoreAclChecker aclChecker;
 
   protected void assertFilestoresApiEnabled(User subject) {
     if (!properties.isNetFileStoresEnabled() && !subject.hasSysadminRole()) {

--- a/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
@@ -640,8 +640,7 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
         session,
         "update StructuredDocument sd join BaseRecord br on br.id = sd.id"
             + " set sd.template_id = null"
-            + " where br.owner_id = :id and sd.template_id is not null"
-        );
+            + " where br.owner_id = :id and sd.template_id is not null");
     for (String recordTable2 : RecordTables2) {
       executeDeleteByRecordOwner(userId, session, recordTable2, "id");
       executeDeleteByRecordOwner(userId, session, recordTable2 + "_AUD", "id");

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -73,9 +73,10 @@ public class FilestoreAclChecker {
   }
 
   private AuthorizationException denied(User user, NfsFileSystem fs, String op) {
+    String fsName = fs == null ? "(unknown)" : fs.getName();
     return new AuthorizationException(
         messages.getMessage(
-            "netfilestores.acl.denied." + op, new Object[] {user.getUsername(), fs.getName()}));
+            "netfilestores.acl.denied." + op, new Object[] {user.getUsername(), fsName}));
   }
 
   private static boolean isGated(NfsFileSystem fs) {

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -45,7 +45,7 @@ public class FilestoreAclChecker {
   }
 
   public boolean canRead(User user, NfsFileSystem fs) {
-    if (fs.getAuthType() == null) {
+    if (fs == null || fs.getAuthType() == null) {
       return false;
     }
     if (!isGated(fs)) {
@@ -55,7 +55,7 @@ public class FilestoreAclChecker {
   }
 
   public boolean canWrite(User user, NfsFileSystem fs) {
-    if (fs.getAuthType() == null) {
+    if (fs == null || fs.getAuthType() == null) {
       return false;
     }
     if (!isGated(fs)) {

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -1,0 +1,87 @@
+package com.researchspace.service;
+
+import com.researchspace.model.User;
+import com.researchspace.model.netfiles.NfsAuthenticationType;
+import com.researchspace.model.netfiles.NfsFileSystem;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.apache.shiro.authz.AuthorizationException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Per-filesystem read/write authorization based on username whitelists.
+ *
+ * <p>Whitelists are only consulted for filesystems with {@link NfsAuthenticationType#NONE} (i.e.
+ * server-wide credentials, no per-user identity at the storage layer). For other auth types both
+ * checks short-circuit to {@code true}, since per-user authentication already gates access.
+ */
+@Component
+public class FilestoreAclChecker {
+
+  static final String EVERYONE = "*";
+
+  /**
+   * Parses a whitelist string into a trimmed, deduplicated set of tokens. Whitespace is stripped
+   * around each token; empty tokens are dropped. Returns an empty set for {@code null} or blank
+   * input.
+   */
+  public static Set<String> parseList(String whitelist) {
+    if (whitelist == null) {
+      return Collections.emptySet();
+    }
+    Set<String> tokens = new LinkedHashSet<>();
+    for (String raw : whitelist.split(",")) {
+      String trimmed = raw.trim();
+      if (!trimmed.isEmpty()) {
+        tokens.add(trimmed);
+      }
+    }
+    return tokens;
+  }
+
+  public boolean canRead(User user, NfsFileSystem fs) {
+    if (!isGated(fs)) {
+      return true;
+    }
+    return inList(user, fs.getReadWhitelist()) || inList(user, fs.getWriteWhitelist());
+  }
+
+  public boolean canWrite(User user, NfsFileSystem fs) {
+    if (!isGated(fs)) {
+      return true;
+    }
+    return inList(user, fs.getWriteWhitelist());
+  }
+
+  public void assertCanRead(User user, NfsFileSystem fs) {
+    if (!canRead(user, fs)) {
+      throw new AuthorizationException(
+          "User '"
+              + user.getUsername()
+              + "' has no read access to filesystem '"
+              + fs.getName()
+              + "'");
+    }
+  }
+
+  public void assertCanWrite(User user, NfsFileSystem fs) {
+    if (!canWrite(user, fs)) {
+      throw new AuthorizationException(
+          "User '"
+              + user.getUsername()
+              + "' has no write access to filesystem '"
+              + fs.getName()
+              + "'");
+    }
+  }
+
+  private static boolean isGated(NfsFileSystem fs) {
+    return NfsAuthenticationType.NONE.equals(fs.getAuthType());
+  }
+
+  private static boolean inList(User user, String whitelist) {
+    Set<String> tokens = parseList(whitelist);
+    return tokens.contains(EVERYONE) || tokens.contains(user.getUsername());
+  }
+}

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -6,7 +6,9 @@ import com.researchspace.model.netfiles.NfsFileSystem;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import lombok.Setter;
 import org.apache.shiro.authz.AuthorizationException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -20,6 +22,8 @@ import org.springframework.stereotype.Component;
 public class FilestoreAclChecker {
 
   public static final String EVERYONE = "*";
+
+  @Autowired @Setter private MessageSourceUtils messages;
 
   /**
    * Parses a whitelist string into a trimmed, deduplicated set of tokens. Whitespace is stripped
@@ -72,15 +76,10 @@ public class FilestoreAclChecker {
     }
   }
 
-  private static AuthorizationException denied(User user, NfsFileSystem fs, String op) {
+  private AuthorizationException denied(User user, NfsFileSystem fs, String op) {
     return new AuthorizationException(
-        "User '"
-            + user.getUsername()
-            + "' has no "
-            + op
-            + " access to filesystem '"
-            + fs.getName()
-            + "'");
+        messages.getMessage(
+            "netfilestores.acl.denied." + op, new Object[] {user.getUsername(), fs.getName()}));
   }
 
   private static boolean isGated(NfsFileSystem fs) {

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -41,6 +41,9 @@ public class FilestoreAclChecker {
   }
 
   public boolean canRead(User user, NfsFileSystem fs) {
+    if (fs.getAuthType() == null) {
+      return false;
+    }
     if (!isGated(fs)) {
       return true;
     }
@@ -48,6 +51,9 @@ public class FilestoreAclChecker {
   }
 
   public boolean canWrite(User user, NfsFileSystem fs) {
+    if (fs.getAuthType() == null) {
+      return false;
+    }
     if (!isGated(fs)) {
       return true;
     }

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -56,24 +56,25 @@ public class FilestoreAclChecker {
 
   public void assertCanRead(User user, NfsFileSystem fs) {
     if (!canRead(user, fs)) {
-      throw new AuthorizationException(
-          "User '"
-              + user.getUsername()
-              + "' has no read access to filesystem '"
-              + fs.getName()
-              + "'");
+      throw denied(user, fs, "read");
     }
   }
 
   public void assertCanWrite(User user, NfsFileSystem fs) {
     if (!canWrite(user, fs)) {
-      throw new AuthorizationException(
-          "User '"
-              + user.getUsername()
-              + "' has no write access to filesystem '"
-              + fs.getName()
-              + "'");
+      throw denied(user, fs, "write");
     }
+  }
+
+  private static AuthorizationException denied(User user, NfsFileSystem fs, String op) {
+    return new AuthorizationException(
+        "User '"
+            + user.getUsername()
+            + "' has no "
+            + op
+            + " access to filesystem '"
+            + fs.getName()
+            + "'");
   }
 
   private static boolean isGated(NfsFileSystem fs) {

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -12,9 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Per-filesystem read/write authorization based on username whitelists.
+ * Per-filesystem read/write authorization based on username allowlists.
  *
- * <p>Whitelists are only consulted for filesystems with {@link NfsAuthenticationType#NONE} (i.e.
+ * <p>Allowlists are only consulted for filesystems with {@link NfsAuthenticationType#NONE} (i.e.
  * server-wide credentials, no per-user identity at the storage layer). For other auth types both
  * checks short-circuit to {@code true}, since per-user authentication already gates access.
  */
@@ -25,13 +25,13 @@ public class FilestoreAclChecker {
 
   private @Autowired @Setter MessageSourceUtils messages;
 
-  /** Splits a comma-separated whitelist into trimmed, non-empty tokens. */
-  public static Set<String> parseList(String whitelist) {
-    if (whitelist == null) {
+  /** Splits a comma-separated allowlist into trimmed, non-empty tokens. */
+  public static Set<String> parseList(String allowlist) {
+    if (allowlist == null) {
       return Collections.emptySet();
     }
     Set<String> tokens = new LinkedHashSet<>();
-    for (String raw : whitelist.split(",")) {
+    for (String raw : allowlist.split(",")) {
       String trimmed = raw.trim();
       if (!trimmed.isEmpty()) {
         tokens.add(trimmed);
@@ -47,7 +47,7 @@ public class FilestoreAclChecker {
     if (!isGated(fs)) {
       return true;
     }
-    return inList(user, fs.getReadWhitelist()) || inList(user, fs.getWriteWhitelist());
+    return inList(user, fs.getReadAllowlist()) || inList(user, fs.getWriteAllowlist());
   }
 
   public boolean canWrite(User user, NfsFileSystem fs) {
@@ -57,7 +57,7 @@ public class FilestoreAclChecker {
     if (!isGated(fs)) {
       return true;
     }
-    return inList(user, fs.getWriteWhitelist());
+    return inList(user, fs.getWriteAllowlist());
   }
 
   public void assertCanRead(User user, NfsFileSystem fs) {
@@ -83,8 +83,8 @@ public class FilestoreAclChecker {
     return NfsAuthenticationType.NONE.equals(fs.getAuthType());
   }
 
-  private static boolean inList(User user, String whitelist) {
-    Set<String> tokens = parseList(whitelist);
+  private static boolean inList(User user, String allowlist) {
+    Set<String> tokens = parseList(allowlist);
     return tokens.contains(EVERYONE) || tokens.contains(user.getUsername());
   }
 }

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class FilestoreAclChecker {
 
-  static final String EVERYONE = "*";
+  public static final String EVERYONE = "*";
 
   /**
    * Parses a whitelist string into a trimmed, deduplicated set of tokens. Whitespace is stripped

--- a/src/main/java/com/researchspace/service/FilestoreAclChecker.java
+++ b/src/main/java/com/researchspace/service/FilestoreAclChecker.java
@@ -23,13 +23,9 @@ public class FilestoreAclChecker {
 
   public static final String EVERYONE = "*";
 
-  @Autowired @Setter private MessageSourceUtils messages;
+  private @Autowired @Setter MessageSourceUtils messages;
 
-  /**
-   * Parses a whitelist string into a trimmed, deduplicated set of tokens. Whitespace is stripped
-   * around each token; empty tokens are dropped. Returns an empty set for {@code null} or blank
-   * input.
-   */
+  /** Splits a comma-separated whitelist into trimmed, non-empty tokens. */
   public static Set<String> parseList(String whitelist) {
     if (whitelist == null) {
       return Collections.emptySet();

--- a/src/main/java/com/researchspace/service/NfsManager.java
+++ b/src/main/java/com/researchspace/service/NfsManager.java
@@ -49,7 +49,7 @@ public interface NfsManager {
 
   boolean verifyFileStoreNameUniqueForUser(String fileStoreName, User user);
 
-  List<NfsFileSystemInfo> getActiveFileSystemInfos();
+  List<NfsFileSystemInfo> getActiveFileSystemInfos(User user);
 
   void saveNfsFileSystem(NfsFileSystem fileSystem);
 

--- a/src/main/java/com/researchspace/service/archive/export/AbstractArchiveExporter.java
+++ b/src/main/java/com/researchspace/service/archive/export/AbstractArchiveExporter.java
@@ -29,6 +29,7 @@ import com.researchspace.model.record.RecordToFolder;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.DiskSpaceLimitException;
 import com.researchspace.service.FilestoreAclChecker;
+import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.RoRService;
 import com.researchspace.service.archive.ArchiveExportServiceManager;
 import com.researchspace.service.archive.ExportImport;
@@ -65,6 +66,7 @@ public abstract class AbstractArchiveExporter implements ArchiveExportServiceMan
   private @Autowired ArchiveExportPlanner archivePlanner;
   private @Autowired RoRService rorService;
   private @Autowired FilestoreAclChecker filestoreAclChecker;
+  private @Autowired MessageSourceUtils messages;
 
   @Override
   public ArchiveResult exportArchive(
@@ -382,6 +384,7 @@ public abstract class AbstractArchiveExporter implements ArchiveExportServiceMan
     if (aconfig.isIncludeNfsLinks()) {
       NfsExportContext nfsContext = new NfsExportContext(aconfig);
       nfsContext.setAclChecker(filestoreAclChecker);
+      nfsContext.setMessages(messages);
       nfsContext.configureArchiveNfsDirForAssemblyFolder(archiveAssmblyFlder);
       context.setNfsContext(nfsContext);
     }

--- a/src/main/java/com/researchspace/service/archive/export/AbstractArchiveExporter.java
+++ b/src/main/java/com/researchspace/service/archive/export/AbstractArchiveExporter.java
@@ -28,6 +28,7 @@ import com.researchspace.model.record.Record;
 import com.researchspace.model.record.RecordToFolder;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.DiskSpaceLimitException;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.RoRService;
 import com.researchspace.service.archive.ArchiveExportServiceManager;
 import com.researchspace.service.archive.ExportImport;
@@ -63,6 +64,7 @@ public abstract class AbstractArchiveExporter implements ArchiveExportServiceMan
   private @Autowired BeanFactory beanFactory;
   private @Autowired ArchiveExportPlanner archivePlanner;
   private @Autowired RoRService rorService;
+  private @Autowired FilestoreAclChecker filestoreAclChecker;
 
   @Override
   public ArchiveResult exportArchive(
@@ -379,6 +381,7 @@ public abstract class AbstractArchiveExporter implements ArchiveExportServiceMan
     exportObjectGenerator.setExportConfig(aconfig);
     if (aconfig.isIncludeNfsLinks()) {
       NfsExportContext nfsContext = new NfsExportContext(aconfig);
+      nfsContext.setAclChecker(filestoreAclChecker);
       nfsContext.configureArchiveNfsDirForAssemblyFolder(archiveAssmblyFlder);
       context.setNfsContext(nfsContext);
     }

--- a/src/main/java/com/researchspace/service/archive/export/NfsExportContext.java
+++ b/src/main/java/com/researchspace/service/archive/export/NfsExportContext.java
@@ -12,6 +12,7 @@ import com.researchspace.netfiles.NfsFolderDetails;
 import com.researchspace.netfiles.NfsResourceDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.service.DiskSpaceChecker;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsFileHandler;
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +45,8 @@ public class NfsExportContext {
   private Map<String, String> folderSummaryMsgs = new HashMap<>();
 
   private IArchiveExportConfig exportConfig;
+
+  private FilestoreAclChecker aclChecker;
 
   public NfsExportContext(IArchiveExportConfig aconfig) {
     exportConfig = aconfig;
@@ -83,6 +86,15 @@ public class NfsExportContext {
           "skipping export of nfs element "
               + nfsTarget.getPath()
               + " as user not logged into "
+              + fileSystemId);
+      return null;
+    }
+    if (aclChecker != null && !aclChecker.canRead(exportConfig.getExporter(), fileSystem)) {
+      errors.put(fileMapKey, "no read access to '" + fileSystem.getName() + "' File System");
+      log.info(
+          "skipping export of nfs element "
+              + nfsTarget.getPath()
+              + " as user has no read access to filesystem "
               + fileSystemId);
       return null;
     }

--- a/src/main/java/com/researchspace/service/archive/export/NfsExportContext.java
+++ b/src/main/java/com/researchspace/service/archive/export/NfsExportContext.java
@@ -2,6 +2,7 @@ package com.researchspace.service.archive.export;
 
 import com.researchspace.archive.ArchivalNfsFile;
 import com.researchspace.archive.model.IArchiveExportConfig;
+import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsElement;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
@@ -95,7 +96,8 @@ public class NfsExportContext {
               + fileSystemId);
       return null;
     }
-    if (aclChecker != null && !aclChecker.canRead(exportConfig.getExporter(), fileSystem)) {
+    User exporter = exportConfig.getExporter();
+    if (aclChecker != null && (exporter == null || !aclChecker.canRead(exporter, fileSystem))) {
       errors.put(
           fileMapKey,
           messages.getMessage(

--- a/src/main/java/com/researchspace/service/archive/export/NfsExportContext.java
+++ b/src/main/java/com/researchspace/service/archive/export/NfsExportContext.java
@@ -13,6 +13,7 @@ import com.researchspace.netfiles.NfsResourceDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.service.DiskSpaceChecker;
 import com.researchspace.service.FilestoreAclChecker;
+import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.NfsFileHandler;
 import java.io.File;
 import java.io.IOException;
@@ -48,6 +49,8 @@ public class NfsExportContext {
 
   private FilestoreAclChecker aclChecker;
 
+  private MessageSourceUtils messages;
+
   public NfsExportContext(IArchiveExportConfig aconfig) {
     exportConfig = aconfig;
     nfsClients = aconfig.getAvailableNfsClients();
@@ -81,7 +84,10 @@ public class NfsExportContext {
     String fileMapKey = fileSystemId + "_" + nfsTarget.getPath();
     NfsClient nfsClient = nfsClients.get(fileSystemId);
     if (nfsClient == null || !nfsClient.isUserLoggedIn()) {
-      errors.put(fileMapKey, "user not logged into '" + fileSystem.getName() + "' File System");
+      errors.put(
+          fileMapKey,
+          messages.getMessage(
+              "archive.export.nfs.user.not.logged.in", new Object[] {fileSystem.getName()}));
       log.info(
           "skipping export of nfs element "
               + nfsTarget.getPath()
@@ -90,7 +96,10 @@ public class NfsExportContext {
       return null;
     }
     if (aclChecker != null && !aclChecker.canRead(exportConfig.getExporter(), fileSystem)) {
-      errors.put(fileMapKey, "no read access to '" + fileSystem.getName() + "' File System");
+      errors.put(
+          fileMapKey,
+          messages.getMessage(
+              "archive.export.nfs.no.read.access", new Object[] {fileSystem.getName()}));
       log.info(
           "skipping export of nfs element "
               + nfsTarget.getPath()
@@ -113,11 +122,13 @@ public class NfsExportContext {
           if (nfsFileDetails != null) {
             diskSpaceChecker.assertEnoughDiskSpaceToCopyFileSizeIntoArchiveDir(
                 nfsFileDetails.getSize(), archiveAssemblyDir);
-            skippedMsg = checkNfsExportFiltersMsgForFile(nfsFileDetails, exportConfig);
+            skippedMsg = checkNfsExportFiltersMsgForFile(nfsFileDetails, exportConfig, messages);
           }
           if (skippedMsg != null) {
             log.info("skipping nfs file " + nfsTarget + ": " + skippedMsg);
-            errors.put(fileMapKey, "file skipped (" + skippedMsg + ")");
+            errors.put(
+                fileMapKey,
+                messages.getMessage("archive.export.nfs.file.skipped", new Object[] {skippedMsg}));
           } else {
             downloadedNfsDetails =
                 nfsFileHandler.downloadNfsFileToRSpace(nfsTarget, nfsClient, targetDir);
@@ -128,7 +139,10 @@ public class NfsExportContext {
         }
       } catch (IOException e) {
         log.info("download error when trying to export nfs element: " + nfsTarget, e);
-        errors.put(fileMapKey, "download error: " + e.getMessage());
+        errors.put(
+            fileMapKey,
+            messages.getMessage(
+                "archive.export.nfs.download.error", new Object[] {e.getMessage()}));
       }
       resolvedResources.put(fileMapKey, downloadedNfsDetails);
     }
@@ -140,7 +154,9 @@ public class NfsExportContext {
    *     included
    */
   public static String checkNfsExportFiltersMsgForFile(
-      NfsFileDetails nfsFileDetails, IArchiveExportConfig exportConfig) {
+      NfsFileDetails nfsFileDetails,
+      IArchiveExportConfig exportConfig,
+      MessageSourceUtils messages) {
     if (exportConfig == null) {
       return null;
     }
@@ -150,13 +166,14 @@ public class NfsExportContext {
 
     if (nfsFileDetails != null) {
       if (fileSizeLimit > 0 && nfsFileDetails.getSize() > fileSizeLimit) {
-        return "file larger than provided size limit";
+        return messages.getMessage("archive.export.nfs.file.too.large", null);
       }
       String fileExtensionLowerCase =
           FilenameUtils.getExtension(nfsFileDetails.getName()).toLowerCase();
       if (CollectionUtils.isNotEmpty(excludedFileExtensions)
           && excludedFileExtensions.contains(fileExtensionLowerCase)) {
-        return "file extension '" + fileExtensionLowerCase + "' excluded";
+        return messages.getMessage(
+            "archive.export.nfs.file.extension.excluded", new Object[] {fileExtensionLowerCase});
       }
     }
     return null;
@@ -185,7 +202,7 @@ public class NfsExportContext {
 
     String internalSummaryMsg = folderSummaryMsgs.get(folderKey);
     if (internalSummaryMsg == null) {
-      return "empty folder";
+      return messages.getMessage("archive.export.nfs.folder.empty", null);
     }
 
     List<String> included = new ArrayList<>();
@@ -200,10 +217,18 @@ public class NfsExportContext {
     }
     String downloadSummaryMsg = "";
     if (included.size() > 0) {
-      downloadSummaryMsg += "Included: " + String.join(", ", included) + "; ";
+      downloadSummaryMsg +=
+          messages.getMessage("archive.export.nfs.folder.included.label", null)
+              + ": "
+              + String.join(", ", included)
+              + "; ";
     }
     if (skipped.size() > 0) {
-      downloadSummaryMsg += "Skipped: " + String.join(", ", skipped) + ";";
+      downloadSummaryMsg +=
+          messages.getMessage("archive.export.nfs.folder.skipped.label", null)
+              + ": "
+              + String.join(", ", skipped)
+              + ";";
     }
     return downloadSummaryMsg;
   }
@@ -261,7 +286,10 @@ public class NfsExportContext {
       if (childDetails != null) {
         childMsg = "included";
       } else {
-        childMsg = child.isFolder() ? "skipped as subfolder" : errors.get(childKey);
+        childMsg =
+            child.isFolder()
+                ? messages.getMessage("archive.export.nfs.folder.skipped.as.subfolder", null)
+                : errors.get(childKey);
       }
       String childSummaryMsg = String.format("%s::%s;;", child.getName(), childMsg);
       String newFolderSummary = folderSummaryMsgs.getOrDefault(folderKey, "") + childSummaryMsg;

--- a/src/main/java/com/researchspace/service/impl/FilestoreWriteManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/FilestoreWriteManagerImpl.java
@@ -20,6 +20,7 @@ import com.researchspace.netfiles.WritableNfsClient;
 import com.researchspace.netfiles.WriteAttribution;
 import com.researchspace.service.BaseRecordManager;
 import com.researchspace.service.ExternalStorageManager;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.FilestoreWriteManager;
 import com.researchspace.service.NfsManager;
 import java.io.IOException;
@@ -47,6 +48,7 @@ public class FilestoreWriteManagerImpl implements FilestoreWriteManager {
   @Autowired @Setter private BaseRecordManager baseRecordManager;
   @Autowired @Setter private ExternalStorageManager externalStorageManager;
   @Autowired @Setter private GalleryFilestoresCredentialsStore credentialsStore;
+  @Autowired @Setter private FilestoreAclChecker aclChecker;
 
   @Override
   public UploadOutcome uploadToFilestore(
@@ -58,6 +60,7 @@ public class FilestoreWriteManagerImpl implements FilestoreWriteManager {
 
     Set<Long> recordIds = request.getRecordIds();
     NfsFileStore filestore = validateInputAndGetFilestore(recordIds, filestoreId, errors);
+    aclChecker.assertCanWrite(user, filestore.getFileSystem());
     WritableNfsClient writableClient =
         resolveWritableClient(user, filestore, request.getCredentials(), errors);
     String absolutePath = resolveAbsoluteFilestorePath(filestore);
@@ -138,6 +141,9 @@ public class FilestoreWriteManagerImpl implements FilestoreWriteManager {
               "Could not find file store with id: " + request.getDestFilestoreId()));
     }
     throwBindExceptionIfErrors(errors);
+
+    aclChecker.assertCanWrite(user, sourceFilestore.getFileSystem());
+    aclChecker.assertCanWrite(user, destFilestore.getFileSystem());
 
     WritableNfsClient sourceClient = resolveWritableClient(user, sourceFilestore, null, errors);
     WritableNfsClient destClient = resolveWritableClient(user, destFilestore, null, errors);

--- a/src/main/java/com/researchspace/service/impl/FilestoreWriteManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/FilestoreWriteManagerImpl.java
@@ -142,7 +142,13 @@ public class FilestoreWriteManagerImpl implements FilestoreWriteManager {
     }
     throwBindExceptionIfErrors(errors);
 
-    aclChecker.assertCanWrite(user, sourceFilestore.getFileSystem());
+    // the transfer reads the source and writes the destination; the source is only modified
+    // when deleteSource is set, so it needs read access unless we are deleting from it.
+    if (request.isDeleteSource()) {
+      aclChecker.assertCanWrite(user, sourceFilestore.getFileSystem());
+    } else {
+      aclChecker.assertCanRead(user, sourceFilestore.getFileSystem());
+    }
     aclChecker.assertCanWrite(user, destFilestore.getFileSystem());
 
     WritableNfsClient sourceClient = resolveWritableClient(user, sourceFilestore, null, errors);

--- a/src/main/java/com/researchspace/service/impl/NfsExportManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/NfsExportManagerImpl.java
@@ -22,6 +22,7 @@ import com.researchspace.netfiles.NfsFolderDetails;
 import com.researchspace.netfiles.NfsResourceDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.service.DiskSpaceChecker;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsExportManager;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.archive.export.NfsExportContext;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -47,6 +49,8 @@ public class NfsExportManagerImpl implements NfsExportManager {
   @Autowired private DiskSpaceChecker diskSpaceChecker;
 
   @Autowired private NfsManager nfsManager;
+
+  @Autowired @Setter private FilestoreAclChecker aclChecker;
 
   @Override
   public NfsExportPlan generateQuickExportPlan(List<GlobalIdentifier> recordsToExport) {
@@ -109,7 +113,7 @@ public class NfsExportManagerImpl implements NfsExportManager {
       IArchiveExportConfig archiveExportConfig) {
 
     plan.clearCheckedNfsLinks();
-    checkFoundLinksOnConnectedFileSystems(plan, nfsClients);
+    checkFoundLinksOnConnectedFileSystems(plan, nfsClients, archiveExportConfig.getExporter());
     addExportFilterMsgForCheckedLinksInPlan(plan, archiveExportConfig);
     setArchiveSizeLimitProperties(plan);
   }
@@ -122,7 +126,7 @@ public class NfsExportManagerImpl implements NfsExportManager {
       "not logged into connected File System";
 
   private void checkFoundLinksOnConnectedFileSystems(
-      NfsExportPlan plan, Map<Long, NfsClient> nfsClients) {
+      NfsExportPlan plan, Map<Long, NfsClient> nfsClients, User exporter) {
     for (NfsElement nfsElem : plan.getFoundNfsLinks().values()) {
       NfsFileStore fileStore = plan.getFoundFileStoresByIdMap().get(nfsElem.getFileStoreId());
       Long fileSystemId = fileStore.getFileSystem().getId();
@@ -134,6 +138,9 @@ public class NfsExportManagerImpl implements NfsExportManager {
         NfsClient nfsClient = nfsClients.get(fileSystemId);
         if (nfsClient == null || !nfsClient.isUserLoggedIn()) {
           plan.addCheckedNfsLinkMsg(fileSystemId, absolutePath, NOT_LOGGED_INTO_FILE_SYSTEM_MSG);
+        } else if (aclChecker != null && !aclChecker.canRead(exporter, fileStore.getFileSystem())) {
+          // skip the remote query when the exporter has no read access on the filesystem
+          plan.addCheckedNfsLinkMsg(fileSystemId, absolutePath, RESOURCE_NOT_ACCESSIBLE_MSG);
         } else {
           if (nfsElem.isFolderLink()) {
             try {

--- a/src/main/java/com/researchspace/service/impl/NfsExportManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/NfsExportManagerImpl.java
@@ -122,12 +122,14 @@ public class NfsExportManagerImpl implements NfsExportManager {
     setArchiveSizeLimitProperties(plan);
   }
 
-  public static final String SUBFOLDER_NOT_INCLUDED_MSG = "subfolder of linked folder";
+  public static final String SUBFOLDER_NOT_INCLUDED_MSG_KEY =
+      "archive.export.nfs.subfolder.not.included";
 
-  public static final String RESOURCE_NOT_ACCESSIBLE_MSG = "resource not accessible";
+  public static final String RESOURCE_NOT_ACCESSIBLE_MSG_KEY =
+      "archive.export.nfs.resource.not.accessible";
 
-  public static final String NOT_LOGGED_INTO_FILE_SYSTEM_MSG =
-      "not logged into connected File System";
+  public static final String NOT_LOGGED_INTO_FILE_SYSTEM_MSG_KEY =
+      "archive.export.nfs.not.logged.in";
 
   private void checkFoundLinksOnConnectedFileSystems(
       NfsExportPlan plan, Map<Long, NfsClient> nfsClients, User exporter) {
@@ -141,12 +143,14 @@ public class NfsExportManagerImpl implements NfsExportManager {
         NfsResourceDetails foundDetails = null;
         NfsClient nfsClient = nfsClients.get(fileSystemId);
         if (nfsClient == null || !nfsClient.isUserLoggedIn()) {
-          plan.addCheckedNfsLinkMsg(fileSystemId, absolutePath, NOT_LOGGED_INTO_FILE_SYSTEM_MSG);
+          plan.addCheckedNfsLinkMsg(
+              fileSystemId, absolutePath, messages.getMessage(NOT_LOGGED_INTO_FILE_SYSTEM_MSG_KEY));
         } else if (exporter != null
             && aclChecker != null
             && !aclChecker.canRead(exporter, fileStore.getFileSystem())) {
           // skip the remote query when the exporter has no read access on the filesystem
-          plan.addCheckedNfsLinkMsg(fileSystemId, absolutePath, RESOURCE_NOT_ACCESSIBLE_MSG);
+          plan.addCheckedNfsLinkMsg(
+              fileSystemId, absolutePath, messages.getMessage(RESOURCE_NOT_ACCESSIBLE_MSG_KEY));
         } else {
           if (nfsElem.isFolderLink()) {
             try {
@@ -158,7 +162,8 @@ public class NfsExportManagerImpl implements NfsExportManager {
             foundDetails = nfsClient.queryForNfsFile(nfsTarget);
           }
           if (foundDetails == null) {
-            plan.addCheckedNfsLinkMsg(fileSystemId, absolutePath, RESOURCE_NOT_ACCESSIBLE_MSG);
+            plan.addCheckedNfsLinkMsg(
+                fileSystemId, absolutePath, messages.getMessage(RESOURCE_NOT_ACCESSIBLE_MSG_KEY));
           } else {
             NfsExportContext.applyFileSystemIdToNfsResource(foundDetails, fileSystemId);
           }
@@ -185,7 +190,7 @@ public class NfsExportManagerImpl implements NfsExportManager {
               plan.addCheckedNfsLinkMsg(
                   folderContentResource.getFileSystemId(),
                   folderContentResource.getFileSystemFullPath(),
-                  SUBFOLDER_NOT_INCLUDED_MSG);
+                  messages.getMessage(SUBFOLDER_NOT_INCLUDED_MSG_KEY));
             }
           }
         }

--- a/src/main/java/com/researchspace/service/impl/NfsExportManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/NfsExportManagerImpl.java
@@ -116,7 +116,8 @@ public class NfsExportManagerImpl implements NfsExportManager {
       IArchiveExportConfig archiveExportConfig) {
 
     plan.clearCheckedNfsLinks();
-    checkFoundLinksOnConnectedFileSystems(plan, nfsClients, archiveExportConfig.getExporter());
+    User exporter = archiveExportConfig == null ? null : archiveExportConfig.getExporter();
+    checkFoundLinksOnConnectedFileSystems(plan, nfsClients, exporter);
     addExportFilterMsgForCheckedLinksInPlan(plan, archiveExportConfig);
     setArchiveSizeLimitProperties(plan);
   }
@@ -141,7 +142,9 @@ public class NfsExportManagerImpl implements NfsExportManager {
         NfsClient nfsClient = nfsClients.get(fileSystemId);
         if (nfsClient == null || !nfsClient.isUserLoggedIn()) {
           plan.addCheckedNfsLinkMsg(fileSystemId, absolutePath, NOT_LOGGED_INTO_FILE_SYSTEM_MSG);
-        } else if (aclChecker != null && !aclChecker.canRead(exporter, fileStore.getFileSystem())) {
+        } else if (exporter != null
+            && aclChecker != null
+            && !aclChecker.canRead(exporter, fileStore.getFileSystem())) {
           // skip the remote query when the exporter has no read access on the filesystem
           plan.addCheckedNfsLinkMsg(fileSystemId, absolutePath, RESOURCE_NOT_ACCESSIBLE_MSG);
         } else {

--- a/src/main/java/com/researchspace/service/impl/NfsExportManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/NfsExportManagerImpl.java
@@ -23,6 +23,7 @@ import com.researchspace.netfiles.NfsResourceDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.service.DiskSpaceChecker;
 import com.researchspace.service.FilestoreAclChecker;
+import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.NfsExportManager;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.archive.export.NfsExportContext;
@@ -51,6 +52,8 @@ public class NfsExportManagerImpl implements NfsExportManager {
   @Autowired private NfsManager nfsManager;
 
   @Autowired @Setter private FilestoreAclChecker aclChecker;
+
+  @Autowired @Setter private MessageSourceUtils messages;
 
   @Override
   public NfsExportPlan generateQuickExportPlan(List<GlobalIdentifier> recordsToExport) {
@@ -188,7 +191,8 @@ public class NfsExportManagerImpl implements NfsExportManager {
 
     for (NfsFileDetails fileToCheck : nfsFilesToCheck) {
       String exportFiltersMsg =
-          NfsExportContext.checkNfsExportFiltersMsgForFile(fileToCheck, archiveExportConfig);
+          NfsExportContext.checkNfsExportFiltersMsgForFile(
+              fileToCheck, archiveExportConfig, messages);
       if (exportFiltersMsg != null) {
         plan.addCheckedNfsLinkMsg(
             fileToCheck.getFileSystemId(), fileToCheck.getFileSystemFullPath(), exportFiltersMsg);

--- a/src/main/java/com/researchspace/service/impl/NfsManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/NfsManagerImpl.java
@@ -9,6 +9,7 @@ import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileStoreInfo;
 import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.model.netfiles.NfsFileSystemInfo;
+import com.researchspace.model.netfiles.NfsUserPermissions;
 import com.researchspace.netfiles.NfsAuthException;
 import com.researchspace.netfiles.NfsAuthentication;
 import com.researchspace.netfiles.NfsClient;
@@ -16,6 +17,7 @@ import com.researchspace.netfiles.NfsException;
 import com.researchspace.netfiles.NfsFactory;
 import com.researchspace.netfiles.WritableNfsClient;
 import com.researchspace.netfiles.WriteAttribution;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsManager;
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +43,7 @@ public class NfsManagerImpl implements NfsManager {
 
   private @Autowired NfsDao nfsDao;
   private @Autowired @Setter NfsFactory nfsFactory;
+  private @Autowired @Setter FilestoreAclChecker aclChecker;
 
   @Autowired
   @Setter
@@ -93,7 +96,9 @@ public class NfsManagerImpl implements NfsManager {
     List<NfsFileStore> userStores = nfsDao.getUserFileStores(user.getId());
     List<NfsFileStoreInfo> userStoreInfos = new ArrayList<>();
     for (NfsFileStore us : userStores) {
-      userStoreInfos.add(us.toFileStoreInfo());
+      NfsFileStoreInfo info = us.toFileStoreInfo();
+      info.setUserPermissions(buildPermissions(user, us.getFileSystem()));
+      userStoreInfos.add(info);
     }
     return userStoreInfos;
   }
@@ -107,12 +112,21 @@ public class NfsManagerImpl implements NfsManager {
   }
 
   @Override
-  public List<NfsFileSystemInfo> getActiveFileSystemInfos() {
+  public List<NfsFileSystemInfo> getActiveFileSystemInfos(User user) {
     List<NfsFileSystemInfo> activeSystemInfos = new ArrayList<>();
     for (NfsFileSystem as : getActiveFileSystems()) {
-      activeSystemInfos.add(as.toFileSystemInfo());
+      NfsFileSystemInfo info = as.toFileSystemInfo();
+      info.setUserPermissions(buildPermissions(user, as));
+      activeSystemInfos.add(info);
     }
     return activeSystemInfos;
+  }
+
+  private NfsUserPermissions buildPermissions(User user, NfsFileSystem fs) {
+    if (user == null || fs == null) {
+      return null;
+    }
+    return new NfsUserPermissions(aclChecker.canRead(user, fs), aclChecker.canWrite(user, fs));
   }
 
   /*

--- a/src/main/java/com/researchspace/service/impl/NfsManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/NfsManagerImpl.java
@@ -123,7 +123,7 @@ public class NfsManagerImpl implements NfsManager {
   }
 
   private NfsUserPermissions buildPermissions(User user, NfsFileSystem fs) {
-    if (user == null || fs == null) {
+    if (user == null) {
       return null;
     }
     return new NfsUserPermissions(aclChecker.canRead(user, fs), aclChecker.canWrite(user, fs));

--- a/src/main/java/com/researchspace/webapp/controller/NfsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsController.java
@@ -13,6 +13,7 @@ import com.researchspace.netfiles.NfsClient;
 import com.researchspace.netfiles.NfsFileDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.netfiles.NfsViewProperty;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsFileHandler;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.UserKeyManager;
@@ -67,6 +68,8 @@ public class NfsController extends BaseController {
   @Autowired private NfsFileHandler nfsFileHandler;
 
   @Autowired private UserKeyManager userKeyManager;
+
+  @Autowired private FilestoreAclChecker aclChecker;
 
   /**
    * @return a view of login dialog for file system
@@ -218,6 +221,7 @@ public class NfsController extends BaseController {
     if (fileStore == null) {
       throw new IllegalArgumentException("could not find file store with id: " + fileStoreId);
     }
+    aclChecker.assertCanRead(user, fileStore.getFileSystem());
 
     Long fileSystemId = fileStore.getFileSystem().getId();
     if (!nfsManager.checkIfUserLoggedIn(fileSystemId, nfsClients, user)) {
@@ -264,6 +268,7 @@ public class NfsController extends BaseController {
     if (fileStore == null) {
       throw new IllegalArgumentException("could not find file store with id: " + fileStoreId);
     }
+    aclChecker.assertCanRead(user, fileStore.getFileSystem());
 
     Long fileSystemId = fileStore.getFileSystem().getId();
     if (!nfsManager.checkIfUserLoggedIn(fileSystemId, nfsClients, user)) {

--- a/src/main/java/com/researchspace/webapp/controller/NfsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsController.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
@@ -69,7 +70,7 @@ public class NfsController extends BaseController {
 
   @Autowired private UserKeyManager userKeyManager;
 
-  @Autowired private FilestoreAclChecker aclChecker;
+  @Autowired @Setter private FilestoreAclChecker aclChecker;
 
   /**
    * @return a view of login dialog for file system
@@ -140,6 +141,7 @@ public class NfsController extends BaseController {
         return getText(NO_FILE_PATHS_IN_DIR_NAME);
     }
     User user = getPrincipalUser(p);
+    aclChecker.assertCanRead(user, nfsManager.getFileSystem(nfsLoginData.getFileSystemId()));
     Map<Long, NfsClient> nfsClients = retrieveNfsClientsMapFromSession(request);
 
     String loginResult =

--- a/src/main/java/com/researchspace/webapp/controller/NfsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsController.java
@@ -78,9 +78,9 @@ public class NfsController extends BaseController {
   }
 
   private void addFileStoresAndFileSystemsToView(Model model, Principal p) {
-    List<NfsFileStoreInfo> userStoreInfos =
-        nfsManager.getFileStoreInfosForUser(getPrincipalUser(p));
-    List<NfsFileSystemInfo> activeSystemInfos = nfsManager.getActiveFileSystemInfos();
+    User principalUser = getPrincipalUser(p);
+    List<NfsFileStoreInfo> userStoreInfos = nfsManager.getFileStoreInfosForUser(principalUser);
+    List<NfsFileSystemInfo> activeSystemInfos = nfsManager.getActiveFileSystemInfos(principalUser);
 
     String userStoresJson = null;
     String activeSystemsJson = null;

--- a/src/main/java/com/researchspace/webapp/controller/NfsFileSystemSaveResult.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsFileSystemSaveResult.java
@@ -15,6 +15,6 @@ public class NfsFileSystemSaveResult implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private Long fileSystemId;
-  private List<String> unknownReadWhitelistUsernames;
-  private List<String> unknownWriteWhitelistUsernames;
+  private List<String> unknownReadAllowlistUsernames;
+  private List<String> unknownWriteAllowlistUsernames;
 }

--- a/src/main/java/com/researchspace/webapp/controller/NfsFileSystemSaveResult.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsFileSystemSaveResult.java
@@ -6,11 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Response payload for the sysadmin save-filesystem endpoint. Carries the saved filesystem id and
- * any non-fatal warnings raised during validation (currently the list of whitelisted usernames that
- * do not match any RSpace user; the save still succeeds and the list is persisted as typed).
- */
+/** Response payload for the sysadmin save-filesystem endpoint. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/researchspace/webapp/controller/NfsFileSystemSaveResult.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsFileSystemSaveResult.java
@@ -1,0 +1,24 @@
+package com.researchspace.webapp.controller;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response payload for the sysadmin save-filesystem endpoint. Carries the saved filesystem id and
+ * any non-fatal warnings raised during validation (currently the list of whitelisted usernames that
+ * do not match any RSpace user; the save still succeeds and the list is persisted as typed).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NfsFileSystemSaveResult implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private Long fileSystemId;
+  private List<String> unknownReadWhitelistUsernames;
+  private List<String> unknownWriteWhitelistUsernames;
+}

--- a/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
@@ -70,8 +70,8 @@ public class NfsSysAdminController extends BaseController {
     assertIsSysAdmin();
     rejectIfUsernamesInBothLists(nfsFileSystem);
 
-    List<String> unknownReaders = findUnknownUsernames(nfsFileSystem.getReadWhitelist());
-    List<String> unknownWriters = findUnknownUsernames(nfsFileSystem.getWriteWhitelist());
+    List<String> unknownReaders = findUnknownUsernames(nfsFileSystem.getReadAllowlist());
+    List<String> unknownWriters = findUnknownUsernames(nfsFileSystem.getWriteAllowlist());
 
     nfsManager.saveNfsFileSystem(nfsFileSystem);
     return new NfsFileSystemSaveResult(nfsFileSystem.getId(), unknownReaders, unknownWriters);
@@ -84,8 +84,8 @@ public class NfsSysAdminController extends BaseController {
    */
   private void rejectIfUsernamesInBothLists(NfsFileSystem nfsFileSystem) {
     Set<String> intersection =
-        new LinkedHashSet<>(FilestoreAclChecker.parseList(nfsFileSystem.getReadWhitelist()));
-    intersection.retainAll(FilestoreAclChecker.parseList(nfsFileSystem.getWriteWhitelist()));
+        new LinkedHashSet<>(FilestoreAclChecker.parseList(nfsFileSystem.getReadAllowlist()));
+    intersection.retainAll(FilestoreAclChecker.parseList(nfsFileSystem.getWriteAllowlist()));
     intersection.remove(FilestoreAclChecker.EVERYONE);
     if (!intersection.isEmpty()) {
       throw new IllegalArgumentException(
@@ -96,13 +96,13 @@ public class NfsSysAdminController extends BaseController {
   }
 
   /**
-   * Returns the subset of whitelisted usernames that do not correspond to any RSpace user. The
+   * Returns the subset of allowlisted usernames that do not correspond to any RSpace user. The
    * 'everyone' sentinel ({@code *}) is ignored. The list is preserved as typed so that sysadmins
    * can pre-provision access for users who have not signed up yet; this is a non-fatal warning.
    */
-  private List<String> findUnknownUsernames(String whitelist) {
+  private List<String> findUnknownUsernames(String allowlist) {
     List<String> unknown = new ArrayList<>();
-    for (String token : FilestoreAclChecker.parseList(whitelist)) {
+    for (String token : FilestoreAclChecker.parseList(allowlist)) {
       if (FilestoreAclChecker.EVERYONE.equals(token)) {
         continue;
       }

--- a/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
@@ -5,7 +5,9 @@ import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsManager;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -65,12 +67,31 @@ public class NfsSysAdminController extends BaseController {
   @ResponseBody
   public NfsFileSystemSaveResult saveFileSystem(@RequestBody NfsFileSystem nfsFileSystem) {
     assertIsSysAdmin();
+    rejectIfUsernamesInBothLists(nfsFileSystem);
 
     List<String> unknownReaders = findUnknownUsernames(nfsFileSystem.getReadWhitelist());
     List<String> unknownWriters = findUnknownUsernames(nfsFileSystem.getWriteWhitelist());
 
     nfsManager.saveNfsFileSystem(nfsFileSystem);
     return new NfsFileSystemSaveResult(nfsFileSystem.getId(), unknownReaders, unknownWriters);
+  }
+
+  /**
+   * Read-only and read+write lists are conceptually disjoint under the new UI labels; a named
+   * username appearing in both is treated as a sysadmin mistake. The 'everyone' sentinel is exempt
+   * because each list independently expressing 'everyone' is a legitimate configuration.
+   */
+  private void rejectIfUsernamesInBothLists(NfsFileSystem nfsFileSystem) {
+    Set<String> intersection =
+        new LinkedHashSet<>(FilestoreAclChecker.parseList(nfsFileSystem.getReadWhitelist()));
+    intersection.retainAll(FilestoreAclChecker.parseList(nfsFileSystem.getWriteWhitelist()));
+    intersection.remove(FilestoreAclChecker.EVERYONE);
+    if (!intersection.isEmpty()) {
+      throw new IllegalArgumentException(
+          "These users are listed for both read and write access; please remove them"
+              + " from one of the lists: "
+              + String.join(", ", intersection));
+    }
   }
 
   /**

--- a/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
@@ -2,7 +2,9 @@ package com.researchspace.webapp.controller;
 
 import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsFileSystem;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsManager;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -61,10 +63,36 @@ public class NfsSysAdminController extends BaseController {
 
   @PostMapping("/save")
   @ResponseBody
-  public Long saveFileSystem(@RequestBody NfsFileSystem nfsFileSystem) {
+  public NfsFileSystemSaveResult saveFileSystem(@RequestBody NfsFileSystem nfsFileSystem) {
     assertIsSysAdmin();
+
+    List<String> unknownReaders = findUnknownUsernames(nfsFileSystem.getReadWhitelist());
+    List<String> unknownWriters = findUnknownUsernames(nfsFileSystem.getWriteWhitelist());
+
     nfsManager.saveNfsFileSystem(nfsFileSystem);
-    return nfsFileSystem.getId();
+    return new NfsFileSystemSaveResult(nfsFileSystem.getId(), unknownReaders, unknownWriters);
+  }
+
+  /**
+   * Returns the subset of whitelisted usernames that do not correspond to any RSpace user. The
+   * 'everyone' sentinel ({@code *}) is ignored. The list is preserved as typed so that sysadmins
+   * can pre-provision access for users who have not signed up yet; this is a non-fatal warning.
+   */
+  private List<String> findUnknownUsernames(String whitelist) {
+    List<String> unknown = new ArrayList<>();
+    for (String token : FilestoreAclChecker.parseList(whitelist)) {
+      if (FilestoreAclChecker.EVERYONE.equals(token)) {
+        continue;
+      }
+      try {
+        if (userManager.getUserByUsername(token) == null) {
+          unknown.add(token);
+        }
+      } catch (RuntimeException notFound) {
+        unknown.add(token);
+      }
+    }
+    return unknown;
   }
 
   @PostMapping("/delete")

--- a/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
@@ -89,9 +89,9 @@ public class NfsSysAdminController extends BaseController {
     intersection.remove(FilestoreAclChecker.EVERYONE);
     if (!intersection.isEmpty()) {
       throw new IllegalArgumentException(
-          "These users are listed for both read and write access; please remove them"
-              + " from one of the lists: "
-              + String.join(", ", intersection));
+          getText(
+              "netfilestores.acl.users.in.both.lists",
+              new Object[] {String.join(", ", intersection)}));
     }
   }
 

--- a/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsSysAdminController.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -109,7 +110,10 @@ public class NfsSysAdminController extends BaseController {
         if (userManager.getUserByUsername(token) == null) {
           unknown.add(token);
         }
-      } catch (RuntimeException notFound) {
+      } catch (ObjectRetrievalFailureException notFound) {
+        // The default Hibernate-backed implementation throws this when the user
+        // does not exist; other RuntimeExceptions (e.g. DB connectivity) are not
+        // swallowed so they surface to the caller and the save is aborted.
         unknown.add(token);
       }
     }

--- a/src/main/resources/bundles/gallery/netfiles.properties
+++ b/src/main/resources/bundles/gallery/netfiles.properties
@@ -29,3 +29,6 @@ archive.export.nfs.folder.empty=empty folder
 archive.export.nfs.folder.skipped.as.subfolder=skipped as subfolder
 archive.export.nfs.folder.included.label=Included
 archive.export.nfs.folder.skipped.label=Skipped
+archive.export.nfs.subfolder.not.included=subfolder of linked folder
+archive.export.nfs.resource.not.accessible=resource not accessible
+archive.export.nfs.not.logged.in=not logged into connected File System

--- a/src/main/resources/bundles/gallery/netfiles.properties
+++ b/src/main/resources/bundles/gallery/netfiles.properties
@@ -14,3 +14,7 @@ net.filestores.error.download=Couldn't retrieve the file, please try again or co
 net.filestores.validation.no.username=Please provide the username
 net.filestores.validation.no.password=Please provide the password
 net.filestores.validation.no.key=Please generate ssh key first
+
+netfilestores.acl.denied.read=User ''{0}'' has no read access to filesystem ''{1}''
+netfilestores.acl.denied.write=User ''{0}'' has no write access to filesystem ''{1}''
+netfilestores.acl.users.in.both.lists=These users are listed for both read and write access; please remove them from one of the lists: {0}

--- a/src/main/resources/bundles/gallery/netfiles.properties
+++ b/src/main/resources/bundles/gallery/netfiles.properties
@@ -18,3 +18,14 @@ net.filestores.validation.no.key=Please generate ssh key first
 netfilestores.acl.denied.read=User ''{0}'' has no read access to filesystem ''{1}''
 netfilestores.acl.denied.write=User ''{0}'' has no write access to filesystem ''{1}''
 netfilestores.acl.users.in.both.lists=These users are listed for both read and write access; please remove them from one of the lists: {0}
+
+archive.export.nfs.user.not.logged.in=user not logged into ''{0}'' File System
+archive.export.nfs.no.read.access=no read access to ''{0}'' File System
+archive.export.nfs.file.skipped=file skipped ({0})
+archive.export.nfs.download.error=download error: {0}
+archive.export.nfs.file.too.large=file larger than provided size limit
+archive.export.nfs.file.extension.excluded=file extension ''{0}'' excluded
+archive.export.nfs.folder.empty=empty folder
+archive.export.nfs.folder.skipped.as.subfolder=skipped as subfolder
+archive.export.nfs.folder.included.label=Included
+archive.export.nfs.folder.skipped.label=Skipped

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -300,11 +300,11 @@ system.netfilesystem.details.auth.none=None (Server-wide access)
 system.netfilesystem.details.button.add=Add
 system.netfilesystem.details.button.update=Update
 system.netfilesystem.button.add.new.filesystem=Add new File System
-system.netfilesystem.details.whitelists.write.question=Who can write to this file system?
-system.netfilesystem.details.whitelists.read.question=Who can read from this file system?
-system.netfilesystem.details.whitelists.anyone=Anyone with an RSpace account
-system.netfilesystem.details.whitelists.only.these=Only the following users:
-system.netfilesystem.details.whitelists.nobody=Nobody (read access only)
+system.netfilesystem.details.allowlists.write.question=Who can write to this file system?
+system.netfilesystem.details.allowlists.read.question=Who can read from this file system?
+system.netfilesystem.details.allowlists.anyone=Anyone with an RSpace account
+system.netfilesystem.details.allowlists.only.these=Only the following users:
+system.netfilesystem.details.allowlists.nobody=Nobody (read access only)
 
 # LDAP settings page
 system.ldap.button.run.sid.retrieval=Retrieve SID values for LDAP users

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -300,10 +300,11 @@ system.netfilesystem.details.auth.none=None (Server-wide access)
 system.netfilesystem.details.button.add=Add
 system.netfilesystem.details.button.update=Update
 system.netfilesystem.button.add.new.filesystem=Add new File System
-system.netfilesystem.details.whitelists.header=Per-user access (server-wide auth only)
-system.netfilesystem.details.whitelists.help=Comma-separated usernames, or {0} for everyone. Write implies read; users on the write list do not also need to be on the read list. Applies only to file systems with 'None (Server-wide access)' authentication.
-system.netfilesystem.details.read.whitelist=Read whitelist
-system.netfilesystem.details.write.whitelist=Read+write whitelist
+system.netfilesystem.details.whitelists.write.question=Who can write to this file system?
+system.netfilesystem.details.whitelists.read.question=Who can read from this file system?
+system.netfilesystem.details.whitelists.anyone=Anyone with an RSpace account
+system.netfilesystem.details.whitelists.only.these=Only the following users:
+system.netfilesystem.details.whitelists.nobody=Nobody (read access only)
 
 # LDAP settings page
 system.ldap.button.run.sid.retrieval=Retrieve SID values for LDAP users

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -300,6 +300,13 @@ system.netfilesystem.details.auth.none=None (Server-wide access)
 system.netfilesystem.details.button.add=Add
 system.netfilesystem.details.button.update=Update
 system.netfilesystem.button.add.new.filesystem=Add new File System
+system.netfilesystem.details.whitelists.header=Per-user access (server-wide auth only)
+system.netfilesystem.details.whitelists.help=Comma-separated usernames, or {0} for everyone. Write implies read; users on the write list do not also need to be on the read list. Applies only to file systems with 'None (Server-wide access)' authentication.
+system.netfilesystem.details.read.whitelist=Read whitelist
+system.netfilesystem.details.write.whitelist=Read+write whitelist
+system.netfilesystem.details.whitelists.unknown.read.users=Unknown usernames on read whitelist (saved as typed): {0}
+system.netfilesystem.details.whitelists.unknown.write.users=Unknown usernames on write whitelist (saved as typed): {0}
+system.netfilesystem.details.whitelists.write.everyone.warning=Write whitelist is set to '*': any logged-in user will be able to write to this file system.
 
 # LDAP settings page
 system.ldap.button.run.sid.retrieval=Retrieve SID values for LDAP users

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -304,9 +304,6 @@ system.netfilesystem.details.whitelists.header=Per-user access (server-wide auth
 system.netfilesystem.details.whitelists.help=Comma-separated usernames, or {0} for everyone. Write implies read; users on the write list do not also need to be on the read list. Applies only to file systems with 'None (Server-wide access)' authentication.
 system.netfilesystem.details.read.whitelist=Read whitelist
 system.netfilesystem.details.write.whitelist=Read+write whitelist
-system.netfilesystem.details.whitelists.unknown.read.users=Unknown usernames on read whitelist (saved as typed): {0}
-system.netfilesystem.details.whitelists.unknown.write.users=Unknown usernames on write whitelist (saved as typed): {0}
-system.netfilesystem.details.whitelists.write.everyone.warning=Write whitelist is set to '*': any logged-in user will be able to write to this file system.
 
 # LDAP settings page
 system.ldap.button.run.sid.retrieval=Retrieve SID values for LDAP users

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1111.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1111.xml
@@ -7,9 +7,7 @@
 
   <changeSet id="2026-05-28-nfs-filesystem-whitelist-columns" context="run" author="matthias">
     <comment>
-      Per-filesystem read/write user whitelists (RSDEV-1111). Values are
-      comma-separated usernames, '*' for everyone, NULL/empty for nobody.
-      Only consulted when authType=NONE (server-wide credentials).
+      Per-filesystem read/write user whitelists (RSDEV-1111).
     </comment>
     <addColumn tableName="NfsFileSystem">
       <column name="readWhitelist" type="VARCHAR(4000)"/>
@@ -23,7 +21,6 @@
     <comment>
       On upgrade, existing server-wide-auth file systems retain read access
       for everyone (preserving prior behaviour) and write access for nobody.
-      Sysadmins must explicitly grant write access via the new UI.
     </comment>
     <sql>
       UPDATE NfsFileSystem SET readWhitelist = '*' WHERE authType = 'NONE';

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1111.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1111.xml
@@ -5,25 +5,25 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-  <changeSet id="2026-05-28-nfs-filesystem-whitelist-columns" context="run" author="matthias">
+  <changeSet id="2026-05-28-nfs-filesystem-allowlist-columns" context="run" author="matthias">
     <comment>
-      Per-filesystem read/write user whitelists (RSDEV-1111).
+      Per-filesystem read/write user allowlists (RSDEV-1111).
     </comment>
     <addColumn tableName="NfsFileSystem">
-      <column name="readWhitelist" type="VARCHAR(4000)"/>
+      <column name="readAllowlist" type="VARCHAR(4000)"/>
     </addColumn>
     <addColumn tableName="NfsFileSystem">
-      <column name="writeWhitelist" type="VARCHAR(4000)"/>
+      <column name="writeAllowlist" type="VARCHAR(4000)"/>
     </addColumn>
   </changeSet>
 
-  <changeSet id="2026-05-28-nfs-filesystem-whitelist-backfill" context="run" author="matthias">
+  <changeSet id="2026-05-28-nfs-filesystem-allowlist-backfill" context="run" author="matthias">
     <comment>
       On upgrade, existing server-wide-auth file systems retain read access
       for everyone (preserving prior behaviour) and write access for nobody.
     </comment>
     <sql>
-      UPDATE NfsFileSystem SET readWhitelist = '*' WHERE authType = 'NONE';
+      UPDATE NfsFileSystem SET readAllowlist = '*' WHERE authType = 'NONE';
     </sql>
   </changeSet>
 

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1111.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1111.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <changeSet id="2026-05-28-nfs-filesystem-whitelist-columns" context="run" author="matthias">
+    <comment>
+      Per-filesystem read/write user whitelists (RSDEV-1111). Values are
+      comma-separated usernames, '*' for everyone, NULL/empty for nobody.
+      Only consulted when authType=NONE (server-wide credentials).
+    </comment>
+    <addColumn tableName="NfsFileSystem">
+      <column name="readWhitelist" type="VARCHAR(4000)"/>
+    </addColumn>
+    <addColumn tableName="NfsFileSystem">
+      <column name="writeWhitelist" type="VARCHAR(4000)"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="2026-05-28-nfs-filesystem-whitelist-backfill" context="run" author="matthias">
+    <comment>
+      On upgrade, existing server-wide-auth file systems retain read access
+      for everyone (preserving prior behaviour) and write access for nobody.
+      Sysadmins must explicitly grant write access via the new UI.
+    </comment>
+    <sql>
+      UPDATE NfsFileSystem SET readWhitelist = '*' WHERE authType = 'NONE';
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -169,6 +169,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-335-remove-jove.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1062.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1063.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-1111.xml"/>
 
 
   <!--  ensure that customUpdates-changeLog.xml always runs LAST! -->

--- a/src/main/webapp/WEB-INF/pages/system/netfilesystem_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/netfilesystem_ajax.jsp
@@ -225,6 +225,25 @@
                 </td>
             </tr>
 
+            <tr class="fileSystemDetailsWhitelistsRow">
+                <td colspan="2">
+                    <h4><spring:message code="system.netfilesystem.details.whitelists.header" /></h4>
+                    <div class="fileSystemDetailsWhitelistsHelp" style="font-size: 0.9em; color: #555; margin-bottom: 0.5em;">
+                        <spring:message code="system.netfilesystem.details.whitelists.help" arguments="*" />
+                    </div>
+                </td>
+            </tr>
+            <tr class="fileSystemDetailsWhitelistsRow">
+                <td><label for="fileSystemReadWhitelist">
+                    <spring:message code="system.netfilesystem.details.read.whitelist" /></label></td>
+                <td><textarea id="fileSystemReadWhitelist" rows="2" style="width: 20em" placeholder="*, alice, bob"></textarea></td>
+            </tr>
+            <tr class="fileSystemDetailsWhitelistsRow">
+                <td><label for="fileSystemWriteWhitelist">
+                    <spring:message code="system.netfilesystem.details.write.whitelist" /></label></td>
+                <td><textarea id="fileSystemWriteWhitelist" rows="2" style="width: 20em" placeholder="alice, bob"></textarea></td>
+            </tr>
+
             <tr>
                 <td><label><spring:message code="system.netfilesystem.details.status" /></label></td>
                 <td>

--- a/src/main/webapp/WEB-INF/pages/system/netfilesystem_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/netfilesystem_ajax.jsp
@@ -195,6 +195,9 @@
                 </td>
             </tr>
 
+            <tr class="fileSystemDetailsS3Row">
+                <td colspan="2"><hr /></td>
+            </tr>
             <tr class="fileSystemDetailsAuthRow">
                 <td><label><spring:message code="system.netfilesystem.details.auth" /></label></td>
                 <td>
@@ -226,24 +229,31 @@
             </tr>
 
             <tr class="fileSystemDetailsWhitelistsRow">
-                <td colspan="2">
-                    <h4><spring:message code="system.netfilesystem.details.whitelists.header" /></h4>
-                    <div class="fileSystemDetailsWhitelistsHelp" style="font-size: 0.9em; color: #555; margin-bottom: 0.5em;">
-                        <spring:message code="system.netfilesystem.details.whitelists.help" arguments="*" />
-                    </div>
+                <td><label><spring:message code="system.netfilesystem.details.whitelists.write.question" /></label></td>
+                <td>
+                    <label><input type="radio" id="fileSystemLimitWriteNo" name="fileSystemLimitWrite" value="no">
+                        <spring:message code="system.netfilesystem.details.whitelists.anyone" /></label><br/>
+                    <label><input type="radio" id="fileSystemLimitWriteYes" name="fileSystemLimitWrite" value="yes">
+                        <spring:message code="system.netfilesystem.details.whitelists.only.these" /></label>
+                    <input id="fileSystemWriteWhitelist" type="text" style="width: 15em" placeholder="alice, bob" /><br/>
+                    <label><input type="radio" id="fileSystemLimitWriteNobody" name="fileSystemLimitWrite" value="nobody">
+                        <spring:message code="system.netfilesystem.details.whitelists.nobody" /></label>
                 </td>
             </tr>
-            <tr class="fileSystemDetailsWhitelistsRow">
-                <td><label for="fileSystemReadWhitelist">
-                    <spring:message code="system.netfilesystem.details.read.whitelist" /></label></td>
-                <td><textarea id="fileSystemReadWhitelist" rows="2" style="width: 20em" placeholder="*, alice, bob"></textarea></td>
-            </tr>
-            <tr class="fileSystemDetailsWhitelistsRow">
-                <td><label for="fileSystemWriteWhitelist">
-                    <spring:message code="system.netfilesystem.details.write.whitelist" /></label></td>
-                <td><textarea id="fileSystemWriteWhitelist" rows="2" style="width: 20em" placeholder="alice, bob"></textarea></td>
+            <tr class="fileSystemDetailsWhitelistsRow fileSystemDetailsReadWhitelistRow">
+                <td><label><spring:message code="system.netfilesystem.details.whitelists.read.question" /></label></td>
+                <td>
+                    <label><input type="radio" id="fileSystemLimitReadNo" name="fileSystemLimitRead" value="no">
+                        <spring:message code="system.netfilesystem.details.whitelists.anyone" /></label><br/>
+                    <label><input type="radio" id="fileSystemLimitReadYes" name="fileSystemLimitRead" value="yes">
+                        <spring:message code="system.netfilesystem.details.whitelists.only.these" /></label>
+                    <input id="fileSystemReadWhitelist" type="text" style="width: 15em" placeholder="carol" />
+                </td>
             </tr>
 
+            <tr class="fileSystemDetailsS3Row">
+                <td colspan="2"><hr /></td>
+            </tr>
             <tr>
                 <td><label><spring:message code="system.netfilesystem.details.status" /></label></td>
                 <td>

--- a/src/main/webapp/WEB-INF/pages/system/netfilesystem_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/netfilesystem_ajax.jsp
@@ -228,26 +228,26 @@
                 </td>
             </tr>
 
-            <tr class="fileSystemDetailsWhitelistsRow">
-                <td><label><spring:message code="system.netfilesystem.details.whitelists.write.question" /></label></td>
+            <tr class="fileSystemDetailsAllowlistsRow">
+                <td><label><spring:message code="system.netfilesystem.details.allowlists.write.question" /></label></td>
                 <td>
                     <label><input type="radio" id="fileSystemLimitWriteNo" name="fileSystemLimitWrite" value="no">
-                        <spring:message code="system.netfilesystem.details.whitelists.anyone" /></label><br/>
+                        <spring:message code="system.netfilesystem.details.allowlists.anyone" /></label><br/>
                     <label><input type="radio" id="fileSystemLimitWriteYes" name="fileSystemLimitWrite" value="yes">
-                        <spring:message code="system.netfilesystem.details.whitelists.only.these" /></label>
-                    <input id="fileSystemWriteWhitelist" type="text" style="width: 15em" placeholder="alice, bob" /><br/>
+                        <spring:message code="system.netfilesystem.details.allowlists.only.these" /></label>
+                    <input id="fileSystemWriteAllowlist" type="text" style="width: 15em" placeholder="alice, bob" /><br/>
                     <label><input type="radio" id="fileSystemLimitWriteNobody" name="fileSystemLimitWrite" value="nobody">
-                        <spring:message code="system.netfilesystem.details.whitelists.nobody" /></label>
+                        <spring:message code="system.netfilesystem.details.allowlists.nobody" /></label>
                 </td>
             </tr>
-            <tr class="fileSystemDetailsWhitelistsRow fileSystemDetailsReadWhitelistRow">
-                <td><label><spring:message code="system.netfilesystem.details.whitelists.read.question" /></label></td>
+            <tr class="fileSystemDetailsAllowlistsRow fileSystemDetailsReadAllowlistRow">
+                <td><label><spring:message code="system.netfilesystem.details.allowlists.read.question" /></label></td>
                 <td>
                     <label><input type="radio" id="fileSystemLimitReadNo" name="fileSystemLimitRead" value="no">
-                        <spring:message code="system.netfilesystem.details.whitelists.anyone" /></label><br/>
+                        <spring:message code="system.netfilesystem.details.allowlists.anyone" /></label><br/>
                     <label><input type="radio" id="fileSystemLimitReadYes" name="fileSystemLimitRead" value="yes">
-                        <spring:message code="system.netfilesystem.details.whitelists.only.these" /></label>
-                    <input id="fileSystemReadWhitelist" type="text" style="width: 15em" placeholder="carol" />
+                        <spring:message code="system.netfilesystem.details.allowlists.only.these" /></label>
+                    <input id="fileSystemReadAllowlist" type="text" style="width: 15em" placeholder="carol" />
                 </td>
             </tr>
 

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -394,9 +394,6 @@ function refreshClientTypeRows() {
     }
     $('#fileSystemUrl').prop('required', !isS3AWSClient);
 
-    // Hide whitelist rows when switching away from S3. The NONE auth radio may still
-    // be 'checked' after such a switch (its label is hidden by the block above, but
-    // the radio state lingers), so refreshAuthTypeRows wouldn't fire on its own.
     refreshWhitelistRows();
 }
 
@@ -409,17 +406,8 @@ function refreshAuthTypeRows() {
 }
 
 function refreshWhitelistRows() {
-    // Whitelists only apply when the NONE auth radio is both selected AND available
-    // for the current client type (today that's S3 only). Requiring both guards the
-    // transient state right after switching client type, when the NONE radio's check
-    // state still lingers from the previous S3 selection.
-    // The read question is meaningful when writers are restricted ('only listed users'
-    // or 'nobody'); when writers are 'anyone', everyone already has read+write so the
-    // read question is moot and its whole row stays hidden.
-    // The username input next to each 'Only the following users:' radio shows
-    // only when that radio is selected.
-    // Visibility and 'required' are kept in sync so a hidden field can never block
-    // form save: switching away from S3 clears required on the now-invisible radios.
+    // Both isS3Client and isNoneAuth must be checked: the NONE radio's state can
+    // linger from a prior S3 selection after switching client type.
     var isS3Client = $('#fileSystemClientTypeS3').prop('checked');
     var isNoneAuth = $('#fileSystemAuthTypeNone').prop('checked');
     var showWhitelists = isS3Client && isNoneAuth;
@@ -437,33 +425,20 @@ function refreshWhitelistRows() {
     $('#fileSystemLimitReadNo').prop('required', showReadQuestion);
 }
 
-// Maps a persisted whitelist value to the radio + input pair:
-//   '*' (everyone)              -> "Anyone with an RSpace account"; input cleared
-//   'alice,bob' (named list)    -> "Only the following users"; input populated
-//   '' or null   (write only)   -> "Nobody (read access only)" radio when suffix==='Write'
-//                                  (Read has no Nobody option, so falls through to no
-//                                  preselection)
-//   undefined    (fresh add)    -> no radio preselected; input cleared
 function setWhitelistFields(suffix, value) {
     var isEveryone = value === '*';
     var hasNames = typeof value === 'string' && value !== '' && !isEveryone;
     $('#fileSystemLimit' + suffix + 'No').prop('checked', isEveryone);
     $('#fileSystemLimit' + suffix + 'Yes').prop('checked', hasNames);
     if (suffix === 'Write') {
-        // persisted '' or null means nobody is on the write list; undefined means
-        // a fresh-add filesystem where no choice has been made yet.
         var isNobody = value === '' || value === null;
         $('#fileSystemLimitWriteNobody').prop('checked', isNobody);
     }
     $('#fileSystem' + suffix + 'Whitelist').val(hasNames ? value : '');
 }
 
-// Inverse of setWhitelistFields: derive the value to submit from the current radio + input.
-// If write access isn't limited (everyone writes), everyone reads too, so the read value
-// is forced to '*' regardless of any orphan state in the hidden read radio/input.
-// The radio groups are marked required via JS (see refreshWhitelistRows), so HTML5
-// form validation prevents save when no choice is made; the sysadmin is forced to
-// pick explicitly rather than relying on a silent default.
+// If write is unrestricted, everyone writes (and therefore reads); force read='*'
+// regardless of any orphan state in the hidden read radio/input.
 function collectWhitelistValue(suffix) {
     if (suffix === 'Read' && $('#fileSystemLimitWriteNo').prop('checked')) {
         return '*';

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -417,24 +417,21 @@ function refreshWhitelistRows() {
     // read question is moot and its whole row stays hidden.
     // The username input next to each 'Only the following users:' radio shows
     // only when that radio is selected.
+    // Visibility and 'required' are kept in sync so a hidden field can never block
+    // form save: switching away from S3 clears required on the now-invisible radios.
     var isS3Client = $('#fileSystemClientTypeS3').prop('checked');
     var isNoneAuth = $('#fileSystemAuthTypeNone').prop('checked');
     var showWhitelists = isS3Client && isNoneAuth;
-    $('.fileSystemDetailsWhitelistsRow').toggle(showWhitelists);
-    if (!showWhitelists) {
-        return;
-    }
-    var writeOnly = $('#fileSystemLimitWriteYes').prop('checked');
-    var writeNobody = $('#fileSystemLimitWriteNobody').prop('checked');
-    $('#fileSystemWriteWhitelist').toggle(writeOnly);
+    var writeOnly = showWhitelists && $('#fileSystemLimitWriteYes').prop('checked');
+    var writeNobody = showWhitelists && $('#fileSystemLimitWriteNobody').prop('checked');
     var showReadQuestion = writeOnly || writeNobody;
+
+    $('.fileSystemDetailsWhitelistsRow').toggle(showWhitelists);
+    $('#fileSystemWriteWhitelist').toggle(writeOnly);
     $('.fileSystemDetailsReadWhitelistRow').toggle(showReadQuestion);
     $('#fileSystemReadWhitelist').toggle(
         showReadQuestion && $('#fileSystemLimitReadYes').prop('checked'));
 
-    // Force the sysadmin to make an explicit choice on each visible group. The
-    // required flag is toggled together with row visibility so non-S3 / non-NONE
-    // filesystems don't get blocked by an invisible required field.
     $('#fileSystemLimitWriteNo').prop('required', showWhitelists);
     $('#fileSystemLimitReadNo').prop('required', showReadQuestion);
 }

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -211,6 +211,10 @@ function displayFileSystemDetailsDiv(fileSystem) {
         }
     }
 
+    $('#fileSystemReadWhitelist').val(fileSystem.readWhitelist || "");
+    $('#fileSystemWriteWhitelist').val(fileSystem.writeWhitelist || "");
+    refreshWhitelistRows();
+
     var isEnabled = isExistingFileSystem && !fileSystem.disabled;
     var isDisabled = isExistingFileSystem && fileSystem.disabled;
     $('#fileSystemStatusEnabled').prop('checked', isEnabled);
@@ -277,6 +281,8 @@ function saveFileSystem() {
             + "\nS3_PATH_STYLE_ACCESS_ENABLED=" + s3PathStyleEnabled;
     }
 
+    var readWhitelist = $('#fileSystemReadWhitelist').val();
+    var writeWhitelist = $('#fileSystemWriteWhitelist').val();
     var fileSystem = {
             id: $('#fileSystemId').html(),
             name: $('#fileSystemName').val(),
@@ -285,12 +291,15 @@ function saveFileSystem() {
             clientType: clientType,
             authType: authType,
             clientOptions: clientOptions,
-            authOptions: authOptions
+            authOptions: authOptions,
+            readWhitelist: authType === 'NONE' ? readWhitelist : null,
+            writeWhitelist: authType === 'NONE' ? writeWhitelist : null
         };
     RS.blockPage("Saving...");
     var jqxhr = RS.sendJsonPostRequestToUrl('/system/netfilesystem/save', fileSystem);
-    jqxhr.done(function() {
+    jqxhr.done(function(result) {
         $().toastmessage('showSuccessToast', 'File System saved');
+        showWhitelistWarnings(result, writeWhitelist);
         loadNetFileSystemsList();
     });
     jqxhr.fail(function () {
@@ -387,9 +396,36 @@ function refreshClientTypeRows() {
 
 function refreshAuthTypeRows() {
     var isPubKeyAuth = $('#fileSystemAuthTypePubKey').prop('checked');
-    
+
     $('.fileSystemDetailsPubKeyRow').toggle(isPubKeyAuth);
     $('#fileSystemPubKeyRegistrationUrl').prop('required', isPubKeyAuth);
+    refreshWhitelistRows();
+}
+
+function refreshWhitelistRows() {
+    // whitelists only apply to filesystems with server-wide auth (authType=NONE)
+    var isNoneAuth = $('#fileSystemAuthTypeNone').prop('checked');
+    $('.fileSystemDetailsWhitelistsRow').toggle(isNoneAuth);
+}
+
+function showWhitelistWarnings(result, writeWhitelist) {
+    if (!result) {
+        return;
+    }
+    if (result.unknownReadWhitelistUsernames && result.unknownReadWhitelistUsernames.length) {
+        $().toastmessage('showWarningToast',
+            'Unknown usernames on read whitelist (saved as typed): '
+            + result.unknownReadWhitelistUsernames.join(', '));
+    }
+    if (result.unknownWriteWhitelistUsernames && result.unknownWriteWhitelistUsernames.length) {
+        $().toastmessage('showWarningToast',
+            'Unknown usernames on write whitelist (saved as typed): '
+            + result.unknownWriteWhitelistUsernames.join(', '));
+    }
+    if (writeWhitelist && writeWhitelist.split(',').map(function(s) { return s.trim(); }).indexOf('*') !== -1) {
+        $().toastmessage('showWarningToast',
+            "Write whitelist is set to '*': any logged-in user will be able to write to this file system.");
+    }
 }
 
 $(document).ready(function() {	

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -431,6 +431,12 @@ function refreshWhitelistRows() {
     $('.fileSystemDetailsReadWhitelistRow').toggle(showReadQuestion);
     $('#fileSystemReadWhitelist').toggle(
         showReadQuestion && $('#fileSystemLimitReadYes').prop('checked'));
+
+    // Force the sysadmin to make an explicit choice on each visible group. The
+    // required flag is toggled together with row visibility so non-S3 / non-NONE
+    // filesystems don't get blocked by an invisible required field.
+    $('#fileSystemLimitWriteNo').prop('required', showWhitelists);
+    $('#fileSystemLimitReadNo').prop('required', showReadQuestion);
 }
 
 // Maps a persisted whitelist value to the radio + input pair:
@@ -457,6 +463,9 @@ function setWhitelistFields(suffix, value) {
 // Inverse of setWhitelistFields: derive the value to submit from the current radio + input.
 // If write access isn't limited (everyone writes), everyone reads too, so the read value
 // is forced to '*' regardless of any orphan state in the hidden read radio/input.
+// The radio groups are marked required via JS (see refreshWhitelistRows), so a missing
+// selection should already be blocked by HTML5 validation; the fall-throughs below also
+// pick spec-safe defaults (read='*', write='') in case validation is bypassed.
 function collectWhitelistValue(suffix) {
     if (suffix === 'Read' && $('#fileSystemLimitWriteNo').prop('checked')) {
         return '*';
@@ -468,7 +477,12 @@ function collectWhitelistValue(suffix) {
     if (limit === 'nobody') {
         return '';
     }
-    return $('#fileSystem' + suffix + 'Whitelist').val();
+    if (limit === 'yes') {
+        return $('#fileSystem' + suffix + 'Whitelist').val();
+    }
+    // Nothing selected: default to spec-safe values matching the upgrade backfill
+    // (everyone can read, nobody can write) rather than locking everyone out.
+    return suffix === 'Read' ? '*' : '';
 }
 
 function showWhitelistWarnings(result) {

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -369,10 +369,11 @@ function refreshClientTypeRows() {
     $('#fileSystemS3Region').prop('required', isS3Client);
     $('.fileSystemDetailsS3PathStyleRow').toggle(isS3Client && !isS3AWSClient);
 
-    if (isSambaClient || isIrodsClient) {
-        $('#fileSystemAuthTypePassword').click();
-    } else if (isS3Client) {
+    if (isS3Client) {
         $('#fileSystemAuthTypeNone').click();
+    } else if (isSambaClient || isIrodsClient
+            || (isSftpClient && $('#fileSystemAuthTypeNone').prop('checked'))) {
+        $('#fileSystemAuthTypePassword').click();
     }
     $('#fileSystemAuthTypePasswordSpan').text(sysNetfileSysDetAuthPasswd);
     $("label[for='fileSystemUrl']").text(sysNetFileSysDetUrl);

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -211,9 +211,9 @@ function displayFileSystemDetailsDiv(fileSystem) {
         }
     }
 
-    setWhitelistFields('Read', fileSystem.readWhitelist);
-    setWhitelistFields('Write', fileSystem.writeWhitelist);
-    refreshWhitelistRows();
+    setAllowlistFields('Read', fileSystem.readAllowlist);
+    setAllowlistFields('Write', fileSystem.writeAllowlist);
+    refreshAllowlistRows();
 
     var isEnabled = isExistingFileSystem && !fileSystem.disabled;
     var isDisabled = isExistingFileSystem && fileSystem.disabled;
@@ -281,8 +281,8 @@ function saveFileSystem() {
             + "\nS3_PATH_STYLE_ACCESS_ENABLED=" + s3PathStyleEnabled;
     }
 
-    var readWhitelist = collectWhitelistValue('Read');
-    var writeWhitelist = collectWhitelistValue('Write');
+    var readAllowlist = collectAllowlistValue('Read');
+    var writeAllowlist = collectAllowlistValue('Write');
     var fileSystem = {
             id: $('#fileSystemId').html(),
             name: $('#fileSystemName').val(),
@@ -292,14 +292,14 @@ function saveFileSystem() {
             authType: authType,
             clientOptions: clientOptions,
             authOptions: authOptions,
-            readWhitelist: authType === 'NONE' ? readWhitelist : null,
-            writeWhitelist: authType === 'NONE' ? writeWhitelist : null
+            readAllowlist: authType === 'NONE' ? readAllowlist : null,
+            writeAllowlist: authType === 'NONE' ? writeAllowlist : null
         };
     RS.blockPage("Saving...");
     var jqxhr = RS.sendJsonPostRequestToUrl('/system/netfilesystem/save', fileSystem);
     jqxhr.done(function(result) {
         $().toastmessage('showSuccessToast', 'File System saved');
-        showWhitelistWarnings(result);
+        showAllowlistWarnings(result);
         loadNetFileSystemsList();
     });
     jqxhr.fail(function () {
@@ -394,7 +394,7 @@ function refreshClientTypeRows() {
     }
     $('#fileSystemUrl').prop('required', !isS3AWSClient);
 
-    refreshWhitelistRows();
+    refreshAllowlistRows();
 }
 
 function refreshAuthTypeRows() {
@@ -402,30 +402,30 @@ function refreshAuthTypeRows() {
 
     $('.fileSystemDetailsPubKeyRow').toggle(isPubKeyAuth);
     $('#fileSystemPubKeyRegistrationUrl').prop('required', isPubKeyAuth);
-    refreshWhitelistRows();
+    refreshAllowlistRows();
 }
 
-function refreshWhitelistRows() {
+function refreshAllowlistRows() {
     // Both isS3Client and isNoneAuth must be checked: the NONE radio's state can
     // linger from a prior S3 selection after switching client type.
     var isS3Client = $('#fileSystemClientTypeS3').prop('checked');
     var isNoneAuth = $('#fileSystemAuthTypeNone').prop('checked');
-    var showWhitelists = isS3Client && isNoneAuth;
-    var writeOnly = showWhitelists && $('#fileSystemLimitWriteYes').prop('checked');
-    var writeNobody = showWhitelists && $('#fileSystemLimitWriteNobody').prop('checked');
+    var showAllowlists = isS3Client && isNoneAuth;
+    var writeOnly = showAllowlists && $('#fileSystemLimitWriteYes').prop('checked');
+    var writeNobody = showAllowlists && $('#fileSystemLimitWriteNobody').prop('checked');
     var showReadQuestion = writeOnly || writeNobody;
 
-    $('.fileSystemDetailsWhitelistsRow').toggle(showWhitelists);
-    $('#fileSystemWriteWhitelist').toggle(writeOnly);
-    $('.fileSystemDetailsReadWhitelistRow').toggle(showReadQuestion);
-    $('#fileSystemReadWhitelist').toggle(
+    $('.fileSystemDetailsAllowlistsRow').toggle(showAllowlists);
+    $('#fileSystemWriteAllowlist').toggle(writeOnly);
+    $('.fileSystemDetailsReadAllowlistRow').toggle(showReadQuestion);
+    $('#fileSystemReadAllowlist').toggle(
         showReadQuestion && $('#fileSystemLimitReadYes').prop('checked'));
 
-    $('#fileSystemLimitWriteNo').prop('required', showWhitelists);
+    $('#fileSystemLimitWriteNo').prop('required', showAllowlists);
     $('#fileSystemLimitReadNo').prop('required', showReadQuestion);
 }
 
-function setWhitelistFields(suffix, value) {
+function setAllowlistFields(suffix, value) {
     var isEveryone = value === '*';
     var hasNames = typeof value === 'string' && value !== '' && !isEveryone;
     $('#fileSystemLimit' + suffix + 'No').prop('checked', isEveryone);
@@ -434,12 +434,12 @@ function setWhitelistFields(suffix, value) {
         var isNobody = value === '' || value === null;
         $('#fileSystemLimitWriteNobody').prop('checked', isNobody);
     }
-    $('#fileSystem' + suffix + 'Whitelist').val(hasNames ? value : '');
+    $('#fileSystem' + suffix + 'Allowlist').val(hasNames ? value : '');
 }
 
 // If write is unrestricted, everyone writes (and therefore reads); force read='*'
 // regardless of any orphan state in the hidden read radio/input.
-function collectWhitelistValue(suffix) {
+function collectAllowlistValue(suffix) {
     if (suffix === 'Read' && $('#fileSystemLimitWriteNo').prop('checked')) {
         return '*';
     }
@@ -450,23 +450,23 @@ function collectWhitelistValue(suffix) {
     if (limit === 'nobody') {
         return '';
     }
-    return $('#fileSystem' + suffix + 'Whitelist').val();
+    return $('#fileSystem' + suffix + 'Allowlist').val();
 }
 
-function showWhitelistWarnings(result) {
+function showAllowlistWarnings(result) {
     if (!result) {
         return;
     }
     // toastmessage renders text as HTML, so escape the sysadmin-typed usernames.
-    if (result.unknownReadWhitelistUsernames && result.unknownReadWhitelistUsernames.length) {
+    if (result.unknownReadAllowlistUsernames && result.unknownReadAllowlistUsernames.length) {
         showStickyWarning(
-            'Unknown usernames on read whitelist (saved as typed): '
-            + result.unknownReadWhitelistUsernames.map(RS.escapeHtml).join(', '));
+            'Unknown usernames on read allowlist (saved as typed): '
+            + result.unknownReadAllowlistUsernames.map(RS.escapeHtml).join(', '));
     }
-    if (result.unknownWriteWhitelistUsernames && result.unknownWriteWhitelistUsernames.length) {
+    if (result.unknownWriteAllowlistUsernames && result.unknownWriteAllowlistUsernames.length) {
         showStickyWarning(
-            'Unknown usernames on write whitelist (saved as typed): '
-            + result.unknownWriteWhitelistUsernames.map(RS.escapeHtml).join(', '));
+            'Unknown usernames on write allowlist (saved as typed): '
+            + result.unknownWriteAllowlistUsernames.map(RS.escapeHtml).join(', '));
     }
 }
 
@@ -483,8 +483,8 @@ $(document).ready(function() {
     $(document).on('change', 'input[name="fileSystemClientTypeSamba"]', refreshClientTypeRows);
     $(document).on('change', 'input[name="fileSystemClientTypeS3"]', refreshClientTypeRows);
     $(document).on('change', 'input[name="fileSystemAuthType"]', refreshAuthTypeRows);
-    $(document).on('change', 'input[name="fileSystemLimitRead"]', refreshWhitelistRows);
-    $(document).on('change', 'input[name="fileSystemLimitWrite"]', refreshWhitelistRows);
+    $(document).on('change', 'input[name="fileSystemLimitRead"]', refreshAllowlistRows);
+    $(document).on('change', 'input[name="fileSystemLimitWrite"]', refreshAllowlistRows);
     $(document).on('click','#addNewFileSystem', addNewFileSystem);
     $(document).on('submit', '#fileSystemDetailsForm', saveFileSystem);
 });

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -483,15 +483,19 @@ function showWhitelistWarnings(result) {
         return;
     }
     if (result.unknownReadWhitelistUsernames && result.unknownReadWhitelistUsernames.length) {
-        $().toastmessage('showWarningToast',
+        showStickyWarning(
             'Unknown usernames on read whitelist (saved as typed): '
             + result.unknownReadWhitelistUsernames.join(', '));
     }
     if (result.unknownWriteWhitelistUsernames && result.unknownWriteWhitelistUsernames.length) {
-        $().toastmessage('showWarningToast',
+        showStickyWarning(
             'Unknown usernames on write whitelist (saved as typed): '
             + result.unknownWriteWhitelistUsernames.join(', '));
     }
+}
+
+function showStickyWarning(text) {
+    $().toastmessage('showToast', { text: text, type: 'warning', sticky: true });
 }
 
 $(document).ready(function() {	

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -457,15 +457,16 @@ function showWhitelistWarnings(result) {
     if (!result) {
         return;
     }
+    // toastmessage renders text as HTML, so escape the sysadmin-typed usernames.
     if (result.unknownReadWhitelistUsernames && result.unknownReadWhitelistUsernames.length) {
         showStickyWarning(
             'Unknown usernames on read whitelist (saved as typed): '
-            + result.unknownReadWhitelistUsernames.join(', '));
+            + result.unknownReadWhitelistUsernames.map(RS.escapeHtml).join(', '));
     }
     if (result.unknownWriteWhitelistUsernames && result.unknownWriteWhitelistUsernames.length) {
         showStickyWarning(
             'Unknown usernames on write whitelist (saved as typed): '
-            + result.unknownWriteWhitelistUsernames.join(', '));
+            + result.unknownWriteWhitelistUsernames.map(RS.escapeHtml).join(', '));
     }
 }
 

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -211,8 +211,8 @@ function displayFileSystemDetailsDiv(fileSystem) {
         }
     }
 
-    $('#fileSystemReadWhitelist').val(fileSystem.readWhitelist || "");
-    $('#fileSystemWriteWhitelist').val(fileSystem.writeWhitelist || "");
+    setWhitelistFields('Read', fileSystem.readWhitelist);
+    setWhitelistFields('Write', fileSystem.writeWhitelist);
     refreshWhitelistRows();
 
     var isEnabled = isExistingFileSystem && !fileSystem.disabled;
@@ -281,8 +281,8 @@ function saveFileSystem() {
             + "\nS3_PATH_STYLE_ACCESS_ENABLED=" + s3PathStyleEnabled;
     }
 
-    var readWhitelist = $('#fileSystemReadWhitelist').val();
-    var writeWhitelist = $('#fileSystemWriteWhitelist').val();
+    var readWhitelist = collectWhitelistValue('Read');
+    var writeWhitelist = collectWhitelistValue('Write');
     var fileSystem = {
             id: $('#fileSystemId').html(),
             name: $('#fileSystemName').val(),
@@ -299,7 +299,7 @@ function saveFileSystem() {
     var jqxhr = RS.sendJsonPostRequestToUrl('/system/netfilesystem/save', fileSystem);
     jqxhr.done(function(result) {
         $().toastmessage('showSuccessToast', 'File System saved');
-        showWhitelistWarnings(result, writeWhitelist);
+        showWhitelistWarnings(result);
         loadNetFileSystemsList();
     });
     jqxhr.fail(function () {
@@ -392,6 +392,11 @@ function refreshClientTypeRows() {
         $('#fileSystemUrl').removeAttr('title').removeAttr('pattern');
     }
     $('#fileSystemUrl').prop('required', !isS3AWSClient);
+
+    // Hide whitelist rows when switching away from S3. The NONE auth radio may still
+    // be 'checked' after such a switch (its label is hidden by the block above, but
+    // the radio state lingers), so refreshAuthTypeRows wouldn't fire on its own.
+    refreshWhitelistRows();
 }
 
 function refreshAuthTypeRows() {
@@ -403,12 +408,70 @@ function refreshAuthTypeRows() {
 }
 
 function refreshWhitelistRows() {
-    // whitelists only apply to filesystems with server-wide auth (authType=NONE)
+    // Whitelists only apply when the NONE auth radio is both selected AND available
+    // for the current client type (today that's S3 only). Requiring both guards the
+    // transient state right after switching client type, when the NONE radio's check
+    // state still lingers from the previous S3 selection.
+    // The read question is meaningful when writers are restricted ('only listed users'
+    // or 'nobody'); when writers are 'anyone', everyone already has read+write so the
+    // read question is moot and its whole row stays hidden.
+    // The username input next to each 'Only the following users:' radio shows
+    // only when that radio is selected.
+    var isS3Client = $('#fileSystemClientTypeS3').prop('checked');
     var isNoneAuth = $('#fileSystemAuthTypeNone').prop('checked');
-    $('.fileSystemDetailsWhitelistsRow').toggle(isNoneAuth);
+    var showWhitelists = isS3Client && isNoneAuth;
+    $('.fileSystemDetailsWhitelistsRow').toggle(showWhitelists);
+    if (!showWhitelists) {
+        return;
+    }
+    var writeOnly = $('#fileSystemLimitWriteYes').prop('checked');
+    var writeNobody = $('#fileSystemLimitWriteNobody').prop('checked');
+    $('#fileSystemWriteWhitelist').toggle(writeOnly);
+    var showReadQuestion = writeOnly || writeNobody;
+    $('.fileSystemDetailsReadWhitelistRow').toggle(showReadQuestion);
+    $('#fileSystemReadWhitelist').toggle(
+        showReadQuestion && $('#fileSystemLimitReadYes').prop('checked'));
 }
 
-function showWhitelistWarnings(result, writeWhitelist) {
+// Maps a persisted whitelist value to the radio + input pair:
+//   '*' (everyone)              -> "Anyone with an RSpace account"; input cleared
+//   'alice,bob' (named list)    -> "Only the following users"; input populated
+//   '' or null   (write only)   -> "Nobody (read access only)" radio when suffix==='Write'
+//                                  (Read has no Nobody option, so falls through to no
+//                                  preselection)
+//   undefined    (fresh add)    -> no radio preselected; input cleared
+function setWhitelistFields(suffix, value) {
+    var isEveryone = value === '*';
+    var hasNames = typeof value === 'string' && value !== '' && !isEveryone;
+    $('#fileSystemLimit' + suffix + 'No').prop('checked', isEveryone);
+    $('#fileSystemLimit' + suffix + 'Yes').prop('checked', hasNames);
+    if (suffix === 'Write') {
+        // persisted '' or null means nobody is on the write list; undefined means
+        // a fresh-add filesystem where no choice has been made yet.
+        var isNobody = value === '' || value === null;
+        $('#fileSystemLimitWriteNobody').prop('checked', isNobody);
+    }
+    $('#fileSystem' + suffix + 'Whitelist').val(hasNames ? value : '');
+}
+
+// Inverse of setWhitelistFields: derive the value to submit from the current radio + input.
+// If write access isn't limited (everyone writes), everyone reads too, so the read value
+// is forced to '*' regardless of any orphan state in the hidden read radio/input.
+function collectWhitelistValue(suffix) {
+    if (suffix === 'Read' && $('#fileSystemLimitWriteNo').prop('checked')) {
+        return '*';
+    }
+    var limit = $('input[name=fileSystemLimit' + suffix + ']:checked').val();
+    if (limit === 'no') {
+        return '*';
+    }
+    if (limit === 'nobody') {
+        return '';
+    }
+    return $('#fileSystem' + suffix + 'Whitelist').val();
+}
+
+function showWhitelistWarnings(result) {
     if (!result) {
         return;
     }
@@ -422,10 +485,6 @@ function showWhitelistWarnings(result, writeWhitelist) {
             'Unknown usernames on write whitelist (saved as typed): '
             + result.unknownWriteWhitelistUsernames.join(', '));
     }
-    if (writeWhitelist && writeWhitelist.split(',').map(function(s) { return s.trim(); }).indexOf('*') !== -1) {
-        $().toastmessage('showWarningToast',
-            "Write whitelist is set to '*': any logged-in user will be able to write to this file system.");
-    }
 }
 
 $(document).ready(function() {	
@@ -437,6 +496,8 @@ $(document).ready(function() {
     $(document).on('change', 'input[name="fileSystemClientTypeSamba"]', refreshClientTypeRows);
     $(document).on('change', 'input[name="fileSystemClientTypeS3"]', refreshClientTypeRows);
     $(document).on('change', 'input[name="fileSystemAuthType"]', refreshAuthTypeRows);
+    $(document).on('change', 'input[name="fileSystemLimitRead"]', refreshWhitelistRows);
+    $(document).on('change', 'input[name="fileSystemLimitWrite"]', refreshWhitelistRows);
     $(document).on('click','#addNewFileSystem', addNewFileSystem);
     $(document).on('submit', '#fileSystemDetailsForm', saveFileSystem);
 });

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -463,9 +463,9 @@ function setWhitelistFields(suffix, value) {
 // Inverse of setWhitelistFields: derive the value to submit from the current radio + input.
 // If write access isn't limited (everyone writes), everyone reads too, so the read value
 // is forced to '*' regardless of any orphan state in the hidden read radio/input.
-// The radio groups are marked required via JS (see refreshWhitelistRows), so a missing
-// selection should already be blocked by HTML5 validation; the fall-throughs below also
-// pick spec-safe defaults (read='*', write='') in case validation is bypassed.
+// The radio groups are marked required via JS (see refreshWhitelistRows), so HTML5
+// form validation prevents save when no choice is made; the sysadmin is forced to
+// pick explicitly rather than relying on a silent default.
 function collectWhitelistValue(suffix) {
     if (suffix === 'Read' && $('#fileSystemLimitWriteNo').prop('checked')) {
         return '*';
@@ -477,12 +477,7 @@ function collectWhitelistValue(suffix) {
     if (limit === 'nobody') {
         return '';
     }
-    if (limit === 'yes') {
-        return $('#fileSystem' + suffix + 'Whitelist').val();
-    }
-    // Nothing selected: default to spec-safe values matching the upgrade backfill
-    // (everyone can read, nobody can write) rather than locking everyone out.
-    return suffix === 'Read' ? '*' : '';
+    return $('#fileSystem' + suffix + 'Whitelist').val();
 }
 
 function showWhitelistWarnings(result) {

--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useS3Filestores.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useS3Filestores.test.tsx
@@ -1,0 +1,155 @@
+import { test, describe, expect, beforeEach, vi, afterEach } from "vitest";
+import "@/__tests__/__mocks__/useOauthToken";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import MockAdapter from "axios-mock-adapter";
+
+import axios from "@/common/axios";
+import useS3Filestores from "../components/useS3Filestores";
+import Alerts from "../../../components/Alerts/Alerts";
+
+// The hook calls axios.create(...) and uses the returned instance, but
+// axios-mock-adapter only intercepts the instance it was constructed against.
+// Stub axios.create so it returns the default instance, which has the mock
+// adapter attached.
+
+function FilestoreList() {
+  const result = useS3Filestores();
+  if (result.tag === "loading") return <div data-testid="state">loading</div>;
+  if (result.tag === "error")
+    return <div data-testid="state">error:{result.error}</div>;
+  return (
+    <ul data-testid="filestores">
+      {result.value.map((fs) => (
+        <li key={fs.id} data-testid={`fs-${fs.id}`}>
+          {fs.name}|canRead={String(fs.canRead)}|canWrite={String(fs.canWrite)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+describe("useS3Filestores", () => {
+  let mockAxios: MockAdapter;
+
+  beforeEach(() => {
+    mockAxios = new MockAdapter(axios);
+    vi.spyOn(axios, "create").mockReturnValue(
+      axios as unknown as ReturnType<typeof axios.create>,
+    );
+  });
+
+  afterEach(() => {
+    mockAxios.restore();
+    vi.restoreAllMocks();
+  });
+
+  test("populates canRead/canWrite from userPermissions when present", async () => {
+    // after the axios.create stub, baseURL is ignored, so the path is just "/filestores"
+    mockAxios.onGet("/filestores").reply(200, [
+      {
+        id: 1,
+        name: "writable-s3",
+        fileSystem: { clientType: "S3" },
+        userPermissions: { canRead: true, canWrite: true },
+      },
+      {
+        id: 2,
+        name: "read-only-s3",
+        fileSystem: { clientType: "S3" },
+        userPermissions: { canRead: true, canWrite: false },
+      },
+    ]);
+
+    render(
+      <Alerts>
+        <FilestoreList />
+      </Alerts>,
+    );
+
+    await waitFor(() => screen.getByTestId("filestores"));
+    expect(screen.getByTestId("fs-1")).toHaveTextContent(
+      "writable-s3|canRead=true|canWrite=true",
+    );
+    expect(screen.getByTestId("fs-2")).toHaveTextContent(
+      "read-only-s3|canRead=true|canWrite=false",
+    );
+  });
+
+  test("stale filestore (canRead=false) is still listed", async () => {
+    // a filestore the user has lost access to since binding remains visible
+    // so the UI can render it as inaccessible rather than silently dropping it
+    // after the axios.create stub, baseURL is ignored, so the path is just "/filestores"
+    mockAxios.onGet("/filestores").reply(200, [
+      {
+        id: 3,
+        name: "stale-s3",
+        fileSystem: { clientType: "S3" },
+        userPermissions: { canRead: false, canWrite: false },
+      },
+    ]);
+
+    render(
+      <Alerts>
+        <FilestoreList />
+      </Alerts>,
+    );
+
+    await waitFor(() => screen.getByTestId("filestores"));
+    expect(screen.getByTestId("fs-3")).toHaveTextContent(
+      "stale-s3|canRead=false|canWrite=false",
+    );
+  });
+
+  test("defaults canRead/canWrite to true when userPermissions absent", async () => {
+    // older backend or non-NONE auth filesystem omits the permissions snapshot;
+    // the UI should remain permissive in that case rather than blocking the user
+    // after the axios.create stub, baseURL is ignored, so the path is just "/filestores"
+    mockAxios.onGet("/filestores").reply(200, [
+      {
+        id: 4,
+        name: "legacy-s3",
+        fileSystem: { clientType: "S3" },
+      },
+    ]);
+
+    render(
+      <Alerts>
+        <FilestoreList />
+      </Alerts>,
+    );
+
+    await waitFor(() => screen.getByTestId("filestores"));
+    expect(screen.getByTestId("fs-4")).toHaveTextContent(
+      "legacy-s3|canRead=true|canWrite=true",
+    );
+  });
+
+  test("non-S3 filestores are filtered out of the list", async () => {
+    // after the axios.create stub, baseURL is ignored, so the path is just "/filestores"
+    mockAxios.onGet("/filestores").reply(200, [
+      {
+        id: 5,
+        name: "an-s3",
+        fileSystem: { clientType: "S3" },
+        userPermissions: { canRead: true, canWrite: true },
+      },
+      {
+        id: 6,
+        name: "an-irods",
+        fileSystem: { clientType: "IRODS" },
+        userPermissions: { canRead: true, canWrite: true },
+      },
+    ]);
+
+    render(
+      <Alerts>
+        <FilestoreList />
+      </Alerts>,
+    );
+
+    await waitFor(() => screen.getByTestId("filestores"));
+    expect(screen.queryByTestId("fs-5")).not.toBeNull();
+    expect(screen.queryByTestId("fs-6")).toBeNull();
+  });
+});

--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useS3Filestores.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useS3Filestores.test.tsx
@@ -11,7 +11,7 @@ import Alerts from "../../../components/Alerts/Alerts";
 // The hook calls axios.create(...) and uses the returned instance, but
 // axios-mock-adapter only intercepts the instance it was constructed against.
 // Stub axios.create so it returns the default instance, which has the mock
-// adapter attached.
+// adapter attached; this also bypasses baseURL so the path is just "/filestores".
 
 function FilestoreList() {
   const result = useS3Filestores();
@@ -45,7 +45,6 @@ describe("useS3Filestores", () => {
   });
 
   test("populates canRead/canWrite from userPermissions when present", async () => {
-    // after the axios.create stub, baseURL is ignored, so the path is just "/filestores"
     mockAxios.onGet("/filestores").reply(200, [
       {
         id: 1,
@@ -79,7 +78,6 @@ describe("useS3Filestores", () => {
   test("stale filestore (canRead=false) is still listed", async () => {
     // a filestore the user has lost access to since binding remains visible
     // so the UI can render it as inaccessible rather than silently dropping it
-    // after the axios.create stub, baseURL is ignored, so the path is just "/filestores"
     mockAxios.onGet("/filestores").reply(200, [
       {
         id: 3,
@@ -104,7 +102,6 @@ describe("useS3Filestores", () => {
   test("defaults canRead/canWrite to true when userPermissions absent", async () => {
     // older backend or non-NONE auth filesystem omits the permissions snapshot;
     // the UI should remain permissive in that case rather than blocking the user
-    // after the axios.create stub, baseURL is ignored, so the path is just "/filestores"
     mockAxios.onGet("/filestores").reply(200, [
       {
         id: 4,
@@ -126,7 +123,6 @@ describe("useS3Filestores", () => {
   });
 
   test("non-S3 filestores are filtered out of the list", async () => {
-    // after the axios.create stub, baseURL is ignored, so the path is just "/filestores"
     mockAxios.onGet("/filestores").reply(200, [
       {
         id: 5,

--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useS3Filestores.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useS3Filestores.test.tsx
@@ -1,7 +1,7 @@
 import { test, describe, expect, beforeEach, vi, afterEach } from "vitest";
 import "@/__tests__/__mocks__/useOauthToken";
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@/__tests__/customQueries";
 import MockAdapter from "axios-mock-adapter";
 
 import axios from "@/common/axios";

--- a/src/main/webapp/ui/src/eln/gallery/components/AddFilestoreDialog.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/AddFilestoreDialog.tsx
@@ -98,8 +98,6 @@ function FilesystemSelectionStep(props: {
                     const url = Parsers.getValueWithKey("url")(obj)
                       .flatMap(Parsers.isString)
                       .elseThrow();
-                    // userPermissions is absent for non-NONE auth (and on older
-                    // backends), in which case treat the filesystem as readable.
                     const canRead = Parsers.getValueWithKey("userPermissions")(
                       obj,
                     )

--- a/src/main/webapp/ui/src/eln/gallery/components/AddFilestoreDialog.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/AddFilestoreDialog.tsx
@@ -64,6 +64,7 @@ function FilesystemSelectionStep(props: {
     id: number;
     name: string;
     url: string;
+    canRead: boolean;
   }>>(null);
   const { getToken } = useOauthToken();
   const api = React.useRef(
@@ -97,12 +98,23 @@ function FilesystemSelectionStep(props: {
                     const url = Parsers.getValueWithKey("url")(obj)
                       .flatMap(Parsers.isString)
                       .elseThrow();
-                    return Result.Ok({ id, name, url });
+                    // userPermissions is absent for non-NONE auth (and on older
+                    // backends), in which case treat the filesystem as readable.
+                    const canRead = Parsers.getValueWithKey("userPermissions")(
+                      obj,
+                    )
+                      .flatMap(Parsers.isObject)
+                      .flatMap(Parsers.isNotNull)
+                      .flatMap(Parsers.getValueWithKey("canRead"))
+                      .flatMap(Parsers.isBoolean)
+                      .orElse(true);
+                    return Result.Ok({ id, name, url, canRead });
                   } catch (e) {
                     return Result.Error<{
                       id: number;
                       name: string;
                       url: string;
+                      canRead: boolean;
                     }>([e instanceof Error ? e : new Error("Unknown error")]);
                   }
                 }),
@@ -147,7 +159,23 @@ function FilesystemSelectionStep(props: {
               key={fs.id}
               value={fs.id}
               control={<Radio />}
-              label={fs.name}
+              disabled={!fs.canRead}
+              label={
+                fs.canRead ? (
+                  fs.name
+                ) : (
+                  <>
+                    {fs.name}
+                    <Typography
+                      component="span"
+                      variant="body2"
+                      sx={{ ml: 1, color: "text.secondary" }}
+                    >
+                      (no read access; contact your sysadmin)
+                    </Typography>
+                  </>
+                )
+              }
             />
           ))}
         </RadioGroup>

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.tsx
@@ -42,7 +42,7 @@ const NoFilestoreAlert = () => (
 const NoWritableFilestoreAlert = () => (
   <Alert severity="error">
     <AlertTitle>You do not have write access to any S3 filestore.</AlertTitle>
-    Your account is not on the write whitelist for any S3 filestore. Ask your
+    Your account is not on the write allowlist for any S3 filestore. Ask your
     system administrator if you need write access.
   </Alert>
 );

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.tsx
@@ -39,6 +39,14 @@ const NoFilestoreAlert = () => (
   </Alert>
 );
 
+const NoWritableFilestoreAlert = () => (
+  <Alert severity="error">
+    <AlertTitle>You do not have write access to any S3 filestore.</AlertTitle>
+    Your account is not on the write whitelist for any S3 filestore. Ask your
+    system administrator if you need write access.
+  </Alert>
+);
+
 type MoveCopyDialogArgs = {
   dialogOpen: boolean;
   setDialogOpen: (open: boolean) => void;
@@ -175,6 +183,10 @@ function MoveCopyDialog({
                     <Grid item>
                       <NoFilestoreAlert />
                     </Grid>
+                  ) : filestores.every((fs) => !fs.canWrite) ? (
+                    <Grid item>
+                      <NoWritableFilestoreAlert />
+                    </Grid>
                   ) : (
                     <>
                       <Grid item>
@@ -254,13 +266,21 @@ function MoveCopyDialog({
                                   <MenuItem
                                     key={fs.id}
                                     selected={fs === selectedFilestore}
+                                    disabled={!fs.canWrite}
                                     onClick={() => {
                                       setSelectedFilestore(fs);
                                       setDestinationAnchorEl(null);
                                     }}
                                     sx={{ width: "400px" }}
                                   >
-                                    <ListItemText primary={fs.name} />
+                                    <ListItemText
+                                      primary={fs.name}
+                                      secondary={
+                                        fs.canWrite
+                                          ? undefined
+                                          : "No write access"
+                                      }
+                                    />
                                   </MenuItem>
                                 ))}
                               </Menu>

--- a/src/main/webapp/ui/src/eln/gallery/components/useS3Filestores.ts
+++ b/src/main/webapp/ui/src/eln/gallery/components/useS3Filestores.ts
@@ -100,10 +100,17 @@ export type S3TransferSource = {
 
 /**
  * An S3 filestore configured by the user in the Gallery's filestore section.
+ *
+ * canRead/canWrite reflect the per-user ACL for the underlying filesystem; a stale
+ * filestore (one the user has lost access to) is still returned by the listing
+ * endpoint with canRead=false, so the UI can render it as inaccessible rather than
+ * silently dropping it.
  */
 export type S3Filestore = {
   id: number;
   name: string;
+  canRead: boolean;
+  canWrite: boolean;
   copy: (recordIds: ReadonlyArray<number>) => Promise<void>;
   move: (recordIds: ReadonlyArray<number>) => Promise<void>;
   transfer: (
@@ -128,7 +135,12 @@ export default function useS3Filestores(): FetchingData.Fetched<
     Result<ReadonlyArray<S3Filestore>>
   >(Result.Ok([]));
 
-  function mkS3Filestore(id: number, name: string): S3Filestore {
+  function mkS3Filestore(
+    id: number,
+    name: string,
+    canRead: boolean,
+    canWrite: boolean,
+  ): S3Filestore {
     async function callEndpoint(
       operation: "move" | "copy",
       recordIds: ReadonlyArray<number>,
@@ -220,6 +232,8 @@ export default function useS3Filestores(): FetchingData.Fetched<
     return {
       id,
       name,
+      canRead,
+      canWrite,
       copy: (recordIds) => callEndpoint("copy", recordIds),
       move: (recordIds) => callEndpoint("move", recordIds),
       transfer: (sources, deleteSource) =>
@@ -257,16 +271,33 @@ export default function useS3Filestores(): FetchingData.Fetched<
             ...s3Only.map((item) =>
               Parsers.isObject(item)
                 .flatMap(Parsers.isNotNull)
-                .flatMap((obj) =>
-                  Result.lift2(mkS3Filestore)(
+                .flatMap((obj) => {
+                  // userPermissions may be absent (older backend, or non-NONE auth)
+                  // — default canRead/canWrite to true so the UI is permissive
+                  // when the backend didn't supply a permissions snapshot.
+                  const perms = Parsers.getValueWithKey("userPermissions")(obj)
+                    .flatMap(Parsers.isObject)
+                    .flatMap(Parsers.isNotNull);
+                  const canRead = perms
+                    .flatMap(Parsers.getValueWithKey("canRead"))
+                    .flatMap(Parsers.isBoolean)
+                    .orElse(true);
+                  const canWrite = perms
+                    .flatMap(Parsers.getValueWithKey("canWrite"))
+                    .flatMap(Parsers.isBoolean)
+                    .orElse(true);
+                  return Result.lift2(
+                    (id: number, name: string): S3Filestore =>
+                      mkS3Filestore(id, name, canRead, canWrite),
+                  )(
                     Parsers.getValueWithKey("id")(obj).flatMap(
                       Parsers.isNumber,
                     ),
                     Parsers.getValueWithKey("name")(obj).flatMap(
                       Parsers.isString,
                     ),
-                  ),
-                ),
+                  );
+                }),
             ),
           );
         }),

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
+import com.researchspace.netfiles.ApiNfsCredentials;
 import com.researchspace.netfiles.NfsFactory;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.NfsFileHandler;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.validation.BindException;
 
 class GalleryFilestoresApiControllerReadAclTest {
 
@@ -32,6 +34,7 @@ class GalleryFilestoresApiControllerReadAclTest {
   @Mock private NfsFileHandler nfsFileHandler;
   @Mock private NfsFactory nfsFactory;
   @Mock private IPropertyHolder propertyHolder;
+  @Mock private GalleryFilestoresCredentialsStore credentialsStore;
   @Mock private User user;
   @Mock private HttpServletResponse response;
 
@@ -44,6 +47,7 @@ class GalleryFilestoresApiControllerReadAclTest {
     controller = new GalleryFilestoresApiController();
     controller.nfsManager = nfsManager;
     controller.aclChecker = GalleryFilestoreTestUtils.filestoreAclCheckerForTest();
+    controller.credentialsStore = credentialsStore;
     controller.deletionManager = deletionManager;
     controller.setNfsFileHandler(nfsFileHandler);
     controller.setNfsFactory(nfsFactory);
@@ -110,6 +114,22 @@ class GalleryFilestoresApiControllerReadAclTest {
         () -> controller.createFilestore(fsId, "myStore", "/some/path", user));
 
     verify(nfsManager, never()).createAndSaveNewFileStore(any(), any(), any(), any());
+  }
+
+  @Test
+  void loginToFilesystem_userNotOnReadWhitelist_throwsAuthorizationException()
+      throws BindException {
+    Long fsId = 1L;
+    NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
+    fs.setReadWhitelist("alice");
+    fs.setWriteWhitelist(null);
+    when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
+
+    assertThrows(
+        AuthorizationException.class,
+        () -> controller.loginToFilesystem(fsId, new ApiNfsCredentials(), null, user));
+
+    verify(credentialsStore, never()).validateCredentialsAndLoginNfs(any(), any(), any(), any());
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
@@ -25,7 +25,7 @@ import org.mockito.MockitoAnnotations;
 
 class GalleryFilestoresApiControllerReadAclTest {
 
-  private static final String USERNAME = "username"; // not in any restrictive whitelist below
+  private static final String USERNAME = "username";
 
   @Mock private NfsManager nfsManager;
   @Mock private RecordDeletionManager deletionManager;
@@ -57,13 +57,12 @@ class GalleryFilestoresApiControllerReadAclTest {
   void browseFilesystem_userNotOnReadWhitelist_throwsAuthorizationException() {
     Long fsId = 1L;
     NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
-    fs.setReadWhitelist("alice"); // USERNAME is not "alice"
+    fs.setReadWhitelist("alice");
     fs.setWriteWhitelist(null);
     when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
 
     assertThrows(AuthorizationException.class, () -> controller.browseFilesystem(fsId, null, user));
 
-    // assertion happens before client construction; nfs factory must not be invoked
     verify(nfsFactory, never()).getNfsClient(any(), any(), any());
   }
 
@@ -110,15 +109,12 @@ class GalleryFilestoresApiControllerReadAclTest {
         AuthorizationException.class,
         () -> controller.createFilestore(fsId, "myStore", "/some/path", user));
 
-    // assertion happens before any save attempt
     verify(nfsManager, never()).createAndSaveNewFileStore(any(), any(), any(), any());
   }
 
   @Test
   void browseFilesystem_userOnWriteWhitelistOnly_isAllowed() throws IOException {
-    // write implies read: a user on the write list but not on the read list can still browse.
-    // We don't stub a full happy-path browse here; we just assert that the read-side check does
-    // NOT throw. Any later failure (e.g. NPE constructing the nfs client) is fine for this test.
+    // write implies read: user on write list but not read list can still browse
     Long fsId = 1L;
     NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
     fs.setReadWhitelist(null);

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
@@ -11,7 +11,6 @@ import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.netfiles.NfsFactory;
 import com.researchspace.properties.IPropertyHolder;
-import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsFileHandler;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.RecordDeletionManager;
@@ -44,7 +43,7 @@ class GalleryFilestoresApiControllerReadAclTest {
 
     controller = new GalleryFilestoresApiController();
     controller.nfsManager = nfsManager;
-    controller.aclChecker = new FilestoreAclChecker();
+    controller.aclChecker = GalleryFilestoreTestUtils.filestoreAclCheckerForTest();
     controller.deletionManager = deletionManager;
     controller.setNfsFileHandler(nfsFileHandler);
     controller.setNfsFactory(nfsFactory);

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
@@ -58,11 +58,11 @@ class GalleryFilestoresApiControllerReadAclTest {
   }
 
   @Test
-  void browseFilesystem_userNotOnReadWhitelist_throwsAuthorizationException() {
+  void browseFilesystem_userNotOnReadAllowlist_throwsAuthorizationException() {
     Long fsId = 1L;
     NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
-    fs.setReadWhitelist("alice");
-    fs.setWriteWhitelist(null);
+    fs.setReadAllowlist("alice");
+    fs.setWriteAllowlist(null);
     when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
 
     assertThrows(AuthorizationException.class, () -> controller.browseFilesystem(fsId, null, user));
@@ -71,12 +71,12 @@ class GalleryFilestoresApiControllerReadAclTest {
   }
 
   @Test
-  void browseFilestore_userNotOnReadWhitelist_throwsAuthorizationException() {
+  void browseFilestore_userNotOnReadAllowlist_throwsAuthorizationException() {
     Long filestoreId = 1L;
     NfsFileStore filestore =
         GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(filestoreId, "fs", user);
-    filestore.getFileSystem().setReadWhitelist("alice");
-    filestore.getFileSystem().setWriteWhitelist(null);
+    filestore.getFileSystem().setReadAllowlist("alice");
+    filestore.getFileSystem().setWriteAllowlist(null);
     when(nfsManager.getNfsFileStore(filestoreId)).thenReturn(filestore);
 
     assertThrows(
@@ -86,12 +86,12 @@ class GalleryFilestoresApiControllerReadAclTest {
   }
 
   @Test
-  void downloadFromFilestore_userNotOnReadWhitelist_throwsAuthorizationException() {
+  void downloadFromFilestore_userNotOnReadAllowlist_throwsAuthorizationException() {
     Long filestoreId = 1L;
     NfsFileStore filestore =
         GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(filestoreId, "fs", user);
-    filestore.getFileSystem().setReadWhitelist("alice");
-    filestore.getFileSystem().setWriteWhitelist(null);
+    filestore.getFileSystem().setReadAllowlist("alice");
+    filestore.getFileSystem().setWriteAllowlist(null);
     when(nfsManager.getNfsFileStore(filestoreId)).thenReturn(filestore);
 
     assertThrows(
@@ -102,11 +102,11 @@ class GalleryFilestoresApiControllerReadAclTest {
   }
 
   @Test
-  void createFilestore_userNotOnReadWhitelist_throwsAuthorizationException() throws IOException {
+  void createFilestore_userNotOnReadAllowlist_throwsAuthorizationException() throws IOException {
     Long fsId = 1L;
     NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
-    fs.setReadWhitelist("alice");
-    fs.setWriteWhitelist(null);
+    fs.setReadAllowlist("alice");
+    fs.setWriteAllowlist(null);
     when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
 
     assertThrows(
@@ -117,12 +117,12 @@ class GalleryFilestoresApiControllerReadAclTest {
   }
 
   @Test
-  void loginToFilesystem_userNotOnReadWhitelist_throwsAuthorizationException()
+  void loginToFilesystem_userNotOnReadAllowlist_throwsAuthorizationException()
       throws BindException {
     Long fsId = 1L;
     NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
-    fs.setReadWhitelist("alice");
-    fs.setWriteWhitelist(null);
+    fs.setReadAllowlist("alice");
+    fs.setWriteAllowlist(null);
     when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
 
     assertThrows(
@@ -133,12 +133,12 @@ class GalleryFilestoresApiControllerReadAclTest {
   }
 
   @Test
-  void browseFilesystem_userOnWriteWhitelistOnly_isAllowed() throws IOException {
+  void browseFilesystem_userOnWriteAllowlistOnly_isAllowed() throws IOException {
     // write implies read: user on write list but not read list can still browse
     Long fsId = 1L;
     NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
-    fs.setReadWhitelist(null);
-    fs.setWriteWhitelist(USERNAME);
+    fs.setReadAllowlist(null);
+    fs.setWriteAllowlist(USERNAME);
     when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
 
     try {

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerReadAclTest.java
@@ -1,0 +1,137 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.model.User;
+import com.researchspace.model.netfiles.NfsFileStore;
+import com.researchspace.model.netfiles.NfsFileSystem;
+import com.researchspace.netfiles.NfsFactory;
+import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.FilestoreAclChecker;
+import com.researchspace.service.NfsFileHandler;
+import com.researchspace.service.NfsManager;
+import com.researchspace.service.RecordDeletionManager;
+import com.researchspace.testutils.GalleryFilestoreTestUtils;
+import java.io.IOException;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.shiro.authz.AuthorizationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class GalleryFilestoresApiControllerReadAclTest {
+
+  private static final String USERNAME = "username"; // not in any restrictive whitelist below
+
+  @Mock private NfsManager nfsManager;
+  @Mock private RecordDeletionManager deletionManager;
+  @Mock private NfsFileHandler nfsFileHandler;
+  @Mock private NfsFactory nfsFactory;
+  @Mock private IPropertyHolder propertyHolder;
+  @Mock private User user;
+  @Mock private HttpServletResponse response;
+
+  private GalleryFilestoresApiController controller;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+
+    controller = new GalleryFilestoresApiController();
+    controller.nfsManager = nfsManager;
+    controller.aclChecker = new FilestoreAclChecker();
+    controller.deletionManager = deletionManager;
+    controller.setNfsFileHandler(nfsFileHandler);
+    controller.setNfsFactory(nfsFactory);
+    controller.properties = propertyHolder;
+
+    when(propertyHolder.isNetFileStoresEnabled()).thenReturn(true);
+    when(user.getUsername()).thenReturn(USERNAME);
+  }
+
+  @Test
+  void browseFilesystem_userNotOnReadWhitelist_throwsAuthorizationException() {
+    Long fsId = 1L;
+    NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
+    fs.setReadWhitelist("alice"); // USERNAME is not "alice"
+    fs.setWriteWhitelist(null);
+    when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
+
+    assertThrows(AuthorizationException.class, () -> controller.browseFilesystem(fsId, null, user));
+
+    // assertion happens before client construction; nfs factory must not be invoked
+    verify(nfsFactory, never()).getNfsClient(any(), any(), any());
+  }
+
+  @Test
+  void browseFilestore_userNotOnReadWhitelist_throwsAuthorizationException() {
+    Long filestoreId = 1L;
+    NfsFileStore filestore =
+        GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(filestoreId, "fs", user);
+    filestore.getFileSystem().setReadWhitelist("alice");
+    filestore.getFileSystem().setWriteWhitelist(null);
+    when(nfsManager.getNfsFileStore(filestoreId)).thenReturn(filestore);
+
+    assertThrows(
+        AuthorizationException.class, () -> controller.browseFilestore(filestoreId, null, user));
+
+    verify(nfsFactory, never()).getNfsClient(any(), any(), any());
+  }
+
+  @Test
+  void downloadFromFilestore_userNotOnReadWhitelist_throwsAuthorizationException() {
+    Long filestoreId = 1L;
+    NfsFileStore filestore =
+        GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(filestoreId, "fs", user);
+    filestore.getFileSystem().setReadWhitelist("alice");
+    filestore.getFileSystem().setWriteWhitelist(null);
+    when(nfsManager.getNfsFileStore(filestoreId)).thenReturn(filestore);
+
+    assertThrows(
+        AuthorizationException.class,
+        () -> controller.downloadFromFilestore(filestoreId, "some/path", null, user, response));
+
+    verify(nfsFactory, never()).getNfsClient(any(), any(), any());
+  }
+
+  @Test
+  void createFilestore_userNotOnReadWhitelist_throwsAuthorizationException() throws IOException {
+    Long fsId = 1L;
+    NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
+    fs.setReadWhitelist("alice");
+    fs.setWriteWhitelist(null);
+    when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
+
+    assertThrows(
+        AuthorizationException.class,
+        () -> controller.createFilestore(fsId, "myStore", "/some/path", user));
+
+    // assertion happens before any save attempt
+    verify(nfsManager, never()).createAndSaveNewFileStore(any(), any(), any(), any());
+  }
+
+  @Test
+  void browseFilesystem_userOnWriteWhitelistOnly_isAllowed() throws IOException {
+    // write implies read: a user on the write list but not on the read list can still browse.
+    // We don't stub a full happy-path browse here; we just assert that the read-side check does
+    // NOT throw. Any later failure (e.g. NPE constructing the nfs client) is fine for this test.
+    Long fsId = 1L;
+    NfsFileSystem fs = GalleryFilestoreTestUtils.createS3FileSystem(fsId);
+    fs.setReadWhitelist(null);
+    fs.setWriteWhitelist(USERNAME);
+    when(nfsManager.getFileSystem(fsId)).thenReturn(fs);
+
+    try {
+      controller.browseFilesystem(fsId, null, user);
+    } catch (AuthorizationException e) {
+      throw new AssertionError("write should imply read; got 403 from ACL check", e);
+    } catch (Exception ignored) {
+      // any non-ACL failure downstream is irrelevant to this test
+    }
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
@@ -559,13 +559,13 @@ class GalleryFilestoresApiControllerWriteOpsTest {
   }
 
   @Test
-  void moveToFilestore_userNotOnWriteWhitelist_throwsAuthorizationException() throws IOException {
-    // override the permissive default with a whitelist that excludes the request's user
+  void moveToFilestore_userNotOnWriteAllowlist_throwsAuthorizationException() throws IOException {
+    // override the permissive default with a allowlist that excludes the request's user
     NfsFileStore restrictedFilestore =
         GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(2L, "restricted", user);
     NfsFileSystem restrictedFs = restrictedFilestore.getFileSystem();
-    restrictedFs.setReadWhitelist("*");
-    restrictedFs.setWriteWhitelist("alice"); // USER's username is "username", not "alice"
+    restrictedFs.setReadAllowlist("*");
+    restrictedFs.setWriteAllowlist("alice"); // USER's username is "username", not "alice"
     when(nfsManager.getNfsFileStore(2L)).thenReturn(restrictedFilestore);
     when(user.getUsername()).thenReturn(USERNAME);
 
@@ -584,14 +584,14 @@ class GalleryFilestoresApiControllerWriteOpsTest {
   }
 
   @Test
-  void transferBetweenFilestores_userNotOnDestWriteWhitelist_throwsAuthorizationException() {
+  void transferBetweenFilestores_userNotOnDestWriteAllowlist_throwsAuthorizationException() {
     Long srcId = 10L;
     Long dstId = 20L;
     when(nfsManager.getNfsFileStore(srcId))
         .thenReturn(GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(srcId, "src", user));
     NfsFileStore destFilestore =
         GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(dstId, "dst", user);
-    destFilestore.getFileSystem().setWriteWhitelist("alice"); // user is "username"
+    destFilestore.getFileSystem().setWriteAllowlist("alice"); // user is "username"
     when(nfsManager.getNfsFileStore(dstId)).thenReturn(destFilestore);
     when(user.getUsername()).thenReturn(USERNAME);
 
@@ -615,7 +615,7 @@ class GalleryFilestoresApiControllerWriteOpsTest {
         GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(srcId, "src", user);
     srcFilestore
         .getFileSystem()
-        .setWriteWhitelist("alice"); // read stays '*', so source is readable
+        .setWriteAllowlist("alice"); // read stays '*', so source is readable
     when(nfsManager.getNfsFileStore(srcId)).thenReturn(srcFilestore);
     when(nfsManager.getNfsFileStore(dstId))
         .thenReturn(GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(dstId, "dst", user));
@@ -644,7 +644,7 @@ class GalleryFilestoresApiControllerWriteOpsTest {
     Long dstId = 20L;
     NfsFileStore srcFilestore =
         GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(srcId, "src", user);
-    srcFilestore.getFileSystem().setWriteWhitelist("alice"); // user is "username"
+    srcFilestore.getFileSystem().setWriteAllowlist("alice"); // user is "username"
     when(nfsManager.getNfsFileStore(srcId)).thenReturn(srcFilestore);
     when(nfsManager.getNfsFileStore(dstId))
         .thenReturn(GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(dstId, "dst", user));

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
@@ -584,7 +584,62 @@ class GalleryFilestoresApiControllerWriteOpsTest {
   }
 
   @Test
-  void transferBetweenFilestores_userNotOnWriteWhitelist_throwsAuthorizationException() {
+  void transferBetweenFilestores_userNotOnDestWriteWhitelist_throwsAuthorizationException() {
+    Long srcId = 10L;
+    Long dstId = 20L;
+    when(nfsManager.getNfsFileStore(srcId))
+        .thenReturn(GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(srcId, "src", user));
+    NfsFileStore destFilestore =
+        GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(dstId, "dst", user);
+    destFilestore.getFileSystem().setWriteWhitelist("alice"); // user is "username"
+    when(nfsManager.getNfsFileStore(dstId)).thenReturn(destFilestore);
+    when(user.getUsername()).thenReturn(USERNAME);
+
+    ApiGalleryFilestoreTransferRequest request =
+        new ApiGalleryFilestoreTransferRequest("src/file.txt", dstId, "dst/file.txt", false);
+
+    assertThrows(
+        AuthorizationException.class,
+        () ->
+            controller.transferBetweenFilestores(
+                srcId, request, new BeanPropertyBindingResult(request, "request"), user));
+  }
+
+  @Test
+  void transferBetweenFilestores_readOnlySourceNonDeleting_isAllowed()
+      throws BindException, IOException {
+    // a non-deleting transfer only reads the source, so write access on the source is not required
+    Long srcId = 10L;
+    Long dstId = 20L;
+    NfsFileStore srcFilestore =
+        GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(srcId, "src", user);
+    srcFilestore
+        .getFileSystem()
+        .setWriteWhitelist("alice"); // read stays '*', so source is readable
+    when(nfsManager.getNfsFileStore(srcId)).thenReturn(srcFilestore);
+    when(nfsManager.getNfsFileStore(dstId))
+        .thenReturn(GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(dstId, "dst", user));
+    WritableNfsClient srcClient = mock(WritableNfsClient.class);
+    WritableNfsClient destClient = mock(WritableNfsClient.class);
+    when(srcClient.supportsServerSideTransfer()).thenReturn(true);
+    when(destClient.supportsServerSideTransfer()).thenReturn(true);
+    when(nfsFactory.getNfsClient(any(), any(), any())).thenReturn(srcClient, destClient);
+    when(user.getUsername()).thenReturn(USERNAME);
+
+    ApiGalleryFilestoreTransferRequest request =
+        new ApiGalleryFilestoreTransferRequest("src/file.txt", dstId, "dst/file.txt", false);
+
+    ApiExternalStorageOperationResult result =
+        controller.transferBetweenFilestores(
+            srcId, request, new BeanPropertyBindingResult(request, "request"), user);
+
+    assertTrue(result.getFileInfoDetails().iterator().next().getSucceeded());
+    verify(srcClient, never()).deleteFile(any());
+  }
+
+  @Test
+  void transferBetweenFilestores_deleteSourceWithoutSourceWrite_throwsAuthorizationException() {
+    // deleting the source modifies it, so write access on the source is required
     Long srcId = 10L;
     Long dstId = 20L;
     NfsFileStore srcFilestore =
@@ -596,7 +651,7 @@ class GalleryFilestoresApiControllerWriteOpsTest {
     when(user.getUsername()).thenReturn(USERNAME);
 
     ApiGalleryFilestoreTransferRequest request =
-        new ApiGalleryFilestoreTransferRequest("src/file.txt", dstId, "dst/file.txt", false);
+        new ApiGalleryFilestoreTransferRequest("src/file.txt", dstId, "dst/file.txt", true);
 
     assertThrows(
         AuthorizationException.class,

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
@@ -23,6 +23,7 @@ import com.researchspace.api.v1.model.EcatAudioFileStub;
 import com.researchspace.api.v1.model.NfsClientStub;
 import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsFileStore;
+import com.researchspace.model.netfiles.NfsFileSystem;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.views.CompositeRecordOperationResult;
 import com.researchspace.netfiles.ApiNfsCredentials;
@@ -34,6 +35,7 @@ import com.researchspace.netfiles.WriteAttribution;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.BaseRecordManager;
 import com.researchspace.service.ExternalStorageManager;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsFileHandler;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.RecordDeletionManager;
@@ -84,10 +86,12 @@ class GalleryFilestoresApiControllerWriteOpsTest {
     filestoreWriteManager.setBaseRecordManager(baseRecordManager);
     filestoreWriteManager.setExternalStorageManager(externalStorageManager);
     filestoreWriteManager.setCredentialsStore(credentialsStore);
+    filestoreWriteManager.setAclChecker(new FilestoreAclChecker());
 
     controller = new GalleryFilestoresApiController();
     controller.nfsManager = nfsManager;
     controller.credentialsStore = credentialsStore;
+    controller.aclChecker = new FilestoreAclChecker();
     controller.deletionManager = deletionManager;
     controller.filestoreWriteManager = filestoreWriteManager;
     controller.setNfsFileHandler(nfsFileHandler);
@@ -553,6 +557,53 @@ class GalleryFilestoresApiControllerWriteOpsTest {
                     user));
 
     assertEquals(1, ex.getAllErrors().size());
+  }
+
+  @Test
+  void moveToFilestore_userNotOnWriteWhitelist_throwsAuthorizationException() throws IOException {
+    // override the permissive default with a whitelist that excludes the request's user
+    NfsFileStore restrictedFilestore =
+        GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(2L, "restricted", user);
+    NfsFileSystem restrictedFs = restrictedFilestore.getFileSystem();
+    restrictedFs.setReadWhitelist("*");
+    restrictedFs.setWriteWhitelist("alice"); // USER's username is "username", not "alice"
+    when(nfsManager.getNfsFileStore(2L)).thenReturn(restrictedFilestore);
+    when(user.getUsername()).thenReturn(USERNAME);
+
+    ApiGalleryFilestoreOperationRequest request =
+        new ApiGalleryFilestoreOperationRequest(
+            validRecordIds, new ApiNfsCredentials(null, USERNAME, PASSWORD));
+
+    assertThrows(
+        AuthorizationException.class,
+        () ->
+            controller.moveToFilestore(
+                2L, request, new BeanPropertyBindingResult(request, "request"), user));
+
+    verify(nfsManager, never())
+        .uploadFilesToNfs(anyCollection(), anyString(), any(WritableNfsClient.class), any());
+  }
+
+  @Test
+  void transferBetweenFilestores_userNotOnWriteWhitelist_throwsAuthorizationException() {
+    Long srcId = 10L;
+    Long dstId = 20L;
+    NfsFileStore srcFilestore =
+        GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(srcId, "src", user);
+    srcFilestore.getFileSystem().setWriteWhitelist("alice"); // user is "username"
+    when(nfsManager.getNfsFileStore(srcId)).thenReturn(srcFilestore);
+    when(nfsManager.getNfsFileStore(dstId))
+        .thenReturn(GalleryFilestoreTestUtils.createS3FileSystemAndFileStore(dstId, "dst", user));
+    when(user.getUsername()).thenReturn(USERNAME);
+
+    ApiGalleryFilestoreTransferRequest request =
+        new ApiGalleryFilestoreTransferRequest("src/file.txt", dstId, "dst/file.txt", false);
+
+    assertThrows(
+        AuthorizationException.class,
+        () ->
+            controller.transferBetweenFilestores(
+                srcId, request, new BeanPropertyBindingResult(request, "request"), user));
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
@@ -35,7 +35,6 @@ import com.researchspace.netfiles.WriteAttribution;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.BaseRecordManager;
 import com.researchspace.service.ExternalStorageManager;
-import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsFileHandler;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.RecordDeletionManager;
@@ -86,12 +85,12 @@ class GalleryFilestoresApiControllerWriteOpsTest {
     filestoreWriteManager.setBaseRecordManager(baseRecordManager);
     filestoreWriteManager.setExternalStorageManager(externalStorageManager);
     filestoreWriteManager.setCredentialsStore(credentialsStore);
-    filestoreWriteManager.setAclChecker(new FilestoreAclChecker());
+    filestoreWriteManager.setAclChecker(GalleryFilestoreTestUtils.filestoreAclCheckerForTest());
 
     controller = new GalleryFilestoresApiController();
     controller.nfsManager = nfsManager;
     controller.credentialsStore = credentialsStore;
-    controller.aclChecker = new FilestoreAclChecker();
+    controller.aclChecker = GalleryFilestoreTestUtils.filestoreAclCheckerForTest();
     controller.deletionManager = deletionManager;
     controller.filestoreWriteManager = filestoreWriteManager;
     controller.setNfsFileHandler(nfsFileHandler);

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryIrodsApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryIrodsApiControllerTest.java
@@ -25,7 +25,6 @@ import com.researchspace.netfiles.WritableNfsClient;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.BaseRecordManager;
 import com.researchspace.service.ExternalStorageManager;
-import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.RecordDeletionManager;
 import com.researchspace.service.impl.FilestoreWriteManagerImpl;
@@ -83,7 +82,7 @@ class GalleryIrodsApiControllerTest {
     filestoreWriteManager.setBaseRecordManager(baseRecordManager);
     filestoreWriteManager.setExternalStorageManager(externalStorageManager);
     filestoreWriteManager.setCredentialsStore(credentialsStore);
-    filestoreWriteManager.setAclChecker(new FilestoreAclChecker());
+    filestoreWriteManager.setAclChecker(GalleryFilestoreTestUtils.filestoreAclCheckerForTest());
     galleryIrodsApiController.setFilestoreWriteManager(filestoreWriteManager);
 
     when(propertyHolder.isNetFileStoresEnabled()).thenReturn(true);

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryIrodsApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryIrodsApiControllerTest.java
@@ -25,6 +25,7 @@ import com.researchspace.netfiles.WritableNfsClient;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.BaseRecordManager;
 import com.researchspace.service.ExternalStorageManager;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.RecordDeletionManager;
 import com.researchspace.service.impl.FilestoreWriteManagerImpl;
@@ -82,6 +83,7 @@ class GalleryIrodsApiControllerTest {
     filestoreWriteManager.setBaseRecordManager(baseRecordManager);
     filestoreWriteManager.setExternalStorageManager(externalStorageManager);
     filestoreWriteManager.setCredentialsStore(credentialsStore);
+    filestoreWriteManager.setAclChecker(new FilestoreAclChecker());
     galleryIrodsApiController.setFilestoreWriteManager(filestoreWriteManager);
 
     when(propertyHolder.isNetFileStoresEnabled()).thenReturn(true);

--- a/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
+++ b/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
@@ -142,6 +142,13 @@ public class FilestoreAclCheckerTest {
   }
 
   @Test
+  public void canRead_nullFilesystem_deniesWithoutNpe() {
+    // a stale filestore binding might return null from getFileSystem(); treat as no access
+    assertFalse(checker.canRead(user("alice"), null));
+    assertFalse(checker.canWrite(user("alice"), null));
+  }
+
+  @Test
   public void canRead_nullAuthType_denies() {
     // a misconfigured row with no auth type should not bypass the ACL
     NfsFileSystem fs = new NfsFileSystem();

--- a/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
+++ b/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
@@ -1,9 +1,9 @@
 package com.researchspace.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.researchspace.model.User;
@@ -12,15 +12,15 @@ import com.researchspace.model.netfiles.NfsClientType;
 import com.researchspace.model.netfiles.NfsFileSystem;
 import java.util.Set;
 import org.apache.shiro.authz.AuthorizationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class FilestoreAclCheckerTest {
+class FilestoreAclCheckerTest {
 
   private FilestoreAclChecker checker;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     checker = new FilestoreAclChecker();
     checker.setMessages(mock(MessageSourceUtils.class));
   }
@@ -28,21 +28,21 @@ public class FilestoreAclCheckerTest {
   // --- parseList ---
 
   @Test
-  public void parseList_nullOrEmpty_returnsEmpty() {
+  void parseList_nullOrEmpty_returnsEmpty() {
     assertTrue(FilestoreAclChecker.parseList(null).isEmpty());
     assertTrue(FilestoreAclChecker.parseList("").isEmpty());
     assertTrue(FilestoreAclChecker.parseList("   ").isEmpty());
   }
 
   @Test
-  public void parseList_singleToken() {
+  void parseList_singleToken() {
     Set<String> tokens = FilestoreAclChecker.parseList("alice");
     assertEquals(1, tokens.size());
     assertTrue(tokens.contains("alice"));
   }
 
   @Test
-  public void parseList_multipleTokensTrimsWhitespace() {
+  void parseList_multipleTokensTrimsWhitespace() {
     Set<String> tokens = FilestoreAclChecker.parseList("  alice ,  bob  ");
     assertEquals(2, tokens.size());
     assertTrue(tokens.contains("alice"));
@@ -50,7 +50,7 @@ public class FilestoreAclCheckerTest {
   }
 
   @Test
-  public void parseList_dropsEmptyTokens() {
+  void parseList_dropsEmptyTokens() {
     Set<String> tokens = FilestoreAclChecker.parseList("alice,,bob,");
     assertEquals(2, tokens.size());
     assertTrue(tokens.contains("alice"));
@@ -58,7 +58,7 @@ public class FilestoreAclCheckerTest {
   }
 
   @Test
-  public void parseList_everyoneSentinel() {
+  void parseList_everyoneSentinel() {
     Set<String> tokens = FilestoreAclChecker.parseList("*");
     assertEquals(1, tokens.size());
     assertTrue(tokens.contains("*"));
@@ -67,21 +67,21 @@ public class FilestoreAclCheckerTest {
   // --- canRead / canWrite, authType=NONE ---
 
   @Test
-  public void canRead_emptyWhitelists_deniesEveryone() {
+  void canRead_emptyWhitelists_deniesEveryone() {
     NfsFileSystem fs = s3FileSystem(null, null);
     assertFalse(checker.canRead(user("alice"), fs));
     assertFalse(checker.canRead(user("bob"), fs));
   }
 
   @Test
-  public void canRead_everyoneSentinel_grantsAll() {
+  void canRead_everyoneSentinel_grantsAll() {
     NfsFileSystem fs = s3FileSystem("*", null);
     assertTrue(checker.canRead(user("alice"), fs));
     assertTrue(checker.canRead(user("anyone"), fs));
   }
 
   @Test
-  public void canRead_namedList_grantsOnlyListedUsers() {
+  void canRead_namedList_grantsOnlyListedUsers() {
     NfsFileSystem fs = s3FileSystem("alice,bob", null);
     assertTrue(checker.canRead(user("alice"), fs));
     assertTrue(checker.canRead(user("bob"), fs));
@@ -89,39 +89,39 @@ public class FilestoreAclCheckerTest {
   }
 
   @Test
-  public void canRead_writeImpliesRead_namedWriter() {
+  void canRead_writeImpliesRead_namedWriter() {
     NfsFileSystem fs = s3FileSystem(null, "alice");
     assertTrue(checker.canRead(user("alice"), fs));
     assertFalse(checker.canRead(user("bob"), fs));
   }
 
   @Test
-  public void canRead_writeImpliesRead_everyoneWrite() {
+  void canRead_writeImpliesRead_everyoneWrite() {
     NfsFileSystem fs = s3FileSystem(null, "*");
     assertTrue(checker.canRead(user("anyone"), fs));
   }
 
   @Test
-  public void canRead_isCaseSensitive() {
+  void canRead_isCaseSensitive() {
     NfsFileSystem fs = s3FileSystem("Alice", null);
     assertTrue(checker.canRead(user("Alice"), fs));
     assertFalse(checker.canRead(user("alice"), fs));
   }
 
   @Test
-  public void canWrite_emptyWriteList_deniesEveryoneEvenIfRead() {
+  void canWrite_emptyWriteList_deniesEveryoneEvenIfRead() {
     NfsFileSystem fs = s3FileSystem("*", null);
     assertFalse(checker.canWrite(user("alice"), fs));
   }
 
   @Test
-  public void canWrite_everyoneSentinel_grantsAll() {
+  void canWrite_everyoneSentinel_grantsAll() {
     NfsFileSystem fs = s3FileSystem(null, "*");
     assertTrue(checker.canWrite(user("alice"), fs));
   }
 
   @Test
-  public void canWrite_namedList_grantsOnlyListedUsers() {
+  void canWrite_namedList_grantsOnlyListedUsers() {
     NfsFileSystem fs = s3FileSystem(null, "alice");
     assertTrue(checker.canWrite(user("alice"), fs));
     assertFalse(checker.canWrite(user("bob"), fs));
@@ -130,26 +130,26 @@ public class FilestoreAclCheckerTest {
   // --- authType gate ---
 
   @Test
-  public void canRead_nonNoneAuthType_shortCircuitsTrue_evenIfWhitelistsEmpty() {
+  void canRead_nonNoneAuthType_shortCircuitsTrue_evenIfWhitelistsEmpty() {
     NfsFileSystem fs = perUserAuthFileSystem(NfsClientType.SAMBA);
     assertTrue(checker.canRead(user("alice"), fs));
   }
 
   @Test
-  public void canWrite_nonNoneAuthType_shortCircuitsTrue_evenIfWhitelistsEmpty() {
+  void canWrite_nonNoneAuthType_shortCircuitsTrue_evenIfWhitelistsEmpty() {
     NfsFileSystem fs = perUserAuthFileSystem(NfsClientType.IRODS);
     assertTrue(checker.canWrite(user("alice"), fs));
   }
 
   @Test
-  public void canRead_nullFilesystem_deniesWithoutNpe() {
+  void canRead_nullFilesystem_deniesWithoutNpe() {
     // a stale filestore binding might return null from getFileSystem(); treat as no access
     assertFalse(checker.canRead(user("alice"), null));
     assertFalse(checker.canWrite(user("alice"), null));
   }
 
   @Test
-  public void canRead_nullAuthType_denies() {
+  void canRead_nullAuthType_denies() {
     // a misconfigured row with no auth type should not bypass the ACL
     NfsFileSystem fs = new NfsFileSystem();
     fs.setClientType(NfsClientType.S3);
@@ -160,7 +160,7 @@ public class FilestoreAclCheckerTest {
   }
 
   @Test
-  public void canWrite_nullAuthType_denies() {
+  void canWrite_nullAuthType_denies() {
     NfsFileSystem fs = new NfsFileSystem();
     fs.setClientType(NfsClientType.S3);
     fs.setAuthType(null);
@@ -169,7 +169,7 @@ public class FilestoreAclCheckerTest {
   }
 
   @Test
-  public void canRead_authTypeNoneOnNonS3Backend_stillEnforced() {
+  void canRead_authTypeNoneOnNonS3Backend_stillEnforced() {
     // hypothetical: Samba configured with authType=NONE should still be gated
     NfsFileSystem fs = new NfsFileSystem();
     fs.setClientType(NfsClientType.SAMBA);
@@ -182,31 +182,21 @@ public class FilestoreAclCheckerTest {
   // --- assert variants ---
 
   @Test
-  public void assertCanRead_authorized_doesNotThrow() {
+  void assertCanRead_authorized_doesNotThrow() {
     NfsFileSystem fs = s3FileSystem("alice", null);
     checker.assertCanRead(user("alice"), fs);
   }
 
   @Test
-  public void assertCanRead_unauthorized_throws() {
+  void assertCanRead_unauthorized_throws() {
     NfsFileSystem fs = s3FileSystem("alice", null);
-    try {
-      checker.assertCanRead(user("bob"), fs);
-      fail("expected AuthorizationException");
-    } catch (AuthorizationException expected) {
-      // ok
-    }
+    assertThrows(AuthorizationException.class, () -> checker.assertCanRead(user("bob"), fs));
   }
 
   @Test
-  public void assertCanWrite_unauthorized_throws() {
+  void assertCanWrite_unauthorized_throws() {
     NfsFileSystem fs = s3FileSystem(null, "alice");
-    try {
-      checker.assertCanWrite(user("bob"), fs);
-      fail("expected AuthorizationException");
-    } catch (AuthorizationException expected) {
-      // ok
-    }
+    assertThrows(AuthorizationException.class, () -> checker.assertCanWrite(user("bob"), fs));
   }
 
   // --- helpers ---

--- a/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
+++ b/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
@@ -199,6 +199,16 @@ class FilestoreAclCheckerTest {
     assertThrows(AuthorizationException.class, () -> checker.assertCanWrite(user("bob"), fs));
   }
 
+  @Test
+  void assertCanRead_nullFilesystem_throwsAuthorizationExceptionNotNpe() {
+    assertThrows(AuthorizationException.class, () -> checker.assertCanRead(user("alice"), null));
+  }
+
+  @Test
+  void assertCanWrite_nullFilesystem_throwsAuthorizationExceptionNotNpe() {
+    assertThrows(AuthorizationException.class, () -> checker.assertCanWrite(user("alice"), null));
+  }
+
   // --- helpers ---
 
   private static User user(String username) {

--- a/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
+++ b/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
@@ -140,6 +140,26 @@ public class FilestoreAclCheckerTest {
   }
 
   @Test
+  public void canRead_nullAuthType_denies() {
+    // a misconfigured row with no auth type should not bypass the ACL
+    NfsFileSystem fs = new NfsFileSystem();
+    fs.setClientType(NfsClientType.S3);
+    fs.setAuthType(null);
+    fs.setReadWhitelist("*");
+    fs.setWriteWhitelist("*");
+    assertFalse(checker.canRead(user("alice"), fs));
+  }
+
+  @Test
+  public void canWrite_nullAuthType_denies() {
+    NfsFileSystem fs = new NfsFileSystem();
+    fs.setClientType(NfsClientType.S3);
+    fs.setAuthType(null);
+    fs.setWriteWhitelist("*");
+    assertFalse(checker.canWrite(user("alice"), fs));
+  }
+
+  @Test
   public void canRead_authTypeNoneOnNonS3Backend_stillEnforced() {
     // hypothetical: Samba configured with authType=NONE should still be gated
     NfsFileSystem fs = new NfsFileSystem();

--- a/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
+++ b/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
@@ -67,7 +67,7 @@ class FilestoreAclCheckerTest {
   // --- canRead / canWrite, authType=NONE ---
 
   @Test
-  void canRead_emptyWhitelists_deniesEveryone() {
+  void canRead_emptyAllowlists_deniesEveryone() {
     NfsFileSystem fs = s3FileSystem(null, null);
     assertFalse(checker.canRead(user("alice"), fs));
     assertFalse(checker.canRead(user("bob"), fs));
@@ -130,13 +130,13 @@ class FilestoreAclCheckerTest {
   // --- authType gate ---
 
   @Test
-  void canRead_nonNoneAuthType_shortCircuitsTrue_evenIfWhitelistsEmpty() {
+  void canRead_nonNoneAuthType_shortCircuitsTrue_evenIfAllowlistsEmpty() {
     NfsFileSystem fs = perUserAuthFileSystem(NfsClientType.SAMBA);
     assertTrue(checker.canRead(user("alice"), fs));
   }
 
   @Test
-  void canWrite_nonNoneAuthType_shortCircuitsTrue_evenIfWhitelistsEmpty() {
+  void canWrite_nonNoneAuthType_shortCircuitsTrue_evenIfAllowlistsEmpty() {
     NfsFileSystem fs = perUserAuthFileSystem(NfsClientType.IRODS);
     assertTrue(checker.canWrite(user("alice"), fs));
   }
@@ -154,8 +154,8 @@ class FilestoreAclCheckerTest {
     NfsFileSystem fs = new NfsFileSystem();
     fs.setClientType(NfsClientType.S3);
     fs.setAuthType(null);
-    fs.setReadWhitelist("*");
-    fs.setWriteWhitelist("*");
+    fs.setReadAllowlist("*");
+    fs.setWriteAllowlist("*");
     assertFalse(checker.canRead(user("alice"), fs));
   }
 
@@ -164,7 +164,7 @@ class FilestoreAclCheckerTest {
     NfsFileSystem fs = new NfsFileSystem();
     fs.setClientType(NfsClientType.S3);
     fs.setAuthType(null);
-    fs.setWriteWhitelist("*");
+    fs.setWriteAllowlist("*");
     assertFalse(checker.canWrite(user("alice"), fs));
   }
 
@@ -174,7 +174,7 @@ class FilestoreAclCheckerTest {
     NfsFileSystem fs = new NfsFileSystem();
     fs.setClientType(NfsClientType.SAMBA);
     fs.setAuthType(NfsAuthenticationType.NONE);
-    fs.setReadWhitelist("alice");
+    fs.setReadAllowlist("alice");
     assertTrue(checker.canRead(user("alice"), fs));
     assertFalse(checker.canRead(user("bob"), fs));
   }
@@ -215,12 +215,12 @@ class FilestoreAclCheckerTest {
     return new User(username);
   }
 
-  private static NfsFileSystem s3FileSystem(String readWhitelist, String writeWhitelist) {
+  private static NfsFileSystem s3FileSystem(String readAllowlist, String writeAllowlist) {
     NfsFileSystem fs = new NfsFileSystem();
     fs.setClientType(NfsClientType.S3);
     fs.setAuthType(NfsAuthenticationType.NONE);
-    fs.setReadWhitelist(readWhitelist);
-    fs.setWriteWhitelist(writeWhitelist);
+    fs.setReadAllowlist(readAllowlist);
+    fs.setWriteAllowlist(writeAllowlist);
     return fs;
   }
 

--- a/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
+++ b/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
@@ -1,0 +1,204 @@
+package com.researchspace.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.researchspace.model.User;
+import com.researchspace.model.netfiles.NfsAuthenticationType;
+import com.researchspace.model.netfiles.NfsClientType;
+import com.researchspace.model.netfiles.NfsFileSystem;
+import java.util.Set;
+import org.apache.shiro.authz.AuthorizationException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FilestoreAclCheckerTest {
+
+  private FilestoreAclChecker checker;
+
+  @Before
+  public void setUp() {
+    checker = new FilestoreAclChecker();
+  }
+
+  // --- parseList ---
+
+  @Test
+  public void parseList_nullOrEmpty_returnsEmpty() {
+    assertTrue(FilestoreAclChecker.parseList(null).isEmpty());
+    assertTrue(FilestoreAclChecker.parseList("").isEmpty());
+    assertTrue(FilestoreAclChecker.parseList("   ").isEmpty());
+  }
+
+  @Test
+  public void parseList_singleToken() {
+    Set<String> tokens = FilestoreAclChecker.parseList("alice");
+    assertEquals(1, tokens.size());
+    assertTrue(tokens.contains("alice"));
+  }
+
+  @Test
+  public void parseList_multipleTokensTrimsWhitespace() {
+    Set<String> tokens = FilestoreAclChecker.parseList("  alice ,  bob  ");
+    assertEquals(2, tokens.size());
+    assertTrue(tokens.contains("alice"));
+    assertTrue(tokens.contains("bob"));
+  }
+
+  @Test
+  public void parseList_dropsEmptyTokens() {
+    Set<String> tokens = FilestoreAclChecker.parseList("alice,,bob,");
+    assertEquals(2, tokens.size());
+    assertTrue(tokens.contains("alice"));
+    assertTrue(tokens.contains("bob"));
+  }
+
+  @Test
+  public void parseList_everyoneSentinel() {
+    Set<String> tokens = FilestoreAclChecker.parseList("*");
+    assertEquals(1, tokens.size());
+    assertTrue(tokens.contains("*"));
+  }
+
+  // --- canRead / canWrite, authType=NONE ---
+
+  @Test
+  public void canRead_emptyWhitelists_deniesEveryone() {
+    NfsFileSystem fs = s3FileSystem(null, null);
+    assertFalse(checker.canRead(user("alice"), fs));
+    assertFalse(checker.canRead(user("bob"), fs));
+  }
+
+  @Test
+  public void canRead_everyoneSentinel_grantsAll() {
+    NfsFileSystem fs = s3FileSystem("*", null);
+    assertTrue(checker.canRead(user("alice"), fs));
+    assertTrue(checker.canRead(user("anyone"), fs));
+  }
+
+  @Test
+  public void canRead_namedList_grantsOnlyListedUsers() {
+    NfsFileSystem fs = s3FileSystem("alice,bob", null);
+    assertTrue(checker.canRead(user("alice"), fs));
+    assertTrue(checker.canRead(user("bob"), fs));
+    assertFalse(checker.canRead(user("carol"), fs));
+  }
+
+  @Test
+  public void canRead_writeImpliesRead_namedWriter() {
+    NfsFileSystem fs = s3FileSystem(null, "alice");
+    assertTrue(checker.canRead(user("alice"), fs));
+    assertFalse(checker.canRead(user("bob"), fs));
+  }
+
+  @Test
+  public void canRead_writeImpliesRead_everyoneWrite() {
+    NfsFileSystem fs = s3FileSystem(null, "*");
+    assertTrue(checker.canRead(user("anyone"), fs));
+  }
+
+  @Test
+  public void canRead_isCaseSensitive() {
+    NfsFileSystem fs = s3FileSystem("Alice", null);
+    assertTrue(checker.canRead(user("Alice"), fs));
+    assertFalse(checker.canRead(user("alice"), fs));
+  }
+
+  @Test
+  public void canWrite_emptyWriteList_deniesEveryoneEvenIfRead() {
+    NfsFileSystem fs = s3FileSystem("*", null);
+    assertFalse(checker.canWrite(user("alice"), fs));
+  }
+
+  @Test
+  public void canWrite_everyoneSentinel_grantsAll() {
+    NfsFileSystem fs = s3FileSystem(null, "*");
+    assertTrue(checker.canWrite(user("alice"), fs));
+  }
+
+  @Test
+  public void canWrite_namedList_grantsOnlyListedUsers() {
+    NfsFileSystem fs = s3FileSystem(null, "alice");
+    assertTrue(checker.canWrite(user("alice"), fs));
+    assertFalse(checker.canWrite(user("bob"), fs));
+  }
+
+  // --- authType gate ---
+
+  @Test
+  public void canRead_nonNoneAuthType_shortCircuitsTrue_evenIfWhitelistsEmpty() {
+    NfsFileSystem fs = perUserAuthFileSystem(NfsClientType.SAMBA);
+    assertTrue(checker.canRead(user("alice"), fs));
+  }
+
+  @Test
+  public void canWrite_nonNoneAuthType_shortCircuitsTrue_evenIfWhitelistsEmpty() {
+    NfsFileSystem fs = perUserAuthFileSystem(NfsClientType.IRODS);
+    assertTrue(checker.canWrite(user("alice"), fs));
+  }
+
+  @Test
+  public void canRead_authTypeNoneOnNonS3Backend_stillEnforced() {
+    // hypothetical: Samba configured with authType=NONE should still be gated
+    NfsFileSystem fs = new NfsFileSystem();
+    fs.setClientType(NfsClientType.SAMBA);
+    fs.setAuthType(NfsAuthenticationType.NONE);
+    fs.setReadWhitelist("alice");
+    assertTrue(checker.canRead(user("alice"), fs));
+    assertFalse(checker.canRead(user("bob"), fs));
+  }
+
+  // --- assert variants ---
+
+  @Test
+  public void assertCanRead_authorized_doesNotThrow() {
+    NfsFileSystem fs = s3FileSystem("alice", null);
+    checker.assertCanRead(user("alice"), fs);
+  }
+
+  @Test
+  public void assertCanRead_unauthorized_throws() {
+    NfsFileSystem fs = s3FileSystem("alice", null);
+    try {
+      checker.assertCanRead(user("bob"), fs);
+      fail("expected AuthorizationException");
+    } catch (AuthorizationException expected) {
+      // ok
+    }
+  }
+
+  @Test
+  public void assertCanWrite_unauthorized_throws() {
+    NfsFileSystem fs = s3FileSystem(null, "alice");
+    try {
+      checker.assertCanWrite(user("bob"), fs);
+      fail("expected AuthorizationException");
+    } catch (AuthorizationException expected) {
+      // ok
+    }
+  }
+
+  // --- helpers ---
+
+  private static User user(String username) {
+    return new User(username);
+  }
+
+  private static NfsFileSystem s3FileSystem(String readWhitelist, String writeWhitelist) {
+    NfsFileSystem fs = new NfsFileSystem();
+    fs.setClientType(NfsClientType.S3);
+    fs.setAuthType(NfsAuthenticationType.NONE);
+    fs.setReadWhitelist(readWhitelist);
+    fs.setWriteWhitelist(writeWhitelist);
+    return fs;
+  }
+
+  private static NfsFileSystem perUserAuthFileSystem(NfsClientType clientType) {
+    NfsFileSystem fs = new NfsFileSystem();
+    fs.setClientType(clientType);
+    fs.setAuthType(NfsAuthenticationType.PASSWORD);
+    return fs;
+  }
+}

--- a/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
+++ b/src/test/java/com/researchspace/service/FilestoreAclCheckerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsAuthenticationType;
@@ -21,6 +22,7 @@ public class FilestoreAclCheckerTest {
   @Before
   public void setUp() {
     checker = new FilestoreAclChecker();
+    checker.setMessages(mock(MessageSourceUtils.class));
   }
 
   // --- parseList ---

--- a/src/test/java/com/researchspace/service/NfsExportManagerTest.java
+++ b/src/test/java/com/researchspace/service/NfsExportManagerTest.java
@@ -35,6 +35,8 @@ public class NfsExportManagerTest extends SpringTransactionalTest {
 
   @Autowired private DiskSpaceChecker diskSpaceChecker;
 
+  @Autowired private com.researchspace.service.MessageSourceUtils messageSource;
+
   private User user;
   private NfsFileSystem testFileSystem;
   private NfsFileStore testFileStore;
@@ -142,7 +144,8 @@ public class NfsExportManagerTest extends SpringTransactionalTest {
     Map<String, String> messages = exportPlan.getCheckedNfsLinkMessages();
     assertEquals(1, messages.size());
     assertEquals(
-        NfsExportManagerImpl.RESOURCE_NOT_ACCESSIBLE_MSG, messages.values().iterator().next());
+        messageSource.getMessage(NfsExportManagerImpl.RESOURCE_NOT_ACCESSIBLE_MSG_KEY),
+        messages.values().iterator().next());
     assertTrue(messages.keySet().iterator().next().endsWith("test_moved.txt"));
     assertEquals(1, exportPlan.getFoundFileSystems().get(0).getCheckedNfsLinkMessages().size());
 

--- a/src/test/java/com/researchspace/service/archive/export/NfsExportContextTest.java
+++ b/src/test/java/com/researchspace/service/archive/export/NfsExportContextTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.when;
 
 import com.researchspace.archive.ArchivalNfsFile;
 import com.researchspace.archive.model.ArchiveExportConfig;
+import com.researchspace.model.User;
+import com.researchspace.model.netfiles.NfsAuthenticationType;
 import com.researchspace.model.netfiles.NfsElement;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
@@ -27,6 +29,7 @@ import com.researchspace.service.DiskSpaceLimitException;
 import com.researchspace.service.NfsFileHandler;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.impl.DiskSpaceCheckerImpl;
+import com.researchspace.testutils.GalleryFilestoreTestUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -75,6 +78,8 @@ public class NfsExportContextTest {
     testFileSystem = new NfsFileSystem();
     testFileSystem.setId(11L);
     testFileSystem.setName("Test FS");
+    // non-NONE authType so the default FilestoreAclChecker short-circuits to allow
+    testFileSystem.setAuthType(NfsAuthenticationType.PASSWORD);
 
     // two filestores pointing to the same filesystem
     testFileStore = new NfsFileStore();
@@ -133,7 +138,9 @@ public class NfsExportContextTest {
     Map<Long, NfsClient> nfsClientMap = Collections.singletonMap(testFileSystem.getId(), nfsClient);
     exportConfig = new ArchiveExportConfig();
     exportConfig.setAvailableNfsClients(nfsClientMap);
+    exportConfig.setExporter(new User("testUser"));
     nfsContext = new NfsExportContext(exportConfig);
+    nfsContext.setAclChecker(GalleryFilestoreTestUtils.filestoreAclCheckerForTest());
 
     // support object returning mock managers
     when(support.getNfsManager()).thenReturn(mockNfsManager);
@@ -293,6 +300,25 @@ public class NfsExportContextTest {
         nfsContext.getDownloadedNfsResourceDetails(testNfsFileElem, support);
     assertNull(downloadException);
     assertEquals(1, nfsContext.getErrors().size());
+  }
+
+  @Test
+  public void testAclDeniedSkipsDownloadAndRecordsError() throws IOException {
+    // user is logged in but ACL forbids read on a NONE-auth filesystem
+    when(nfsClient.isUserLoggedIn()).thenReturn(true);
+    testFileSystem.setAuthType(NfsAuthenticationType.NONE);
+    testFileSystem.setReadWhitelist("someoneElse");
+    testFileSystem.setWriteWhitelist(null);
+
+    NfsResourceDetails denied =
+        nfsContext.getDownloadedNfsResourceDetails(testNfsFileElem, support);
+    assertNull(denied);
+    assertEquals(1, nfsContext.getErrors().size());
+    assertEquals(
+        "no read access to 'Test FS' File System",
+        nfsContext.getErrors().values().iterator().next());
+
+    verify(mockNfsFileHandler, never()).downloadNfsFileToRSpace(any(), any(), any());
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/archive/export/NfsExportContextTest.java
+++ b/src/test/java/com/researchspace/service/archive/export/NfsExportContextTest.java
@@ -26,6 +26,7 @@ import com.researchspace.netfiles.NfsResourceDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.service.DiskSpaceChecker;
 import com.researchspace.service.DiskSpaceLimitException;
+import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.NfsFileHandler;
 import com.researchspace.service.NfsManager;
 import com.researchspace.service.impl.DiskSpaceCheckerImpl;
@@ -35,11 +36,13 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.context.support.StaticMessageSource;
 
 public class NfsExportContextTest {
 
@@ -141,6 +144,7 @@ public class NfsExportContextTest {
     exportConfig.setExporter(new User("testUser"));
     nfsContext = new NfsExportContext(exportConfig);
     nfsContext.setAclChecker(GalleryFilestoreTestUtils.filestoreAclCheckerForTest());
+    nfsContext.setMessages(messageSourceWithExportBundleKeys());
 
     // support object returning mock managers
     when(support.getNfsManager()).thenReturn(mockNfsManager);
@@ -148,6 +152,27 @@ public class NfsExportContextTest {
 
     diskSpaceChecker = new DiskSpaceCheckerImpl();
     when(support.getDiskSpaceChecker()).thenReturn(diskSpaceChecker);
+  }
+
+  private static MessageSourceUtils messageSourceWithExportBundleKeys() {
+    StaticMessageSource source = new StaticMessageSource();
+    Locale loc = Locale.getDefault();
+    source.addMessage(
+        "archive.export.nfs.user.not.logged.in", loc, "user not logged into ''{0}'' File System");
+    source.addMessage(
+        "archive.export.nfs.no.read.access", loc, "no read access to ''{0}'' File System");
+    source.addMessage("archive.export.nfs.file.skipped", loc, "file skipped ({0})");
+    source.addMessage("archive.export.nfs.download.error", loc, "download error: {0}");
+    source.addMessage(
+        "archive.export.nfs.file.too.large", loc, "file larger than provided size limit");
+    source.addMessage(
+        "archive.export.nfs.file.extension.excluded", loc, "file extension ''{0}'' excluded");
+    source.addMessage("archive.export.nfs.folder.empty", loc, "empty folder");
+    source.addMessage(
+        "archive.export.nfs.folder.skipped.as.subfolder", loc, "skipped as subfolder");
+    source.addMessage("archive.export.nfs.folder.included.label", loc, "Included");
+    source.addMessage("archive.export.nfs.folder.skipped.label", loc, "Skipped");
+    return new MessageSourceUtils(source);
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/archive/export/NfsExportContextTest.java
+++ b/src/test/java/com/researchspace/service/archive/export/NfsExportContextTest.java
@@ -347,6 +347,23 @@ public class NfsExportContextTest {
   }
 
   @Test
+  public void testNullExporterSkipsDownloadAndRecordsNoReadAccess() throws IOException {
+    // a null exporter has no identity to evaluate the ACL against; deny rather than NPE
+    when(nfsClient.isUserLoggedIn()).thenReturn(true);
+    exportConfig.setExporter(null);
+
+    NfsResourceDetails denied =
+        nfsContext.getDownloadedNfsResourceDetails(testNfsFileElem, support);
+    assertNull(denied);
+    assertEquals(1, nfsContext.getErrors().size());
+    assertEquals(
+        "no read access to 'Test FS' File System",
+        nfsContext.getErrors().values().iterator().next());
+
+    verify(mockNfsFileHandler, never()).downloadNfsFileToRSpace(any(), any(), any());
+  }
+
+  @Test
   public void checkNfsDownloadNotStartedIfNotEnoughDiskSpace() throws IOException {
 
     // mock nfs client being logged in

--- a/src/test/java/com/researchspace/service/archive/export/NfsExportContextTest.java
+++ b/src/test/java/com/researchspace/service/archive/export/NfsExportContextTest.java
@@ -332,8 +332,8 @@ public class NfsExportContextTest {
     // user is logged in but ACL forbids read on a NONE-auth filesystem
     when(nfsClient.isUserLoggedIn()).thenReturn(true);
     testFileSystem.setAuthType(NfsAuthenticationType.NONE);
-    testFileSystem.setReadWhitelist("someoneElse");
-    testFileSystem.setWriteWhitelist(null);
+    testFileSystem.setReadAllowlist("someoneElse");
+    testFileSystem.setWriteAllowlist(null);
 
     NfsResourceDetails denied =
         nfsContext.getDownloadedNfsResourceDetails(testNfsFileElem, support);

--- a/src/test/java/com/researchspace/service/impl/NfsExportManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/NfsExportManagerImplTest.java
@@ -96,9 +96,9 @@ class NfsExportManagerImplTest {
   }
 
   @Test
-  void userNotOnReadWhitelist_marksResourceNotAccessibleAndSkipsQuery() {
-    fileSystem.setReadWhitelist("alice");
-    fileSystem.setWriteWhitelist(null);
+  void userNotOnReadAllowlist_marksResourceNotAccessibleAndSkipsQuery() {
+    fileSystem.setReadAllowlist("alice");
+    fileSystem.setWriteAllowlist(null);
 
     manager.scanFileSystemsForFoundNfsLinks(plan, nfsClients, exportConfig);
 
@@ -109,9 +109,9 @@ class NfsExportManagerImplTest {
   }
 
   @Test
-  void userOnReadWhitelist_queriesForNfsFile() {
-    fileSystem.setReadWhitelist("testUser");
-    fileSystem.setWriteWhitelist(null);
+  void userOnReadAllowlist_queriesForNfsFile() {
+    fileSystem.setReadAllowlist("testUser");
+    fileSystem.setWriteAllowlist(null);
 
     NfsFileDetails details = new NfsFileDetails("test.txt");
     details.setFileSystemFullPath("/test.txt");
@@ -125,8 +125,8 @@ class NfsExportManagerImplTest {
   @Test
   void nullExportConfig_skipsAclCheckAndStillScans() {
     // a null config has no exporter to evaluate the ACL against; the scan must still run
-    fileSystem.setReadWhitelist("alice");
-    fileSystem.setWriteWhitelist(null);
+    fileSystem.setReadAllowlist("alice");
+    fileSystem.setWriteAllowlist(null);
     NfsFileDetails details = new NfsFileDetails("test.txt");
     details.setFileSystemFullPath("/test.txt");
     when(nfsClient.queryForNfsFile(any(NfsTarget.class))).thenReturn(details);

--- a/src/test/java/com/researchspace/service/impl/NfsExportManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/NfsExportManagerImplTest.java
@@ -20,11 +20,14 @@ import com.researchspace.netfiles.NfsFileDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.service.DiskSpaceChecker;
 import com.researchspace.service.FilestoreAclChecker;
+import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.testutils.GalleryFilestoreTestUtils;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticMessageSource;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class NfsExportManagerImplTest {
@@ -40,12 +43,15 @@ class NfsExportManagerImplTest {
   private ArchiveExportConfig exportConfig;
   private NfsExportPlan plan;
   private Map<Long, NfsClient> nfsClients;
+  private MessageSourceUtils messages;
 
   @BeforeEach
   void setUp() {
     manager = new NfsExportManagerImpl();
     FilestoreAclChecker aclChecker = GalleryFilestoreTestUtils.filestoreAclCheckerForTest();
     manager.setAclChecker(aclChecker);
+    messages = exportMessageSource();
+    manager.setMessages(messages);
     ReflectionTestUtils.setField(manager, "diskSpaceChecker", mock(DiskSpaceChecker.class));
 
     nfsClient = mock(NfsClient.class);
@@ -75,6 +81,20 @@ class NfsExportManagerImplTest {
     nfsClients = Collections.singletonMap(FS_ID, nfsClient);
   }
 
+  private static MessageSourceUtils exportMessageSource() {
+    StaticMessageSource source = new StaticMessageSource();
+    Locale loc = Locale.getDefault();
+    source.addMessage(
+        NfsExportManagerImpl.RESOURCE_NOT_ACCESSIBLE_MSG_KEY, loc, "resource not accessible");
+    source.addMessage(
+        NfsExportManagerImpl.NOT_LOGGED_INTO_FILE_SYSTEM_MSG_KEY,
+        loc,
+        "not logged into connected File System");
+    source.addMessage(
+        NfsExportManagerImpl.SUBFOLDER_NOT_INCLUDED_MSG_KEY, loc, "subfolder of linked folder");
+    return new MessageSourceUtils(source);
+  }
+
   @Test
   void userNotOnReadWhitelist_marksResourceNotAccessibleAndSkipsQuery() {
     fileSystem.setReadWhitelist("alice");
@@ -83,7 +103,7 @@ class NfsExportManagerImplTest {
     manager.scanFileSystemsForFoundNfsLinks(plan, nfsClients, exportConfig);
 
     assertEquals(
-        NfsExportManagerImpl.RESOURCE_NOT_ACCESSIBLE_MSG,
+        messages.getMessage(NfsExportManagerImpl.RESOURCE_NOT_ACCESSIBLE_MSG_KEY),
         plan.getCheckedNfsLinkMessages().get(FS_ID + "_/test.txt"));
     verify(nfsClient, never()).queryForNfsFile(any(NfsTarget.class));
   }

--- a/src/test/java/com/researchspace/service/impl/NfsExportManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/NfsExportManagerImplTest.java
@@ -1,0 +1,104 @@
+package com.researchspace.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.archive.model.ArchiveExportConfig;
+import com.researchspace.model.User;
+import com.researchspace.model.netfiles.NfsAuthenticationType;
+import com.researchspace.model.netfiles.NfsClientType;
+import com.researchspace.model.netfiles.NfsElement;
+import com.researchspace.model.netfiles.NfsFileStore;
+import com.researchspace.model.netfiles.NfsFileSystem;
+import com.researchspace.netfiles.NfsClient;
+import com.researchspace.netfiles.NfsExportPlan;
+import com.researchspace.netfiles.NfsFileDetails;
+import com.researchspace.netfiles.NfsTarget;
+import com.researchspace.service.DiskSpaceChecker;
+import com.researchspace.service.FilestoreAclChecker;
+import com.researchspace.testutils.GalleryFilestoreTestUtils;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class NfsExportManagerImplTest {
+
+  private static final long FS_ID = 11L;
+  private static final long FILESTORE_ID = 21L;
+
+  private NfsExportManagerImpl manager;
+  private NfsClient nfsClient;
+  private NfsFileSystem fileSystem;
+  private NfsFileStore fileStore;
+  private User exporter;
+  private ArchiveExportConfig exportConfig;
+  private NfsExportPlan plan;
+  private Map<Long, NfsClient> nfsClients;
+
+  @BeforeEach
+  void setUp() {
+    manager = new NfsExportManagerImpl();
+    FilestoreAclChecker aclChecker = GalleryFilestoreTestUtils.filestoreAclCheckerForTest();
+    manager.setAclChecker(aclChecker);
+    ReflectionTestUtils.setField(manager, "diskSpaceChecker", mock(DiskSpaceChecker.class));
+
+    nfsClient = mock(NfsClient.class);
+    when(nfsClient.isUserLoggedIn()).thenReturn(true);
+
+    fileSystem = new NfsFileSystem();
+    fileSystem.setId(FS_ID);
+    fileSystem.setName("test fs");
+    fileSystem.setAuthType(NfsAuthenticationType.NONE);
+    fileSystem.setClientType(NfsClientType.S3);
+
+    fileStore = new NfsFileStore();
+    fileStore.setId(FILESTORE_ID);
+    fileStore.setPath("");
+    fileStore.setFileSystem(fileSystem);
+
+    exporter = new User("testUser");
+    exportConfig = new ArchiveExportConfig();
+    exportConfig.setExporter(exporter);
+
+    plan = new NfsExportPlan();
+    plan.addFoundFileStore(fileStore);
+    plan.addFoundFileSystem(fileSystem.toFileSystemInfo());
+    NfsElement link = new NfsElement(FILESTORE_ID, "/test.txt");
+    plan.addFoundNfsLink(FS_ID, "/test.txt", link);
+
+    nfsClients = Collections.singletonMap(FS_ID, nfsClient);
+  }
+
+  @Test
+  void userNotOnReadWhitelist_marksResourceNotAccessibleAndSkipsQuery() {
+    fileSystem.setReadWhitelist("alice");
+    fileSystem.setWriteWhitelist(null);
+
+    manager.scanFileSystemsForFoundNfsLinks(plan, nfsClients, exportConfig);
+
+    assertEquals(
+        NfsExportManagerImpl.RESOURCE_NOT_ACCESSIBLE_MSG,
+        plan.getCheckedNfsLinkMessages().get(FS_ID + "_/test.txt"));
+    verify(nfsClient, never()).queryForNfsFile(any(NfsTarget.class));
+  }
+
+  @Test
+  void userOnReadWhitelist_queriesForNfsFile() {
+    fileSystem.setReadWhitelist("testUser");
+    fileSystem.setWriteWhitelist(null);
+
+    NfsFileDetails details = new NfsFileDetails("test.txt");
+    details.setFileSystemFullPath("/test.txt");
+    when(nfsClient.queryForNfsFile(any(NfsTarget.class))).thenReturn(details);
+
+    manager.scanFileSystemsForFoundNfsLinks(plan, nfsClients, exportConfig);
+
+    verify(nfsClient).queryForNfsFile(any(NfsTarget.class));
+  }
+}

--- a/src/test/java/com/researchspace/service/impl/NfsExportManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/NfsExportManagerImplTest.java
@@ -101,4 +101,18 @@ class NfsExportManagerImplTest {
 
     verify(nfsClient).queryForNfsFile(any(NfsTarget.class));
   }
+
+  @Test
+  void nullExportConfig_skipsAclCheckAndStillScans() {
+    // a null config has no exporter to evaluate the ACL against; the scan must still run
+    fileSystem.setReadWhitelist("alice");
+    fileSystem.setWriteWhitelist(null);
+    NfsFileDetails details = new NfsFileDetails("test.txt");
+    details.setFileSystemFullPath("/test.txt");
+    when(nfsClient.queryForNfsFile(any(NfsTarget.class))).thenReturn(details);
+
+    manager.scanFileSystemsForFoundNfsLinks(plan, nfsClients, null);
+
+    verify(nfsClient).queryForNfsFile(any(NfsTarget.class));
+  }
 }

--- a/src/test/java/com/researchspace/service/impl/NfsManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/NfsManagerImplTest.java
@@ -105,8 +105,8 @@ public class NfsManagerImplTest {
 
   @Test
   public void getActiveFileSystemInfos_populatesUserPermissionsForRequestingUser() {
-    s3FileSystem.setReadWhitelist("testUser");
-    s3FileSystem.setWriteWhitelist(null);
+    s3FileSystem.setReadAllowlist("testUser");
+    s3FileSystem.setWriteAllowlist(null);
     when(nfsDao.getActiveFileSystems()).thenReturn(List.of(s3FileSystem));
 
     List<NfsFileSystemInfo> infos = nfsManager.getActiveFileSystemInfos(testUser);
@@ -120,8 +120,8 @@ public class NfsManagerImplTest {
 
   @Test
   public void getActiveFileSystemInfos_userNotInAnyList_canReadAndWriteAreFalse() {
-    s3FileSystem.setReadWhitelist("alice");
-    s3FileSystem.setWriteWhitelist("alice");
+    s3FileSystem.setReadAllowlist("alice");
+    s3FileSystem.setWriteAllowlist("alice");
     when(nfsDao.getActiveFileSystems()).thenReturn(List.of(s3FileSystem));
 
     List<NfsFileSystemInfo> infos = nfsManager.getActiveFileSystemInfos(testUser);
@@ -138,7 +138,7 @@ public class NfsManagerImplTest {
     irods.setName("irods");
     irods.setClientType(NfsClientType.IRODS);
     irods.setAuthType(NfsAuthenticationType.PASSWORD);
-    // empty whitelists; should be ignored because authType != NONE
+    // empty allowlists; should be ignored because authType != NONE
     when(nfsDao.getActiveFileSystems()).thenReturn(List.of(irods));
 
     List<NfsFileSystemInfo> infos = nfsManager.getActiveFileSystemInfos(testUser);
@@ -150,8 +150,8 @@ public class NfsManagerImplTest {
 
   @Test
   public void getFileStoreInfosForUser_populatesUserPermissionsFromUnderlyingFilesystem() {
-    s3FileSystem.setReadWhitelist("*");
-    s3FileSystem.setWriteWhitelist(null);
+    s3FileSystem.setReadAllowlist("*");
+    s3FileSystem.setWriteAllowlist(null);
     NfsFileStore filestore = new NfsFileStore();
     filestore.setId(42L);
     filestore.setName("staleFilestore");

--- a/src/test/java/com/researchspace/service/impl/NfsManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/NfsManagerImplTest.java
@@ -12,13 +12,19 @@ import com.researchspace.dao.NfsDao;
 import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsAuthenticationType;
 import com.researchspace.model.netfiles.NfsClientType;
+import com.researchspace.model.netfiles.NfsFileStore;
+import com.researchspace.model.netfiles.NfsFileStoreInfo;
 import com.researchspace.model.netfiles.NfsFileSystem;
+import com.researchspace.model.netfiles.NfsFileSystemInfo;
+import com.researchspace.model.netfiles.NfsUserPermissions;
 import com.researchspace.netfiles.NfsClient;
 import com.researchspace.netfiles.NfsFactory;
 import com.researchspace.netfiles.NfsRSpaceProvidedAuthentication;
 import com.researchspace.netfiles.s3.S3NfsClient;
+import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.aws.S3Utilities;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +62,9 @@ public class NfsManagerImplTest {
     s3FileSystem.setAuthType(NfsAuthenticationType.NONE);
 
     when(nfsDao.getNfsFileSystem(FILE_SYSTEM_ID)).thenReturn(s3FileSystem);
+
+    // real ACL checker; FilestoreAclChecker has no dependencies of its own
+    nfsManager.setAclChecker(new FilestoreAclChecker());
   }
 
   @Test
@@ -93,6 +102,71 @@ public class NfsManagerImplTest {
     String loggedAs = nfsManager.getLoggedAsUsernameIfUserLoggedIn(2L, nfsClients, testUser);
 
     assertNull(loggedAs, "disabled filesystem should return null");
+  }
+
+  @Test
+  public void getActiveFileSystemInfos_populatesUserPermissionsForRequestingUser() {
+    s3FileSystem.setReadWhitelist("testUser");
+    s3FileSystem.setWriteWhitelist(null);
+    when(nfsDao.getActiveFileSystems()).thenReturn(List.of(s3FileSystem));
+
+    List<NfsFileSystemInfo> infos = nfsManager.getActiveFileSystemInfos(testUser);
+
+    assertEquals(1, infos.size());
+    NfsUserPermissions perms = infos.get(0).getUserPermissions();
+    assertNotNull(perms);
+    assertEquals(true, perms.isCanRead());
+    assertEquals(false, perms.isCanWrite());
+  }
+
+  @Test
+  public void getActiveFileSystemInfos_userNotInAnyList_canReadAndWriteAreFalse() {
+    s3FileSystem.setReadWhitelist("alice");
+    s3FileSystem.setWriteWhitelist("alice");
+    when(nfsDao.getActiveFileSystems()).thenReturn(List.of(s3FileSystem));
+
+    List<NfsFileSystemInfo> infos = nfsManager.getActiveFileSystemInfos(testUser);
+
+    NfsUserPermissions perms = infos.get(0).getUserPermissions();
+    assertEquals(false, perms.isCanRead());
+    assertEquals(false, perms.isCanWrite());
+  }
+
+  @Test
+  public void getActiveFileSystemInfos_perUserAuthBackend_isAlwaysReadableAndWritable() {
+    NfsFileSystem irods = new NfsFileSystem();
+    irods.setId(99L);
+    irods.setName("irods");
+    irods.setClientType(NfsClientType.IRODS);
+    irods.setAuthType(NfsAuthenticationType.PASSWORD);
+    // empty whitelists; should be ignored because authType != NONE
+    when(nfsDao.getActiveFileSystems()).thenReturn(List.of(irods));
+
+    List<NfsFileSystemInfo> infos = nfsManager.getActiveFileSystemInfos(testUser);
+
+    NfsUserPermissions perms = infos.get(0).getUserPermissions();
+    assertEquals(true, perms.isCanRead());
+    assertEquals(true, perms.isCanWrite());
+  }
+
+  @Test
+  public void getFileStoreInfosForUser_populatesUserPermissionsFromUnderlyingFilesystem() {
+    s3FileSystem.setReadWhitelist("*");
+    s3FileSystem.setWriteWhitelist(null);
+    NfsFileStore filestore = new NfsFileStore();
+    filestore.setId(42L);
+    filestore.setName("staleFilestore");
+    filestore.setUser(testUser);
+    filestore.setFileSystem(s3FileSystem);
+    when(nfsDao.getUserFileStores(testUser.getId())).thenReturn(List.of(filestore));
+
+    List<NfsFileStoreInfo> infos = nfsManager.getFileStoreInfosForUser(testUser);
+
+    assertEquals(1, infos.size());
+    NfsUserPermissions perms = infos.get(0).getUserPermissions();
+    assertNotNull(perms);
+    assertEquals(true, perms.isCanRead());
+    assertEquals(false, perms.isCanWrite());
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/impl/NfsManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/NfsManagerImplTest.java
@@ -169,6 +169,26 @@ public class NfsManagerImplTest {
   }
 
   @Test
+  public void getFileStoreInfosForUser_orphanedFilestore_marksUserPermissionsInaccessible() {
+    // filestore whose filesystem has been deleted: the listing endpoint must still expose
+    // explicit canRead=false/canWrite=false so the frontend renders it as inaccessible
+    // rather than defaulting to permissive when userPermissions is absent.
+    NfsFileStore orphan = new NfsFileStore();
+    orphan.setId(99L);
+    orphan.setName("orphan");
+    orphan.setUser(testUser);
+    orphan.setFileSystem(null);
+    when(nfsDao.getUserFileStores(testUser.getId())).thenReturn(List.of(orphan));
+
+    List<NfsFileStoreInfo> infos = nfsManager.getFileStoreInfosForUser(testUser);
+
+    NfsUserPermissions perms = infos.get(0).getUserPermissions();
+    assertNotNull(perms);
+    assertEquals(false, perms.isCanRead());
+    assertEquals(false, perms.isCanWrite());
+  }
+
+  @Test
   public void s3FileSystem_returnsUsernameOnSubsequentCalls() {
     S3Utilities s3Utilities = mock(S3Utilities.class);
     S3NfsClient s3Client = new S3NfsClient(null, s3Utilities);

--- a/src/test/java/com/researchspace/service/impl/NfsManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/NfsManagerImplTest.java
@@ -21,8 +21,8 @@ import com.researchspace.netfiles.NfsClient;
 import com.researchspace.netfiles.NfsFactory;
 import com.researchspace.netfiles.NfsRSpaceProvidedAuthentication;
 import com.researchspace.netfiles.s3.S3NfsClient;
-import com.researchspace.service.FilestoreAclChecker;
 import com.researchspace.service.aws.S3Utilities;
+import com.researchspace.testutils.GalleryFilestoreTestUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,8 +63,7 @@ public class NfsManagerImplTest {
 
     when(nfsDao.getNfsFileSystem(FILE_SYSTEM_ID)).thenReturn(s3FileSystem);
 
-    // real ACL checker; FilestoreAclChecker has no dependencies of its own
-    nfsManager.setAclChecker(new FilestoreAclChecker());
+    nfsManager.setAclChecker(GalleryFilestoreTestUtils.filestoreAclCheckerForTest());
   }
 
   @Test

--- a/src/test/java/com/researchspace/testutils/GalleryFilestoreTestUtils.java
+++ b/src/test/java/com/researchspace/testutils/GalleryFilestoreTestUtils.java
@@ -49,6 +49,10 @@ public class GalleryFilestoreTestUtils {
     fileSystem.setDisabled(false);
     fileSystem.setName("s3_test_instance");
     fileSystem.setUrl("https://s3.example.com");
+    // default permissive ACL so existing tests don't need to opt-in;
+    // ACL-specific tests override these values.
+    fileSystem.setReadWhitelist("*");
+    fileSystem.setWriteWhitelist("*");
     return fileSystem;
   }
 

--- a/src/test/java/com/researchspace/testutils/GalleryFilestoreTestUtils.java
+++ b/src/test/java/com/researchspace/testutils/GalleryFilestoreTestUtils.java
@@ -65,8 +65,8 @@ public class GalleryFilestoreTestUtils {
     fileSystem.setUrl("https://s3.example.com");
     // default permissive ACL so existing tests don't need to opt-in;
     // ACL-specific tests override these values.
-    fileSystem.setReadWhitelist("*");
-    fileSystem.setWriteWhitelist("*");
+    fileSystem.setReadAllowlist("*");
+    fileSystem.setWriteAllowlist("*");
     return fileSystem;
   }
 

--- a/src/test/java/com/researchspace/testutils/GalleryFilestoreTestUtils.java
+++ b/src/test/java/com/researchspace/testutils/GalleryFilestoreTestUtils.java
@@ -1,12 +1,26 @@
 package com.researchspace.testutils;
 
+import static org.mockito.Mockito.mock;
+
 import com.researchspace.model.User;
 import com.researchspace.model.netfiles.NfsAuthenticationType;
 import com.researchspace.model.netfiles.NfsClientType;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.netfiles.NfsFileSystem;
+import com.researchspace.service.FilestoreAclChecker;
+import com.researchspace.service.MessageSourceUtils;
 
 public class GalleryFilestoreTestUtils {
+
+  /**
+   * Builds a real {@link FilestoreAclChecker} wired with a mock {@link MessageSourceUtils} so unit
+   * tests don't NPE inside the exception-message resolution path.
+   */
+  public static FilestoreAclChecker filestoreAclCheckerForTest() {
+    FilestoreAclChecker checker = new FilestoreAclChecker();
+    checker.setMessages(mock(MessageSourceUtils.class));
+    return checker;
+  }
 
   public static NfsFileSystem createIrodsFileSystem(Long id) {
     NfsFileSystem fileSystem = new NfsFileSystem();

--- a/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
@@ -26,6 +26,7 @@ import com.researchspace.netfiles.NfsFileDetails;
 import com.researchspace.netfiles.NfsTarget;
 import com.researchspace.netfiles.NfsViewProperty;
 import com.researchspace.service.NfsManager;
+import com.researchspace.testutils.GalleryFilestoreTestUtils;
 import com.researchspace.testutils.SpringTransactionalTest;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -36,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.text.StringEscapeUtils;
+import org.apache.shiro.authz.AuthorizationException;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -140,8 +142,10 @@ public class NfsControllerTest extends SpringTransactionalTest {
 
   @Test
   public void testLoginToNfs() {
+    // before stubbing manager.loginToNfs the call returns NEED_LOG_IN_MSG
     String loginResult =
-        controller.loginToNfs(1L, "username", "password", "target_dir", request, principalStub);
+        controller.loginToNfs(
+            TEST_FILE_SYSTEM_ID, "username", "password", "target_dir", request, principalStub);
     assertEquals(NEED_LOG_IN_MSG, loginResult);
     when(nfsManagerMock.loginToNfs(
             eq(TEST_FILE_SYSTEM_ID),
@@ -205,6 +209,24 @@ public class NfsControllerTest extends SpringTransactionalTest {
 
     assertFalse("after download file should be deleted", tempFile.exists());
     assertFalse("temp parent folder should be deleted", tempParentFolder.exists());
+  }
+
+  @Test
+  public void loginToNfsWithJson_userNotOnReadWhitelistForNoneAuth_throwsAuthorizationException() {
+    // ACL check should fire before nfsManager.loginToNfs for NONE-auth filesystems
+    testNfsFileSystem.setAuthType(NfsAuthenticationType.NONE);
+    testNfsFileSystem.setReadWhitelist("someoneElse");
+    testNfsFileSystem.setWriteWhitelist(null);
+    controller.setAclChecker(GalleryFilestoreTestUtils.filestoreAclCheckerForTest());
+
+    NfsController.NfsLoginData data =
+        new NfsController.NfsLoginData(TEST_FILE_SYSTEM_ID, "u", "p", null);
+    try {
+      controller.loginToNfsWithJson(data, request, principalStub);
+      org.junit.Assert.fail("expected AuthorizationException");
+    } catch (AuthorizationException expected) {
+      // expected
+    }
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
@@ -125,7 +125,7 @@ public class NfsControllerTest extends SpringTransactionalTest {
     testNfsFileSystemInfoList.add(testNfsFileSystem.toFileSystemInfo());
 
     when(nfsManagerMock.getFileStoreInfosForUser(testUser)).thenReturn(testNfsFileStoreInfoList);
-    when(nfsManagerMock.getActiveFileSystemInfos()).thenReturn(testNfsFileSystemInfoList);
+    when(nfsManagerMock.getActiveFileSystemInfos(testUser)).thenReturn(testNfsFileSystemInfoList);
     controller.getNetFilesLoginView(model, principalStub);
 
     // filesystem json double-escaped (RSPAC-2360)

--- a/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
@@ -212,11 +212,11 @@ public class NfsControllerTest extends SpringTransactionalTest {
   }
 
   @Test
-  public void loginToNfsWithJson_userNotOnReadWhitelistForNoneAuth_throwsAuthorizationException() {
+  public void loginToNfsWithJson_userNotOnReadAllowlistForNoneAuth_throwsAuthorizationException() {
     // ACL check should fire before nfsManager.loginToNfs for NONE-auth filesystems
     testNfsFileSystem.setAuthType(NfsAuthenticationType.NONE);
-    testNfsFileSystem.setReadWhitelist("someoneElse");
-    testNfsFileSystem.setWriteWhitelist(null);
+    testNfsFileSystem.setReadAllowlist("someoneElse");
+    testNfsFileSystem.setWriteAllowlist(null);
     controller.setAclChecker(GalleryFilestoreTestUtils.filestoreAclCheckerForTest());
 
     NfsController.NfsLoginData data =

--- a/src/test/java/com/researchspace/webapp/controller/NfsExportControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsExportControllerMVCIT.java
@@ -33,6 +33,8 @@ public class NfsExportControllerMVCIT extends MVCTestBase {
 
   @Autowired private NfsExportController controller;
 
+  @Autowired private com.researchspace.service.MessageSourceUtils messageSource;
+
   @Before
   public void setup() throws Exception {
     super.setUp();
@@ -132,7 +134,7 @@ public class NfsExportControllerMVCIT extends MVCTestBase {
             .getCheckedNfsLinkMessages()
             .size()); // from skipped subfolder
     assertEquals(
-        NfsExportManagerImpl.SUBFOLDER_NOT_INCLUDED_MSG,
+        messageSource.getMessage(NfsExportManagerImpl.SUBFOLDER_NOT_INCLUDED_MSG_KEY),
         fullPlan.getCheckedNfsLinkMessages().values().iterator().next());
 
     // let's re-generate full export plan and ensure the results are the same

--- a/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
@@ -99,6 +99,48 @@ public class NfsSysAdminControllerTest {
   }
 
   @Test
+  public void saveFileSystem_usernameInBothLists_rejectedAndNotSaved() {
+    nfs.setReadWhitelist("alice,carol");
+    nfs.setWriteWhitelist("alice,bob");
+
+    IllegalArgumentException ex =
+        org.junit.Assert.assertThrows(
+            IllegalArgumentException.class, () -> nfsSystemCtrller.saveFileSystem(nfs));
+    org.junit.Assert.assertTrue(
+        "expected error to name the duplicated user, got: " + ex.getMessage(),
+        ex.getMessage().contains("alice"));
+    verify(netFilesMgr, never()).saveNfsFileSystem(nfs);
+  }
+
+  @Test
+  public void saveFileSystem_everyoneSentinelInBothLists_isAllowed() {
+    // '*' in both lists means 'everyone reads, everyone writes' — a valid configuration,
+    // not a duplicate of a named user.
+    nfs.setReadWhitelist("*");
+    nfs.setWriteWhitelist("*");
+
+    NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
+
+    assertEquals(12L, result.getFileSystemId().longValue());
+    verify(netFilesMgr, atLeastOnce()).saveNfsFileSystem(nfs);
+  }
+
+  @Test
+  public void saveFileSystem_emptyWriteWhitelist_isNobodyAndDoesNotTriggerLookup() {
+    // The 'Nobody (read access only)' radio submits an empty string for the write list.
+    // parseList returns an empty set, so no lookup is attempted; the value is persisted as-is.
+    nfs.setReadWhitelist("alice");
+    nfs.setWriteWhitelist("");
+    when(userMgr.getUserByUsername("alice")).thenReturn(sysadmin);
+
+    NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
+
+    assertTrue(result.getUnknownReadWhitelistUsernames().isEmpty());
+    assertTrue(result.getUnknownWriteWhitelistUsernames().isEmpty());
+    verify(netFilesMgr, atLeastOnce()).saveNfsFileSystem(nfs);
+  }
+
+  @Test
   public void saveFileSystem_everyoneSentinel_doesNotTriggerLookup() {
     nfs.setReadWhitelist("*");
     nfs.setWriteWhitelist("*");

--- a/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
@@ -87,15 +87,15 @@ public class NfsSysAdminControllerTest {
   public void saveFileSystem() {
     NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
     assertEquals(12L, result.getFileSystemId().longValue());
-    assertTrue(result.getUnknownReadWhitelistUsernames().isEmpty());
-    assertTrue(result.getUnknownWriteWhitelistUsernames().isEmpty());
+    assertTrue(result.getUnknownReadAllowlistUsernames().isEmpty());
+    assertTrue(result.getUnknownWriteAllowlistUsernames().isEmpty());
     verify(netFilesMgr, atLeastOnce()).saveNfsFileSystem(nfs);
   }
 
   @Test
   public void saveFileSystem_unknownUsernames_returnedAsWarningButSaveSucceeds() {
-    nfs.setReadWhitelist("alice,bob");
-    nfs.setWriteWhitelist("carol");
+    nfs.setReadAllowlist("alice,bob");
+    nfs.setWriteAllowlist("carol");
     when(userMgr.getUserByUsername("alice")).thenReturn(sysadmin);
     when(userMgr.getUserByUsername("bob")).thenReturn(null);
     when(userMgr.getUserByUsername("carol"))
@@ -103,15 +103,15 @@ public class NfsSysAdminControllerTest {
 
     NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
 
-    assertEquals(java.util.List.of("bob"), result.getUnknownReadWhitelistUsernames());
-    assertEquals(java.util.List.of("carol"), result.getUnknownWriteWhitelistUsernames());
+    assertEquals(java.util.List.of("bob"), result.getUnknownReadAllowlistUsernames());
+    assertEquals(java.util.List.of("carol"), result.getUnknownWriteAllowlistUsernames());
     verify(netFilesMgr, atLeastOnce()).saveNfsFileSystem(nfs);
   }
 
   @Test
   public void saveFileSystem_usernameInBothLists_rejectedAndNotSaved() {
-    nfs.setReadWhitelist("alice,carol");
-    nfs.setWriteWhitelist("alice,bob");
+    nfs.setReadAllowlist("alice,carol");
+    nfs.setWriteAllowlist("alice,bob");
 
     IllegalArgumentException ex =
         org.junit.Assert.assertThrows(
@@ -126,8 +126,8 @@ public class NfsSysAdminControllerTest {
   public void saveFileSystem_everyoneSentinelInBothLists_isAllowed() {
     // '*' in both lists means 'everyone reads, everyone writes' — a valid configuration,
     // not a duplicate of a named user.
-    nfs.setReadWhitelist("*");
-    nfs.setWriteWhitelist("*");
+    nfs.setReadAllowlist("*");
+    nfs.setWriteAllowlist("*");
 
     NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
 
@@ -136,29 +136,29 @@ public class NfsSysAdminControllerTest {
   }
 
   @Test
-  public void saveFileSystem_emptyWriteWhitelist_isNobodyAndDoesNotTriggerLookup() {
+  public void saveFileSystem_emptyWriteAllowlist_isNobodyAndDoesNotTriggerLookup() {
     // The 'Nobody (read access only)' radio submits an empty string for the write list.
     // parseList returns an empty set, so no lookup is attempted; the value is persisted as-is.
-    nfs.setReadWhitelist("alice");
-    nfs.setWriteWhitelist("");
+    nfs.setReadAllowlist("alice");
+    nfs.setWriteAllowlist("");
     when(userMgr.getUserByUsername("alice")).thenReturn(sysadmin);
 
     NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
 
-    assertTrue(result.getUnknownReadWhitelistUsernames().isEmpty());
-    assertTrue(result.getUnknownWriteWhitelistUsernames().isEmpty());
+    assertTrue(result.getUnknownReadAllowlistUsernames().isEmpty());
+    assertTrue(result.getUnknownWriteAllowlistUsernames().isEmpty());
     verify(netFilesMgr, atLeastOnce()).saveNfsFileSystem(nfs);
   }
 
   @Test
   public void saveFileSystem_everyoneSentinel_doesNotTriggerLookup() {
-    nfs.setReadWhitelist("*");
-    nfs.setWriteWhitelist("*");
+    nfs.setReadAllowlist("*");
+    nfs.setWriteAllowlist("*");
 
     NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
 
-    assertTrue(result.getUnknownReadWhitelistUsernames().isEmpty());
-    assertTrue(result.getUnknownWriteWhitelistUsernames().isEmpty());
+    assertTrue(result.getUnknownReadAllowlistUsernames().isEmpty());
+    assertTrue(result.getUnknownWriteAllowlistUsernames().isEmpty());
     verify(userMgr, never()).getUserByUsername(Mockito.anyString());
   }
 

--- a/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
@@ -75,8 +75,39 @@ public class NfsSysAdminControllerTest {
 
   @Test
   public void saveFileSystem() {
-    assertEquals(12, nfsSystemCtrller.saveFileSystem(nfs).intValue());
+    NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
+    assertEquals(12L, result.getFileSystemId().longValue());
+    assertTrue(result.getUnknownReadWhitelistUsernames().isEmpty());
+    assertTrue(result.getUnknownWriteWhitelistUsernames().isEmpty());
     verify(netFilesMgr, atLeastOnce()).saveNfsFileSystem(nfs);
+  }
+
+  @Test
+  public void saveFileSystem_unknownUsernames_returnedAsWarningButSaveSucceeds() {
+    nfs.setReadWhitelist("alice,bob");
+    nfs.setWriteWhitelist("carol");
+    when(userMgr.getUserByUsername("alice")).thenReturn(sysadmin);
+    when(userMgr.getUserByUsername("bob")).thenReturn(null);
+    when(userMgr.getUserByUsername("carol"))
+        .thenThrow(new org.springframework.orm.ObjectRetrievalFailureException("User", "carol"));
+
+    NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
+
+    assertEquals(java.util.List.of("bob"), result.getUnknownReadWhitelistUsernames());
+    assertEquals(java.util.List.of("carol"), result.getUnknownWriteWhitelistUsernames());
+    verify(netFilesMgr, atLeastOnce()).saveNfsFileSystem(nfs);
+  }
+
+  @Test
+  public void saveFileSystem_everyoneSentinel_doesNotTriggerLookup() {
+    nfs.setReadWhitelist("*");
+    nfs.setWriteWhitelist("*");
+
+    NfsFileSystemSaveResult result = nfsSystemCtrller.saveFileSystem(nfs);
+
+    assertTrue(result.getUnknownReadWhitelistUsernames().isEmpty());
+    assertTrue(result.getUnknownWriteWhitelistUsernames().isEmpty());
+    verify(userMgr, never()).getUserByUsername(Mockito.anyString());
   }
 
   @Test(expected = AuthorizationException.class)

--- a/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -46,6 +48,14 @@ public class NfsSysAdminControllerTest {
     sysadmin = TestFactory.createAnyUserWithRole("any", Constants.SYSADMIN_ROLE);
     otherUser = TestFactory.createAnyUserWithRole("any", Constants.ADMIN_ROLE);
     when(userMgr.getAuthenticatedUserInSession()).thenReturn(sysadmin);
+    // resolve any i18n key to a string containing the first arg so existing
+    // assertions on exception message content keep working
+    when(msgSource.getMessage(anyString(), any(Object[].class)))
+        .thenAnswer(
+            inv -> {
+              Object[] args = inv.getArgument(1);
+              return args == null || args.length == 0 ? "" : String.valueOf(args[0]);
+            });
     nfs = new NfsFileSystem();
     nfs.setId(12L);
   }


### PR DESCRIPTION
## Summary

  Implements [RSDEV-1111](https://researchspace.atlassian.net/browse/RSDEV-1111): sysadmin-managed per-filesystem
  **read** and **read+write** user allowlist for S3 (and any future server-wide-auth backend).

  - Read allowlist gates browse, download, and link operations
  - Write allowlist gates move-to-S3, S3-to-S3 transfer, and the write ops added by sibling subtasks of RSDEV-1024
  - Write implies read; the two lists must be disjoint
  - `*` means "everyone with an RSpace account"
  - The enforcement gate is `NfsAuthenticationType == NONE`, not `clientType == S3`. Today that coincides with S3, but
  the design is forward-compatible with any server-wide-auth backend.

  ## Design decisions

  - **Storage:** two `VARCHAR(4000)` columns on `NfsFileSystem`. `*` = everyone, `null` / `""` = nobody, otherwise
  comma-separated case-sensitive usernames.
  - **Throw site:** single service-layer bean `FilestoreAclChecker` (`@Component`). Throws
  `org.apache.shiro.authz.AuthorizationException`, which the existing `RestExceptionHandler` maps to 403.
  - **DTO shape:** new `NfsUserPermissions { canRead, canWrite }` nested under `NfsFileSystemInfo` and
  `NfsFileStoreInfo`, populated for the request's user. Serialized only when non-null so existing JSON consumers are
  unaffected.
  - **Stale filestores:** users who lose access keep their existing filestore binding listed (with `canRead=false`) so
  the UI can render it as inaccessible rather than silently dropping it.
  - **Upgrade migration:** existing `authType=NONE` rows get `readAllowlist='*'` (preserving prior "everyone reads"
  behaviour) and `writeAllowlist=NULL` (sysadmin must explicitly grant write access).

  ## What's in the diff

  **Backend**
  - `FilestoreAclChecker` plus `assertCanRead` / `assertCanWrite` wired into `FilestoreWriteManagerImpl`,
  `GalleryFilestoresApiController` (browse / download / createFilestore), and the legacy `NfsController`
  (link-from-document path).
  - `NfsManagerImpl.getActiveFileSystemInfos(user)` / `getFileStoreInfosForUser(user)` populate `userPermissions` per
  filesystem.
  - `NfsSysAdminController.saveFileSystem` accepts the two allowlists, rejects duplicates across the lists, and warns
  about unknown usernames (saved as-typed for pre-provisioning).
  - Liquibase changeset `changeLog-rsdev-1111.xml` adds the columns and backfills `authType=NONE` rows.
  - Entity fields + new `NfsUserPermissions` DTO live in [`rspace-core-model` companion PR](TODO).

  **Frontend (React)**
  - `useS3Filestores` hook propagates `canRead` / `canWrite`.
  - `MoveToS3` dialog disables non-writable destinations in the picker and shows a dedicated alert when the user has
  zero writable S3 filestores.
  - `AddFilestoreDialog` disables inaccessible filesystems in the "Select a File system" step with an inline "no read
  access; contact your sysadmin" hint.

  **Sysadmin UI (JSP)**
  - Two new questions in the file-system dialog (S3 only):
    - "Who can write to this file system?" with `Anyone with an RSpace account` / `Only the following users: [...]` /
  `Nobody (read access only)`
    - "Who can read from this file system?" (only shown when writers are restricted) with `Anyone with an RSpace
  account` / `Only the following users: [...]`

  ## Tests

  - Backend: 40+ new tests across `FilestoreAclCheckerTest`, `GalleryFilestoresApiControllerReadAclTest`,
  `GalleryFilestoresApiControllerWriteOpsTest`, `NfsManagerImplTest`, `NfsSysAdminControllerTest`. Cover ACL matrix,
  write-implies-read, authType gate, listing-endpoint userPermissions population, duplicate-across-lists rejection,
  empty-write-list "Nobody" semantics.
  - Frontend: `useS3Filestores.test.tsx` covers `userPermissions` parsing (populated / stale / absent / non-S3
  filtering).
  - `GalleryIrodsApiControllerTest` updated for the new `aclChecker` dependency.
  - `NfsControllerTest` (SpringTransactionalTest, requires DB) verified locally against a real DB.

  ## Test plan

  - [x] `mvn clean test` passes
  - [x] `cd src/main/webapp/ui && npm run tsc && npm run test` pass
  - [x] Manual sanity: sysadmin can edit allowlists; a user not in the read list sees the filesystem greyed in Add
  Filestore dialog; write actions disabled when not in write list; existing S3 deployment retains read=everyone on
  upgrade.

  ## Notes

[Companion PR](https://github.com/rspace-os/rspace-core-model/pull/68) on `rspace-core-model` adds the entity fields and `NfsUserPermissions` DTO. Merge that first.