### PR TITLE
RSDEV-1131: Related Items link fields for Inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ src/main/webapp/ui/junit.xml
 .worktrees/
 
 .pnpm-store
+# Playwright outputs (repo root; written by the component-test runner)
+/test-results/
+/playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ These instructions apply to the entire repository unless a deeper `AGENTS.md` ov
 - When searching the repo, prefer `rg` and `rg --files`.
 - Do not edit minified files unless the user explicitly asks for it.
 - Plan documents (design notes, multi-step implementation plans, scratch analyses) must be written to the `.claude/` folder, which is gitignored. Never place plan files at the repository root or anywhere else inside `src/`. The `.claude/` folder is the only sanctioned location for ephemeral working notes that should not be committed.
+- **Never run the Maven `install` phase or install dependencies into the local Maven repository.** Do not run `mvn install`, `./mvnw install`, `mvn install:install-file`, `mvn deploy:deploy-file`, or any command that would write artefacts into `~/.m2/repository`. This applies to this project, to sibling projects in the workspace (notably `rspace-core-model`), and to any dependency the user is iterating on. Reason: locally installed artefacts silently shadow the jitpack-built artefact at the same Maven coordinate, so the running JVM ends up with bytecode that does not match what the pom claims to use. That mismatch produces failures that look like a code bug but are really a classpath bug, and it wastes hours to track down. Stick to phases that do not touch `~/.m2`: `mvn compile`, `mvn package`, `mvn test`, `mvn verify`. Dependencies are consumed via jitpack at the version pinned in `pom.xml` — if the user wants to test an unpublished change to a sibling project, ask them to push it and trigger a remote build, then bump the pom to the new commit-hash version. Do not work around this by installing locally.
 
 ## Project Overview
 
@@ -73,6 +74,13 @@ The `rspacedbuser` credentials must match `src/main/resources/rs.properties`.
 # Subsequent runs (keep existing DB)
 ./mvnw jetty:run -Denvironment=keepdbintact -Dspring.profiles.active=run -DreactDevMode=true
 ```
+
+> **Dev cache-busting for legacy assets:** in dev mode (`reactDevMode=true`), legacy
+> `/scripts/` and `/styles/` assets (e.g. `recordInfoPanel.js`) are served without a `?v=`
+> cache-buster, so the browser keeps serving a previously cached copy after you edit them.
+> If a legacy JS/CSS change does not show up, hard-refresh (Cmd+Shift+R), or add
+> `-DlegacyAssetCacheBustingInDevMode=true` to the `jetty:run` command so those assets are
+> cache-busted automatically. The React/Vite bundle is unaffected (it is always served fresh).
 
 Access at `http://localhost:8080`. Test users: `user1a`–`user8h`, admin: `sysadmin1`.
 
@@ -189,6 +197,14 @@ pnpm run test -- src/components/MyComponent/__tests__/MyComponent.test.tsx
 - **Test setup:** Global setup in `src/__tests__/setup.ts` polyfills `localStorage`, `sessionStorage`, `TextEncoder`/`TextDecoder`.
 - **Console suppression:** Use `silenceConsole()` from test helpers to suppress expected errors.
 - **Test timeout:** 20 seconds (configured in `vitest.config.ts`).
+- **Vitest must execute with `src/main/webapp/ui` as its working directory.** The `vite.config.ts` that owns module aliases (`@/` -> `src/`, `Styles` -> `src/util/styles.ts`) lives there. Running `vitest` from any other directory produces module-resolution failures such as `Cannot find package '@/__tests__/customQueries'` or `Cannot find package 'Styles'`, which look like a source bug but are a cwd problem. Since the pnpm migration the package.json lives at the repo root, so the sanctioned entry is `pnpm test <path-relative-to-ui>` from the repo root (the script cd's into `ui` itself). `npx vitest run <path>` from inside `ui` also works. Beware: `pnpm exec vitest` from inside `ui` can fail with `ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE` because `ui` no longer has its own package.json.
+- **Lint dialect required by this repo's ESLint config — write it compliant from the first draft instead of fixing up afterwards:**
+  - Use `expect(node).toBeInTheDocument()` / `not.toBeInTheDocument()`, never `.toBeTruthy()` / `toBeNull()` for DOM existence.
+  - Use `expect(node).toHaveAttribute(name, value)`, never `expect(node.getAttribute(name)).toBe(value)`.
+  - Use `expect(button).toBeDisabled()`, never `expect((button as HTMLButtonElement).disabled).toBe(true)`.
+  - For `vi.mocked(obj.method)`, extract the method to a local first (`const m = obj.method; vi.mocked(m)`), otherwise `@typescript-eslint/unbound-method` fires.
+  - `testing-library/no-container` and `no-node-access` are enabled. If you genuinely need `container.querySelector` (rare — usually to inspect a non-semantic child of a MUI component), wrap the block in `/* eslint-disable testing-library/no-node-access, testing-library/no-container */` with a comment explaining why.
+- **MUI `Select` inside `FormField` has a broken accessible name.** Its `aria-labelledby` is set to its own id rather than the label's, so `getByRole('combobox', { name: /field type/i })` returns no matches and `getByLabelText('Field type')` resolves to the FormControl wrapper rather than the select itself, so neither query reliably reaches the control. The reliable query is a stable `data-testid` on the display element: pass `SelectDisplayProps={{ "data-testid": "MySelect" } as React.HTMLAttributes<HTMLDivElement>}` and then `screen.getByTestId('MySelect')`.
 
 ### Internationalization (i18n)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ These instructions apply to the entire repository unless a deeper `AGENTS.md` ov
 - When searching the repo, prefer `rg` and `rg --files`.
 - Do not edit minified files unless the user explicitly asks for it.
 - Plan documents (design notes, multi-step implementation plans, scratch analyses) must be written to the `.claude/` folder, which is gitignored. Never place plan files at the repository root or anywhere else inside `src/`. The `.claude/` folder is the only sanctioned location for ephemeral working notes that should not be committed.
+- **Never run the Maven `install` phase or install dependencies into the local Maven repository.** Do not run `mvn install`, `./mvnw install`, `mvn install:install-file`, `mvn deploy:deploy-file`, or any command that would write artefacts into `~/.m2/repository`. This applies to this project, to sibling projects in the workspace (notably `rspace-core-model`), and to any dependency the user is iterating on. Reason: locally installed artefacts silently shadow the jitpack-built artefact at the same Maven coordinate, so the running JVM ends up with bytecode that does not match what the pom claims to use. That mismatch produces failures that look like a code bug but are really a classpath bug, and it wastes hours to track down. Stick to phases that do not touch `~/.m2`: `mvn compile`, `mvn package`, `mvn test`, `mvn verify`. Dependencies are consumed via jitpack at the version pinned in `pom.xml` — if the user wants to test an unpublished change to a sibling project, ask them to push it and trigger a remote build, then bump the pom to the new commit-hash version. Do not work around this by installing locally.
 
 ## Project Overview
 
@@ -73,6 +74,13 @@ The `rspacedbuser` credentials must match `src/main/resources/rs.properties`.
 # Subsequent runs (keep existing DB)
 ./mvnw jetty:run -Denvironment=keepdbintact -Dspring.profiles.active=run -DreactDevMode=true
 ```
+
+> **Dev cache-busting for legacy assets:** in dev mode (`reactDevMode=true`), legacy
+> `/scripts/` and `/styles/` assets (e.g. `recordInfoPanel.js`) are served without a `?v=`
+> cache-buster, so the browser keeps serving a previously cached copy after you edit them.
+> If a legacy JS/CSS change does not show up, hard-refresh (Cmd+Shift+R), or add
+> `-DlegacyAssetCacheBustingInDevMode=true` to the `jetty:run` command so those assets are
+> cache-busted automatically. The React/Vite bundle is unaffected (it is always served fresh).
 
 Access at `http://localhost:8080`. Test users: `user1a`–`user8h`, admin: `sysadmin1`.
 
@@ -189,6 +197,14 @@ pnpm run test -- src/components/MyComponent/__tests__/MyComponent.test.tsx
 - **Test setup:** Global setup in `src/__tests__/setup.ts` polyfills `localStorage`, `sessionStorage`, `TextEncoder`/`TextDecoder`.
 - **Console suppression:** Use `silenceConsole()` from test helpers to suppress expected errors.
 - **Test timeout:** 20 seconds (configured in `vitest.config.ts`).
+- **Vitest must execute with `src/main/webapp/ui` as its working directory.** The `vite.config.ts` that owns module aliases (`@/` -> `src/`, `Styles` -> `src/util/styles.ts`) lives there. Running `vitest` from any other directory produces module-resolution failures such as `Cannot find package '@/__tests__/customQueries'` or `Cannot find package 'Styles'`, which look like a source bug but are a cwd problem. Since the pnpm migration the package.json lives at the repo root, so the sanctioned entry is `pnpm test <path-relative-to-ui>` from the repo root (the script cd's into `ui` itself). `npx vitest run <path>` from inside `ui` also works. Beware: `pnpm exec vitest` from inside `ui` can fail with `ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE` because `ui` no longer has its own package.json.
+- **Lint dialect required by this repo's ESLint config — write it compliant from the first draft instead of fixing up afterwards:**
+  - Use `expect(node).toBeInTheDocument()` / `not.toBeInTheDocument()`, never `.toBeTruthy()` / `toBeNull()` for DOM existence.
+  - Use `expect(node).toHaveAttribute(name, value)`, never `expect(node.getAttribute(name)).toBe(value)`.
+  - Use `expect(button).toBeDisabled()`, never `expect((button as HTMLButtonElement).disabled).toBe(true)`.
+  - For `vi.mocked(obj.method)`, extract the method to a local first (`const m = obj.method; vi.mocked(m)`), otherwise `@typescript-eslint/unbound-method` fires.
+  - `testing-library/no-container` and `no-node-access` are enabled. If you genuinely need `container.querySelector` (rare — usually to inspect a non-semantic child of a MUI component), wrap the block in `/* eslint-disable testing-library/no-node-access, testing-library/no-container */` with a comment explaining why.
+- **MUI `Select` inside `FormField` has a broken accessible name.** Its `aria-labelledby` is set to its own id rather than the label's, so `getByRole('combobox', { name: /field type/i })` returns no matches and `getByLabelText('Field type')` resolves to the FormControl wrapper rather than the select itself, so neither query reliably reaches the control. The reliable query is a stable `data-testid` on the display element: pass `SelectDisplayProps={{ "data-testid": "MySelect" } as React.HTMLAttributes<HTMLDivElement>}` and then `screen.getByTestId('MySelect')`.
 
 ### Internationalization (i18n)
 

--- a/DevDocs/CONTEXT.md
+++ b/DevDocs/CONTEXT.md
@@ -1,0 +1,31 @@
+# RSpace inventory Link fields
+
+Ubiquitous language for the inventory "Related Items" Link-field feature
+(RSDEV-1131): the link card, its target-state pills, and the Open action.
+
+## Language
+
+**Link target**:
+The record an inventory Link field points at, identified by its Global ID.
+Either an Inventory item (SA/SS/IC/IN/IT) or an ELN record (SD/NB/GL).
+_Avoid_: linked item, destination
+
+**Target deleted (pill)**:
+The link target currently exists in a soft-deleted state and is readable by
+the viewer. Only readable targets can surface this state at all.
+_Avoid_: trashed, removed
+
+**No access (pill)**:
+The link target is not readable by the current viewer, for whatever reason:
+unshared after the link was made, never shared with this viewer, or
+hard-deleted by another owner. The system deliberately does not distinguish
+these causes, and the state is indistinguishable from "record does not exist"
+so that existence is never disclosed (see ADR-0002).
+_Avoid_: Item unshared, unshared, hidden
+
+**Open (link card action)**:
+Navigates to the link target. Offered only when following it lands somewhere
+useful: removed for deleted or inaccessible ELN targets (their routes produce
+error pages), kept for deleted Inventory targets (the trash viewer works) and
+for all readable targets.
+_Avoid_: view, go to

--- a/DevDocs/DeveloperNotes/Troubleshooting.md
+++ b/DevDocs/DeveloperNotes/Troubleshooting.md
@@ -55,3 +55,38 @@ Also note, if the limit is
 exceeded on a deployed RSpace, the error is different - the UI fails to send
 *ANY* data when autosave is attempted and the user sees an error message that required
 parameter 'dataView' is missing.
+
+### Inventory TinyMCE editor is blank only when running the Vite dev server with `-DreactDevMode=true`
+
+***Symptom:*** In the Inventory UI, rich-text (TinyMCE) editors do not appear in EDIT mode.
+For example, opening a template and clicking EDIT shows no editor for the Description field,
+and formatted-text custom fields / Text extra fields show no editor either. Inspecting the DOM
+reveals only a hidden backing element such as
+`<textarea id="tiny-react_..." style="visibility: hidden;"></textarea>` with no `.tox` editor
+next to it. A collateral dev-only console warning also appears in `TagsCombobox`:
+`MUI: Unable to find the input element ... useAutocomplete expects an input element`.
+
+***When it happens:*** Only when BOTH of these are true at the same time:
+
+* the Vite dev server is running (`npm run serve`), AND
+* RSpace is launched with `-DreactDevMode=true`.
+
+Either one alone is fine. Running in production mode (a launch config WITHOUT
+`-DreactDevMode=true`, and not running the Vite server) works correctly.
+
+***Why:*** `-DreactDevMode=true` loads the React app from the Vite dev server, which is the
+React **development** build with `StrictMode` active. React 18 StrictMode intentionally
+double-invokes the lifecycle in development (mount, then unmount, then remount on first mount).
+The `@tinymce/tinymce-react` wrapper does not survive that synthetic unmount/remount: the editor
+is created on the first mount, torn down on the StrictMode unmount, and not re-initialised on the
+remount, leaving the hidden textarea. The MUI Autocomplete warning is a related, harmless symptom
+of the same double-mount. The production React build treats StrictMode as a no-op, so neither
+symptom occurs there.
+
+***This is not an application/code bug.*** The crashing components
+(`Inventory/Template/Fields/DefaultValueField.tsx`, `components/Inputs/TextField.tsx`,
+`components/Inputs/StyledTinyMceEditor.tsx`, `Tags/TagsCombobox.tsx`) are unchanged and the
+shipped/production build works. To develop rich-text areas of Inventory locally, run without
+`-DreactDevMode=true` (use the prebuilt bundle). A proper fix (hardening the TinyMCE wrapper
+against StrictMode, or relaxing StrictMode on the TinyMCE-hosting entries) is tracked in
+RSDEV-1159.

--- a/DevDocs/adr/0001-eln-link-picker-tree-styling.md
+++ b/DevDocs/adr/0001-eln-link-picker-tree-styling.md
@@ -1,0 +1,82 @@
+# Reproduce the ELN/Workspace tree look in the Inventory link "Browse ELN" picker
+
+Status: accepted
+
+## Context
+
+The Inventory structured-Link field's "Browse ELN" dialog (`ElnRecordPicker` →
+`ElnFolderBrowser`) lets a user pick an ELN document, notebook, folder or Gallery
+file as a link target. It renders a MUI `SimpleTreeView` (via the generic
+`src/components/Tree.tsx`) and looked nothing like the rest of RSpace.
+
+The requirement was that the picker's tree should look like the **ELN/Workspace
+tree**, and that the same look be applied to Gallery items shown in it; explicitly
+*not* like the Inventory picker.
+
+The ELN/Workspace tree is rendered by **legacy jQuery Fancytree**
+(`workspace.jsp` loads `jquery.fancytree/dist/skin-bootstrap/...`), styled by
+Fancytree's skin-bootstrap CSS plus RSpace's `styles/tags/fileTreeBrowser.css`.
+That CSS targets Fancytree's DOM (`.fancytree-node`, `.fancytree-title`,
+`.fancytree-expander`, `.fancytree-icon`), which is entirely different from the
+MUI tree's DOM (`.MuiTreeItem-content`, `.MuiTreeItem-label`). So the ELN CSS
+**cannot be reused** (its selectors will not bind to the MUI markup).
+
+## Decision
+
+Reproduce the ELN/Workspace tree look in the picker's MUI tree, scoped to the
+Link-picker files only:
+
+- **Reuse the ELN icon assets by URL** (no copies) for ELN node types: folder →
+  `/images/icons/folder.png`, notebook → `/images/icons/notebook.png`, document →
+  `/images/icons/unknownDocument.png`, and folder expanders → `/images/icons/RightArrow25.png`
+  (collapsed) / `DownArrow25.png` (expanded).
+- **Gallery (MEDIA) files use the Gallery's own per-type icons**, not the ELN set, so they look
+  like the Gallery (images, PDFs, documents, spreadsheets, etc.). The picker **reuses** the
+  Gallery's extension groupings (`src/eln/gallery/fileExtensionsByType.json`) and the shared
+  `justFilenameExtension` parser (`src/util/files.ts`), and **copies only** the small
+  category→SVG map (`/images/icons/{image,document,pdf,sheet,presentation,audio,video,chemistry,dna,html,csv,xml,zip}.svg`),
+  falling back to `/images/icons/unknown.svg`. `useGalleryListing` is not modified. DMP gallery
+  files fall back to `unknown.svg` (the picker's `folders/tree` node carries no gallery-section
+  info, which the Gallery's `dmp.svg` special-case needs).
+- **Copy the few visual values** that cannot be reused (DOM mismatch): selected-row
+  background `rgba(193, 193, 193, 0.5)`, ~25px rows, ~20px per-level indent.
+- Node labels show the **name only** (the picked target's global ID still surfaces in
+  the chip after selection), matching the ELN tree.
+- Styling is **picker-local** (applied at `ElnFolderBrowser` via `sx`/slots on the
+  forwarded MUI tree); the generic `Tree` is not modified.
+
+**Hard constraint honoured:** zero changes to existing ELN/Gallery styling or code. The Gallery's
+`fileExtensionsByType.json` and the shared `justFilenameExtension` are *imported* (read-only reuse),
+not modified. No edits to `fileTreeBrowser.css`, Fancytree assets, the MUI theme, `useGalleryListing`
+or any other `src/eln/gallery/*` file, or `src/components/Tree.tsx` (also used by `FolderTree`).
+Verified by the `git diff` scope.
+
+## Considered options
+
+- **A — reproduce the ELN/Fancytree look in MUI (chosen).** Only way to echo the
+  *workspace* tree the user asked for, given the CSS cannot be reused.
+- **B — reuse the React Gallery tree styling** (`eln/gallery/TreeView` `StyledTreeItem`:
+  `callToAction` selection). Rejected: it matches the Gallery surface, which is a
+  distinct look from the Workspace ELN tree the requirement named.
+- **C — reuse the Inventory picker styling** (`LinkTargetBrowser`/`InventoryPicker`).
+  Rejected: that is the look the requirement explicitly excluded.
+
+## Consequences
+
+- A small number of visual values (selection colour, row height, indent) are duplicated
+  from `fileTreeBrowser.css` because the legacy CSS cannot bind to MUI's DOM. The icon
+  assets, by contrast, are genuinely reused by URL and stay in sync if those assets change.
+- The picker deliberately mimics a legacy jQuery component's look. If RSpace later ships a
+  React Workspace tree, the picker should adopt it rather than keep mimicking Fancytree.
+
+## Terminology
+
+- **ELN / Workspace tree** — the legacy Fancytree document/notebook/folder tree in the
+  Workspace, styled by `fileTreeBrowser.css` + Fancytree skin-bootstrap. The look this
+  picker reproduces.
+- **Gallery tree** — the React `eln/gallery/TreeView` (MUI, `callToAction` selection). A
+  distinct look; not the target here.
+- **Inventory picker** — `LinkTargetBrowser` wrapping `InventoryPicker`; the "Browse
+  Inventory" target chooser. Explicitly *not* the look to copy.
+- **ELN link picker** — this feature's "Browse ELN" dialog: `ElnRecordPicker` +
+  `ElnFolderBrowser`.

--- a/DevDocs/adr/0002-link-target-state-non-disclosure.md
+++ b/DevDocs/adr/0002-link-target-state-non-disclosure.md
@@ -1,0 +1,37 @@
+# Link target summaries conflate "unreadable" with "nonexistent"
+
+Status: accepted
+
+The link-target summary endpoint (`GET /api/inventory/v1/linkTargets/{globalId}/summary`,
+RSDEV-1182) backs the link card's state pills. It is callable with any
+well-formed Global ID, so its responses must not let a caller probe which
+records exist. We decided that the summary's `readable: false` deliberately
+covers every degraded case identically: target unshared from the viewer,
+never shared with the viewer, nonexistent, or hard-deleted by another owner
+all produce field-for-field identical payloads (globalId only, `name`/`type`
+null, `deleted` false). A unit test pins this invariant.
+
+The user-facing consequence is that the card's pill says **"No access"**
+rather than "Item unshared": unshared-after-linking is indistinguishable from
+never-shared without consulting share history, and the pill must never imply
+knowledge the viewer is not entitled to.
+
+## Considered options
+
+* **Per-viewer share-history detection** (to label genuinely unshared targets
+  differently): rejected. It needs a new query chain per link per viewer,
+  and only buys a more specific word on the pill.
+* **"Item unshared" wording on the generic no-access state**: rejected as
+  inaccurate for never-shared viewers, who legitimately see links on records
+  shared with them whose targets never were.
+
+## Consequences
+
+* `deleted: true` can only ever arrive alongside `readable: true` (redaction
+  zeroes it), so the "Target deleted" and "No access" pills can never co-occur
+  and need no precedence logic.
+* The "No access" pill also appears to viewers who never had access and for
+  hard-deleted targets they do not own. This is accepted: in every such case
+  Open could only produce an error page.
+* Inventory targets ignore `readable` in the UI: every logged-in user retains
+  the limited-read view, so Open keeps working and no pill is shown.

--- a/pom.xml
+++ b/pom.xml
@@ -1456,7 +1456,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>RSDEV-1131-Inventory-link-related-items-ee1fb11cc3-1</version>
+      <version>2.27.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
   </parent>
 
   <repositories>
@@ -436,6 +436,25 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-unix-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.mnode.ical4j</groupId>
+      <artifactId>ical4j</artifactId>
+      <version>${ical4j.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-collections4</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1437,7 +1456,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>2.26.0</version>
+      <version>RSDEV-1131-Inventory-link-related-items-ee1fb11cc3-1</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/src/main/java/com/researchspace/api/v1/InventoryLinkTargetApi.java
+++ b/src/main/java/com/researchspace/api/v1/InventoryLinkTargetApi.java
@@ -1,0 +1,23 @@
+/**
+ * RSpace Inventory API: read-time summary of an Inventory Link target. Backs the "Target deleted"
+ * pill and target-name display on link cards without populating a summary into every outgoing link
+ * payload (which would run on list endpoints; see RSDEV-1182).
+ */
+package com.researchspace.api.v1;
+
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.model.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/inventory/v1")
+public interface InventoryLinkTargetApi {
+
+  /**
+   * Resolves the current state (globalId, name, type, deleted) of a link target, Inventory or ELN
+   * alike. Permission-redacted: targets the caller cannot read return a globalId-only summary.
+   */
+  @GetMapping("/linkTargets/{globalId}/summary")
+  ApiInventoryLinkTargetSummary getLinkTargetSummary(@PathVariable String globalId, User user);
+}

--- a/src/main/java/com/researchspace/api/v1/InventoryReferencingItemsApi.java
+++ b/src/main/java/com/researchspace/api/v1/InventoryReferencingItemsApi.java
@@ -1,0 +1,37 @@
+/**
+ * RSpace Inventory API: back-references for Inventory Link extra-fields. Returns the items whose
+ * Link extraField points at the supplied target item.
+ */
+package com.researchspace.api.v1;
+
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.model.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/inventory/v1")
+public interface InventoryReferencingItemsApi {
+
+  @GetMapping("/samples/{id}/referencingItems")
+  ApiInventoryReferencingItems getReferencingItemsForSample(@PathVariable Long id, User user);
+
+  @GetMapping("/subSamples/{id}/referencingItems")
+  ApiInventoryReferencingItems getReferencingItemsForSubSample(@PathVariable Long id, User user);
+
+  @GetMapping("/containers/{id}/referencingItems")
+  ApiInventoryReferencingItems getReferencingItemsForContainer(@PathVariable Long id, User user);
+
+  @GetMapping("/instruments/{id}/referencingItems")
+  ApiInventoryReferencingItems getReferencingItemsForInstrument(@PathVariable Long id, User user);
+
+  /**
+   * Generic, target-agnostic back-reference lookup. Returns the Inventory items whose Link
+   * extra-field points at the supplied target GlobalID, which may be an Inventory item or an ELN
+   * item (document, notebook, gallery file). Permission-filtered to sources the user can read. Used
+   * by the ELN-side "Related inventory items" panels.
+   */
+  @GetMapping("/referencingItems/{globalId}")
+  ApiInventoryReferencingItems getReferencingItemsForGlobalId(
+      @PathVariable String globalId, User user);
+}

--- a/src/main/java/com/researchspace/api/v1/controller/InventoryLinkTargetApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InventoryLinkTargetApiController.java
@@ -1,0 +1,21 @@
+package com.researchspace.api.v1.controller;
+
+import com.researchspace.api.v1.InventoryLinkTargetApi;
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.model.User;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+
+@ApiController
+public class InventoryLinkTargetApiController implements InventoryLinkTargetApi {
+
+  @Autowired private InventoryLinkManager inventoryLinkManager;
+
+  @Override
+  public ApiInventoryLinkTargetSummary getLinkTargetSummary(
+      @PathVariable String globalId, @RequestAttribute(name = "user") User user) {
+    return inventoryLinkManager.getTargetSummary(globalId, user);
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/controller/InventoryReferencingItemsApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InventoryReferencingItemsApiController.java
@@ -1,0 +1,56 @@
+package com.researchspace.api.v1.controller;
+
+import com.researchspace.api.v1.InventoryReferencingItemsApi;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+
+@ApiController
+public class InventoryReferencingItemsApiController implements InventoryReferencingItemsApi {
+
+  @Autowired private InventoryLinkManager inventoryLinkManager;
+
+  @Override
+  public ApiInventoryReferencingItems getReferencingItemsForSample(
+      @PathVariable Long id, @RequestAttribute(name = "user") User user) {
+    return forItem(GlobalIdPrefix.SA, id, user);
+  }
+
+  @Override
+  public ApiInventoryReferencingItems getReferencingItemsForSubSample(
+      @PathVariable Long id, @RequestAttribute(name = "user") User user) {
+    return forItem(GlobalIdPrefix.SS, id, user);
+  }
+
+  @Override
+  public ApiInventoryReferencingItems getReferencingItemsForContainer(
+      @PathVariable Long id, @RequestAttribute(name = "user") User user) {
+    return forItem(GlobalIdPrefix.IC, id, user);
+  }
+
+  @Override
+  public ApiInventoryReferencingItems getReferencingItemsForInstrument(
+      @PathVariable Long id, @RequestAttribute(name = "user") User user) {
+    return forItem(GlobalIdPrefix.IN, id, user);
+  }
+
+  @Override
+  public ApiInventoryReferencingItems getReferencingItemsForGlobalId(
+      @PathVariable String globalId, @RequestAttribute(name = "user") User user) {
+    ApiInventoryReferencingItems result = new ApiInventoryReferencingItems();
+    result.setReferencingItems(inventoryLinkManager.findReferencingItems(globalId, user));
+    return result;
+  }
+
+  private ApiInventoryReferencingItems forItem(GlobalIdPrefix prefix, Long id, User user) {
+    String globalId = new GlobalIdentifier(prefix, id).getIdString();
+    ApiInventoryReferencingItems result = new ApiInventoryReferencingItems();
+    result.setReferencingItems(inventoryLinkManager.findReferencingItems(globalId, user));
+    return result;
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldValidator.java
@@ -1,9 +1,11 @@
 package com.researchspace.api.v1.controller;
 
 import com.researchspace.api.v1.model.ApiField;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.service.inventory.DataCiteRelationType;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -63,6 +65,21 @@ abstract class SampleTemplateFieldValidator implements Validator {
             "errors.inventory.template.invalid.field.content",
             new Object[] {e.getMessage()},
             e.getMessage());
+      }
+    }
+
+    // Link fields: every entry in the allowed-relation-types whitelist must be a valid DataCite
+    // relation type. A null/empty whitelist is permitted and means "all relation types allowed".
+    if (apiTemplateField.getType() == ApiFieldType.LINK
+        && apiTemplateField.getAllowedRelationTypes() != null) {
+      for (String relationType : apiTemplateField.getAllowedRelationTypes()) {
+        if (!DataCiteRelationType.isValid(relationType)) {
+          errors.rejectValue(
+              "allowedRelationTypes",
+              "errors.inventory.template.invalid.relation.type",
+              new Object[] {relationType},
+              "invalid relation type");
+        }
       }
     }
   }

--- a/src/main/java/com/researchspace/api/v1/model/ApiExtraField.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiExtraField.java
@@ -12,6 +12,8 @@ import com.researchspace.core.util.jsonserialisers.ISO8601DateTimeSerialiser;
 import com.researchspace.model.User;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.field.ExtraField;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.record.IActiveUserStrategy;
 import java.util.Date;
 import lombok.Data;
@@ -35,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
   "modifiedBy",
   "type",
   "content",
+  "link",
   "parentGlobalId",
   "_links"
 })
@@ -45,6 +48,9 @@ public class ApiExtraField extends IdentifiableNameableApiObject {
 
   @JsonProperty("content")
   private String content;
+
+  @JsonProperty("link")
+  private ApiInventoryLink link;
 
   @JsonProperty("lastModified")
   @JsonSerialize(using = ISO8601DateTimeSerialiser.class)
@@ -75,7 +81,10 @@ public class ApiExtraField extends IdentifiableNameableApiObject {
     TEXT("text"),
 
     @JsonProperty("number")
-    NUMBER("number");
+    NUMBER("number"),
+
+    @JsonProperty("link")
+    LINK("link");
 
     private String value;
 
@@ -106,6 +115,9 @@ public class ApiExtraField extends IdentifiableNameableApiObject {
     setDeleted(field.isDeleted());
     setContent(field.getData());
     setGlobalId(field.getOid().toString());
+    if (field instanceof ExtraLinkField && ((ExtraLinkField) field).getLink() != null) {
+      setLink(new ApiInventoryLink(((ExtraLinkField) field).getLink()));
+    }
     if (field.getConnectedRecordOid() != null) {
       setParentGlobalId(field.getConnectedRecordGlobalIdentifier());
       setParentRecordInfo(ApiInventoryRecordInfo.fromInventoryRecord(field.getInventoryRecord()));
@@ -126,11 +138,35 @@ public class ApiExtraField extends IdentifiableNameableApiObject {
         contentChanged = true;
       }
     }
+    if (dbField instanceof ExtraLinkField && link != null) {
+      contentChanged |= applyLinkPayload((ExtraLinkField) dbField);
+    }
     if (contentChanged) {
       dbField.setModificationDate(new Date());
       dbField.setModifiedBy(user.getUsername(), IActiveUserStrategy.CHECK_OPERATE_AS);
     }
     return contentChanged;
+  }
+
+  /**
+   * Applies relationType changes from the incoming API payload onto the existing persisted
+   * InventoryLink. Target and version-pin changes are applied in the service layer instead
+   * (ApiExtraFieldsHelper's applyExistingLinkFieldChanges, which can reach the
+   * InventoryLinkManager): both need target validation and a recapture of the pinned audit revision
+   * (targetRevisionId), which this DTO cannot perform. Setting the pin here in-place would leave
+   * the stored revision pointing at the previously pinned version.
+   */
+  private boolean applyLinkPayload(ExtraLinkField dbField) {
+    InventoryLink dbLink = dbField.getLink();
+    if (dbLink == null) {
+      return false;
+    }
+    String newRelation = link.getRelationType();
+    if (newRelation != null && !newRelation.equals(dbLink.getRelationType())) {
+      dbLink.setRelationType(newRelation);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/com/researchspace/api/v1/model/ApiField.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiField.java
@@ -68,7 +68,10 @@ public abstract class ApiField extends IdentifiableNameableApiObject {
     URI("uri"),
 
     @JsonProperty("identifier")
-    IDENTIFIER("identifier");
+    IDENTIFIER("identifier"),
+
+    @JsonProperty("link")
+    LINK("link");
 
     private String value;
 

--- a/src/main/java/com/researchspace/api/v1/model/ApiFieldToModelFieldFactory.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiFieldToModelFieldFactory.java
@@ -3,6 +3,7 @@ package com.researchspace.api.v1.model;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
 import com.researchspace.model.inventory.field.InventoryRadioFieldDef;
 import org.springframework.stereotype.Component;
@@ -46,6 +47,14 @@ public class ApiFieldToModelFieldFactory {
         radioDef.setRadioOptionsList(field.getDefinition().getOptions());
         toAdd = new InventoryRadioField(radioDef, field.getName());
         break;
+      case LINK:
+        InventoryLinkField linkField = new InventoryLinkField();
+        linkField.setAllowedRelationTypes(
+            ApiInventoryEntityField.joinRelationTypes(field.getAllowedRelationTypes()));
+        // The optional default link target is created via the InventoryLinkManager write path
+        // (which captures the Envers revision); the stateless factory only sets the whitelist.
+        toAdd = linkField;
+        break;
       default:
         throw new IllegalArgumentException(
             String.format("Unsupported field type %s", field.getType()));
@@ -55,7 +64,9 @@ public class ApiFieldToModelFieldFactory {
     toAdd.setColumnIndex(field.getColumnIndex());
     if (toAdd.isOptionsStoringField()) {
       toAdd.setSelectedOptions(field.getSelectedOptions());
-    } else {
+    } else if (!(toAdd instanceof InventoryLinkField)) {
+      // Link fields hold their value in the InventoryLink association, not the data column,
+      // so they must not have the (empty) content string written into their data.
       toAdd.setFieldData(field.getContent());
     }
     if (field.getMandatory() != null) {

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
@@ -2,6 +2,7 @@
 package com.researchspace.api.v1.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -10,15 +11,19 @@ import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
 import com.researchspace.model.inventory.field.InventoryRadioFieldDef;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
 
 /** A field in a Document, with a list of attached Files */
 @Data
@@ -50,6 +55,16 @@ public class ApiInventoryEntityField extends ApiField {
 
   @JsonProperty("selectedOptions")
   private List<String> selectedOptions;
+
+  /** Link field: the whitelist of permitted DataCite relation types. Empty/null means all. */
+  @JsonProperty("allowedRelationTypes")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private List<String> allowedRelationTypes;
+
+  /** Link field: the (optional) single link value (target + relation + version pin). */
+  @JsonProperty("link")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private ApiInventoryLink link;
 
   @JsonProperty("mandatory")
   private Boolean mandatory;
@@ -123,6 +138,12 @@ public class ApiInventoryEntityField extends ApiField {
       if (field.getAttachedFile() != null) {
         setAttachment(new ApiInventoryFile(field.getAttachedFile()));
       }
+    } else if (field instanceof InventoryLinkField) {
+      InventoryLinkField linkField = (InventoryLinkField) field;
+      setAllowedRelationTypes(splitRelationTypes(linkField.getAllowedRelationTypes()));
+      if (linkField.getLink() != null) {
+        setLink(new ApiInventoryLink(linkField.getLink()));
+      }
     }
 
     if (field.isOptionsStoringField()) {
@@ -130,6 +151,32 @@ public class ApiInventoryEntityField extends ApiField {
     } else {
       setContent(field.getFieldData());
     }
+  }
+
+  /** Splits the model's pipe-delimited relation-type whitelist into a list; empty/null -&gt; []. */
+  static List<String> splitRelationTypes(String pipeDelimited) {
+    if (StringUtils.isBlank(pipeDelimited)) {
+      return new ArrayList<>();
+    }
+    return Arrays.stream(pipeDelimited.split("\\|"))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Joins an allowed-relation-types list into the model's pipe-delimited form; empty -&gt; null.
+   */
+  static String joinRelationTypes(List<String> relationTypes) {
+    if (relationTypes == null || relationTypes.isEmpty()) {
+      return null;
+    }
+    String joined =
+        relationTypes.stream()
+            .map(s -> s == null ? "" : s.trim())
+            .filter(s -> !s.isEmpty())
+            .collect(Collectors.joining("|"));
+    return joined.isEmpty() ? null : joined;
   }
 
   @JsonIgnore
@@ -221,6 +268,14 @@ public class ApiInventoryEntityField extends ApiField {
 
   private boolean applyContentChangesToDbField(InventoryEntityField dbField) {
     boolean contentChanged = false;
+
+    // a link field's value lives in its InventoryLink (applied through the
+    // service-layer InventoryLinkManager), not in the data column; pushing the
+    // client's (empty) content into setFieldData would trip the mandatory-field
+    // check for link fields populated by a template's "update all samples"
+    if (dbField instanceof InventoryLinkField) {
+      return false;
+    }
 
     // for choice/radio the content comes/goes through selectedOptions
     boolean isOptionsField = dbField.isOptionsStoringField();

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryLink.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryLink.java
@@ -1,0 +1,48 @@
+package com.researchspace.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.field.InventoryLink;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** API payload representing a Link extra-field's target/relation metadata. */
+@Data
+@NoArgsConstructor
+@JsonPropertyOrder({"relationType", "targetGlobalId", "versionPin"})
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class ApiInventoryLink {
+
+  @JsonProperty("relationType")
+  private String relationType;
+
+  @JsonProperty("targetGlobalId")
+  private String targetGlobalId;
+
+  @JsonProperty("versionPin")
+  private Long versionPin;
+
+  public ApiInventoryLink(InventoryLink link) {
+    this.relationType = link.getRelationType();
+    this.targetGlobalId = link.getTargetGlobalId();
+    this.versionPin = link.getVersionPin();
+  }
+
+  /**
+   * Returns the version pin derived from any "vN" suffix on the targetGlobalId. Returns null if the
+   * id has no suffix or is unparseable.
+   */
+  public Long derivedVersionPin() {
+    if (targetGlobalId == null) {
+      return null;
+    }
+    try {
+      GlobalIdentifier gid = new GlobalIdentifier(targetGlobalId);
+      return gid.hasVersionId() ? gid.getVersionId() : null;
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryLinkTargetSummary.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryLinkTargetSummary.java
@@ -1,0 +1,34 @@
+package com.researchspace.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Summary of an InventoryLink's target as seen at read time. */
+@Data
+@NoArgsConstructor
+@JsonPropertyOrder({"globalId", "name", "type", "deleted", "readable"})
+public class ApiInventoryLinkTargetSummary {
+
+  @JsonProperty("globalId")
+  private String globalId;
+
+  @JsonProperty("name")
+  private String name;
+
+  /** Item type, e.g. SAMPLE/SUBSAMPLE/CONTAINER/INSTRUMENT */
+  @JsonProperty("type")
+  private String type;
+
+  @JsonProperty("deleted")
+  private boolean deleted;
+
+  /**
+   * True only when the actor can read the target. False deliberately conflates "unreadable" with
+   * "nonexistent": both produce field-for-field identical payloads so callers cannot probe which
+   * records exist (see DevDocs/adr/0002-link-target-state-non-disclosure.md).
+   */
+  @JsonProperty("readable")
+  private boolean readable;
+}

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryReferencingItem.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryReferencingItem.java
@@ -1,0 +1,45 @@
+package com.researchspace.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.researchspace.core.util.jsonserialisers.ISO8601DateTimeDeserialiser;
+import com.researchspace.core.util.jsonserialisers.ISO8601DateTimeSerialiser;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Single row of a referencing-items response (an item that links to the requested target). */
+@Data
+@NoArgsConstructor
+@JsonPropertyOrder({
+  "sourceGlobalId",
+  "sourceName",
+  "sourceType",
+  "relationType",
+  "versionPin",
+  "modifiedAt"
+})
+public class ApiInventoryReferencingItem {
+
+  @JsonProperty("sourceGlobalId")
+  private String sourceGlobalId;
+
+  @JsonProperty("sourceName")
+  private String sourceName;
+
+  /** Item type of the source: SAMPLE / SUBSAMPLE / CONTAINER / INSTRUMENT */
+  @JsonProperty("sourceType")
+  private String sourceType;
+
+  @JsonProperty("relationType")
+  private String relationType;
+
+  @JsonProperty("versionPin")
+  private Long versionPin;
+
+  @JsonProperty("modifiedAt")
+  @JsonSerialize(using = ISO8601DateTimeSerialiser.class)
+  @JsonDeserialize(using = ISO8601DateTimeDeserialiser.class)
+  private Long modifiedAtMillis;
+}

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryReferencingItems.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryReferencingItems.java
@@ -1,0 +1,20 @@
+package com.researchspace.api.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response wrapper listing the inventory items that reference a target record via a Link
+ * extraField. The target may be an Inventory item or an ELN record (document, notebook or gallery
+ * file): the referencing-items endpoints serve both.
+ */
+@Data
+@NoArgsConstructor
+public class ApiInventoryReferencingItems {
+
+  @JsonProperty("referencingItems")
+  private List<ApiInventoryReferencingItem> referencingItems = new ArrayList<>();
+}

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplate.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplate.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang3.Validate;
   "revisionId",
   "version",
   "historicalVersion",
+  "samplesToUpdateCount",
   "subSampleAlias",
   "defaultUnitId",
   "subSamplesCount",
@@ -59,6 +60,15 @@ public class ApiSampleTemplate extends ApiSample {
 
   @JsonProperty("defaultUnitId")
   private Integer defaultUnitId;
+
+  /**
+   * Number of the requesting user's samples that were created from an older version of this
+   * template and could be updated to its latest version. Drives whether the UI offers the "Update
+   * Samples" action; 0 means there is nothing to update. Populated on outgoing single-template
+   * responses only (not on the lighter list/search view), and left 0 on limited (no-read) views.
+   */
+  @JsonProperty("samplesToUpdateCount")
+  private int samplesToUpdateCount;
 
   public ApiSampleTemplate() {
     setTemplate(true);

--- a/src/main/java/com/researchspace/api/v1/service/ApiFieldsHelper.java
+++ b/src/main/java/com/researchspace/api/v1/service/ApiFieldsHelper.java
@@ -3,6 +3,7 @@ package com.researchspace.api.v1.service;
 import com.researchspace.api.v1.model.ApiDocumentField;
 import com.researchspace.api.v1.model.ApiField;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.linkedelements.RichTextUpdater;
 import com.researchspace.model.EcatAudio;
 import com.researchspace.model.EcatChemistryFile;
@@ -342,6 +343,25 @@ public class ApiFieldsHelper {
                 "errors.inventory." + entityTypeName + ".mandatory.field.no.selection",
                 new Object[] {templateField.getName()},
                 "no option selected for mandatory field");
+          }
+        } else if (FieldType.LINK.equals(templateField.getType())) {
+          // Link fields carry their value in the `link` object, not `content` (which is always
+          // empty for them). So the mandatory check must read the incoming link's target,
+          // falling back to any link already present on the field when no value is supplied.
+          boolean hasLinkTarget;
+          if (hasApiFieldForTemplateField) {
+            ApiInventoryLink incomingLink = incomingApiFields.get(i).getLink();
+            hasLinkTarget =
+                incomingLink != null && StringUtils.isNotBlank(incomingLink.getTargetGlobalId());
+          } else {
+            hasLinkTarget = templateField.isValidValueForMandatoryField(null);
+          }
+          if (!hasLinkTarget) {
+            errors.rejectValue(
+                "fields",
+                "errors.inventory." + entityTypeName + ".mandatory.field.empty",
+                new Object[] {templateField.getName()},
+                "no content for mandatory field");
           }
         } else {
           String incomingContent =

--- a/src/main/java/com/researchspace/dao/InventoryLinkDao.java
+++ b/src/main/java/com/researchspace/dao/InventoryLinkDao.java
@@ -1,0 +1,28 @@
+package com.researchspace.dao;
+
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import java.util.List;
+
+/** DAO for the InventoryLink table backing Inventory Link extra-fields. */
+public interface InventoryLinkDao extends GenericDao<InventoryLink, Long> {
+
+  /**
+   * Returns the ExtraLinkField rows whose link points at the supplied target record, matched by
+   * (prefix, database id) so that version-pinned links (e.g. {@code SD123v5}) still surface on the
+   * base record ({@code SD123}). Filters out soft-deleted fields and soft-deleted links. Used to
+   * drive the "referencing items" back-ref lookup by joining each field back to its parent
+   * inventory record.
+   */
+  List<ExtraLinkField> findReferencingLinkFields(GlobalIdPrefix targetPrefix, Long targetDbId);
+
+  /**
+   * The template-defined structured link fields (on samples) whose non-deleted link targets the
+   * given record. Counterpart of {@link #findReferencingLinkFields} for {@code
+   * InventoryLinkField}s, so structured links appear in back-references like extra-field links.
+   */
+  List<InventoryLinkField> findReferencingStructuredLinkFields(
+      GlobalIdPrefix targetPrefix, Long targetDbId);
+}

--- a/src/main/java/com/researchspace/dao/hibernate/InventoryLinkDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/InventoryLinkDaoHibernate.java
@@ -1,0 +1,64 @@
+package com.researchspace.dao.hibernate;
+
+import com.researchspace.dao.GenericDaoHibernate;
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InventoryLinkDaoHibernate extends GenericDaoHibernate<InventoryLink, Long>
+    implements InventoryLinkDao {
+
+  public InventoryLinkDaoHibernate() {
+    super(InventoryLink.class);
+  }
+
+  @Override
+  public List<ExtraLinkField> findReferencingLinkFields(
+      GlobalIdPrefix targetPrefix, Long targetDbId) {
+    List<InventoryLink> links = liveLinksTargeting(targetPrefix, targetDbId);
+    if (links.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery(
+            "from ExtraLinkField ef where ef.link in :links and ef.deleted = false",
+            ExtraLinkField.class)
+        .setParameterList("links", links)
+        .list();
+  }
+
+  @Override
+  public List<InventoryLinkField> findReferencingStructuredLinkFields(
+      GlobalIdPrefix targetPrefix, Long targetDbId) {
+    List<InventoryLink> links = liveLinksTargeting(targetPrefix, targetDbId);
+    if (links.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery(
+            "from InventoryLinkField f where f.link in :links and f.deleted = false",
+            InventoryLinkField.class)
+        .setParameterList("links", links)
+        .list();
+  }
+
+  private List<InventoryLink> liveLinksTargeting(GlobalIdPrefix targetPrefix, Long targetDbId) {
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery(
+            "from InventoryLink where targetPrefix=:prefix and targetDbId=:dbId and"
+                + " deleted=false",
+            InventoryLink.class)
+        .setParameter("prefix", targetPrefix)
+        .setParameter("dbId", targetDbId)
+        .list();
+  }
+}

--- a/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDeletionDaoHibernate.java
@@ -424,6 +424,29 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
 
     execute(userId, session, "delete from Container_AUD where owner_id = :id");
     execute(userId, session, "delete from Container where owner_id = :id");
+
+    // Hard-delete InventoryLink rows orphaned by the field deletions above. The FKs point
+    // field -> link, so once the user's ExtraField / InventoryEntityField rows (and their _AUD
+    // copies) are gone the rows are unreachable garbage that would otherwise leak forever
+    // (mirrors the StoichiometryInventoryLink cleanup). The sweep only matches rows with no
+    // remaining referrer in any live or audited field table, so links belonging to other
+    // users' surviving fields are untouched. _AUD first, then main.
+    executeUnparameterised(
+        session,
+        "delete il from InventoryLink_AUD il"
+            + " left join ExtraField ef on ef.link_id = il.id"
+            + " left join ExtraField_AUD efa on efa.link_id = il.id"
+            + " left join InventoryEntityField ief on ief.link_id = il.id"
+            + " left join InventoryEntityField_AUD iefa on iefa.link_id = il.id"
+            + " where ef.id is null and efa.id is null and ief.id is null and iefa.id is null");
+    executeUnparameterised(
+        session,
+        "delete il from InventoryLink il"
+            + " left join ExtraField ef on ef.link_id = il.id"
+            + " left join ExtraField_AUD efa on efa.link_id = il.id"
+            + " left join InventoryEntityField ief on ief.link_id = il.id"
+            + " left join InventoryEntityField_AUD iefa on iefa.link_id = il.id"
+            + " where ef.id is null and efa.id is null and ief.id is null and iefa.id is null");
   }
 
   private void deleteAppConfigs(Long userId, Session session) {
@@ -702,6 +725,15 @@ public class UserDeletionDaoHibernate implements UserDeletionDao {
     Query<?> query = session.createSQLQuery(idQuery);
     query.setParameter("id", userId);
     query.executeUpdate();
+    session.flush();
+  }
+
+  /**
+   * Like {@link #execute} but for statements with no bind parameters. The cross-user orphan sweeps
+   * have no {@code :id} placeholder, and binding one anyway makes Hibernate throw at runtime.
+   */
+  private void executeUnparameterised(Session session, String sql) {
+    session.createSQLQuery(sql).executeUpdate();
     session.flush();
   }
 

--- a/src/main/java/com/researchspace/service/AuditManager.java
+++ b/src/main/java/com/researchspace/service/AuditManager.java
@@ -55,6 +55,21 @@ public interface AuditManager {
   Number getRevisionNumberForMediaFileVersion(Long mediaId, Number version);
 
   /**
+   * Like {@link #getRevisionNumberForDocumentVersion} but returns {@code null} when that version
+   * has no audit row instead of throwing. Mirrors {@link
+   * #getRevisionNumberForInventoryRecordVersion}'s null-on-absent contract, so a best-effort caller
+   * (e.g. capturing a link's pinned revision) can degrade to "unresolved" without the throwing
+   * variant's {@link IllegalArgumentException} marking the surrounding transaction rollback-only.
+   */
+  Number findRevisionNumberForDocumentVersion(Long docId, Number userVersion);
+
+  /**
+   * Like {@link #getRevisionNumberForMediaFileVersion} but returns {@code null} when that version
+   * has no audit row instead of throwing. See {@link #findRevisionNumberForDocumentVersion}.
+   */
+  Number findRevisionNumberForMediaFileVersion(Long mediaId, Number version);
+
+  /**
    * Returns the newest Envers revision number carrying the given user-facing version of an audited
    * inventory record, or null if no revision carries that version.
    */

--- a/src/main/java/com/researchspace/service/impl/AuditManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/AuditManagerImpl.java
@@ -158,6 +158,20 @@ public class AuditManagerImpl implements AuditManager {
   }
 
   @Override
+  public Number findRevisionNumberForDocumentVersion(Long docId, Number userVersion) {
+    List<AuditedEntity<StructuredDocument>> docRevisionList =
+        auditDao.getRevisionsForDocumentVersion(docId, userVersion);
+    return docRevisionList.isEmpty() ? null : docRevisionList.get(0).getRevision().intValue();
+  }
+
+  @Override
+  public Number findRevisionNumberForMediaFileVersion(Long mediaId, Number version) {
+    List<AuditedEntity<EcatMediaFile>> revisionList =
+        auditDao.getRevisionsForMediaFileVersion(mediaId, version);
+    return revisionList.isEmpty() ? null : revisionList.get(0).getRevision().intValue();
+  }
+
+  @Override
   public <T> Number getRevisionNumberForInventoryRecordVersion(
       Class<T> cls, Long recordId, Number version) {
     List<AuditedEntity<T>> revisionList =

--- a/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordSharingManagerImpl.java
@@ -866,6 +866,11 @@ public class RecordSharingManagerImpl implements RecordSharingManager {
           permFac.createIdPermission(PermissionDomain.RECORD, permType, toUnshare.getId()));
       saveUserOrGroup(toUnshareWith);
       permissnUtils.refreshCache();
+      // the sharee's cached Shiro authorisation still grants RECORD:READ on the
+      // unshared record; notify them so their next permission-checked request
+      // refreshes the cache (refreshCacheIfNotified) instead of serving the
+      // stale grant until restart
+      permissnUtils.notifyUserOrGroupToRefreshCache(toUnshareWith);
       if (toUnshareWith.isUser() && toUnshare.isNotebook()) {
 
         RecordSharingACL acl = toUnshare.getSharingACL();

--- a/src/main/java/com/researchspace/service/inventory/ApiExtraFieldsHelper.java
+++ b/src/main/java/com/researchspace/service/inventory/ApiExtraFieldsHelper.java
@@ -1,19 +1,26 @@
 package com.researchspace.service.inventory;
 
+import com.researchspace.api.v1.auth.ApiRuntimeException;
 import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiInstrumentEntity;
+import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.api.v1.model.ApiSampleWithoutSubSamples;
 import com.researchspace.api.v1.model.ApiSubSample;
 import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.ExtraField;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.record.IRecordFactory;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +38,9 @@ import org.springframework.validation.Validator;
 public class ApiExtraFieldsHelper implements Validator {
 
   private IRecordFactory recordFactory;
+  private final InventoryLinkValidator linkValidator = new InventoryLinkValidator();
+
+  @Autowired private InventoryLinkManager inventoryLinkManager;
 
   public ApiExtraFieldsHelper(@Autowired IRecordFactory recordFactory) {
     this.recordFactory = recordFactory;
@@ -49,10 +59,32 @@ public class ApiExtraFieldsHelper implements Validator {
       ValidationUtils.rejectIfEmptyOrWhitespace(
           errors, "name", "errors.required", "name is required");
     }
+    if (aef.getTypeAsFieldType() == FieldType.LINK) {
+      validateLinkPayload(aef, errors);
+      return;
+    }
     ExtraField extraField = recordFactory.createExtraField(aef.getTypeAsFieldType());
     String validationMsg = extraField.validateNewData(aef.getContent());
     if (!StringUtils.isEmpty(validationMsg)) {
       errors.rejectValue("content", "", validationMsg);
+    }
+  }
+
+  private void validateLinkPayload(ApiExtraField aef, Errors errors) {
+    if (aef.getLink() == null) {
+      errors.rejectValue(
+          "link", "errors.required", new Object[] {"link"}, "link payload is required");
+      return;
+    }
+    String sourceGlobalId =
+        aef.getParentGlobalId() != null
+            ? aef.getParentGlobalId()
+            : (aef.getParentRecordInfo() != null ? aef.getParentRecordInfo().getGlobalId() : null);
+    errors.pushNestedPath("link");
+    try {
+      linkValidator.validate(aef.getLink(), sourceGlobalId, errors);
+    } finally {
+      errors.popNestedPath();
     }
   }
 
@@ -80,7 +112,27 @@ public class ApiExtraFieldsHelper implements Validator {
         apiInstrument.getExtraFields(), instrument.getActiveExtraFields(), instrument, user);
   }
 
-  private boolean createDeleteRequestedExtraFields(
+  /**
+   * Creates the extra-fields supplied when an Inventory record is first created (POST), Link fields
+   * included, so that a record created together with a link persists that link. Mirrors the
+   * new-field branch of {@link #createDeleteRequestedExtraFields}: without this the create path
+   * built the field but dropped its {@link com.researchspace.model.inventory.field.InventoryLink}
+   * (RSDEV-1131), because only the update (PUT) path routed new fields through the link-aware
+   * creator.
+   */
+  public void addExtraFieldsForNewInventoryRecord(
+      List<ApiExtraField> incomingFields, InventoryRecord parentInvRec, User user) {
+    if (CollectionUtils.isEmpty(incomingFields)) {
+      return;
+    }
+    InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
+        null, incomingFields);
+    for (ApiExtraField apiField : incomingFields) {
+      addRecordExtraFieldForIncomingApiField(apiField, user, parentInvRec);
+    }
+  }
+
+  boolean createDeleteRequestedExtraFields(
       List<ApiExtraField> incomingFields,
       List<ExtraField> dbFields,
       InventoryRecord parentInvRec,
@@ -88,7 +140,7 @@ public class ApiExtraFieldsHelper implements Validator {
 
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         null, incomingFields);
-    boolean changed = false;
+    boolean changed = applyExistingLinkFieldChanges(incomingFields, dbFields, user);
     if (!CollectionUtils.isEmpty(incomingFields)) {
       for (ApiExtraField apiField : incomingFields) {
         if (apiField.isNewFieldRequest()) {
@@ -97,19 +149,17 @@ public class ApiExtraFieldsHelper implements Validator {
         }
         if (apiField.isDeleteFieldRequest()) {
           if (apiField.getId() == null) {
-            throw new IllegalArgumentException(
-                "'id' property not provided "
-                    + "for an extra field with 'deleteFieldRequest' flag");
+            throw new ApiRuntimeException("errors.inventory.field.deleteRequest.idMissing");
           }
           Optional<ExtraField> dbFieldOpt =
               dbFields.stream().filter(sf -> apiField.getId().equals(sf.getId())).findFirst();
           if (!dbFieldOpt.isPresent()) {
-            throw new IllegalArgumentException(
-                "Extra field id: "
-                    + apiField.getId()
-                    + " doesn't match id of any pre-existing extra field");
+            throw new ApiRuntimeException(
+                "errors.inventory.field.deleteRequest.idUnknown", apiField.getId());
           }
-          dbFieldOpt.get().setDeleted(true);
+          ExtraField dbField = dbFieldOpt.get();
+          softDeleteLinkIfPresent(dbField, user);
+          dbField.setDeleted(true);
           changed = true;
         }
       }
@@ -120,12 +170,155 @@ public class ApiExtraFieldsHelper implements Validator {
     return changed;
   }
 
+  /**
+   * Soft-deletes the {@link InventoryLink} backing a Link extra-field when that field is itself
+   * being soft-deleted, so the link row (and its Envers audit trail) stays in step with the field.
+   * A field soft-delete only flips the field's {@code deleted} flag: being an ordinary update
+   * rather than a JPA remove it does not trigger the {@code cascade}/{@code orphanRemoval} on
+   * {@code ExtraLinkField#link}, and it never dereferences the link. Without this the link row
+   * would linger with {@code deleted=false} after its parent field is gone. (The
+   * structured-link-field clear path differs deliberately: clearing a value dereferences the row,
+   * which the orphanRemoval mapping hard-deletes at flush; see {@code
+   * SampleApiManagerImpl#applyLinkFieldValue}.) No-op for non-link fields or a link field that has
+   * no link yet.
+   */
+  private void softDeleteLinkIfPresent(ExtraField dbField, User user) {
+    if (dbField instanceof ExtraLinkField) {
+      InventoryLink link = ((ExtraLinkField) dbField).getLink();
+      if (link != null) {
+        inventoryLinkManager.deleteLink(link, user);
+      }
+    }
+  }
+
+  /**
+   * Applies target and version-pin changes to existing Link extra-fields. The DTO apply loop
+   * ({@code ApiExtraField#applyChangesToDatabaseExtraField}) cannot reach the service-layer {@link
+   * InventoryLinkManager}, so a retargeted link would otherwise be silently dropped and the
+   * previous target returned on save. Changes go through {@link InventoryLinkManager#updateLink},
+   * which validates the new target (existence + readability) and recaptures the pinned audit
+   * revision; an extra-field whose link is still unset gains its first link via {@link
+   * InventoryLinkManager#createLink}. Relation-type-only changes are left to the DTO apply loop.
+   */
+  boolean applyExistingLinkFieldChanges(
+      List<ApiExtraField> incomingFields, List<ExtraField> dbFields, User user) {
+    if (CollectionUtils.isEmpty(incomingFields)) {
+      return false;
+    }
+    boolean changed = false;
+    for (ApiExtraField apiField : incomingFields) {
+      if (apiField.isNewFieldRequest()
+          || apiField.isDeleteFieldRequest()
+          || apiField.getId() == null) {
+        continue;
+      }
+      ApiInventoryLink apiLink = apiField.getLink();
+      if (apiLink == null || StringUtils.isBlank(apiLink.getTargetGlobalId())) {
+        continue;
+      }
+      Optional<ExtraField> dbFieldOpt =
+          dbFields.stream().filter(f -> apiField.getId().equals(f.getId())).findFirst();
+      if (!dbFieldOpt.isPresent() || !(dbFieldOpt.get() instanceof ExtraLinkField)) {
+        continue;
+      }
+      ExtraLinkField dbLinkField = (ExtraLinkField) dbFieldOpt.get();
+      // the controller-layer validator is skipped when the payload omits "type",
+      // so the self-link and relation-type rules must also hold on this service-layer path
+      rejectSelfLink(apiLink, dbLinkField);
+      assertRelationTypeValid(apiLink);
+      InventoryLink dbLink = dbLinkField.getLink();
+      if (dbLink == null) {
+        dbLinkField.setLink(inventoryLinkManager.createLink(apiLink, user));
+        changed = true;
+      } else if (linkChanged(apiLink, dbLink)) {
+        inventoryLinkManager.updateLink(dbLink, apiLink, user);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  private void rejectSelfLink(ApiInventoryLink apiLink, ExtraLinkField dbLinkField) {
+    GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
+    if (target != null
+        && InventoryLinkValidator.isSelfLink(
+            target, dbLinkField.getConnectedRecordGlobalIdentifier())) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.selfLinkForbidden", apiLink.getTargetGlobalId());
+    }
+  }
+
+  /**
+   * Rejects a relation type that is not in the DataCite vocabulary. The controller-layer {@link
+   * #validate} only runs its LINK branch when the incoming DTO carries {@code type="link"}, and a
+   * relation-type-only change does not route through {@link InventoryLinkManager#updateLink}, so
+   * without this guard a client that omits {@code type} could persist an invalid relation type via
+   * the DTO apply loop. A null relation is left alone: the DTO loop only writes a non-null change,
+   * so it cannot introduce an invalid value.
+   */
+  private void assertRelationTypeValid(ApiInventoryLink apiLink) {
+    String relationType = apiLink.getRelationType();
+    if (relationType != null && !DataCiteRelationType.isValid(relationType)) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.relationTypeInvalid", relationType);
+    }
+  }
+
+  /**
+   * True when the incoming payload points at a different target or version than the stored link.
+   * Compared on the parsed base id plus the effective pin (a "vN" suffix counts as a pin), so a
+   * client that pins via the suffix with {@code versionPin: null} does not churn an unchanged row
+   * with spurious updates. An unparseable incoming id counts as changed so the manager rejects it
+   * with its clean validation error.
+   */
+  private boolean linkChanged(ApiInventoryLink apiLink, InventoryLink dbLink) {
+    GlobalIdentifier incoming = parseTargetOrNull(apiLink.getTargetGlobalId());
+    if (incoming == null) {
+      return true;
+    }
+    Long effectivePin =
+        apiLink.derivedVersionPin() != null ? apiLink.derivedVersionPin() : apiLink.getVersionPin();
+    return incoming.getPrefix() != dbLink.getTargetPrefix()
+        || !Objects.equals(incoming.getDbId(), dbLink.getTargetDbId())
+        || !Objects.equals(effectivePin, dbLink.getVersionPin());
+  }
+
+  private GlobalIdentifier parseTargetOrNull(String targetGlobalId) {
+    try {
+      return new GlobalIdentifier(targetGlobalId);
+    } catch (IllegalArgumentException | NullPointerException ex) {
+      return null;
+    }
+  }
+
   private void addRecordExtraFieldForIncomingApiField(
       ApiExtraField apiField, User user, InventoryRecord parentInvRec) {
-    ExtraField newField =
-        recordFactory.createExtraField(
-            apiField.getName(), apiField.getTypeAsFieldType(), user, parentInvRec);
-    newField.setData(apiField.getContent());
+    ExtraField newField;
+    if (apiField.getTypeAsFieldType() == FieldType.LINK) {
+      newField = buildExtraLinkField(apiField, user, parentInvRec);
+    } else {
+      newField =
+          recordFactory.createExtraField(
+              apiField.getName(), apiField.getTypeAsFieldType(), user, parentInvRec);
+      newField.setData(apiField.getContent());
+    }
     parentInvRec.addExtraField(newField); // update parent's field list
+  }
+
+  private ExtraLinkField buildExtraLinkField(
+      ApiExtraField apiField, User user, InventoryRecord parentInvRec) {
+    ExtraLinkField linkField = new ExtraLinkField();
+    linkField.setInventoryRecord(parentInvRec);
+    if (!StringUtils.isBlank(apiField.getName())) {
+      linkField.setName(apiField.getName());
+    }
+    linkField.setCreatedBy(user.getUsername());
+    linkField.setModifiedBy(user.getUsername());
+    ApiInventoryLink apiLink = apiField.getLink();
+    if (apiLink != null) {
+      InventoryLink persisted = inventoryLinkManager.createLink(apiLink, user);
+      linkField.setLink(persisted);
+    }
+    return linkField;
   }
 }

--- a/src/main/java/com/researchspace/service/inventory/DataCiteRelationType.java
+++ b/src/main/java/com/researchspace/service/inventory/DataCiteRelationType.java
@@ -1,0 +1,68 @@
+package com.researchspace.service.inventory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Controlled vocabulary for inventory link relation types, mirroring DataCite Metadata Schema 4.7
+ * relationType values plus PIDINST-aligned IsCalibratedBy/Calibrates.
+ */
+public final class DataCiteRelationType {
+
+  private static final Set<String> VALUES =
+      Collections.unmodifiableSet(
+          new LinkedHashSet<>(
+              Arrays.asList(
+                  "IsCitedBy",
+                  "Cites",
+                  "IsSupplementTo",
+                  "IsSupplementedBy",
+                  "IsContinuedBy",
+                  "Continues",
+                  "IsDescribedBy",
+                  "Describes",
+                  "HasMetadata",
+                  "IsMetadataFor",
+                  "HasVersion",
+                  "IsVersionOf",
+                  "IsNewVersionOf",
+                  "IsPreviousVersionOf",
+                  "IsPartOf",
+                  "HasPart",
+                  "IsPublishedIn",
+                  "IsReferencedBy",
+                  "References",
+                  "IsDocumentedBy",
+                  "Documents",
+                  "IsCompiledBy",
+                  "Compiles",
+                  "IsVariantFormOf",
+                  "IsOriginalFormOf",
+                  "IsIdenticalTo",
+                  "IsReviewedBy",
+                  "Reviews",
+                  "IsDerivedFrom",
+                  "IsSourceOf",
+                  "IsRequiredBy",
+                  "Requires",
+                  "IsObsoletedBy",
+                  "Obsoletes",
+                  "IsCollectedBy",
+                  "Collects",
+                  "IsTranslationOf",
+                  "HasTranslation",
+                  "IsCalibratedBy",
+                  "Calibrates")));
+
+  private DataCiteRelationType() {}
+
+  public static boolean isValid(String value) {
+    return value != null && VALUES.contains(value);
+  }
+
+  public static Set<String> allValues() {
+    return VALUES;
+  }
+}

--- a/src/main/java/com/researchspace/service/inventory/InventoryLinkManager.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryLinkManager.java
@@ -1,0 +1,46 @@
+package com.researchspace.service.inventory;
+
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.field.InventoryLink;
+import java.util.List;
+
+/**
+ * Service-layer API for managing Inventory Link payloads (the row backing each {@code
+ * ExtraLinkField}) and resolving back-references.
+ */
+public interface InventoryLinkManager {
+
+  /**
+   * Persists a new InventoryLink row from the supplied API payload. Does not attach to an
+   * ExtraLinkField; the caller is responsible for wiring the returned entity into the parent.
+   */
+  InventoryLink createLink(ApiInventoryLink apiLink, User actor);
+
+  /** Updates an existing InventoryLink row in place, preserving its created_at timestamp. */
+  InventoryLink updateLink(InventoryLink existing, ApiInventoryLink apiLink, User actor);
+
+  /** Marks the link as soft-deleted. */
+  void deleteLink(InventoryLink existing, User actor);
+
+  /**
+   * Returns the items that link to the given target GlobalID (ignoring version suffix), filtered to
+   * sources the requesting user can read. The target itself must exist and be readable by the
+   * actor: a malformed id, a missing record and an unreadable record all produce the same "target
+   * not found" error, so the response never confirms the existence of a record the caller may not
+   * read.
+   */
+  List<ApiInventoryReferencingItem> findReferencingItems(String targetGlobalId, User actor);
+
+  /**
+   * Resolves the audit-backed summary (globalId, name, type, deleted) of the CURRENT state of a
+   * link target, applying read permission: unreadable targets degrade to a globalId-only summary so
+   * names are never disclosed. Any version suffix on the id is ignored, since the summary backs the
+   * "Target deleted" pill, which reflects the record as it is now rather than as pinned. Malformed
+   * ids and prefixes that are not allowed link target kinds are rejected with the same i18n errors
+   * as the write path.
+   */
+  ApiInventoryLinkTargetSummary getTargetSummary(String targetGlobalId, User actor);
+}

--- a/src/main/java/com/researchspace/service/inventory/InventoryLinkValidator.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryLinkValidator.java
@@ -1,0 +1,115 @@
+package com.researchspace.service.inventory;
+
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.core.GlobalIdentifier;
+import java.util.EnumSet;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.validation.Errors;
+
+/**
+ * Validates an incoming {@link ApiInventoryLink} payload independent of database state. Checks
+ * relationType against the DataCite vocabulary, syntactic GlobalID parse, that the target prefix is
+ * a supported link target (Inventory items including sample templates, or ELN documents, notebooks
+ * and gallery files), and forbids self-links. Existence and read-permission checks live in the
+ * manager layer, where the acting user is available.
+ */
+public class InventoryLinkValidator {
+
+  /**
+   * True when the prefix is a kind that links may target (shared with the manager's write-path
+   * validation).
+   */
+  public static boolean isAllowedTargetPrefix(GlobalIdPrefix prefix) {
+    return prefix != null && ALLOWED_TARGET_PREFIXES.contains(prefix);
+  }
+
+  /** True when target points at the same record as sourceGlobalId (version suffixes ignored). */
+  public static boolean isSelfLink(GlobalIdentifier target, String sourceGlobalId) {
+    if (StringUtils.isBlank(sourceGlobalId) || target == null) {
+      return false;
+    }
+    try {
+      GlobalIdentifier source = new GlobalIdentifier(sourceGlobalId);
+      return source.getPrefix() == target.getPrefix() && source.getDbId().equals(target.getDbId());
+    } catch (IllegalArgumentException ex) {
+      return false;
+    }
+  }
+
+  private static final Set<GlobalIdPrefix> ALLOWED_TARGET_PREFIXES =
+      EnumSet.of(
+          GlobalIdPrefix.SA,
+          GlobalIdPrefix.SS,
+          GlobalIdPrefix.IC,
+          GlobalIdPrefix.IN,
+          GlobalIdPrefix.IT,
+          GlobalIdPrefix.SD,
+          GlobalIdPrefix.NB,
+          GlobalIdPrefix.GL);
+
+  /**
+   * Validates the supplied link. Errors are rejected as {@code relationType} / {@code
+   * targetGlobalId} field codes relative to whatever nested path the passed {@link Errors} object
+   * is currently positioned at. This validator does not push a {@code link} path itself: callers
+   * that want the errors to surface under {@code link.*} must {@code pushNestedPath("link")} on the
+   * Errors object before calling (as {@code ApiExtraFieldsHelper} does). {@code sourceGlobalId}
+   * (the GlobalID of the parent item the link is being attached to) is used to detect self-links.
+   */
+  public void validate(ApiInventoryLink link, String sourceGlobalId, Errors errors) {
+    if (link == null) {
+      return;
+    }
+    validateRelationType(link, errors);
+    validateTarget(link, sourceGlobalId, errors);
+  }
+
+  private void validateRelationType(ApiInventoryLink link, Errors errors) {
+    if (!DataCiteRelationType.isValid(link.getRelationType())) {
+      errors.rejectValue(
+          "relationType",
+          "errors.inventory.field.link.relationTypeInvalid",
+          new Object[] {link.getRelationType()},
+          "relationType not in DataCite vocabulary");
+    }
+  }
+
+  private void validateTarget(ApiInventoryLink link, String sourceGlobalId, Errors errors) {
+    String target = link.getTargetGlobalId();
+    if (StringUtils.isBlank(target)) {
+      errors.rejectValue(
+          "targetGlobalId",
+          "errors.inventory.field.link.targetNotFound",
+          new Object[] {target},
+          "targetGlobalId is required");
+      return;
+    }
+    GlobalIdentifier parsed;
+    try {
+      parsed = new GlobalIdentifier(target);
+    } catch (IllegalArgumentException ex) {
+      errors.rejectValue(
+          "targetGlobalId",
+          "errors.inventory.field.link.targetNotFound",
+          new Object[] {target},
+          "targetGlobalId is not a valid GlobalID");
+      return;
+    }
+    if (!ALLOWED_TARGET_PREFIXES.contains(parsed.getPrefix())) {
+      errors.rejectValue(
+          "targetGlobalId",
+          "errors.inventory.field.link.targetKindUnsupported",
+          new Object[] {parsed.getPrefix().name()},
+          "target kind not supported");
+      return;
+    }
+    if (isSelfLink(parsed, sourceGlobalId)) {
+      errors.rejectValue(
+          "targetGlobalId",
+          "errors.inventory.field.link.selfLinkForbidden",
+          new Object[] {target},
+          "link target cannot equal its source item");
+    }
+  }
+}

--- a/src/main/java/com/researchspace/service/inventory/LinkTargetResolver.java
+++ b/src/main/java/com/researchspace/service/inventory/LinkTargetResolver.java
@@ -1,0 +1,23 @@
+package com.researchspace.service.inventory;
+
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
+
+/**
+ * Resolves an Inventory Link target GlobalID (inventory item or ELN item) to decide whether it
+ * points at a record that actually exists and that the supplied user is permitted to read. Used by
+ * link validation to reject links to non-existent or unreadable targets, regardless of whether the
+ * target lives in the Inventory or in the ELN. Not transactional itself: implementations touch
+ * DAOs, so they must be invoked within the transaction of a calling {@code *Manager} service.
+ */
+public interface LinkTargetResolver {
+
+  /**
+   * @param target the parsed link target GlobalID (any version suffix is ignored: the base record's
+   *     existence and readability is what matters)
+   * @param user the acting user
+   * @return true if the target resolves to a real record the user can READ, false if it does not
+   *     exist, is not readable, or has an unsupported prefix
+   */
+  boolean targetExistsAndIsReadable(GlobalIdentifier target, User user);
+}

--- a/src/main/java/com/researchspace/service/inventory/LinkTargetSnapshotResolver.java
+++ b/src/main/java/com/researchspace/service/inventory/LinkTargetSnapshotResolver.java
@@ -1,0 +1,43 @@
+package com.researchspace.service.inventory;
+
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+
+/**
+ * Resolves an Inventory link's target through the Envers audit ({@code _AUD}) tables rather than
+ * the live record. A link is either "latest" (resolves dynamically to the newest non-delete
+ * revision) or "pinned" (resolves to one specific revision captured at pin time).
+ */
+public interface LinkTargetSnapshotResolver {
+
+  /**
+   * Resolves the Envers revision (REV) that a user-facing target version maps to. Used at pin time
+   * to capture the exact audit row alongside the display version. Returns {@code null} when the
+   * version is null or the target family has no user-facing versioning (e.g. notebooks).
+   *
+   * @param prefix the target's GlobalID prefix (SD, NB, GL, SA, SS, IC, IN)
+   * @param dbId the target's database id
+   * @param version the user-facing version being pinned, or null for "latest"
+   */
+  Long resolveRevisionForVersion(GlobalIdPrefix prefix, Long dbId, Long version);
+
+  /**
+   * Resolves a link target to a summary built from its audit snapshot. When {@code
+   * targetRevisionId} is set the exact revision is loaded; otherwise the newest non-delete revision
+   * is used ("latest").
+   *
+   * <p>Authorization: the summary's name and type are populated only when the actor may READ the
+   * target (live read permission, including soft-deleted, or owner of the snapshot when only audit
+   * data remains after a hard delete). Otherwise a minimal summary carrying only the globalId is
+   * returned, so an inaccessible target is never disclosed by name.
+   *
+   * @param prefix the target's GlobalID prefix
+   * @param dbId the target's database id
+   * @param versionPin the user-facing version for display, or null for "latest"
+   * @param targetRevisionId the exact Envers revision to load, or null for "latest"
+   * @param user the actor whose read permission gates disclosure
+   */
+  ApiInventoryLinkTargetSummary resolveSummary(
+      GlobalIdPrefix prefix, Long dbId, Long versionPin, Long targetRevisionId, User user);
+}

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
@@ -4,7 +4,6 @@ import static com.researchspace.api.v1.model.ApiInventoryRecordInfo.tagDifferenc
 
 import com.axiope.search.SearchUtils;
 import com.researchspace.api.v1.model.ApiBarcode;
-import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiGroupBasicInfo;
 import com.researchspace.api.v1.model.ApiInventoryEditLock;
 import com.researchspace.api.v1.model.ApiInventoryEditLock.ApiInventoryEditLockStatus;
@@ -26,7 +25,6 @@ import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.SubSample;
-import com.researchspace.model.inventory.field.ExtraField;
 import com.researchspace.model.permissions.ACLElement;
 import com.researchspace.model.permissions.ConstraintBasedPermission;
 import com.researchspace.model.permissions.PermissionDomain;
@@ -41,7 +39,6 @@ import com.researchspace.service.inventory.ApiBarcodesHelper;
 import com.researchspace.service.inventory.ApiExtraFieldsHelper;
 import com.researchspace.service.inventory.ApiIdentifiersHelper;
 import com.researchspace.service.inventory.InventoryApiManager;
-import com.researchspace.service.inventory.InventoryFieldNameUniquenessValidator;
 import com.researchspace.service.inventory.InventoryFileApiManager;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
 import java.awt.image.BufferedImage;
@@ -111,15 +108,10 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
     }
     saveSharingACLForIncomingApiInvRec(invRec, apiInvRec);
 
-    InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
-        null, apiInvRec.getExtraFields());
-    for (ApiExtraField apiExtraField : apiInvRec.getExtraFields()) {
-      ExtraField extraField =
-          recordFactory.createExtraField(
-              apiExtraField.getName(), apiExtraField.getTypeAsFieldType(), user, invRec);
-      extraField.setData(apiExtraField.getContent());
-      invRec.addExtraField(extraField);
-    }
+    // create extra-fields (Link fields included) through the link-aware helper so a record
+    // created together with a link persists that link; a plain create loop here built the
+    // ExtraLinkField but dropped its InventoryLink (RSDEV-1131).
+    extraFieldHelper.addExtraFieldsForNewInventoryRecord(apiInvRec.getExtraFields(), invRec, user);
 
     for (ApiBarcode apiBarcode : apiInvRec.getBarcodes()) {
       Barcode barcode = new Barcode(apiBarcode.getData(), user.getUsername());

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImpl.java
@@ -1,0 +1,182 @@
+package com.researchspace.service.inventory.impl;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.service.inventory.DataCiteRelationType;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.service.inventory.InventoryLinkValidator;
+import com.researchspace.service.inventory.InventoryPermissionUtils;
+import com.researchspace.service.inventory.LinkTargetResolver;
+import com.researchspace.service.inventory.LinkTargetSnapshotResolver;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InventoryLinkManagerImpl implements InventoryLinkManager {
+
+  @Autowired private InventoryLinkDao linkDao;
+  @Autowired private InventoryPermissionUtils permissionUtils;
+  @Autowired private LinkTargetResolver linkTargetResolver;
+  @Autowired private LinkTargetSnapshotResolver snapshotResolver;
+
+  @Override
+  public InventoryLink createLink(ApiInventoryLink apiLink, User actor) {
+    validateForWrite(apiLink);
+    assertTargetExistsAndReadable(apiLink, actor);
+    InventoryLink entity = new InventoryLink();
+    applyApiToEntity(apiLink, entity);
+    return linkDao.save(entity);
+  }
+
+  @Override
+  public InventoryLink updateLink(InventoryLink existing, ApiInventoryLink apiLink, User actor) {
+    validateForWrite(apiLink);
+    assertTargetExistsAndReadable(apiLink, actor);
+    applyApiToEntity(apiLink, existing);
+    return linkDao.save(existing);
+  }
+
+  @Override
+  public void deleteLink(InventoryLink existing, User actor) {
+    existing.setDeleted(true);
+    linkDao.save(existing);
+  }
+
+  @Override
+  public List<ApiInventoryReferencingItem> findReferencingItems(String targetGlobalId, User actor) {
+    GlobalIdentifier target;
+    try {
+      target = new GlobalIdentifier(targetGlobalId);
+    } catch (IllegalArgumentException ex) {
+      // a malformed Global ID does not resolve to any target; surface it as a clean API error
+      // rather than letting the raw IllegalArgumentException escape to the HTTP layer
+      throw new ApiRuntimeException("errors.inventory.field.link.targetNotFound", targetGlobalId);
+    }
+    // the caller must be able to READ the target itself: filtering the sources alone would
+    // still confirm an unreadable record's existence and reveal its inbound links to anyone
+    // who guesses its id. Same error as the malformed/missing case, so nothing is disclosed.
+    if (!linkTargetResolver.targetExistsAndIsReadable(target, actor)) {
+      throw new ApiRuntimeException("errors.inventory.field.link.targetNotFound", targetGlobalId);
+    }
+    List<ApiInventoryReferencingItem> rows = new ArrayList<>();
+    for (ExtraLinkField field :
+        linkDao.findReferencingLinkFields(target.getPrefix(), target.getDbId())) {
+      addRowIfReadable(rows, field.getInventoryRecord(), field.getLink(), actor);
+    }
+    // template-defined structured link fields are first-class links too
+    for (InventoryLinkField field :
+        linkDao.findReferencingStructuredLinkFields(target.getPrefix(), target.getDbId())) {
+      addRowIfReadable(rows, field.getInventoryRecord(), field.getLink(), actor);
+    }
+    return rows;
+  }
+
+  private void addRowIfReadable(
+      List<ApiInventoryReferencingItem> rows,
+      InventoryRecord parent,
+      InventoryLink link,
+      User actor) {
+    if (parent == null || link == null || parent.isDeleted()) {
+      return;
+    }
+    if (!permissionUtils.canUserReadInventoryRecord(parent, actor)) {
+      return;
+    }
+    ApiInventoryReferencingItem row = new ApiInventoryReferencingItem();
+    row.setSourceGlobalId(parent.getOid().toString());
+    row.setSourceName(parent.getName());
+    row.setSourceType(parent.getType().toString());
+    row.setRelationType(link.getRelationType());
+    row.setVersionPin(link.getVersionPin());
+    if (link.getModifiedAt() != null) {
+      row.setModifiedAtMillis(link.getModifiedAt().getTime());
+    }
+    rows.add(row);
+  }
+
+  @Override
+  public ApiInventoryLinkTargetSummary getTargetSummary(String targetGlobalId, User actor) {
+    GlobalIdentifier gid = parseAllowedTargetOrThrow(targetGlobalId);
+    // current state of the base record: pin/revision deliberately null so the
+    // "Target deleted" pill reflects the record as it is now, not as pinned
+    return snapshotResolver.resolveSummary(gid.getPrefix(), gid.getDbId(), null, null, actor);
+  }
+
+  /**
+   * Rejects links whose target does not resolve to a real record the actor can READ. Applies to all
+   * targets, Inventory and ELN alike. The version suffix (if any) is ignored: only the base record
+   * needs to exist and be readable.
+   */
+  /**
+   * Structural validation of an incoming link payload, mirroring {@link InventoryLinkValidator}.
+   * The controller-layer validator can be bypassed (an extra-field update payload that omits {@code
+   * type} skips the LINK validation branch, and structured sample fields never run it), so the
+   * manager enforces the same rules at the single write path: a parseable target id, an allowed
+   * target kind, and a DataCite relation type. Failures map to 422 with the same bundle keys the
+   * validator uses.
+   */
+  private void validateForWrite(ApiInventoryLink apiLink) {
+    parseAllowedTargetOrThrow(apiLink.getTargetGlobalId());
+    if (!DataCiteRelationType.isValid(apiLink.getRelationType())) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.relationTypeInvalid", apiLink.getRelationType());
+    }
+  }
+
+  /**
+   * Parses a target Global ID and asserts its prefix is an allowed link target kind, mapping
+   * failures to the same 422 i18n errors on both the write path and the summary read path.
+   */
+  private GlobalIdentifier parseAllowedTargetOrThrow(String targetGlobalId) {
+    GlobalIdentifier gid;
+    try {
+      gid = new GlobalIdentifier(targetGlobalId);
+    } catch (IllegalArgumentException | NullPointerException ex) {
+      throw new ApiRuntimeException("errors.inventory.field.link.targetNotFound", targetGlobalId);
+    }
+    if (!InventoryLinkValidator.isAllowedTargetPrefix(gid.getPrefix())) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.targetKindUnsupported", gid.getPrefix().name());
+    }
+    return gid;
+  }
+
+  private void assertTargetExistsAndReadable(ApiInventoryLink apiLink, User actor) {
+    GlobalIdentifier gid = new GlobalIdentifier(apiLink.getTargetGlobalId());
+    if (!linkTargetResolver.targetExistsAndIsReadable(gid, actor)) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.targetNotFound", apiLink.getTargetGlobalId());
+    }
+  }
+
+  private void applyApiToEntity(ApiInventoryLink api, InventoryLink entity) {
+    entity.setRelationType(api.getRelationType());
+    GlobalIdentifier gid = new GlobalIdentifier(api.getTargetGlobalId());
+    // persist the unsuffixed base id: the version lives in versionPin, so a
+    // "vN" suffix on the incoming id must not be doubly encoded in the row
+    entity.setTargetGlobalId(new GlobalIdentifier(gid.getPrefix(), gid.getDbId()).getIdString());
+    entity.setTargetPrefix(gid.getPrefix());
+    entity.setTargetDbId(gid.getDbId());
+    Long versionPin = gid.hasVersionId() ? gid.getVersionId() : api.getVersionPin();
+    entity.setVersionPin(versionPin);
+    // Capture the exact audit revision the pinned version maps to. Null version means "latest",
+    // which the snapshot resolver resolves dynamically at read time, so no revision is stored.
+    Long revisionId =
+        versionPin == null
+            ? null
+            : snapshotResolver.resolveRevisionForVersion(
+                gid.getPrefix(), gid.getDbId(), versionPin);
+    entity.setTargetRevisionId(revisionId);
+  }
+}

--- a/src/main/java/com/researchspace/service/inventory/impl/LinkTargetResolverImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/LinkTargetResolverImpl.java
@@ -1,0 +1,94 @@
+package com.researchspace.service.inventory.impl;
+
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.permissions.IPermissionUtils;
+import com.researchspace.model.record.BaseRecord;
+import com.researchspace.service.BaseRecordManager;
+import com.researchspace.service.inventory.InventoryPermissionUtils;
+import com.researchspace.service.inventory.LinkTargetResolver;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import javax.ws.rs.NotFoundException;
+import org.apache.shiro.authz.AuthorizationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectRetrievalFailureException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves a link target across modules: Inventory items via {@link InventoryPermissionUtils}, ELN
+ * items (documents, notebooks, gallery files) via {@link BaseRecordManager}. The supported prefixes
+ * mirror {@link com.researchspace.service.inventory.InventoryLinkValidator}'s allowed target kinds.
+ * Any failure to resolve a record (not found, not readable, unsupported prefix) is reported as "not
+ * readable" rather than propagated, so the caller can reject the link uniformly.
+ */
+@Component("linkTargetResolver")
+public class LinkTargetResolverImpl implements LinkTargetResolver {
+
+  private static final Set<GlobalIdPrefix> INVENTORY_PREFIXES =
+      EnumSet.of(
+          GlobalIdPrefix.SA,
+          GlobalIdPrefix.SS,
+          GlobalIdPrefix.IC,
+          GlobalIdPrefix.IN,
+          GlobalIdPrefix.IT);
+
+  private static final Set<GlobalIdPrefix> ELN_BASE_RECORD_PREFIXES =
+      EnumSet.of(GlobalIdPrefix.SD, GlobalIdPrefix.NB, GlobalIdPrefix.GL);
+
+  @Autowired private InventoryPermissionUtils inventoryPermissionUtils;
+  @Autowired private BaseRecordManager baseRecordManager;
+  @Autowired private IPermissionUtils permissionUtils;
+
+  @Override
+  public boolean targetExistsAndIsReadable(GlobalIdentifier target, User user) {
+    if (target == null) {
+      return false;
+    }
+    // an unshare notifies the affected user to refresh their cached Shiro
+    // authorisation; apply any pending refresh before checking, or the
+    // viewer keeps the revoked read grant until the server restarts
+    permissionUtils.refreshCacheIfNotified();
+    GlobalIdentifier base =
+        target.hasVersionId() ? new GlobalIdentifier(target.getPrefix(), target.getDbId()) : target;
+    GlobalIdPrefix prefix = base.getPrefix();
+    if (INVENTORY_PREFIXES.contains(prefix)) {
+      return isInventoryReadable(base, user);
+    }
+    if (ELN_BASE_RECORD_PREFIXES.contains(prefix)) {
+      return isElnReadable(base, user);
+    }
+    return false;
+  }
+
+  private boolean isInventoryReadable(GlobalIdentifier target, User user) {
+    try {
+      return inventoryPermissionUtils.canUserReadInventoryRecord(target, user);
+    } catch (NotFoundException e) {
+      return false;
+    }
+  }
+
+  private boolean isElnReadable(GlobalIdentifier target, User user) {
+    try {
+      List<BaseRecord> readable =
+          baseRecordManager.getByGlobalIdsAndReadPermission(
+              Collections.singletonList(target), user);
+      // the loader resolves by numeric id alone, so a typed id can load a
+      // different record kind sharing the number (e.g. "GL150" loads folder
+      // FL150): only a record whose own oid prefix matches the requested one
+      // counts as the link target
+      for (BaseRecord record : readable) {
+        if (record.getOid() != null && record.getOid().getPrefix() == target.getPrefix()) {
+          return true;
+        }
+      }
+      return false;
+    } catch (ObjectRetrievalFailureException | AuthorizationException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImpl.java
@@ -1,0 +1,207 @@
+package com.researchspace.service.inventory.impl;
+
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.model.EcatMediaFile;
+import com.researchspace.model.User;
+import com.researchspace.model.audit.AuditedEntity;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.Container;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SubSample;
+import com.researchspace.model.record.BaseRecord;
+import com.researchspace.model.record.Folder;
+import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.service.AuditManager;
+import com.researchspace.service.inventory.LinkTargetResolver;
+import com.researchspace.service.inventory.LinkTargetSnapshotResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves Inventory link targets through the Envers audit tables. See {@link
+ * LinkTargetSnapshotResolver}. Not transactional itself; invoked within the transaction of the
+ * calling {@code *Manager} service.
+ */
+@Component("linkTargetSnapshotResolver")
+public class LinkTargetSnapshotResolverImpl implements LinkTargetSnapshotResolver {
+
+  @Autowired private AuditManager auditManager;
+  @Autowired private LinkTargetResolver linkTargetResolver;
+
+  @Override
+  public Long resolveRevisionForVersion(GlobalIdPrefix prefix, Long dbId, Long version) {
+    if (prefix == null || version == null) {
+      return null;
+    }
+    Number revision = null;
+    // All three branches use the non-throwing "find" lookups: capturing the pinned revision is
+    // best-effort (applyApiToEntity stores null = "resolve latest at read time" when a version has
+    // no audit row), so an unresolved version must degrade to null rather than throw. The throwing
+    // getRevisionNumberFor{Document,MediaFile}Version variants would, crossing the transactional
+    // AuditManager boundary, mark the caller's transaction rollback-only and fail the whole save.
+    if (prefix == GlobalIdPrefix.SD) {
+      revision = auditManager.findRevisionNumberForDocumentVersion(dbId, version);
+    } else if (prefix == GlobalIdPrefix.GL) {
+      revision = auditManager.findRevisionNumberForMediaFileVersion(dbId, version);
+    } else if (isInventoryPrefix(prefix)) {
+      revision =
+          auditManager.getRevisionNumberForInventoryRecordVersion(
+              entityClassFor(prefix), dbId, version);
+    }
+    return revision == null ? null : revision.longValue();
+  }
+
+  @Override
+  public ApiInventoryLinkTargetSummary resolveSummary(
+      GlobalIdPrefix prefix, Long dbId, Long versionPin, Long targetRevisionId, User user) {
+    ApiInventoryLinkTargetSummary summary = new ApiInventoryLinkTargetSummary();
+    if (prefix == null || dbId == null) {
+      return summary;
+    }
+    summary.setGlobalId(buildGlobalId(prefix, dbId, versionPin));
+
+    Class<?> cls = entityClassFor(prefix);
+    if (cls == null) {
+      return summary;
+    }
+    AuditedEntity<?> snapshot =
+        targetRevisionId != null
+            ? auditManager.getObjectForRevision(cls, dbId, targetRevisionId)
+            : auditManager.getNewestRevisionForEntity(cls, dbId);
+    if (snapshot == null || snapshot.getEntity() == null) {
+      return summary;
+    }
+    Object entity = snapshot.getEntity();
+    if (!isReadable(prefix, dbId, entity, user)) {
+      // Redacted: globalId only, never disclose name/type of a target the actor cannot read.
+      return summary;
+    }
+    summary.setReadable(true);
+    summary.setType(typeFor(prefix));
+    summary.setName(nameOf(entity));
+    summary.setDeleted(deletedOf(entity));
+    return summary;
+  }
+
+  /**
+   * Read permission for the target snapshot. The snapshot owner is checked first because a user can
+   * always read their own record, deleted or not, and that check cannot throw. This matters for a
+   * soft-deleted folder/notebook: the live readability lookup loads the folder with
+   * includeDeleted=false and throws (the document branch returns deleted records, but the folder
+   * branch does not). Because that lookup runs through a transactional {@code *Manager}, the throw
+   * marks the summary's transaction rollback-only even though it is caught, 500ing the summary
+   * endpoint so the link card shows no "Target deleted" pill and keeps Open. Short-circuiting on
+   * the owner avoids the throwing call for the owner (who deleted the notebook in the reported
+   * case). Non-owners still go through the live check, which also covers shared, still-live
+   * targets.
+   */
+  private boolean isReadable(GlobalIdPrefix prefix, Long dbId, Object entity, User user) {
+    User owner = ownerOf(entity);
+    if (owner != null
+        && user != null
+        && owner.getUsername() != null
+        && owner.getUsername().equals(user.getUsername())) {
+      return true;
+    }
+    GlobalIdentifier baseGid = new GlobalIdentifier(prefix, dbId);
+    return linkTargetResolver.targetExistsAndIsReadable(baseGid, user);
+  }
+
+  private String buildGlobalId(GlobalIdPrefix prefix, Long dbId, Long versionPin) {
+    String base = prefix.name() + dbId;
+    return versionPin == null ? base : base + "v" + versionPin;
+  }
+
+  private boolean isInventoryPrefix(GlobalIdPrefix prefix) {
+    return prefix == GlobalIdPrefix.SA
+        || prefix == GlobalIdPrefix.SS
+        || prefix == GlobalIdPrefix.IC
+        || prefix == GlobalIdPrefix.IN
+        || prefix == GlobalIdPrefix.IT;
+  }
+
+  private Class<?> entityClassFor(GlobalIdPrefix prefix) {
+    switch (prefix) {
+      case SA:
+        return Sample.class;
+      case SS:
+        return SubSample.class;
+      case IC:
+        return Container.class;
+      case IN:
+        return Instrument.class;
+      case IT:
+        // Sample templates are persisted as Sample rows (treated as SA elsewhere).
+        return Sample.class;
+      case SD:
+        return StructuredDocument.class;
+      case NB:
+        // notebooks are persisted as Folder rows; Envers audits Folder, not
+        // Notebook (which is not a separately-mapped entity). Querying
+        // Notebook.class throws (NotAuditedException), which crosses the
+        // transactional getTargetSummary boundary and 500s the summary, leaving
+        // the link card with no "Target deleted" pill and Open still shown.
+        return Folder.class;
+      case GL:
+        return EcatMediaFile.class;
+      default:
+        return null;
+    }
+  }
+
+  private String typeFor(GlobalIdPrefix prefix) {
+    switch (prefix) {
+      case SA:
+        return "SAMPLE";
+      case SS:
+        return "SUBSAMPLE";
+      case IC:
+        return "CONTAINER";
+      case IN:
+        return "INSTRUMENT";
+      case IT:
+        return "SAMPLE";
+      case SD:
+        return "DOCUMENT";
+      case NB:
+        return "NOTEBOOK";
+      case GL:
+        return "MEDIA_FILE";
+      default:
+        return null;
+    }
+  }
+
+  private String nameOf(Object entity) {
+    if (entity instanceof InventoryRecord) {
+      return ((InventoryRecord) entity).getName();
+    }
+    if (entity instanceof BaseRecord) {
+      return ((BaseRecord) entity).getName();
+    }
+    return null;
+  }
+
+  private boolean deletedOf(Object entity) {
+    if (entity instanceof InventoryRecord) {
+      return ((InventoryRecord) entity).isDeleted();
+    }
+    if (entity instanceof BaseRecord) {
+      return ((BaseRecord) entity).isDeleted();
+    }
+    return false;
+  }
+
+  private User ownerOf(Object entity) {
+    if (entity instanceof InventoryRecord) {
+      return ((InventoryRecord) entity).getOwner();
+    }
+    if (entity instanceof BaseRecord) {
+      return ((BaseRecord) entity).getOwner();
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -1,8 +1,10 @@
 package com.researchspace.service.inventory.impl;
 
 import com.axiope.search.InventorySearchConfig.InventorySearchDeletedOption;
+import com.researchspace.api.v1.auth.ApiRuntimeException;
 import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
 import com.researchspace.api.v1.model.ApiSample;
@@ -22,6 +24,7 @@ import com.researchspace.core.util.jsonserialisers.LocalDateDeserialiser;
 import com.researchspace.dao.SampleDao;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.events.InventoryAccessEvent;
 import com.researchspace.model.events.InventoryCreationEvent;
 import com.researchspace.model.events.InventoryDeleteEvent;
@@ -37,17 +40,24 @@ import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.record.IActiveUserStrategy;
+import com.researchspace.service.inventory.DataCiteRelationType;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.InventoryFieldNameUniquenessValidator;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.service.inventory.InventoryLinkValidator;
 import com.researchspace.service.inventory.InventoryMoveHelper;
 import com.researchspace.service.inventory.SampleApiManager;
 import com.researchspace.service.inventory.SubSampleApiManager;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotFoundException;
@@ -67,6 +77,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   private @Autowired InventoryMoveHelper inventoryMoveHelper;
   private @Autowired InventoryAuditApiManager inventoryAuditMgr;
   private @Autowired ApiFieldToModelFieldFactory apiFieldToModelFieldFactory;
+  private @Autowired InventoryLinkManager inventoryLinkManager;
 
   @Override
   public ApiSampleSearchResult getSamplesForUser(
@@ -254,6 +265,15 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
   private void assertDefaultFieldsValid(List<InventoryEntityField> activeFields) {
     for (InventoryEntityField field : activeFields) {
+      if (field instanceof InventoryLinkField) {
+        // Link fields hold their value in the InventoryLink object, not fieldData (which is always
+        // empty for them), and a mandatory link is legitimately unfilled when a sample is first
+        // created from a template (the same state "update all samples" leaves pre-existing samples
+        // in); it is filled by a later link update. assertFieldDataValid would reject the empty
+        // content as a missing mandatory value, so skip the fieldData check for link fields - this
+        // mirrors the LINK special-casing in ApiFieldsHelper.validateMandatoryFieldsForEntityPost.
+        continue;
+      }
       field.assertFieldDataValid(field.getFieldData());
     }
   }
@@ -321,10 +341,153 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
       String newFieldContent = apiField.getContent();
       InventoryEntityField inventoryEntityField = inventoryEntityFieldList.get(i);
 
-      if (inventoryEntityField.isOptionsStoringField()) {
+      if (inventoryEntityField instanceof InventoryLinkField) {
+        applyLinkFieldValue((InventoryLinkField) inventoryEntityField, apiField, user);
+      } else if (inventoryEntityField.isOptionsStoringField()) {
         inventoryEntityField.setSelectedOptions(apiField.getSelectedOptions());
       } else {
         inventoryEntityField.setFieldData(newFieldContent);
+      }
+    }
+  }
+
+  /**
+   * Applies a sample's chosen link value to its structured link field, going through the {@link
+   * InventoryLinkManager} so the target is parsed/validated and the Envers revision captured (the
+   * same path used by extra-field links). An unchanged payload is a no-op (previously every save
+   * replaced the row, resetting its identity and creation date); a changed payload updates the
+   * field's existing InventoryLink row in place; clearing the value dereferences the row, which the
+   * field's {@code orphanRemoval} mapping hard-deletes at flush (an Envers DEL revision keeps the
+   * history in {@code InventoryLink_AUD}; a prior soft-delete write would be collapsed into that
+   * same DEL revision, so none is attempted). This differs deliberately from the extra-field delete
+   * path, where the FIELD itself is soft-deleted and its link row therefore survives soft-deleted
+   * alongside it. The chosen relation type must be permitted by the template field's
+   * allowed-relation-types whitelist (an empty whitelist permits all).
+   */
+  boolean applyLinkFieldValue(
+      InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    ApiInventoryLink apiLink = apiField.getLink();
+    String target = apiLink == null ? null : apiLink.getTargetGlobalId();
+    InventoryLink existing = field.getLink();
+    if (target == null || target.trim().isEmpty()) {
+      if (existing == null) {
+        return false; // no link before, none requested now
+      }
+      field.setLink(null); // orphanRemoval hard-deletes the dereferenced row at flush
+      return true;
+    }
+    Long effectivePin =
+        apiLink.derivedVersionPin() != null ? apiLink.derivedVersionPin() : apiLink.getVersionPin();
+    // compare on the parsed base id, not the raw string: the stored row holds the
+    // unsuffixed id (the pin lives in versionPin), so a suffixed incoming id like
+    // "SA2v4" would otherwise never compare equal and every save would fire a
+    // spurious update (and Envers revision). Mirrors ApiExtraFieldsHelper.linkChanged.
+    GlobalIdentifier incoming = parseTargetOrNull(target);
+    if (existing != null
+        && incoming != null
+        && incoming.getPrefix() == existing.getTargetPrefix()
+        && Objects.equals(incoming.getDbId(), existing.getTargetDbId())
+        && Objects.equals(effectivePin, existing.getVersionPin())
+        && Objects.equals(apiLink.getRelationType(), existing.getRelationType())) {
+      return false; // unchanged
+    }
+    assertRelationAllowed(field, apiLink.getRelationType());
+    if (existing != null) {
+      field.setLink(inventoryLinkManager.updateLink(existing, apiLink, user));
+    } else {
+      field.setLink(inventoryLinkManager.createLink(apiLink, user));
+    }
+    return true;
+  }
+
+  /**
+   * Applies link values to an existing sample's structured link fields (the update path). The DTO
+   * apply loop leaves link fields untouched because it cannot reach the service-layer {@link
+   * InventoryLinkManager}; this matches each modified link field by id and applies it here.
+   */
+  private boolean applyLinkFieldValuesOnUpdate(
+      ApiSampleWithoutSubSamples apiSample, Sample dbSample, User user) {
+    if (apiSample.getFields() == null) {
+      return false;
+    }
+    boolean changed = false;
+    for (ApiInventoryEntityField apiField : apiSample.getFields()) {
+      if (apiField.isNewFieldRequest()
+          || apiField.isDeleteFieldRequest()
+          || apiField.getId() == null) {
+        continue;
+      }
+      Optional<InventoryEntityField> dbFieldOpt =
+          dbSample.getActiveFields().stream()
+              .filter(
+                  f ->
+                      f instanceof InventoryLinkField
+                          && Objects.equals(f.getId(), apiField.getId()))
+              .findFirst();
+      if (dbFieldOpt.isPresent()) {
+        rejectSelfLink(apiField.getLink(), dbSample);
+        changed |= applyLinkFieldValue((InventoryLinkField) dbFieldOpt.get(), apiField, user);
+      }
+    }
+    return changed;
+  }
+
+  private void assertRelationAllowed(InventoryLinkField field, String relationType) {
+    // a chosen relation must be a real DataCite relation type, even when the whitelist is empty.
+    // ApiRuntimeException maps to a 422 with the resolved bundle message, where a raw
+    // IllegalArgumentException would surface as an unmapped 500.
+    if (!DataCiteRelationType.isValid(relationType)) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.relationTypeInvalid", relationType);
+    }
+    String allowed = field.getAllowedRelationTypes();
+    if (allowed == null || allowed.trim().isEmpty()) {
+      return; // empty whitelist = all relation types allowed
+    }
+    if (!Arrays.asList(allowed.split("\\|")).contains(relationType)) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.relationTypeNotPermitted", relationType, field.getName());
+    }
+  }
+
+  private void rejectSelfLink(ApiInventoryLink apiLink, Sample dbSample) {
+    if (apiLink == null || dbSample.getOid() == null) {
+      return;
+    }
+    GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
+    if (target == null) {
+      return; // malformed/blank targets are handled by the manager / clear path
+    }
+    if (InventoryLinkValidator.isSelfLink(target, dbSample.getOid().toString())) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.selfLinkForbidden", apiLink.getTargetGlobalId());
+    }
+  }
+
+  private GlobalIdentifier parseTargetOrNull(String targetGlobalId) {
+    try {
+      return new GlobalIdentifier(targetGlobalId);
+    } catch (IllegalArgumentException | NullPointerException ex) {
+      return null;
+    }
+  }
+
+  /**
+   * Soft-deletes the {@link InventoryLink} backing a structured link field once that field has been
+   * soft-deleted, so the link row (and its Envers audit trail) stays in step with the field. The
+   * field's {@code deleted} flag is flipped in the model layer (a template link-field delete, or
+   * its propagation to child samples through {@code Sample#updateToLatestTemplateVersion}), which
+   * cannot reach the service-layer {@link InventoryLinkManager}; a soft-delete is also an ordinary
+   * update rather than a JPA remove, so the {@code cascade}/{@code orphanRemoval} on {@code
+   * InventoryLinkField#link} never fires. Without this the link row would linger with {@code
+   * deleted=false} after its field is gone. No-op unless the field is a deleted {@link
+   * InventoryLinkField} whose link is still live.
+   */
+  void softDeleteLinkOfDeletedLinkField(InventoryEntityField field, User user) {
+    if (field instanceof InventoryLinkField && field.isDeleted()) {
+      InventoryLink link = ((InventoryLinkField) field).getLink();
+      if (link != null && !link.isDeleted()) {
+        inventoryLinkManager.deleteLink(link, user);
       }
     }
   }
@@ -376,7 +539,24 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
               apiSubSamples.get(i), sample.getSubSamples().get(i), user);
         }
       }
+    } else if (apiSample instanceof ApiSampleTemplate) {
+      setSamplesToUpdateCount((ApiSampleTemplate) apiSample, sample, user);
     }
+  }
+
+  /**
+   * Records, on the outgoing template DTO, how many of {@code user}'s samples were created from an
+   * older version of this template and could therefore be updated to its latest version. This is
+   * the same "behind" set the bulk update endpoint acts on, so the count is 0 exactly when there is
+   * nothing to update - notably for a template that is merely the target of a link from some sample
+   * (that sample is not created from the template, so it is not counted).
+   */
+  void setSamplesToUpdateCount(ApiSampleTemplate apiTemplate, Sample template, User user) {
+    apiTemplate.setSamplesToUpdateCount(
+        sampleDao
+            .getSamplesLinkingOlderTemplateVersionForUser(
+                template.getId(), template.getVersion(), user)
+            .size());
   }
 
   private void populateOutgoingApiSampleWithFullSubSamples(
@@ -558,6 +738,9 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
         identifiersHelper.createAssignRequestedIdentifiers(
             apiSample.getIdentifiers(), dbSample, user);
     contentChanged |= apiSample.applyChangesToDatabaseSample(dbSample, user);
+    if (!dbSample.isTemplate()) {
+      contentChanged |= applyLinkFieldValuesOnUpdate(apiSample, dbSample, user);
+    }
     contentChanged |= saveSharingACLForIncomingApiInvRec(dbSample, apiSample);
     contentChanged |= saveIncomingSampleImage(dbSample, apiSample, user);
     dbSample.refreshActiveFieldsAndColumnIndex();
@@ -800,7 +983,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
     boolean temporaryLock = lockItemForEdit(dbSample, user);
     try {
       dbSample = getIfExists(dbSample.getId());
-      boolean contentChanged = createDeleteRequestedFieldsInDbSampleTemplate(apiSample, dbSample);
+      boolean contentChanged =
+          createDeleteRequestedFieldsInDbSampleTemplate(apiSample, dbSample, user);
       contentChanged |= apiSample.applyChangesToDatabaseTemplate(dbSample, user);
       updateDbSample(apiSample, dbSample, contentChanged, user);
     } finally {
@@ -813,7 +997,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   }
 
   private boolean createDeleteRequestedFieldsInDbSampleTemplate(
-      ApiSampleWithoutSubSamples apiSample, Sample dbTemplate) {
+      ApiSampleWithoutSubSamples apiSample, Sample dbTemplate, User user) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiSample.getFields(), null);
     boolean changed = false;
@@ -826,21 +1010,18 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
       }
       if (apiField.isDeleteFieldRequest()) {
         if (apiField.getId() == null) {
-          throw new IllegalArgumentException(
-              "'id' property not provided "
-                  + "for a template field with 'deleteFieldRequest' flag");
+          throw new ApiRuntimeException("errors.inventory.field.deleteRequest.idMissing");
         }
         Optional<InventoryEntityField> dbFieldOpt =
             dbTemplate.getActiveFields().stream()
                 .filter(sf -> apiField.getId().equals(sf.getId()))
                 .findFirst();
         if (dbFieldOpt.isEmpty()) {
-          throw new IllegalArgumentException(
-              "Field id: "
-                  + apiField.getId()
-                  + " doesn't match id of any pre-existing template field");
+          throw new ApiRuntimeException(
+              "errors.inventory.field.deleteRequest.idUnknown", apiField.getId());
         }
         dbTemplate.deleteSampleField(dbFieldOpt.get(), apiField.isDeleteFieldOnSampleUpdate());
+        softDeleteLinkOfDeletedLinkField(dbFieldOpt.get(), user);
         changed = true;
       }
     }
@@ -859,7 +1040,16 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
     try {
       dbSample = getIfExists(dbSample.getId());
       if (!dbTemplate.getVersion().equals(dbSample.getSTemplateLinkedVersion())) {
+        // Snapshot the link fields before the sync: propagating a deleted template link-field
+        // marks the matching sample field deleted in the model layer, which cannot soft-delete the
+        // field's InventoryLink. Reconcile those orphaned links here once the sync has run.
+        List<InventoryLinkField> linkFieldsBeforeUpdate =
+            dbSample.getActiveFields().stream()
+                .filter(InventoryLinkField.class::isInstance)
+                .map(InventoryLinkField.class::cast)
+                .collect(Collectors.toList());
         dbSample.updateToLatestTemplateVersion();
+        linkFieldsBeforeUpdate.forEach(field -> softDeleteLinkOfDeletedLinkField(field, user));
         saveDbSampleUpdate(dbSample, user);
       }
     } finally {

--- a/src/main/java/com/researchspace/webapp/controller/RecordSharingController.java
+++ b/src/main/java/com/researchspace/webapp/controller/RecordSharingController.java
@@ -45,6 +45,7 @@ public class RecordSharingController extends BaseController {
   public static final String SHAREE = "sharee";
 
   private @Autowired RecordSharingManager recShareMgr;
+
   private @Autowired SharingHandler sharingHandler;
   @Autowired private SystemPropertyPermissionManager systemPropertyPermissionManager;
 

--- a/src/main/java/com/researchspace/webapp/controller/ReferencingInventoryItemsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/ReferencingInventoryItemsController.java
@@ -1,0 +1,55 @@
+package com.researchspace.webapp.controller;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.model.User;
+import com.researchspace.model.field.ErrorList;
+import com.researchspace.service.MessageSourceUtils;
+import com.researchspace.service.UserManager;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import java.security.Principal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * Session-authenticated lookup of the Inventory items that link to a given ELN record. Backs the
+ * ELN-side "Related inventory items" panels (the legacy record info panel for documents/notebooks
+ * and the React gallery info panel). Those run in the browser session and do not present the API
+ * key or OAuth bearer token that the {@code /api/inventory/v1} endpoints require, so they call this
+ * {@code /workspace} endpoint instead. It delegates to the same permission-filtered manager method
+ * as the API endpoint, so callers only ever see items they may read.
+ */
+@Controller
+@RequestMapping("/workspace")
+public class ReferencingInventoryItemsController {
+
+  @Autowired private InventoryLinkManager inventoryLinkManager;
+  @Autowired private UserManager userManager;
+  @Autowired private MessageSourceUtils messageSource;
+
+  @ResponseBody
+  @GetMapping("/getReferencingInventoryItems/{globalId}")
+  public ResponseEntity<?> getReferencingInventoryItems(
+      @PathVariable("globalId") String globalId, Principal principal) {
+    User user = userManager.getUserByUsername(principal.getName());
+    try {
+      ApiInventoryReferencingItems result = new ApiInventoryReferencingItems();
+      result.setReferencingItems(inventoryLinkManager.findReferencingItems(globalId, user));
+      return ResponseEntity.ok(result);
+    } catch (ApiRuntimeException e) {
+      // findReferencingItems throws this for a malformed globalId. No @ControllerAdvice applies to
+      // this session @Controller and it does not extend BaseController, so the exception would
+      // otherwise escape to Spring's default dispatcher as an HTML 500. Translate it to a
+      // structured JSON 404 so this endpoint's contract stays JSON, matching the api.v1
+      // referencing-items endpoint.
+      return ResponseEntity.status(HttpStatus.NOT_FOUND)
+          .body(ErrorList.of(messageSource.getMessage(e.getErrorCode(), e.getArgs())));
+    }
+  }
+}

--- a/src/main/java/com/researchspace/webapp/controller/StructuredDocumentController.java
+++ b/src/main/java/com/researchspace/webapp/controller/StructuredDocumentController.java
@@ -1145,12 +1145,12 @@ public class StructuredDocumentController extends BaseController {
     }
 
     StructuredDocument currentDoc = (StructuredDocument) record;
-    AuditedRecord auditedRecord = null;
-    if (!currentDoc.isDeleted()) {
-      auditedRecord = auditMgr.getDocumentRevisionOrVersion(currentDoc, revision, null);
-    } else {
-      auditedRecord = auditMgr.restoredDeletedForView(recordId);
-    }
+    // Envers retains every revision's content regardless of the document's current deletion state,
+    // so resolve the requested revision the same way whether or not it is deleted. The deleted
+    // case must NOT use restoredDeletedForView here: that returns the live deletion-point row and
+    // ignores `revision`, so a deleted document would render the same content for every requested
+    // version (e.g. a link pinned to v3 would show the version it had at deletion, not v3).
+    AuditedRecord auditedRecord = auditMgr.getDocumentRevisionOrVersion(currentDoc, revision, null);
     StructuredDocument auditedDoc = auditedRecord.getRecordAsDocument();
     // PRT-385 Set temp record to null here to prevent errors when accessing temp records that dont
     // exist.
@@ -1220,12 +1220,13 @@ public class StructuredDocumentController extends BaseController {
           "Viewing record's audit history only works with StructuredDocuments!");
     }
 
-    Number revision;
-    if (!record.isDeleted()) {
-      revision = auditMgr.getRevisionNumberForDocumentVersion(record.getId(), userVersion);
-    } else {
-      revision = auditMgr.restoredDeletedForView(recordId).getRevision();
-    }
+    // Resolve the audit revision for the requested version. Envers retains the full version
+    // history of soft-deleted documents (a soft delete is a MOD, not an Envers DEL), so the
+    // version->revision lookup works whether or not the target is currently deleted. The deleted
+    // case must NOT use restoredDeletedForView here: its AuditedRecord carries a null revision,
+    // which produced a "...&revision=null" redirect that failed to bind to the Integer 'revision'
+    // param on the /audit/view endpoint.
+    Number revision = auditMgr.getRevisionNumberForDocumentVersion(record.getId(), userVersion);
 
     return "redirect:"
         + STRUCTURED_DOCUMENT_AUDIT_VIEW_URL

--- a/src/main/resources/bundles/inventory/inventory.properties
+++ b/src/main/resources/bundles/inventory/inventory.properties
@@ -13,6 +13,7 @@ errors.inventory.template.reserved.field.name={0} is a reserved field name, plea
 errors.inventory.template.empty.field.name=Field name cannot be empty
 errors.inventory.template.field.name.too.long={0} is too long for a template field name, max length is {1}
 errors.inventory.template.empty.field.type=Field type cannot be empty
+errors.inventory.template.invalid.relation.type={0} is not a valid DataCite relation type
 errors.inventory.field.duplicate.name=Field name ''{0}'' is duplicated. Field names on a record must be unique.
 
 errors.inventory.sample.mandatory.field.empty=Field ''{0}'' is mandatory, but provided value was empty
@@ -54,3 +55,11 @@ errors.inventory.import.instrument.templateId.and.templateInfo.conflict=Provide 
 errors.inventory.import.instrument.column.count.mismatch=Number of unmapped CSV columns is {0}, but number of fields in instrument template is {1}. The CSV file must exactly map all the template fields.
 errors.inventory.import.instrument.csv.line.unexpected.column.count=Unexpected number of values in CSV line, expected: {0}, was: {1}
 errors.inventory.import.instrument.unrecognized.field.mapping=Unrecognized field mapping for instrument import: {0}
+# RSDEV-1131 Inventory Link field (step 1)
+errors.inventory.field.link.targetKindUnsupported=Link target must be an Inventory item (sample, subsample, container or instrument) or an ELN document, notebook or gallery file; ''{0}'' is not supported.
+errors.inventory.field.link.targetNotFound=Link target ''{0}'' could not be found or you do not have permission to read it.
+errors.inventory.field.link.selfLinkForbidden=An item cannot link to itself: ''{0}''.
+errors.inventory.field.link.relationTypeInvalid=Relation type ''{0}'' is not in the DataCite controlled vocabulary.
+errors.inventory.field.link.relationTypeNotPermitted=Relation type ''{0}'' is not permitted for field ''{1}''.
+errors.inventory.field.deleteRequest.idMissing=''id'' property not provided for a field with ''deleteFieldRequest'' flag.
+errors.inventory.field.deleteRequest.idUnknown=Field id {0} doesn''t match the id of any pre-existing field.

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -152,10 +152,13 @@
         <mapping class="com.researchspace.model.inventory.field.InventoryUriField"/>
         <mapping class="com.researchspace.model.inventory.field.InventoryReferenceField"/>
         <mapping class="com.researchspace.model.inventory.field.InventoryAttachmentField"/>
+        <mapping class="com.researchspace.model.inventory.field.InventoryLinkField"/>
 
         <mapping class="com.researchspace.model.inventory.field.ExtraField"/>
         <mapping class="com.researchspace.model.inventory.field.ExtraNumberField"/>
         <mapping class="com.researchspace.model.inventory.field.ExtraTextField"/>
+        <mapping class="com.researchspace.model.inventory.field.ExtraLinkField"/>
+        <mapping class="com.researchspace.model.inventory.field.InventoryLink"/>
         <mapping class="com.researchspace.model.inventory.field.InventoryRadioFieldDef"/>
         <mapping class="com.researchspace.model.inventory.field.InventoryChoiceFieldDef"/>
 

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1131.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1131.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <!--
+      RSDEV-1131 Step 1: Inventory Link related items.
+      Creates InventoryLink table and audit, adds link_id FK on ExtraField/ExtraField_AUD.
+  -->
+
+  <!-- ChangeSet 1: Create InventoryLink table -->
+  <changeSet id="2026-05-28-rsdev1131-create-inventorylink" context="run" author="nhanlon2">
+    <createTable tableName="InventoryLink">
+      <column name="id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="target_globalid" type="varchar(64)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="target_prefix" type="varchar(8)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="target_db_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="version_pin" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="relation_type" type="varchar(64)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="created_at" type="datetime">
+        <constraints nullable="false"/>
+      </column>
+      <column name="modified_at" type="datetime">
+        <constraints nullable="false"/>
+      </column>
+      <column name="deleted" type="bit" defaultValueNumeric="0">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <createIndex tableName="InventoryLink"
+      indexName="IDX_InvLink_target_prefix_dbid">
+      <column name="target_prefix"/>
+      <column name="target_db_id"/>
+    </createIndex>
+
+    <createIndex tableName="InventoryLink"
+      indexName="IDX_InvLink_relation_type">
+      <column name="relation_type"/>
+    </createIndex>
+  </changeSet>
+
+  <!-- ChangeSet 2: Create InventoryLink_AUD audit table -->
+  <changeSet id="2026-05-28-rsdev1131-create-inventorylink-aud" context="run" author="nhanlon2">
+    <createTable tableName="InventoryLink_AUD">
+      <column name="id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="REV" type="int">
+        <constraints nullable="false"/>
+      </column>
+      <column name="REVTYPE" type="tinyint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="target_globalid" type="varchar(64)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="target_prefix" type="varchar(8)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="target_db_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="version_pin" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+      <column name="relation_type" type="varchar(64)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="created_at" type="datetime">
+        <constraints nullable="true"/>
+      </column>
+      <column name="modified_at" type="datetime">
+        <constraints nullable="true"/>
+      </column>
+      <column name="deleted" type="bit">
+        <constraints nullable="true"/>
+      </column>
+    </createTable>
+
+    <addPrimaryKey tableName="InventoryLink_AUD"
+      columnNames="id, REV"
+      constraintName="PK_InventoryLink_AUD"/>
+
+    <addForeignKeyConstraint
+      constraintName="FK_InvLinkAud_to_RevInfo"
+      baseTableName="InventoryLink_AUD"
+      baseColumnNames="REV"
+      referencedTableName="REVINFO"
+      referencedColumnNames="REV"/>
+  </changeSet>
+
+  <!-- ChangeSet 3: Add link_id column + FK to ExtraField and ExtraField_AUD -->
+  <changeSet id="2026-05-28-rsdev1131-extrafield-link-id" context="run" author="nhanlon2">
+    <addColumn tableName="ExtraField">
+      <column name="link_id" type="bigint">
+        <constraints nullable="true" unique="true" uniqueConstraintName="UC_ExtraField_link_id"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="ExtraField_AUD">
+      <column name="link_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+
+    <addForeignKeyConstraint
+      constraintName="FK_ExtraField_to_InvLink"
+      baseTableName="ExtraField"
+      baseColumnNames="link_id"
+      referencedTableName="InventoryLink"
+      referencedColumnNames="id"/>
+  </changeSet>
+
+  <!--
+      ChangeSet 4: add target_revision_id (the Envers REV a pinned link resolved to; null = latest).
+      Added as a separate addColumn changeSet rather than folded into ChangeSet 1, because ChangeSet 1
+      has already been applied to existing dev databases and Liquibase will not re-run it. This applies
+      cleanly to both existing DBs (adds the column) and fresh installs (ChangeSet 1 creates the table
+      without it, then this adds it).
+  -->
+  <changeSet id="2026-06-03-rsdev1131-add-target-revision-id" context="run" author="nhanlon2">
+    <addColumn tableName="InventoryLink">
+      <column name="target_revision_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="InventoryLink_AUD">
+      <column name="target_revision_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <!--
+      ChangeSet 5: structured Link template field (InventoryLinkField, @DiscriminatorValue("link")).
+      Adds the single optional InventoryLink value (link_id, FK) and the pipe-delimited
+      allowed-relation-types whitelist (allowed_relation_types) to the single-table
+      InventoryEntityField hierarchy and its Envers _AUD table. Separate addColumn changeSet (new id)
+      so it applies to both existing dev DBs and fresh installs.
+  -->
+  <changeSet id="2026-06-04-rsdev1131-inventoryentityfield-link" context="run" author="nhanlon2">
+    <addColumn tableName="InventoryEntityField">
+      <column name="link_id" type="bigint">
+        <constraints nullable="true" unique="true" uniqueConstraintName="UC_InvEntityField_link_id"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="InventoryEntityField">
+      <column name="allowed_relation_types" type="varchar(1024)">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="InventoryEntityField_AUD">
+      <column name="link_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="InventoryEntityField_AUD">
+      <column name="allowed_relation_types" type="varchar(1024)">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+
+    <addForeignKeyConstraint
+      constraintName="FK_InvEntityField_to_InvLink"
+      baseTableName="InventoryEntityField"
+      baseColumnNames="link_id"
+      referencedTableName="InventoryLink"
+      referencedColumnNames="id"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -58,6 +58,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1135.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-416-pr2-cleanup.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1154.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-1131.xml"/>
 
 
   <!-- These two run last: recurring-changeLog.xml (runAlways diagnostics / batch re-init) then

--- a/src/main/webapp/WEB-INF/pages/recordInfoPanel.jsp
+++ b/src/main/webapp/WEB-INF/pages/recordInfoPanel.jsp
@@ -219,6 +219,7 @@ There are no references to this file.
         this or a new document
       </div>
       <div class="infoPanelInternalLinksDiv" style="display:none"></div>
+      <div class="infoPanelRelatedInventoryItemsDiv" style="display:none"></div>
       <div class="infoPanelSharingDiv" style="display:none"></div>
       <div class="publicLinksDiv" style="display:none"></div>
 

--- a/src/main/webapp/resources/rspace_api_inventory_specs_2_13_0.yaml
+++ b/src/main/webapp/resources/rspace_api_inventory_specs_2_13_0.yaml
@@ -2746,6 +2746,156 @@ paths:
           description: Success - settings are updated.
         "422":
           $ref: "#/components/responses/UnprocessableQuery"
+  "/samples/{sampleId}/referencingItems":
+    get:
+      summary: List Inventory items linking to a Sample
+      description: >
+        Returns the Inventory items whose "Related Items" Link field points at
+        this Sample (its inbound links / back-references). Results are
+        permission-filtered to the source items the current user can read. A
+        target that does not exist, or that the user cannot read, is reported
+        with the same "not found" error as a missing one, so the endpoint cannot
+        be used to probe which records exist.
+      tags:
+        - Related Items
+      parameters:
+        - $ref: "#/components/parameters/sampleIdParam"
+      responses:
+        "200":
+          description: The items referencing this Sample.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryReferencingItems"
+        "422":
+          $ref: "#/components/responses/UnprocessableQuery"
+  "/subSamples/{subSampleId}/referencingItems":
+    get:
+      summary: List Inventory items linking to a SubSample
+      description: >
+        As `/samples/{sampleId}/referencingItems`, but for a SubSample target.
+      tags:
+        - Related Items
+      parameters:
+        - $ref: "#/components/parameters/subSampleIdParam"
+      responses:
+        "200":
+          description: The items referencing this SubSample.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryReferencingItems"
+        "422":
+          $ref: "#/components/responses/UnprocessableQuery"
+  "/containers/{containerId}/referencingItems":
+    get:
+      summary: List Inventory items linking to a Container
+      description: >
+        As `/samples/{sampleId}/referencingItems`, but for a Container target.
+      tags:
+        - Related Items
+      parameters:
+        - $ref: "#/components/parameters/containerIdParam"
+      responses:
+        "200":
+          description: The items referencing this Container.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryReferencingItems"
+        "422":
+          $ref: "#/components/responses/UnprocessableQuery"
+  "/instruments/{instrumentId}/referencingItems":
+    get:
+      summary: List Inventory items linking to an Instrument
+      description: >
+        As `/samples/{sampleId}/referencingItems`, but for an Instrument target.
+      tags:
+        - Related Items
+      parameters:
+        - name: instrumentId
+          in: path
+          required: true
+          description: A unique identifier of the instrument.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: The items referencing this Instrument.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryReferencingItems"
+        "422":
+          $ref: "#/components/responses/UnprocessableQuery"
+  "/referencingItems/{globalId}":
+    get:
+      summary: List Inventory items linking to any target by Global ID
+      description: >
+        Target-agnostic back-reference lookup: returns the Inventory items whose
+        "Related Items" Link field points at the supplied target Global ID. The
+        target may be an Inventory item (SA, SS, IC, IN) or an ELN record - a
+        document (SD), notebook (NB) or gallery file (GL). Used by the ELN-side
+        "Related inventory items" panels. Results are permission-filtered to the
+        source items the current user can read; a target that does not exist, or
+        that the user cannot read, returns the same "not found" error as a
+        missing one.
+      tags:
+        - Related Items
+      parameters:
+        - name: globalId
+          in: path
+          required: true
+          description: >-
+            Global ID of the target - an Inventory item (e.g. `SA123`) or an ELN
+            record (e.g. `SD456`, `NB78`, `GL90`). Any version suffix (e.g.
+            `SA123v2`) is ignored; back-references match on the base record.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The items referencing this target.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryReferencingItems"
+        "422":
+          $ref: "#/components/responses/UnprocessableQuery"
+  "/linkTargets/{globalId}/summary":
+    get:
+      summary: Summarise an Inventory Link target
+      description: >
+        Resolves the current state (Global ID, name, type, deleted) of a
+        "Related Items" Link target, Inventory or ELN alike. Backs the target
+        name and "Target deleted" indicator shown on link cards. Permission
+        redacted: for a target the caller cannot read (or that does not exist)
+        the response contains only `globalId` with `readable` false, deliberately
+        identical for unreadable and nonexistent targets so callers cannot probe
+        which records exist.
+      tags:
+        - Related Items
+      parameters:
+        - name: globalId
+          in: path
+          required: true
+          description: >-
+            Global ID of the link target - an Inventory item or an ELN record
+            (document, notebook or gallery file). A version suffix (e.g.
+            `SD456v2`) is accepted.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: >-
+            The target summary (redacted to `globalId` only when the caller
+            cannot read the target).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryLinkTargetSummary"
+        "422":
+          $ref: "#/components/responses/UnprocessableQuery"
 servers:
   - url: /api/inventory/v1
 components:
@@ -3863,3 +4013,83 @@ components:
         httpCode: 422
         internalCode: 42201
         message: Query could not be processed.
+    InventoryReferencingItems:
+      type: object
+      description: >
+        Inventory items that reference a target record through a "Related Items"
+        Link field (the target's inbound links). The target may be an Inventory
+        item or an ELN record.
+      properties:
+        referencingItems:
+          type: array
+          description: >-
+            The referencing items, permission-filtered to those the caller can
+            read. Empty when nothing readable links to the target.
+          items:
+            $ref: "#/components/schemas/InventoryReferencingItem"
+    InventoryReferencingItem:
+      type: object
+      description: A single Inventory item that links to the requested target.
+      properties:
+        sourceGlobalId:
+          type: string
+          description: Global ID of the referencing (source) Inventory item.
+          example: SA123
+        sourceName:
+          type: string
+          description: Name of the referencing item.
+        sourceType:
+          type: string
+          description: Inventory type of the referencing item.
+          enum:
+            - SAMPLE
+            - SUBSAMPLE
+            - CONTAINER
+            - INSTRUMENT
+        relationType:
+          type: string
+          description: >-
+            The DataCite 4.7 relationship type of the link (plus the PIDINST
+            `IsCalibratedBy` / `Calibrates` pair).
+          example: References
+        versionPin:
+          type: integer
+          format: int64
+          nullable: true
+          description: >-
+            The pinned user-facing version of the target this link points at, or
+            null when the link follows the latest version.
+        modifiedAt:
+          type: string
+          format: date-time
+          description: When the link was last modified.
+    InventoryLinkTargetSummary:
+      type: object
+      description: >
+        Read-time summary of a "Related Items" Link target. For a target the
+        caller cannot read (or that does not exist) only `globalId` is populated
+        and `readable` is false - deliberately identical for unreadable and
+        nonexistent targets (see ADR 0002, link-target-state non-disclosure).
+      properties:
+        globalId:
+          type: string
+          description: >-
+            Global ID of the target, including a version suffix when the link is
+            pinned (e.g. `SA123v2`).
+          example: SA123
+        name:
+          type: string
+          description: Current name of the target. Empty when not readable.
+        type:
+          type: string
+          description: >-
+            Type of the target, e.g. SAMPLE, SUBSAMPLE, CONTAINER, INSTRUMENT,
+            DOCUMENT, NOTEBOOK or MEDIA_FILE.
+        deleted:
+          type: boolean
+          description: True when the target record is currently soft-deleted.
+        readable:
+          type: boolean
+          description: >-
+            True only when the caller can read the target; false deliberately
+            conflates "unreadable" with "nonexistent".

--- a/src/main/webapp/scripts/pages/recordInfoPanel.js
+++ b/src/main/webapp/scripts/pages/recordInfoPanel.js
@@ -238,6 +238,16 @@ function generate$RecordInfoPanel(info) {
     _setInfoPanelInternalLinksHtml($newInfoPanel.find('.infoPanelInternalLinksDiv'), info, recordTypeNameToDisplay);
   }
 
+  // Inventory items can link to this ELN document/notebook via an Inventory Link
+  // extra-field; surface those back-references in a distinct section.
+  var showRelatedInventoryItems = isStructuredDocument || isNotebook;
+  $newInfoPanel.find('.infoPanelRelatedInventoryItemsDiv').toggle(showRelatedInventoryItems);
+  if (showRelatedInventoryItems) {
+    _setInfoPanelRelatedInventoryItemsHtml(
+      $newInfoPanel.find('.infoPanelRelatedInventoryItemsDiv'), info,
+      isStructuredDocument ? 'document' : 'notebook');
+  }
+
   var showSharingStatus = isStructuredDocument || isNotebook;
   $newInfoPanel.find('.infoPanelSharingDiv').toggle(showSharingStatus);
   if (showSharingStatus) {
@@ -375,6 +385,44 @@ function _setInfoPanelInternalLinksHtml($internalLinksDiv, info, recordTypeNameT
     return false;
   });
 }
+/**
+ * Renders the "Related inventory items" section: the Inventory items (samples,
+ * subsamples, containers, instruments) whose Link extra-field points at this ELN
+ * record. Reads the shared, permission-filtered back-reference endpoint, the same
+ * one used by the React gallery info panel. The relation is shown with the
+ * Inventory item as the subject (e.g. "SA1 IsPartOf this document").
+ */
+function _setInfoPanelRelatedInventoryItemsHtml($div, info, recordTypeNameToDisplay) {
+  $div.empty().append(
+    "<strong>Related inventory items</strong><br/>"
+    + "<span class='relatedInventoryItemsContent'>Loading&hellip;</span>");
+  var $content = $div.find('.relatedInventoryItemsContent');
+
+  var req = $.get("/workspace/getReferencingInventoryItems/" + encodeURIComponent(info.oid.idString));
+  req.done(function (resp) {
+    var items = (resp && resp.referencingItems) || [];
+    if (!items.length) {
+      $content.text("No Inventory items link to this " + recordTypeNameToDisplay + ".");
+      return;
+    }
+    var html = "<ul>";
+    $.each(items, function (i, item) {
+      var globalId = item.sourceGlobalId;
+      var name = item.sourceName || "";
+      var relation = item.relationType || "";
+      html += "<li><a href='/globalId/" + encodeURIComponent(globalId) + "'>" + RS.escapeHtml(globalId) + "</a>: "
+        + RS.escapeHtml(name)
+        + (relation ? " <em>(" + RS.escapeHtml(relation) + ")</em>" : "")
+        + "</li>";
+    });
+    html += "</ul>";
+    $content.html(html);
+  });
+  req.fail(function () {
+    $content.text("Could not load related Inventory items.");
+  });
+}
+
 const makePublicLink = (info, isNotebook, panel) => {
   const publicExistsRequest = $.get('/public/publishedView/publiclink?globalId=' + info.oid.idString);
   publicExistsRequest.done(function (resp) {

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/Fields.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/Fields.tsx
@@ -17,6 +17,7 @@ import { truncateIsoTimestamp } from "../../../../stores/definitions/Units";
 import type InventoryBaseRecord from "../../../../stores/models/InventoryBaseRecord";
 import AttachmentField from "../../../components/Fields/Attachments/AttachmentField";
 import FormField from "../../../components/Inputs/FormField";
+import LinkFieldValue from "./LinkFieldValue";
 
 type FieldsArgs = {
   onErrorStateChange: (fieldName: string, hasError: boolean) => void;
@@ -274,6 +275,31 @@ function Fields({ onErrorStateChange, sample }: FieldsArgs): React.ReactNode {
                 field.setError(false); // URIs are strings, so isNaN is not the right validation
                 onErrorStateChange(`template_${field.name}`, (field.mandatory && !field.hasContent) || field.error);
               }}
+            />
+          )}
+        />
+      );
+    }
+
+    if (field.type === "link") {
+      return (
+        <FormField
+          {...commonProps}
+          key={field.name}
+          value={field.link?.targetGlobalId ?? ""}
+          // ID is not used because there is no singular HTMLInputElement to attach it to
+          doNotAttachIdToLabel
+          // the field name is shown inside the link card (after "Link"), like a
+          // custom Link extra-field, so the duplicate label above the card is hidden
+          hideLabel
+          renderInput={() => (
+            <LinkFieldValue
+              field={field}
+              sourceGlobalId={sample.globalId ?? ""}
+              disabled={!sample.isFieldEditable("fields")}
+              onChange={() =>
+                onErrorStateChange(`template_${field.name}`, (field.mandatory && !field.hasContent) || field.error)
+              }
             />
           )}
         />

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
@@ -1,0 +1,228 @@
+import SettingsIcon from "@mui/icons-material/Settings";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { observer } from "mobx-react-lite";
+import type React from "react";
+import { useEffect, useState } from "react";
+import IconButtonWithTooltip from "../../../../components/IconButtonWithTooltip";
+import type { Field, FieldLink } from "../../../../stores/definitions/Field";
+import { DATACITE_RELATION_TYPES } from "../../../components/Fields/Link/dataciteRelationTypes";
+import { isInventoryGlobalId, supportsVersionPin } from "../../../components/Fields/Link/iconForGlobalId";
+import LinkEditor from "../../../components/Fields/Link/LinkEditor";
+import LinkField from "../../../components/Fields/Link/LinkField";
+import { validateTarget } from "../../../components/Fields/Link/linkTarget";
+import { checkLinkTargetExists } from "../../../components/Fields/Link/linkTargetExists";
+import useLinkTargetSummary from "../../../components/Fields/Link/useLinkTargetSummary";
+
+type LinkFieldValueArgs = {
+  field: Field;
+  /** The Global ID of the sample owning this field, used to forbid self-links. */
+  sourceGlobalId: string;
+  disabled: boolean;
+  onChange: () => void;
+};
+
+/**
+ * Editor + display for a sample's structured Link field value. A committed link is shown with the
+ * same {@link LinkField} card used for manually-created (extra-field) links: an outline, relation
+ * and target chips, an info dialog, a version pill (and version-pin control), and an Open button.
+ * A settings cog overlaid on the card reveals the editor, where the relationship type (constrained to the template field's
+ * allowed set, or any DataCite type when the whitelist is empty) and a target are chosen and then
+ * committed on Apply, mirroring the extra-field Link editor. The editor body itself is the shared
+ * {@link LinkEditor}.
+ */
+function LinkFieldValue({ field, sourceGlobalId, disabled, onChange }: LinkFieldValueArgs): React.ReactNode {
+  const committedRelationType = field.link?.relationType ?? "";
+  const committedTargetGlobalId = field.link?.targetGlobalId ?? "";
+  const committedVersionPin = field.link?.versionPin ?? null;
+  const hasLink = committedTargetGlobalId !== "";
+
+  // Show the display card for an existing link; drop straight into the editor for an empty field.
+  const [editing, setEditing] = useState(!hasLink);
+  // set when Apply finds the typed target does not resolve on the server
+  const [targetExistenceError, setTargetExistenceError] = useState<string | null>(null);
+  const [checkingTarget, setCheckingTarget] = useState(false);
+
+  // staged (uncommitted) edits; committed to the field model only on Apply
+  const [stagedRelationType, setStagedRelationType] = useState<string>(committedRelationType);
+  const [stagedTargetGlobalId, setStagedTargetGlobalId] = useState<string>(committedTargetGlobalId);
+  const [stagedVersionPin, setStagedVersionPin] = useState<number | null>(committedVersionPin);
+
+  // A no-access committed target (an unshared ELN item) cannot be
+  // version-pinned, so the clock stays greyed while editing it. Keyed on the
+  // committed target and only fetched while editing, so it clears after a
+  // successful Apply commits a different, readable target and is reimposed on
+  // the next edit after Discard. Inventory targets keep a limited-read view, so
+  // they are never "no access".
+  const committedSummary = useLinkTargetSummary(editing ? committedTargetGlobalId : "");
+  const committedNoAccess = committedSummary?.readable === false && !isInventoryGlobalId(committedTargetGlobalId);
+
+  const setStagedTarget = (targetGlobalId: string): void => {
+    setTargetExistenceError(null);
+    setStagedTargetGlobalId(targetGlobalId);
+    // a version pin belongs to a specific target, so retargeting reverts to Latest
+    if (targetGlobalId !== stagedTargetGlobalId) {
+      setStagedVersionPin(null);
+    }
+  };
+
+  // re-sync staged state when the committed link changes (record switch, post-save round-trip)
+  useEffect(() => {
+    setStagedRelationType(committedRelationType);
+    setStagedTargetGlobalId(committedTargetGlobalId);
+    setStagedVersionPin(committedVersionPin);
+  }, [committedRelationType, committedTargetGlobalId, committedVersionPin]);
+
+  const changed =
+    stagedRelationType !== committedRelationType ||
+    stagedTargetGlobalId !== committedTargetGlobalId ||
+    stagedVersionPin !== committedVersionPin;
+
+  // surface unapplied editor state on the field model so the record-level Save
+  // is blocked (with a clear message) instead of silently dropping the staged
+  // edit and saving the previous link
+  useEffect(() => {
+    field.setError(changed);
+  }, [changed, field]);
+
+  const relationOptions =
+    field.allowedRelationTypes.length > 0 ? field.allowedRelationTypes : [...DATACITE_RELATION_TYPES];
+
+  const bothEmpty = stagedRelationType === "" && stagedTargetGlobalId === "";
+  const bothSet = stagedRelationType !== "" && stagedTargetGlobalId !== "";
+  // typed targets are validated like the extra-field editor: parseable, a
+  // supported prefix, and not a self-link
+  const targetValidity =
+    stagedTargetGlobalId === "" ? { ok: true, reason: "" } : validateTarget(stagedTargetGlobalId, sourceGlobalId);
+  // a stageable value is either fully cleared (removing the link) or a complete, valid link
+  const canApply = changed && !checkingTarget && !targetExistenceError && (bothEmpty || (bothSet && targetValidity.ok));
+
+  const validationMessage =
+    changed && !bothEmpty && !bothSet ? "Select both a relationship type and a target before applying." : "";
+
+  const apply = async (): Promise<void> => {
+    const nextLink: FieldLink | null = bothEmpty
+      ? null
+      : {
+          relationType: stagedRelationType,
+          targetGlobalId: stagedTargetGlobalId,
+          versionPin: stagedVersionPin,
+        };
+    // a structurally-valid Global ID must also resolve to a real, readable
+    // record; check (re)targeted links against the server before committing
+    if (nextLink && nextLink.targetGlobalId !== committedTargetGlobalId) {
+      setCheckingTarget(true);
+      const exists = await checkLinkTargetExists(nextLink.targetGlobalId);
+      setCheckingTarget(false);
+      if (!exists) {
+        setTargetExistenceError(`${nextLink.targetGlobalId} does not exist, or you do not have permission to view it.`);
+        return;
+      }
+    }
+    field.setAttributesDirty({ link: nextLink });
+    field.setError(false);
+    setEditing(false);
+    onChange();
+  };
+
+  const discard = (): void => {
+    setTargetExistenceError(null);
+    setStagedRelationType(committedRelationType);
+    setStagedTargetGlobalId(committedTargetGlobalId);
+    setStagedVersionPin(committedVersionPin);
+    if (hasLink) {
+      setEditing(false);
+    }
+  };
+
+  const committedLink = field.link;
+  if (committedLink && committedTargetGlobalId !== "" && !editing) {
+    return (
+      <Box sx={{ position: "relative" }}>
+        {!disabled && (
+          <Box sx={{ position: "absolute", top: 0, right: 0, zIndex: 1 }}>
+            <IconButtonWithTooltip
+              title="Edit link"
+              size="small"
+              onClick={() => setEditing(true)}
+              icon={<SettingsIcon fontSize="small" />}
+            />
+          </Box>
+        )}
+        <LinkField name={field.name} link={committedLink} editable={!disabled} />
+      </Box>
+    );
+  }
+
+  // View mode with no link to show or edit: show an explicit placeholder
+  // rather than headers with blank space beneath them.
+  if (disabled) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        None
+      </Typography>
+    );
+  }
+
+  return (
+    <Box>
+      {/* The FormField label is hidden, so surface the field name here. */}
+      {field.name && (
+        <Typography variant="subtitle1" component="span" sx={{ fontWeight: 700 }}>
+          {field.name}
+        </Typography>
+      )}
+      <LinkEditor
+        relationType={stagedRelationType}
+        onRelationTypeChange={(value) => setStagedRelationType(value)}
+        relationOptions={relationOptions}
+        relationFreeSolo={false}
+        relationLabel="Relationship type"
+        targetGlobalId={stagedTargetGlobalId}
+        onTargetChange={(globalId) => setStagedTarget(globalId)}
+        targetError={Boolean(targetExistenceError) || !targetValidity.ok}
+        targetHelperText={
+          targetExistenceError ??
+          (!targetValidity.ok ? targetValidity.reason : "Paste a Global ID, or use the Browse buttons above.")
+        }
+        validationMessage={validationMessage}
+        versionPin={stagedVersionPin}
+        onVersionPinChange={(pin) => setStagedVersionPin(pin)}
+        canPinVersion={
+          stagedTargetGlobalId !== "" &&
+          targetValidity.ok &&
+          supportsVersionPin(stagedTargetGlobalId) &&
+          !committedNoAccess
+        }
+      />
+      <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+        <Button
+          color="callToAction"
+          disableElevation
+          variant="contained"
+          aria-label="Apply link"
+          onClick={() => {
+            void apply();
+          }}
+          disabled={!canApply}
+          data-test-id="ApplyLinkButton"
+        >
+          Apply
+        </Button>
+        <Button
+          variant="text"
+          aria-label="Discard link changes"
+          onClick={discard}
+          disabled={!changed && !hasLink}
+          data-test-id="DiscardLinkButton"
+        >
+          Discard
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+
+export default observer(LinkFieldValue);

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
@@ -1,0 +1,438 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/__tests__/customQueries";
+import type { Field } from "@/stores/definitions/Field";
+import materialTheme from "@/theme";
+import LinkFieldValue from "../LinkFieldValue";
+
+// The target-picker dialogs pull in the store/ApiService chain at module load, which is
+// irrelevant to this component's relation-constraint behaviour; stub them out.
+vi.mock("@/Inventory/components/Fields/Link/LinkTargetBrowser", () => ({
+  default: () => null,
+}));
+vi.mock("@/Inventory/components/Fields/Link/ElnRecordPicker", () => ({
+  default: () => null,
+}));
+// RecordTypeIcon needs app context to resolve its icon; irrelevant to this component's logic.
+vi.mock("@/components/RecordTypeIcon", () => ({ default: () => null }));
+// Typed targets are existence-checked against the server on Apply; default to "exists".
+const { mockCheckLinkTargetExists } = vi.hoisted(() => ({
+  mockCheckLinkTargetExists: vi.fn(() => Promise.resolve(true)),
+}));
+vi.mock("@/Inventory/components/Fields/Link/linkTargetExists", () => ({
+  checkLinkTargetExists: mockCheckLinkTargetExists,
+}));
+// The editor greys the version-pin clock for a no-access committed target via
+// this summary hook; default to "no summary" (null) so unrelated tests are
+// unaffected, and override per-test for the no-access case.
+const { mockUseLinkTargetSummary } = vi.hoisted(() => ({
+  mockUseLinkTargetSummary: vi.fn(),
+}));
+vi.mock("@/Inventory/components/Fields/Link/useLinkTargetSummary", () => ({
+  default: (globalId: string) => mockUseLinkTargetSummary(globalId) as unknown,
+}));
+// The real dialog fetches revision history; stub it with a confirm button.
+vi.mock("@/Inventory/components/Fields/Link/VersionLockDialog", () => ({
+  default: ({
+    open,
+    globalId,
+    onConfirm,
+  }: {
+    open: boolean;
+    globalId: string;
+    onConfirm: (v: number | null) => void;
+  }) =>
+    open ? (
+      <div data-testid="version-lock-dialog" data-globalid={globalId}>
+        <button type="button" data-testid="version-lock-dialog-confirm-7" onClick={() => onConfirm(7)}>
+          confirm 7
+        </button>
+      </div>
+    ) : null,
+}));
+// LinkField has its own tests; stub it so we can assert it is used for the committed-link display
+// without pulling in its info/version dialog chain. The edit affordance is no longer LinkField's
+// inline button but the settings cog LinkFieldValue overlays on the card, so the stub omits it.
+vi.mock("@/Inventory/components/Fields/Link/LinkField", () => ({
+  // LinkField now renders its own static Open link from the target/versionPin, so
+  // LinkFieldValue no longer passes an onOpen callback (open routing is covered by
+  // LinkField's own tests).
+  default: ({ link }: { link: { relationType: string; targetGlobalId: string } }) => (
+    <div data-testid="link-field-display">
+      <span>{link.relationType}</span>
+      <span>{link.targetGlobalId}</span>
+    </div>
+  ),
+}));
+
+function linkField(overrides: Partial<Field> = {}): Field {
+  return {
+    name: "Related items",
+    type: "link",
+    allowedRelationTypes: ["References", "IsDerivedFrom"],
+    link: null,
+    setAttributesDirty: vi.fn(),
+    setError: vi.fn(),
+    ...overrides,
+  } as unknown as Field;
+}
+
+// The editor's Apply button uses the custom `callToAction` palette, so a theme is required.
+function renderField(props: { field: Field; sourceGlobalId: string; disabled: boolean; onChange: () => void }) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <LinkFieldValue {...props} />
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockUseLinkTargetSummary.mockReturnValue(null);
+});
+
+describe("LinkFieldValue", () => {
+  it("constrains the relationship type options to the field's allowed set", async () => {
+    const user = userEvent.setup();
+    renderField({
+      field: linkField(),
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.click(screen.getByRole("button", { name: /open/i }));
+
+    const options = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(options).toEqual(["References", "IsDerivedFrom"]);
+  });
+
+  it("shows the full link card for a committed link and reveals the editor on Edit", async () => {
+    const user = userEvent.setup();
+    const field = linkField({
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA20",
+        versionPin: null,
+      },
+    });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    // a committed link renders via the shared LinkField card, not the inline editor
+    expect(screen.getByTestId("link-field-display")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /apply link/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /edit link/i }));
+
+    // the editor is now shown
+    expect(screen.getByRole("button", { name: /apply link/i })).toBeInTheDocument();
+  });
+
+  it("commits the staged link to the field model on Apply", async () => {
+    const user = userEvent.setup();
+    const setAttributesDirty = vi.fn();
+    const field = linkField({
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA20",
+        versionPin: null,
+      },
+      setAttributesDirty,
+    });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit link/i }));
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(screen.getByRole("option", { name: "IsDerivedFrom" }));
+    await user.click(screen.getByRole("button", { name: /apply link/i }));
+
+    expect(setAttributesDirty).toHaveBeenCalledWith({
+      link: {
+        relationType: "IsDerivedFrom",
+        targetGlobalId: "SA20",
+        versionPin: null,
+      },
+    });
+  });
+
+  it("lets a target Global ID be typed directly", async () => {
+    const user = userEvent.setup();
+    const setAttributesDirty = vi.fn();
+    const field = linkField({ setAttributesDirty });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SS33");
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(screen.getByRole("option", { name: "References" }));
+    await user.click(screen.getByRole("button", { name: /apply link/i }));
+
+    expect(setAttributesDirty).toHaveBeenCalledWith({
+      link: {
+        relationType: "References",
+        targetGlobalId: "SS33",
+        versionPin: null,
+      },
+    });
+  });
+
+  it("rejects a typed target with an unsupported prefix", async () => {
+    const user = userEvent.setup();
+    const setAttributesDirty = vi.fn();
+    const field = linkField({ setAttributesDirty });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "XX5");
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(screen.getByRole("option", { name: "References" }));
+
+    expect(
+      screen.getByText(/target must be an inventory item or an eln document, notebook or gallery file/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /apply link/i })).toBeDisabled();
+    expect(setAttributesDirty).not.toHaveBeenCalled();
+  });
+
+  it("flags the field model while link edits are unapplied so record save is blocked", async () => {
+    const user = userEvent.setup();
+    const setError = vi.fn();
+    const field = linkField({
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA20",
+        versionPin: null,
+      },
+      setError,
+    });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit link/i }));
+    // remove the target: the staged state now diverges from the committed link
+    await user.click(screen.getByTestId("CancelIcon"));
+
+    expect(setError).toHaveBeenLastCalledWith(true);
+
+    // discarding restores the committed link and clears the flag
+    await user.click(screen.getByRole("button", { name: /discard link/i }));
+    expect(setError).toHaveBeenLastCalledWith(false);
+  });
+
+  it("shows the field name while editing", () => {
+    // the editor opens immediately for an empty field; because the FormField
+    // label above the editor is hidden (the name is meant to live inside the
+    // card), the editor itself must surface the field name
+    renderField({
+      field: linkField({ name: "Parent sample" }),
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    expect(screen.getByRole("button", { name: /apply link/i })).toBeInTheDocument();
+    expect(screen.getByText("Parent sample")).toBeInTheDocument();
+  });
+
+  it("shows the field name after opening the editor on a committed link", async () => {
+    // the cog->editor path is the second way into the editor; the committed
+    // card (stubbed here) does not render the name, so finding it after Edit
+    // proves the editor itself surfaces the field name
+    const user = userEvent.setup();
+    const field = linkField({
+      name: "Parent sample",
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA20",
+        versionPin: null,
+      },
+    });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit link/i }));
+
+    expect(screen.getByRole("button", { name: /apply link/i })).toBeInTheDocument();
+    expect(screen.getByText("Parent sample")).toBeInTheDocument();
+  });
+
+  it("greys out the version-pin clock while editing a no-access committed link", async () => {
+    // an unshared ELN target cannot be version-pinned; the clock stays greyed
+    // until Apply commits a different, readable target (and is reimposed on the
+    // next edit after Discard reverts to the unshared target)
+    mockUseLinkTargetSummary.mockReturnValue({
+      globalId: "SD5",
+      name: null,
+      type: null,
+      deleted: false,
+      readable: false,
+    });
+    const user = userEvent.setup();
+    const field = linkField({
+      link: {
+        relationType: "References",
+        targetGlobalId: "SD5",
+        versionPin: null,
+      },
+    });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit link/i }));
+
+    expect(screen.getByRole("button", { name: /pin version for sd5/i })).toBeDisabled();
+  });
+
+  it("shows None in view mode when the field has no link", () => {
+    renderField({
+      field: linkField(),
+      sourceGlobalId: "SA1",
+      disabled: true,
+      onChange: () => {},
+    });
+
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+
+  it("rejects applying a typed target that does not exist on the server", async () => {
+    mockCheckLinkTargetExists.mockResolvedValueOnce(false);
+    const user = userEvent.setup();
+    const setAttributesDirty = vi.fn();
+    const field = linkField({ setAttributesDirty });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SS9999");
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(screen.getByRole("option", { name: "References" }));
+    await user.click(screen.getByRole("button", { name: /apply link/i }));
+
+    expect(
+      await screen.findByText(/SS9999 does not exist, or you do not have permission to view it/i),
+    ).toBeInTheDocument();
+    expect(setAttributesDirty).not.toHaveBeenCalled();
+  });
+
+  it("prevents applying a self-link", async () => {
+    const user = userEvent.setup();
+    const setAttributesDirty = vi.fn();
+    const field = linkField({
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA10",
+        versionPin: null,
+      },
+      setAttributesDirty,
+    });
+    renderField({
+      field,
+      sourceGlobalId: "SA10",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit link/i }));
+    // re-pick a relation but keep the same (self) target -> must remain un-appliable
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(screen.getByRole("option", { name: "IsDerivedFrom" }));
+
+    expect(screen.getByText("An item cannot link to itself.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /apply link/i })).toBeDisabled();
+    expect(setAttributesDirty).not.toHaveBeenCalled();
+  });
+});
+
+describe("LinkFieldValue version pin is edited in the editor and committed on Apply", () => {
+  function renderCommitted(targetGlobalId = "SA20") {
+    const field = linkField({
+      link: {
+        relationType: "References",
+        targetGlobalId,
+        versionPin: null,
+      },
+    });
+    renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+    return { field };
+  }
+
+  it("stages a pin chosen via the clock and only commits it on Apply", async () => {
+    const user = userEvent.setup();
+    const { field } = renderCommitted();
+
+    await user.click(screen.getByRole("button", { name: /edit link/i }));
+    await user.click(screen.getByRole("button", { name: /pin version for sa20/i }));
+    expect(screen.getByTestId("version-lock-dialog")).toHaveAttribute("data-globalid", "SA20");
+    await user.click(screen.getByTestId("version-lock-dialog-confirm-7"));
+
+    // staged in the editor, not yet committed
+    expect(screen.getByText(/pinned to v7/i)).toBeInTheDocument();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const setAttributesDirty = field.setAttributesDirty;
+    expect(vi.mocked(setAttributesDirty)).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /apply link/i }));
+
+    expect(vi.mocked(setAttributesDirty)).toHaveBeenCalledWith({
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA20",
+        versionPin: 7,
+      },
+    });
+  });
+
+  it("resets the staged pin when the target is changed", async () => {
+    const user = userEvent.setup();
+    renderCommitted();
+
+    await user.click(screen.getByRole("button", { name: /edit link/i }));
+    await user.click(screen.getByRole("button", { name: /pin version for sa20/i }));
+    await user.click(screen.getByTestId("version-lock-dialog-confirm-7"));
+    expect(screen.getByText(/pinned to v7/i)).toBeInTheDocument();
+
+    // a pin belongs to a specific target, so retargeting reverts to Latest
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "9");
+
+    expect(screen.queryByText(/pinned to v7/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/^latest$/i)).toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -1,6 +1,8 @@
 import AddIcon from "@mui/icons-material/Add";
+import Autocomplete from "@mui/material/Autocomplete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import MuiTextField from "@mui/material/TextField";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import InputWrapper from "../../../components/Inputs/InputWrapper";
@@ -11,6 +13,7 @@ import type FieldModel from "../../../stores/models/FieldModel";
 import { hasOptions } from "../../../stores/models/FieldTypes";
 import * as ArrayUtils from "../../../util/ArrayUtils";
 import { match } from "../../../util/Util";
+import { DATACITE_RELATION_TYPES } from "../../components/Fields/Link/dataciteRelationTypes";
 import CustomField from "../../components/Inputs/CustomField";
 
 type DefaultValueFieldArgs = {
@@ -33,6 +36,48 @@ function DefaultValueField({ field, editing }: DefaultValueFieldArgs): React.Rea
    * have to be re-rendered anyway.
    */
   const key = React.useMemo(() => field.id ?? crypto.randomUUID(), [field.id]);
+
+  /*
+   * Link template fields don't store a "default value" in the usual sense; instead the template
+   * defines which DataCite relationship types samples may use. An empty whitelist means all
+   * relationship types are allowed.
+   */
+  if (field.type === "link") {
+    return (
+      <InputWrapper
+        label="Allowed relationship types"
+        explanation="The DataCite relationship types that links may use on samples created from this template. Leave empty to allow all relationship types."
+      >
+        <Autocomplete
+          multiple
+          disabled={!editing}
+          options={[...DATACITE_RELATION_TYPES]}
+          value={field.allowedRelationTypes}
+          // already-chosen types are greyed out rather than toggled off; they
+          // are removed via their chip's delete icon instead
+          getOptionDisabled={(option) => field.allowedRelationTypes.includes(option)}
+          onChange={(_event, value) => field.setAttributesDirty({ allowedRelationTypes: value })}
+          renderInput={(params) => {
+            const { slotProps, ...textFieldProps } = params;
+            return (
+              <MuiTextField
+                {...textFieldProps}
+                variant="standard"
+                placeholder={field.allowedRelationTypes.length === 0 ? "All relationship types" : ""}
+                slotProps={{
+                  ...slotProps,
+                  htmlInput: {
+                    ...slotProps.htmlInput,
+                    "aria-label": "Allowed relationship types",
+                  },
+                }}
+              />
+            );
+          }}
+        />
+      </InputWrapper>
+    );
+  }
 
   const errorState = match<void, string | null>([
     [() => !_hasOptions, null],

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
@@ -1,0 +1,57 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/__tests__/customQueries";
+import { makeMockField } from "../../../../stores/models/__tests__/FieldModel/mocking";
+import materialTheme from "../../../../theme";
+import DefaultValueField from "../DefaultValueField";
+
+vi.mock("../../../../common/InvApiService", () => ({ default: {} }));
+
+describe("DefaultValueField", () => {
+  describe("link fields' allowed relationship types", () => {
+    it("greys out already-selected relation types in the dropdown instead of letting them toggle off", async () => {
+      const user = userEvent.setup();
+      const field = makeMockField({
+        type: "link",
+        allowedRelationTypes: ["IsCitedBy"],
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      await user.click(screen.getByRole("combobox", { name: /allowed relationship types/i }));
+      const chosen = await screen.findByRole("option", { name: "IsCitedBy" });
+      expect(chosen).toHaveAttribute("aria-disabled", "true");
+
+      // a real pointer cannot reach the disabled option (pointer-events: none),
+      // so the chosen set cannot be toggled off from the dropdown
+      await expect(user.click(chosen)).rejects.toThrow(/pointer-events: none/);
+      expect(field.allowedRelationTypes).toEqual(["IsCitedBy"]);
+    });
+
+    it("leaves unchosen relation types selectable", async () => {
+      const user = userEvent.setup();
+      const field = makeMockField({
+        type: "link",
+        allowedRelationTypes: ["IsCitedBy"],
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      await user.click(screen.getByRole("combobox", { name: /allowed relationship types/i }));
+      const unchosen = await screen.findByRole("option", { name: "Cites" });
+      expect(unchosen).not.toHaveAttribute("aria-disabled", "true");
+
+      await user.click(unchosen);
+      expect(field.allowedRelationTypes).toEqual(["IsCitedBy", "Cites"]);
+    });
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/FieldTypeMenuItem.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/FieldTypeMenuItem.test.tsx
@@ -1,0 +1,21 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/__tests__/customQueries";
+import { FieldTypes } from "@/stores/models/FieldTypes";
+import materialTheme from "@/theme";
+import FieldTypeMenuItem from "../FieldTypeMenuItem";
+
+describe("FieldTypeMenuItem", () => {
+  it("renders standalone (inMenu=false) without crashing", () => {
+    // MUI 9 MenuItems throw "MenuListContext is missing" unless wrapped in a
+    // Menu or MenuList; the closed-state trigger renders outside the Menu, so
+    // it must provide its own MenuList (clicking "add new field" blanked the
+    // whole template page via the error boundary)
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <FieldTypeMenuItem field={FieldTypes.plain_text} onClick={vi.fn()} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText("Plain text")).toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/ExtraFields.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/ExtraFields.tsx
@@ -9,6 +9,7 @@ import TextField from "../../../../components/Inputs/TextField";
 import NoValue from "../../../../components/NoValue";
 import type Result from "../../../../stores/models/InventoryBaseRecord";
 import FormField from "../../../components/Inputs/FormField";
+import LinkField from "../Link/LinkField";
 import NewField from "./NewField";
 import UpdateField from "./UpdateField";
 
@@ -21,9 +22,46 @@ function ExtraFields({ onErrorStateChange, result }: ExtraFieldsArgs): React.Rea
   const EachField = observer(({ editable }: { editable: boolean }): React.ReactNode => {
     const extraFieldsDisabled = !editable;
     return result.visibleExtraFields.map((ef, i) => (
-      <div key={ef.name} aria-live="polite">
+      // the key must be stable while the field is edited: keying by the
+      // user-editable name would remount the editor (dropping focus and
+      // local state) whenever a rename commits, and two unsaved fields can
+      // both briefly be named ""
+      <div key={ef.id !== null ? `field-${ef.id}` : `unsaved-${i}`} aria-live="polite">
         {ef.editing ? (
           <UpdateField extraField={ef} index={i} record={result} />
+        ) : ef.type === "Link" ? (
+          <Box sx={{ mt: 1, position: "relative" }}>
+            {!extraFieldsDisabled && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  right: 0,
+                  zIndex: 1,
+                }}
+              >
+                <IconButtonWithTooltip
+                  title="Field settings"
+                  size="small"
+                  onClick={() => ef.setEditing(true)}
+                  icon={<SettingsIcon fontSize="small" />}
+                />
+                <IconButtonWithTooltip
+                  title="Delete field"
+                  size="small"
+                  onClick={() => result.removeExtraField(ef.id, result.extraFields.indexOf(ef))}
+                  icon={<CloseIcon fontSize="small" />}
+                />
+              </div>
+            )}
+            {ef.link?.targetGlobalId ? (
+              <LinkField name={ef.name} link={ef.link} editable={editable} />
+            ) : (
+              // a Link row can exist before its link payload does; the
+              // settings affordance above still lets the user set one
+              <NoValue label="No link set" />
+            )}
+          </Box>
         ) : ef.type === "Number" ? (
           <FormField
             label={ef.name}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/UpdateField.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/UpdateField.tsx
@@ -6,10 +6,16 @@ import TextField from "@mui/material/TextField";
 import type React from "react";
 import { useEffect, useState } from "react";
 import FormField from "../../../../components/Inputs/FormField";
-import type { ExtraField } from "../../../../stores/definitions/ExtraField";
+import type { ExtraField, ExtraFieldType } from "../../../../stores/definitions/ExtraField";
 import type { InventoryRecord } from "../../../../stores/definitions/InventoryRecord";
 import { match } from "../../../../util/Util";
 import { pick } from "../../../../util/unsafeUtils";
+import { DATACITE_RELATION_TYPES, isValidDataCiteRelationType } from "../Link/dataciteRelationTypes";
+import { isInventoryGlobalId, supportsVersionPin } from "../Link/iconForGlobalId";
+import LinkEditor from "../Link/LinkEditor";
+import { validateTarget } from "../Link/linkTarget";
+import { checkLinkTargetExists } from "../Link/linkTargetExists";
+import useLinkTargetSummary from "../Link/useLinkTargetSummary";
 
 type UpdateFieldArgs = {
   extraField: ExtraField;
@@ -17,9 +23,44 @@ type UpdateFieldArgs = {
   record: InventoryRecord;
 };
 
+type LinkState = {
+  relationType: string;
+  targetGlobalId: string;
+  targetName: string;
+  versionPin: number | null;
+};
+
+function emptyLinkState(): LinkState {
+  return {
+    relationType: "",
+    targetGlobalId: "",
+    targetName: "",
+    versionPin: null,
+  };
+}
+
+function linkStateFromExtraField(extraField: ExtraField): LinkState {
+  const link = extraField.link;
+  return link
+    ? {
+        relationType: link.relationType,
+        targetGlobalId: link.targetGlobalId,
+        targetName: "",
+        versionPin: link.versionPin ?? null,
+      }
+    : emptyLinkState();
+}
+
 export default function UpdateField({ extraField, index, record }: UpdateFieldArgs): React.ReactNode {
-  const [fieldState, setFieldState] = useState({ name: "", type: "" });
+  const [fieldState, setFieldState] = useState<{
+    name: string;
+    type: ExtraFieldType | "";
+  }>({ name: "", type: "" });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [linkState, setLinkState] = useState<LinkState>(emptyLinkState());
+  // set when Apply finds the typed target does not resolve on the server
+  const [targetExistenceError, setTargetExistenceError] = useState<string | null>(null);
+  const [checkingTarget, setCheckingTarget] = useState(false);
 
   useEffect(() => {
     if (extraField) {
@@ -27,13 +68,65 @@ export default function UpdateField({ extraField, index, record }: UpdateFieldAr
         name: extraField.name,
         type: extraField.type,
       });
+      setLinkState(linkStateFromExtraField(extraField));
     }
   }, [extraField]);
 
+  // Mid-edit values live only in this editor and are committed on Apply.
+  // The record-level Save is greyed out while the editor is open
+  // (ExtraFieldModel.isValid rejects an editing field), so nothing typed here
+  // can be lost to a premature Save, and the model's pre-edit state stays
+  // intact for Cancel. Syncing staged values into the model as they were
+  // typed (the previous approach) made canSubmit's "something changed" check
+  // compare equal values, greying out Apply on a fully-filled new field.
+
+  const sourceGlobalId = record.globalId ?? "";
+  const isLink = fieldState.type === "Link";
+  const relationValid = !isLink || isValidDataCiteRelationType(linkState.relationType);
+  const targetValidity = isLink ? validateTarget(linkState.targetGlobalId, sourceGlobalId) : { ok: true, reason: "" };
+  const linkValid = relationValid && targetValidity.ok;
+  // surface the relation error on the relation field once the user has begun entering the link
+  const showRelationError =
+    isLink && !relationValid && (linkState.relationType !== "" || linkState.targetGlobalId !== "");
+  // the target error shows for any non-empty invalid target, and also when an
+  // existing link's target has been removed ("Target Global ID is required")
+  const showTargetError = isLink && !targetValidity.ok && (linkState.targetGlobalId !== "" || !extraField.initial);
+
+  const initialLink = linkStateFromExtraField(extraField);
+  const linkChanged =
+    extraField.type === "Link" &&
+    (linkState.relationType !== initialLink.relationType ||
+      linkState.targetGlobalId !== initialLink.targetGlobalId ||
+      linkState.versionPin !== initialLink.versionPin);
+
+  // Surface an invalid in-progress edit of an existing link (e.g. a removed
+  // target) on the model, so the record-level Save is blocked with an error
+  // instead of silently reverting to the stored link. New fields are covered
+  // by the live model sync above plus the model's own link validation. Only
+  // Link fields are touched: Number fields manage invalidInput themselves.
+  const dirtyAndInvalid = !extraField.initial && isLink && linkChanged && !linkValid;
+  useEffect(() => {
+    if (extraField.type !== "Link") return;
+    extraField.setInvalidInput(dirtyAndInvalid);
+  }, [dirtyAndInvalid, extraField]);
+
+  // A no-access committed target (an unshared ELN item) cannot be
+  // version-pinned, so the clock stays greyed while editing it. Keyed on the
+  // committed target, so it clears after a successful Apply commits a
+  // different, readable target and is reimposed on the next edit after Cancel.
+  // Inventory targets keep a limited-read view, so they are never "no access".
+  const committedTarget = extraField.link?.targetGlobalId ?? "";
+  const committedSummary = useLinkTargetSummary(committedTarget);
+  const committedNoAccess = committedSummary?.readable === false && !isInventoryGlobalId(committedTarget);
+
   const canSubmit =
     !errorMessage &&
+    !targetExistenceError &&
+    !checkingTarget &&
     fieldState.name !== "" &&
-    (fieldState.name !== extraField.name || fieldState.type !== extraField.type);
+    fieldState.type !== "" &&
+    (fieldState.type !== "Link" || linkValid) &&
+    (fieldState.name !== extraField.name || fieldState.type !== extraField.type || linkChanged);
 
   const handleNameChange = ({ target: { value } }: { target: { value: string } }) => {
     setFieldState({
@@ -59,15 +152,63 @@ export default function UpdateField({ extraField, index, record }: UpdateFieldAr
   const handleTypeChange = ({ target: { value } }: { target: { value: string } }) => {
     setFieldState({
       ...fieldState,
-      type: value,
+      type: value as ExtraFieldType,
+    });
+    if (value === "Link" && !linkState.targetGlobalId) {
+      setLinkState(emptyLinkState());
+    }
+  };
+
+  // a version pin belongs to a specific target, so retargeting reverts to Latest
+  const versionPinFor = (targetGlobalId: string): number | null =>
+    targetGlobalId === linkState.targetGlobalId ? linkState.versionPin : null;
+
+  // single handler for picks, typed edits, and clearing; globalId/name are "" when cleared
+  const handleTargetChange = (globalId: string, name: string) => {
+    setTargetExistenceError(null);
+    setLinkState({
+      ...linkState,
+      targetGlobalId: globalId,
+      targetName: name,
+      versionPin: versionPinFor(globalId),
     });
   };
 
-  const update = () => {
-    record.updateExtraField(extraField.name, fieldState);
+  const update = async () => {
+    if (fieldState.type === "Link") {
+      // a structurally-valid Global ID must also resolve to a real, readable
+      // record; check (re)targeted links against the server before committing
+      if (linkState.targetGlobalId !== initialLink.targetGlobalId) {
+        setCheckingTarget(true);
+        const exists = await checkLinkTargetExists(linkState.targetGlobalId);
+        setCheckingTarget(false);
+        if (!exists) {
+          setTargetExistenceError(
+            `${linkState.targetGlobalId} does not exist, or you do not have permission to view it.`,
+          );
+          return;
+        }
+      }
+      extraField.setInvalidInput(false);
+      record.updateExtraField(extraField.name, {
+        name: fieldState.name,
+        type: fieldState.type,
+        link: {
+          relationType: linkState.relationType,
+          targetGlobalId: linkState.targetGlobalId,
+          versionPin: linkState.versionPin,
+        },
+      });
+    } else {
+      record.updateExtraField(extraField.name, {
+        name: fieldState.name,
+        type: fieldState.type,
+      });
+    }
   };
 
   const discardChanges = () => {
+    extraField.setInvalidInput(false);
     record.updateExtraField(
       extraField.name,
       pick("name", "type")(extraField) as {
@@ -77,78 +218,105 @@ export default function UpdateField({ extraField, index, record }: UpdateFieldAr
     );
   };
 
+  if (!extraField) return null;
+
   return (
-    <>
-      {extraField && (
-        <Grid
-          container
-          spacing={1}
-          role="group"
-          aria-label={extraField.id === null ? "New extra field" : `Editing extra field with name ${extraField.name}`}
-        >
-          <Grid
-            size={{
-              md: 7,
-              xs: 12,
-            }}
-          >
-            <FormField
-              value={fieldState.name}
-              label="Field name"
-              renderInput={(props) => <TextField {...props} variant="standard" onChange={handleNameChange} />}
-              maxLength={255}
-              error={Boolean(errorMessage)}
-              helperText={errorMessage}
-            />
-          </Grid>
-          <Grid
-            size={{
-              md: 5,
-              xs: 12,
-            }}
-          >
-            <FormField
-              value={fieldState.type}
-              label="Field type"
-              disabled={Boolean(extraField.id)}
-              renderInput={(props) => (
-                <Select {...props} sx={{ mt: 3 }} variant="standard" onChange={handleTypeChange}>
-                  <MenuItem value="Text">Text</MenuItem>
-                  <MenuItem value="Number">Number</MenuItem>
-                </Select>
-              )}
-            />
-          </Grid>
-          <Grid
-            size={{
-              md: 12,
-              xs: 12,
-            }}
-          >
-            <Button
-              color="callToAction"
-              disableElevation
-              variant="contained"
-              aria-label="Update field"
-              onClick={update}
-              disabled={!canSubmit}
-              data-test-id={"ApplyOrUpdateButton"}
+    <Grid
+      container
+      spacing={1}
+      role="group"
+      aria-label={extraField.id === null ? "New extra field" : `Editing extra field with name ${extraField.name}`}
+    >
+      <Grid size={{ md: 7, xs: 12 }}>
+        <FormField
+          value={fieldState.name}
+          label="Field name"
+          renderInput={(props) => <TextField {...props} variant="standard" onChange={handleNameChange} />}
+          maxLength={255}
+          error={Boolean(errorMessage)}
+          helperText={errorMessage}
+        />
+      </Grid>
+      <Grid size={{ md: 5, xs: 12 }}>
+        <FormField
+          value={fieldState.type}
+          label="Field type"
+          disabled={Boolean(extraField.id)}
+          renderInput={(props) => (
+            <Select
+              {...props}
+              sx={{ mt: 3 }}
+              variant="standard"
+              onChange={handleTypeChange}
+              SelectDisplayProps={
+                {
+                  "data-testid": "FieldTypeSelect",
+                } as React.HTMLAttributes<HTMLDivElement>
+              }
             >
-              {extraField.initial ? "Apply" : "Update"}
-            </Button>
-            <Button
-              sx={{ marginLeft: "10px" }}
-              disableElevation
-              variant="text"
-              aria-label="Cancel update"
-              onClick={() => (extraField.initial ? record.removeExtraField(null, index) : discardChanges())}
-              data-test-id={"DiscardOrCancelButton"}
-            >
-              {extraField.initial ? "Discard" : "Cancel"}
-            </Button>
-          </Grid>
+              <MenuItem value="Text">Text</MenuItem>
+              <MenuItem value="Number">Number</MenuItem>
+              <MenuItem value="Link">Link</MenuItem>
+            </Select>
+          )}
+        />
+      </Grid>
+
+      {fieldState.type === "Link" && (
+        <Grid size={12}>
+          <LinkEditor
+            relationType={linkState.relationType}
+            onRelationTypeChange={(value) => setLinkState({ ...linkState, relationType: value })}
+            relationOptions={[...DATACITE_RELATION_TYPES]}
+            relationFreeSolo
+            relationLabel="Relation type"
+            relationError={showRelationError}
+            relationHelperText={showRelationError ? "Pick a DataCite relation type" : ""}
+            targetGlobalId={linkState.targetGlobalId}
+            targetName={linkState.targetName}
+            onTargetChange={handleTargetChange}
+            targetError={Boolean(targetExistenceError) || showTargetError}
+            targetHelperText={
+              targetExistenceError ??
+              (showTargetError ? targetValidity.reason : "Paste a Global ID, or use the Browse buttons above.")
+            }
+            versionPin={linkState.versionPin}
+            onVersionPinChange={(versionPin) => setLinkState({ ...linkState, versionPin })}
+            canPinVersion={
+              linkState.targetGlobalId !== "" &&
+              targetValidity.ok &&
+              supportsVersionPin(linkState.targetGlobalId) &&
+              !committedNoAccess
+            }
+          />
         </Grid>
       )}
-    </>
+
+      <Grid size={12}>
+        <Button
+          color="callToAction"
+          disableElevation
+          variant="contained"
+          aria-label="Update field"
+          onClick={() => {
+            void update();
+          }}
+          disabled={!canSubmit}
+          data-test-id={"ApplyOrUpdateButton"}
+        >
+          {extraField.initial ? "Apply" : "Update"}
+        </Button>
+        <Button
+          style={{ marginLeft: "10px" }}
+          disableElevation
+          variant="text"
+          aria-label="Cancel update"
+          onClick={() => (extraField.initial ? record.removeExtraField(null, index) : discardChanges())}
+          data-test-id={"DiscardOrCancelButton"}
+        >
+          {extraField.initial ? "Discard" : "Cancel"}
+        </Button>
+      </Grid>
+    </Grid>
   );
 }

--- a/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/__tests__/ExtraFields.link.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/__tests__/ExtraFields.link.test.tsx
@@ -1,0 +1,145 @@
+// tinymce is pulled in transitively at import time and calls window.matchMedia
+// during module evaluation, which jsdom does not implement. The shared per-file
+// mock supplies it and must be imported before any source module that reads it.
+import "@/__tests__/__mocks__/matchMedia";
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import materialTheme from "../../../../../theme";
+
+// Mock heavyweight collaborators so the ExtraFields wrapper can be exercised in
+// isolation. InventoryBaseRecord pulls in the full stores layer at module load,
+// which transitively constructs ApiServiceBase; we only need the type, not the
+// runtime, in this test.
+vi.mock("../../../../../stores/models/InventoryBaseRecord", () => ({
+  default: class {},
+}));
+
+vi.mock("../UpdateField", () => ({
+  default: () => <div data-testid="update-field" />,
+}));
+
+vi.mock("../NewField", () => ({
+  default: () => <div data-testid="new-field" />,
+}));
+
+vi.mock("../../Link/LinkField", () => ({
+  // custom (extra) Link fields are edited via the field's settings cog, so
+  // ExtraFields no longer passes onEdit and LinkField shows no inline Edit button.
+  // LinkField now renders its own static Open link from the target/versionPin, so
+  // ExtraFields no longer passes an onOpen callback (open routing is covered by
+  // LinkField's own tests).
+  default: (props: { name: string; link: { targetGlobalId: string; versionPin: number | null } }) => (
+    <div
+      data-testid="link-field"
+      data-name={props.name}
+      data-target={props.link.targetGlobalId}
+      data-version-pin={props.link.versionPin == null ? "" : String(props.link.versionPin)}
+    />
+  ),
+}));
+
+import ExtraFields from "../ExtraFields";
+
+function makeLinkField(
+  overrides: {
+    name?: string;
+    versionPin?: number | null;
+    targetGlobalId?: string;
+    setEditing?: (v: boolean) => void;
+    setAttributesDirty?: (attrs: Record<string, unknown>) => void;
+  } = {},
+) {
+  return {
+    id: 1,
+    name: overrides.name ?? "linked sample",
+    type: "Link",
+    content: "",
+    editing: false,
+    editable: true,
+    initial: false,
+    invalidInput: false,
+    deleteFieldRequest: false,
+    newFieldRequest: false,
+    link: {
+      relationType: "References",
+      targetGlobalId: overrides.targetGlobalId ?? "SA42",
+      versionPin: overrides.versionPin ?? null,
+    },
+    setEditing: overrides.setEditing ?? vi.fn(),
+    setAttributesDirty: overrides.setAttributesDirty ?? vi.fn(),
+    setAttributes: vi.fn(),
+    setInvalidInput: vi.fn(),
+  };
+}
+
+function makeResult(extraFields: ReturnType<typeof makeLinkField>[]) {
+  return {
+    globalId: "SA1",
+    extraFields,
+    visibleExtraFields: extraFields,
+    isFieldEditable: () => true,
+    removeExtraField: vi.fn(),
+  };
+}
+
+describe("ExtraFields - Link extra-field branch", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a LinkField for each Link extra-field, passing name and target", () => {
+    const result = makeResult([
+      makeLinkField({ name: "a", versionPin: null }),
+      makeLinkField({ name: "b", versionPin: 3 }),
+    ]);
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <ExtraFields onErrorStateChange={() => {}} result={result as unknown as never} />
+      </ThemeProvider>,
+    );
+    const cards = screen.getAllByTestId("link-field");
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toHaveAttribute("data-name", "a");
+    expect(cards[0]).toHaveAttribute("data-version-pin", "");
+    expect(cards[1]).toHaveAttribute("data-name", "b");
+    expect(cards[1]).toHaveAttribute("data-version-pin", "3");
+  });
+
+  it("renders a placeholder instead of crashing when a Link field has no link payload", () => {
+    // an ExtraLinkField row can exist before its InventoryLink is populated;
+    // passing that null into LinkField would crash on render
+    const field = { ...makeLinkField({}), link: null };
+    const result = makeResult([field as unknown as ReturnType<typeof makeLinkField>]);
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <ExtraFields onErrorStateChange={() => {}} result={result as unknown as never} />
+      </ThemeProvider>,
+    );
+    expect(screen.queryByTestId("link-field")).not.toBeInTheDocument();
+    expect(screen.getByText(/no link set/i)).toBeInTheDocument();
+  });
+
+  it("enters edit mode via the settings cog, without mutating the model from the view card", async () => {
+    // links are edited like every other custom field type: through the field's
+    // settings cog, not an inline Edit button on the card. The pin (and every
+    // other link property) is staged in the editor and committed on Update, so
+    // the view card never mutates the model directly.
+    const setAttributesDirty = vi.fn();
+    const setEditing = vi.fn();
+    const result = makeResult([makeLinkField({ setAttributesDirty, setEditing, versionPin: 7 })]);
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <ExtraFields onErrorStateChange={() => {}} result={result as unknown as never} />
+      </ThemeProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Field settings" }));
+
+    expect(setEditing).toHaveBeenCalledWith(true);
+    expect(setAttributesDirty).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/__tests__/ExtraFields.typing.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/__tests__/ExtraFields.typing.test.tsx
@@ -1,0 +1,75 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/__tests__/customQueries";
+import materialTheme from "../../../../../theme";
+
+vi.mock("@/common/InvApiService", () => ({ default: {} }));
+// cut the RootStore -> SearchStore -> TemplateModel module cycle, which is not
+// exercised by this list-level test
+vi.mock("@/stores/stores/getRootStore", () => ({
+  default: () => ({
+    unitStore: { getUnit: () => ({ label: "ml" }) },
+  }),
+}));
+vi.mock("../../Link/LinkTargetBrowser", () => ({ default: () => null }));
+vi.mock("../../Link/ElnRecordPicker", () => ({ default: () => null }));
+vi.mock("../../Link/linkTargetExists", () => ({
+  checkLinkTargetExists: vi.fn(() => Promise.resolve(true)),
+}));
+
+// SampleModel must load before the model -> RootStore import chain, otherwise
+// the TemplateModel/SampleModel module cycle hits an uninitialised
+// SAMPLE_FIELDS during module evaluation
+import { makeMockSample } from "../../../../../stores/models/__tests__/SampleModel/mocking";
+import ExtraFields from "../ExtraFields";
+
+/**
+ * Regression test: while a brand-new extra field is being created, UpdateField
+ * live-syncs the typed name into the model so the record-level Save validates
+ * it. The list row must NOT be keyed by the (now mutating) name, or every
+ * keystroke remounts the editor and the in-flight keystrokes are dropped:
+ * typing "name" left just "n" in the field.
+ */
+describe("ExtraFields new-field name typing", () => {
+  it("keeps every keystroke while typing the name of a brand-new field", async () => {
+    const sample = makeMockSample();
+    // mirrors NewField's "Add new field" button
+    sample.addExtraField({
+      id: null,
+      globalId: null,
+      name: "",
+      type: "text",
+      content: "",
+      parentGlobalId: sample.globalId,
+      editing: true,
+      initial: true,
+    } as Parameters<typeof sample.addExtraField>[0]);
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <ExtraFields onErrorStateChange={vi.fn()} result={sample} />
+      </ThemeProvider>,
+    );
+
+    const nameField = () => screen.getByRole("textbox", { name: /field name/i });
+    await user.click(nameField());
+    await user.keyboard("name");
+
+    expect(nameField()).toHaveValue("name");
+    // mid-edit values live only in the editor; the model is untouched and
+    // reports itself invalid, so the record-level Save is greyed out instead
+    // of silently saving a half-finished field
+    expect(sample.extraFields[0].name).toBe("");
+    expect(sample.extraFields[0].isValid.isOk).toBe(false);
+    // and the user can carry on to Apply the new field
+    const applyButton = screen.getByRole("button", { name: /update field/i });
+    expect(applyButton).toBeEnabled();
+
+    await user.click(applyButton);
+
+    // Apply commits the staged values and unblocks the record-level Save
+    expect(sample.extraFields[0].name).toBe("name");
+    expect(sample.extraFields[0].isValid.isOk).toBe(true);
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/__tests__/UpdateField.link.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/ExtraFields/__tests__/UpdateField.link.test.tsx
@@ -1,0 +1,567 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@/__tests__/customQueries";
+import materialTheme from "../../../../../theme";
+
+vi.mock("../../Link/LinkTargetBrowser", () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="link-target-browser" /> : null),
+}));
+
+vi.mock("../../Link/ElnRecordPicker", () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="eln-record-picker" /> : null),
+}));
+
+// Typed targets are existence-checked against the server on Apply; default to "exists".
+const { mockCheckLinkTargetExists } = vi.hoisted(() => ({
+  mockCheckLinkTargetExists: vi.fn(() => Promise.resolve(true)),
+}));
+vi.mock("../../Link/linkTargetExists", () => ({
+  checkLinkTargetExists: mockCheckLinkTargetExists,
+}));
+
+// The real dialog fetches revision history; stub it with confirm buttons.
+vi.mock("../../Link/VersionLockDialog", () => ({
+  default: ({
+    open,
+    globalId,
+    currentVersionPin,
+    onConfirm,
+  }: {
+    open: boolean;
+    globalId: string;
+    currentVersionPin: number | null;
+    onConfirm: (v: number | null) => void;
+  }) =>
+    open ? (
+      <div
+        data-testid="version-lock-dialog"
+        data-globalid={globalId}
+        data-current-pin={currentVersionPin == null ? "" : String(currentVersionPin)}
+      >
+        <button type="button" data-testid="version-lock-dialog-confirm-7" onClick={() => onConfirm(7)}>
+          confirm 7
+        </button>
+      </div>
+    ) : null,
+}));
+
+// The editor greys the version-pin clock for a no-access committed target via
+// this summary hook (which also pulls the ApiService chain at import); default
+// to "no summary" (null) so unrelated tests are unaffected.
+const { mockUseLinkTargetSummary } = vi.hoisted(() => ({
+  mockUseLinkTargetSummary: vi.fn(),
+}));
+vi.mock("../../Link/useLinkTargetSummary", () => ({
+  default: (globalId: string) => mockUseLinkTargetSummary(globalId) as unknown,
+}));
+
+import type { ExtraField } from "../../../../../stores/definitions/ExtraField";
+import type { InventoryRecord } from "../../../../../stores/definitions/InventoryRecord";
+import UpdateField from "../UpdateField";
+
+function makeExtraField(
+  overrides: Partial<ExtraField> & {
+    link?: {
+      relationType: string;
+      targetGlobalId: string;
+      versionPin: number | null;
+    } | null;
+  } = {},
+): ExtraField {
+  return {
+    id: null,
+    name: "",
+    type: "Text",
+    content: "",
+    owner: { fieldNamesInUse: [] } as unknown as InventoryRecord,
+    initial: true,
+    deleteFieldRequest: false,
+    newFieldRequest: true,
+    editing: true,
+    editable: true,
+    invalidInput: false,
+    hasContent: false,
+    isValid: { isValid: true },
+    setAttributes: vi.fn(),
+    setAttributesDirty: vi.fn(),
+    setEditing: vi.fn(),
+    setInvalidInput: vi.fn(),
+    link: null,
+    ...overrides,
+  } as unknown as ExtraField;
+}
+
+function makeRecord(): InventoryRecord {
+  return {
+    globalId: "SA1",
+    removeExtraField: vi.fn(),
+    updateExtraField: vi.fn(),
+  } as unknown as InventoryRecord;
+}
+
+async function selectFieldType(label: "Text" | "Number" | "Link") {
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("FieldTypeSelect"));
+  const listbox = await screen.findByRole("listbox");
+  await user.click(within(listbox).getByText(label));
+}
+
+beforeEach(() => {
+  mockUseLinkTargetSummary.mockReturnValue(null);
+});
+
+describe("UpdateField — Field Type select includes Link", () => {
+  afterEach(cleanup);
+
+  it("offers Text, Number and Link in the Field Type dropdown", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.click(screen.getByTestId("FieldTypeSelect"));
+    const listbox = await screen.findByRole("listbox");
+    expect(within(listbox).getByText("Text")).toBeInTheDocument();
+    expect(within(listbox).getByText("Number")).toBeInTheDocument();
+    expect(within(listbox).getByText("Link")).toBeInTheDocument();
+  });
+
+  it("reveals Relation type and Target inputs only when Link is selected", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    expect(screen.queryByRole("combobox", { name: /relation type/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /target global id/i })).not.toBeInTheDocument();
+
+    await selectFieldType("Link");
+
+    expect(screen.getByRole("combobox", { name: /relation type/i })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /target global id/i })).toBeInTheDocument();
+  });
+
+  it("opens the inventory browser dialog from the Browse Inventory button", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await selectFieldType("Link");
+    await user.click(screen.getByRole("button", { name: /browse inventory/i }));
+    expect(screen.getByTestId("link-target-browser")).toBeInTheDocument();
+  });
+
+  it("calls record.updateExtraField with the link payload on Apply", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /field name/i }), "Linked sample");
+    await selectFieldType("Link");
+    await user.type(screen.getByRole("combobox", { name: /relation type/i }), "References");
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SA99");
+
+    await user.click(screen.getByRole("button", { name: /update field/i }));
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const updateExtraField = record.updateExtraField;
+    expect(vi.mocked(updateExtraField).mock.calls.at(-1)).toEqual([
+      "",
+      {
+        name: "Linked sample",
+        type: "Link",
+        link: {
+          relationType: "References",
+          targetGlobalId: "SA99",
+          versionPin: null,
+        },
+      },
+    ]);
+  });
+
+  it("leaves the model untouched until Apply, with Apply enabled once filled", async () => {
+    // mid-edit values live only in the editor; the record-level Save is greyed
+    // out while the editor is open (ExtraFieldModel.isValid), so nothing needs
+    // to be synced early. Pushing staged values into the model as they were
+    // typed made canSubmit's "something changed" check compare equal values,
+    // greying out Apply on a fully-filled new link.
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /field name/i }), "Linked sample");
+    await selectFieldType("Link");
+    await user.type(screen.getByRole("combobox", { name: /relation type/i }), "References");
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SA99");
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const setAttributesDirty = extraField.setAttributesDirty;
+    expect(vi.mocked(setAttributesDirty)).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /update field/i })).toBeEnabled();
+  });
+
+  it("does not sync edits to the model for an existing field (commit-on-Apply preserved)", async () => {
+    const extraField = makeExtraField({
+      id: 1,
+      name: "Existing",
+      type: "Link",
+      initial: false,
+      newFieldRequest: false,
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: null,
+      },
+    });
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "0");
+
+    // An existing field must not be mutated until the user presses Update, so
+    // that Cancel can revert. The live-sync is scoped to brand-new fields only.
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const setAttributesDirty = extraField.setAttributesDirty;
+    expect(vi.mocked(setAttributesDirty)).not.toHaveBeenCalled();
+  });
+
+  it("shows the relation-type error on the relation field, not the target field", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await selectFieldType("Link");
+    // provide a valid target but leave the relation type empty
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SA99");
+
+    // the relation prompt appears and is attached to the relation field, while the target
+    // field keeps its own default helper text (the prompt must not leak onto the target field)
+    expect(screen.getByText("Pick a DataCite relation type")).toBeInTheDocument();
+    expect(screen.getByText("Paste a Global ID, or use the Browse buttons above.")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /relation type/i })).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("opens the ELN picker from the Browse ELN button", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await selectFieldType("Link");
+    await user.click(screen.getByRole("button", { name: /browse eln/i }));
+    expect(screen.getByTestId("eln-record-picker")).toBeInTheDocument();
+  });
+
+  it("accepts an ELN document target (SD) in the link payload on Apply", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /field name/i }), "Linked doc");
+    await selectFieldType("Link");
+    await user.type(screen.getByRole("combobox", { name: /relation type/i }), "References");
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SD42");
+
+    await user.click(screen.getByRole("button", { name: /update field/i }));
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const updateExtraField = record.updateExtraField;
+    expect(vi.mocked(updateExtraField).mock.calls.at(-1)).toEqual([
+      "",
+      {
+        name: "Linked doc",
+        type: "Link",
+        link: {
+          relationType: "References",
+          targetGlobalId: "SD42",
+          versionPin: null,
+        },
+      },
+    ]);
+  });
+
+  it("rejects applying a typed target that does not exist on the server", async () => {
+    mockCheckLinkTargetExists.mockResolvedValueOnce(false);
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /field name/i }), "Linked sample");
+    await selectFieldType("Link");
+    await user.type(screen.getByRole("combobox", { name: /relation type/i }), "References");
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SA99999");
+
+    await user.click(screen.getByRole("button", { name: /update field/i }));
+
+    expect(
+      await screen.findByText(/SA99999 does not exist, or you do not have permission to view it/i),
+    ).toBeInTheDocument();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const updateExtraField = record.updateExtraField;
+    expect(vi.mocked(updateExtraField)).not.toHaveBeenCalled();
+  });
+
+  it("clears the existence error once the target is edited", async () => {
+    mockCheckLinkTargetExists.mockResolvedValueOnce(false);
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /field name/i }), "Linked sample");
+    await selectFieldType("Link");
+    await user.type(screen.getByRole("combobox", { name: /relation type/i }), "References");
+    const targetInput = screen.getByRole("textbox", {
+      name: /target global id/i,
+    });
+    await user.type(targetInput, "SA99999");
+    await user.click(screen.getByRole("button", { name: /update field/i }));
+    await screen.findByText(/does not exist/i);
+
+    await user.type(targetInput, "9");
+
+    expect(screen.queryByText(/does not exist/i)).not.toBeInTheDocument();
+  });
+
+  it("flags the model when an existing link's target is removed, so Save is blocked instead of silently reverting", async () => {
+    const extraField = makeExtraField({
+      id: 1,
+      name: "Existing",
+      type: "Link",
+      initial: false,
+      newFieldRequest: false,
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: null,
+      },
+    });
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.clear(screen.getByRole("textbox", { name: /target global id/i }));
+
+    // the model is flagged so the record-level Save reports the missing target
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const setInvalidInput = extraField.setInvalidInput;
+    expect(vi.mocked(setInvalidInput)).toHaveBeenLastCalledWith(true);
+    // and the target field itself explains what is wrong
+    expect(screen.getByText(/target global id is required/i)).toBeInTheDocument();
+  });
+
+  it("clears the invalid flag when the edit is cancelled", async () => {
+    const extraField = makeExtraField({
+      id: 1,
+      name: "Existing",
+      type: "Link",
+      initial: false,
+      newFieldRequest: false,
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: null,
+      },
+    });
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.clear(screen.getByRole("textbox", { name: /target global id/i }));
+    await user.click(screen.getByRole("button", { name: /cancel update/i }));
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const setInvalidInput = extraField.setInvalidInput;
+    expect(vi.mocked(setInvalidInput)).toHaveBeenLastCalledWith(false);
+  });
+
+  it("rejects a typed version suffix and points the user at the clock", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /field name/i }), "Pinned link");
+    await selectFieldType("Link");
+    await user.type(screen.getByRole("combobox", { name: /relation type/i }), "References");
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SA6v1");
+
+    expect(screen.getByText(/without a version.*clock/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /update field/i })).toBeDisabled();
+  });
+
+  it("disables Apply when self-link is selected", async () => {
+    const extraField = makeExtraField();
+    const record = makeRecord();
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /field name/i }), "Loop");
+    await selectFieldType("Link");
+    await user.type(screen.getByRole("combobox", { name: /relation type/i }), "References");
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "SA1");
+
+    expect(screen.getByRole("button", { name: /update field/i })).toBeDisabled();
+  });
+});
+
+describe("UpdateField — version pin is edited in the editor and committed on Update", () => {
+  afterEach(cleanup);
+
+  function renderExistingLinkField(targetGlobalId = "SA42") {
+    const extraField = makeExtraField({
+      id: 1,
+      name: "Linked sample",
+      type: "Link",
+      initial: false,
+      newFieldRequest: false,
+      link: {
+        relationType: "References",
+        targetGlobalId,
+        versionPin: null,
+      },
+    });
+    const record = makeRecord();
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <UpdateField extraField={extraField} index={0} record={record} />
+      </ThemeProvider>,
+    );
+    return { extraField, record };
+  }
+
+  it("stages a pin chosen via the clock and only commits it on Update", async () => {
+    const { record } = renderExistingLinkField();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /pin version for sa42/i }));
+    expect(screen.getByTestId("version-lock-dialog")).toHaveAttribute("data-globalid", "SA42");
+    await user.click(screen.getByTestId("version-lock-dialog-confirm-7"));
+
+    // staged in the editor, not yet committed
+    expect(screen.getByText(/pinned to v7/i)).toBeInTheDocument();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const updateExtraField = record.updateExtraField;
+    expect(vi.mocked(updateExtraField)).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /update field/i }));
+
+    expect(vi.mocked(updateExtraField).mock.calls.at(-1)).toEqual([
+      "Linked sample",
+      {
+        name: "Linked sample",
+        type: "Link",
+        link: {
+          relationType: "References",
+          targetGlobalId: "SA42",
+          versionPin: 7,
+        },
+      },
+    ]);
+  });
+
+  it("resets the staged pin when the target is changed", async () => {
+    renderExistingLinkField();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /pin version for sa42/i }));
+    await user.click(screen.getByTestId("version-lock-dialog-confirm-7"));
+    expect(screen.getByText(/pinned to v7/i)).toBeInTheDocument();
+
+    // a pin belongs to a specific target, so retargeting reverts to Latest
+    await user.type(screen.getByRole("textbox", { name: /target global id/i }), "9");
+
+    expect(screen.queryByText(/pinned to v7/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/^latest$/i)).toBeInTheDocument();
+  });
+
+  it("greys the clock for targets that cannot be version-pinned", () => {
+    renderExistingLinkField("GL5");
+
+    expect(screen.getByRole("button", { name: /pin version for gl5/i })).toBeDisabled();
+  });
+
+  it("greys the clock while editing a no-access committed target", () => {
+    // SD supports version-pinning, so this isolates the no-access rule from the
+    // supports-pinning rule: an unshared target cannot be pinned. A successful
+    // retarget+Update (which commits a readable target) re-enables it on the
+    // next edit; Discard leaves the unshared target and keeps it greyed.
+    mockUseLinkTargetSummary.mockReturnValue({
+      globalId: "SD5",
+      name: null,
+      type: null,
+      deleted: false,
+      readable: false,
+    });
+    renderExistingLinkField("SD5");
+
+    expect(screen.getByRole("button", { name: /pin version for sd5/i })).toBeDisabled();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/DocumentSections.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/DocumentSections.tsx
@@ -1,0 +1,297 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Link from "@mui/material/Link";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import Stack from "@mui/material/Stack";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import Typography from "@mui/material/Typography";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { getLinkedByRecords } from "@/modules/workspace/linkedRecords";
+import { getPublicLink } from "@/modules/workspace/publicLink";
+import type {
+  LinkedRecords,
+  WorkspaceRecordEditStatus,
+  WorkspaceRecordInformation,
+  WorkspaceRecordSignatureStatus,
+} from "@/modules/workspace/schema";
+import { GlobalIdLink, MetaRow } from "./MetaTable";
+import RelatedInventoryItems from "./RelatedInventoryItems";
+
+export interface DocumentSectionsProps {
+  info: WorkspaceRecordInformation;
+  /** True for notebook (NB) targets; false for structured documents (SD). */
+  isNotebook: boolean;
+  /**
+   * When the link is pinned to a specific SD version, the version number. When set, the
+   * dialog is a "version view": a warning header is shown, mirroring the ELN
+   * record-info panel.
+   */
+  pinnedVersion?: number | null;
+}
+
+// ELN status/signature labels (mirrors recordInfoPanel.js).
+const STATUS_LABELS: Record<WorkspaceRecordEditStatus, string> = {
+  VIEW_MODE: "viewable & editable",
+  EDIT_MODE: "currently edited by you",
+  CANNOT_EDIT_OTHER_EDITING: "edit in progress",
+  CANNOT_EDIT_NO_PERMISSION: "viewable",
+  CAN_NEVER_EDIT: "read-only",
+};
+
+const SIGNATURE_LABELS: Record<WorkspaceRecordSignatureStatus, string> = {
+  UNSIGNED: "unsigned",
+  SIGNED_AND_LOCKED: "signed",
+  AWAITING_WITNESS: "signed, awaiting witness",
+  WITNESSED: "signed and witnessed",
+  UNSIGNABLE: "unsignable",
+  SIGNED_AND_LOCKED_WITNESSES_DECLINED: "signed, all witnesses declined",
+};
+
+/** Status label, mirroring recordInfoPanel.js (appends the editor for in-progress edits). */
+function statusLabel(status: WorkspaceRecordEditStatus, currentEditor: string | null | undefined): string {
+  if (status === "CANNOT_EDIT_OTHER_EDITING" && currentEditor) {
+    return `edit in progress by ${currentEditor}`;
+  }
+  return STATUS_LABELS[status];
+}
+
+/** Undo the server's tag encoding the way recordInfoPanel.js does. */
+function formatTags(tags: string | null | undefined): string {
+  if (!tags) return "";
+  return tags.replaceAll(",", ", ").replaceAll("__rspactags_forsl__", "/").replaceAll("__rspactags_comma__", ",");
+}
+
+/** The lazy "linked by N docs" section (Link group 2). */
+function LinkedByDocs({
+  info,
+  recordTypeName,
+}: {
+  info: WorkspaceRecordInformation;
+  recordTypeName: string;
+}): React.ReactElement {
+  const [linked, setLinked] = useState<LinkedRecords | null>(null);
+  const [loading, setLoading] = useState(false);
+  const count = info.linkedByCount ?? 0;
+
+  if (!count) {
+    return <Typography variant="body2">There are no links to this {recordTypeName}.</Typography>;
+  }
+
+  const docOrDocs = count === 1 ? "doc" : "docs";
+
+  const showLinked = async (): Promise<void> => {
+    setLoading(true);
+    try {
+      setLinked(await getLinkedByRecords(info.id));
+    } catch {
+      // degrade to the empty state rather than an unhandled rejection
+      setLinked({ readable: [], privateByOwner: [] });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (linked === null) {
+    return (
+      <Box>
+        <Typography variant="body2">
+          This {recordTypeName} is linked by {count} {docOrDocs}.
+        </Typography>
+        <Button size="small" disabled={loading} onClick={() => void showLinked()}>
+          Show linked {docOrDocs}
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Typography variant="body2">This {recordTypeName} is linked by:</Typography>
+      <List dense disablePadding sx={{ pl: 3, my: 0.5, listStyleType: "disc" }}>
+        {linked.readable.map((r) => (
+          <ListItem key={r.globalId} disableGutters sx={{ display: "list-item", py: 0 }}>
+            <GlobalIdLink globalId={r.globalId} />: {r.name}
+          </ListItem>
+        ))}
+        {linked.privateByOwner.map((p) => (
+          <ListItem key={p.ownerFullName} disableGutters sx={{ display: "list-item", py: 0 }}>
+            {p.count} private {p.count === 1 ? "doc" : "docs"} belonging to {p.ownerFullName}
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}
+
+/** The sharing + publication section (mirrors recordInfoPanel.js sharing HTML). */
+function SharingAndPublication({
+  info,
+  isNotebook,
+}: {
+  info: WorkspaceRecordInformation;
+  isNotebook: boolean;
+}): React.ReactElement {
+  const recordTypeName = isNotebook ? "notebook" : "document";
+  const [publicLink, setPublicLink] = useState<string | null>(null);
+  const [publicChecked, setPublicChecked] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void getPublicLink(info.oid.idString)
+      .then((link) => {
+        if (active) setPublicLink(link);
+      })
+      // no public link is the normal case for most records; treat a lookup
+      // failure the same rather than leaving an unhandled rejection
+      .catch(() => {})
+      .finally(() => {
+        if (active) setPublicChecked(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [info.oid.idString]);
+
+  const isShared = Boolean(info.shared) || Boolean(info.implicitlyShared);
+
+  return (
+    <Box>
+      <Typography variant="subtitle2">Sharing</Typography>
+      {!isShared ? (
+        <Typography variant="body2">This {recordTypeName} is not shared.</Typography>
+      ) : (
+        <>
+          <Typography variant="body2">This {recordTypeName} is shared:</Typography>
+          <List dense disablePadding sx={{ pl: 3, my: 0.5, listStyleType: "disc" }}>
+            {Object.entries(info.sharedGroupsAndAccess ?? {}).map(([group, access]) => (
+              <ListItem key={`g-${group}`} disableGutters sx={{ display: "list-item", py: 0 }}>
+                with {group} (group) for {access.toLowerCase()}
+              </ListItem>
+            ))}
+            {Object.entries(info.sharedUsersAndAccess ?? {}).map(([user, access]) => (
+              <ListItem key={`u-${user}`} disableGutters sx={{ display: "list-item", py: 0 }}>
+                with {user} (user) for {access.toLowerCase()}
+              </ListItem>
+            ))}
+            {Object.entries(info.sharedNotebooksAndOwners ?? {}).map(([nb, owner]) => (
+              <ListItem key={`nb-${nb}`} disableGutters sx={{ display: "list-item", py: 0 }}>
+                into Notebook <GlobalIdLink globalId={nb} /> (owner: {owner})
+              </ListItem>
+            ))}
+            {Object.entries(info.implicitShares ?? {}).map(([nb, owner]) => (
+              <ListItem key={`im-${nb}`} disableGutters sx={{ display: "list-item", py: 0 }}>
+                implicitly - is in shared Notebook <GlobalIdLink globalId={nb} /> (shared with: {owner})
+              </ListItem>
+            ))}
+          </List>
+        </>
+      )}
+      {publicChecked &&
+        (publicLink === null ? (
+          <Typography variant="body2">This {recordTypeName} is not published.</Typography>
+        ) : (
+          <Typography variant="body2">
+            {publicLink.includes("initialRecordToDisplay")
+              ? "This document is in a published notebook:"
+              : `This ${recordTypeName} is published:`}{" "}
+            <Link
+              href={`${window.location.origin}/public/publishedView/${
+                publicLink.includes("initialRecordToDisplay") || isNotebook ? "notebook" : "document"
+              }/${publicLink}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              public link
+            </Link>
+          </Typography>
+        ))}
+    </Box>
+  );
+}
+
+/**
+ * Document/notebook body for {@link ElnRecordInfoDialog}. Mirrors the ELN
+ * `#recordInfoDialog` for SD/NB targets: the core metadata table, the three link groups
+ * (self / linked-by / forms+template), related inventory items, and sharing +
+ * publication.
+ */
+export default function DocumentSections({
+  info,
+  isNotebook,
+  pinnedVersion,
+}: DocumentSectionsProps): React.ReactElement {
+  const recordTypeName = isNotebook ? "notebook" : "document";
+  const isStructuredDocument = !isNotebook;
+  const isVersionView = pinnedVersion != null;
+  // The version-stripped global id, used for the "latest" link in the version header.
+  const unversionedGlobalId = info.oid.idString.replace(/v\d+$/, "");
+  const tags = formatTags(info.tags);
+
+  return (
+    <Stack spacing={2}>
+      {isVersionView ? (
+        <Box
+          role="note"
+          sx={{
+            border: "1px solid",
+            borderColor: "warning.main",
+            borderRadius: 1,
+            p: 1,
+          }}
+        >
+          <Typography variant="body2">
+            The information below describes <strong>version {pinnedVersion}</strong> of a document {unversionedGlobalId}
+            , which may not be the latest version.
+          </Typography>
+        </Box>
+      ) : null}
+      <Box>
+        <Typography variant="h6" component="div" sx={{ mb: 1 }}>
+          {info.name}
+        </Typography>
+        <Table size="small">
+          <TableBody>
+            <MetaRow label="Unique Id">
+              <GlobalIdLink globalId={isVersionView ? `${unversionedGlobalId}v${pinnedVersion}` : info.oid.idString} />
+            </MetaRow>
+            <MetaRow label="Type">{info.type}</MetaRow>
+            {info.path ? <MetaRow label="Path">{info.path}</MetaRow> : null}
+            {isStructuredDocument && info.version != null ? <MetaRow label="Version">{info.version}</MetaRow> : null}
+            <MetaRow label="Owner">{info.ownerFullName}</MetaRow>
+            <MetaRow label="Creation Date">{info.creationDateWithClientTimezoneOffset}</MetaRow>
+            <MetaRow label="Last Modified">{info.modificationDateWithClientTimezoneOffset}</MetaRow>
+            {isStructuredDocument && info.status ? (
+              <MetaRow label="Status">{statusLabel(info.status, info.currentEditor)}</MetaRow>
+            ) : null}
+            {isStructuredDocument && info.signatureStatus ? (
+              <MetaRow label="Signature Status">{SIGNATURE_LABELS[info.signatureStatus]}</MetaRow>
+            ) : null}
+            {isStructuredDocument && info.templateFormName ? (
+              <MetaRow label="Created from">{info.templateFormName}</MetaRow>
+            ) : null}
+            {isStructuredDocument && info.templateFormId ? (
+              <MetaRow label="Form ID">
+                <GlobalIdLink globalId={info.templateFormId.idString} />
+              </MetaRow>
+            ) : null}
+            {isStructuredDocument && info.templateOid ? (
+              <MetaRow label="Template Name">
+                <GlobalIdLink globalId={info.templateOid}>{info.templateName ?? info.templateOid}</GlobalIdLink>
+              </MetaRow>
+            ) : null}
+            {tags ? <MetaRow label="Tags">{tags}</MetaRow> : null}
+          </TableBody>
+        </Table>
+      </Box>
+
+      <LinkedByDocs info={info} recordTypeName={recordTypeName} />
+
+      <RelatedInventoryItems globalId={info.oid.idString} recordTypeName={recordTypeName} />
+
+      <SharingAndPublication info={info} isNotebook={isNotebook} />
+    </Stack>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnFolderBrowser.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnFolderBrowser.tsx
@@ -1,0 +1,307 @@
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import Typography from "@mui/material/Typography";
+import { treeItemClasses } from "@mui/x-tree-view/TreeItem";
+import React from "react";
+// Reuse the Gallery's own extension groupings so MEDIA files get the Gallery's per-type icons.
+import EXT_BY_TYPE from "@/eln/gallery/fileExtensionsByType.json";
+import { justFilenameExtension } from "@/util/files";
+import { Tree, TreeItem } from "../../../../components/Tree";
+import useFolders, { type FolderTreeNode } from "../../../../hooks/api/useFolders";
+
+// The /api/v1/folders/tree endpoint tags each row with an ApiRecordType: FOLDER,
+// NOTEBOOK, DOCUMENT, MEDIA, SNIPPET. We request documents, notebooks and folders;
+// the endpoint bundles Gallery/MEDIA files in with documents (it only excludes
+// MEDIA_FILE when "document" is absent) and lists the Gallery root, so media files
+// are reachable in this tree too.
+const TYPES_TO_INCLUDE: Set<"document" | "notebook" | "folder"> = new Set(["document", "notebook", "folder"]);
+// Documents, notebooks and Gallery files are valid link targets; folders are navigate-only.
+const PICKABLE_TYPES = new Set(["DOCUMENT", "NOTEBOOK", "MEDIA"]);
+// Folders and notebooks have children that can be revealed; documents are leaves.
+const EXPANDABLE_TYPES = new Set(["FOLDER", "NOTEBOOK"]);
+
+export type ElnTreeSelection = {
+  globalId: string;
+  name: string;
+  type: string;
+};
+
+function isPickable(node: FolderTreeNode): boolean {
+  return PICKABLE_TYPES.has(node.type);
+}
+
+function isExpandable(node: FolderTreeNode): boolean {
+  return EXPANDABLE_TYPES.has(node.type);
+}
+
+/*
+ * The picker reproduces the ELN/Workspace (Fancytree) tree look. The ELN's CSS
+ * (styles/tags/fileTreeBrowser.css) targets Fancytree's DOM and cannot bind to this MUI tree,
+ * so we reuse its served icon assets by URL and copy the few visual values it can't share.
+ * See DevDocs/adr/0001-eln-link-picker-tree-styling.md. Nothing outside this picker is changed.
+ */
+const ELN_ICON_BASE = "/images/icons";
+
+/*
+ * Gallery (MEDIA) files reuse the Gallery's own per-type icons: the same extension groupings
+ * (fileExtensionsByType.json) and extension parser (justFilenameExtension) the Gallery uses,
+ * mapped to its category SVG icons (image/document/pdf/...). Only this small category->icon map
+ * is copied; the extension data and parser are reused, and useGalleryListing is not modified.
+ */
+const mapToSvgImageIcon = (extensions: ReadonlyArray<string>, filename: string): ReadonlyArray<[string, string]> =>
+  extensions.map((ext) => [ext, `${ELN_ICON_BASE}/${filename}.svg`]);
+
+const galleryFileIconMap = new Map<string, string>([
+  ...mapToSvgImageIcon(EXT_BY_TYPE.CHEMISTRY, "chemistry"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.DNA, "dna"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.AUDIO, "audio"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.VIDEO, "video"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.SPREADSHEET, "sheet"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.IMAGES, "image"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.DOCUMENTS, "document"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.PRESENTATION, "presentation"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.HTML, "html"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.CSV, "csv"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.PDF, "pdf"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.XML, "xml"),
+  ...mapToSvgImageIcon(EXT_BY_TYPE.ZIP, "zip"),
+]);
+
+/** Gallery file icon, matching the Gallery: extension -> category SVG, else the unknown fallback. */
+function galleryIconUrl(name: string): string {
+  return galleryFileIconMap.get(justFilenameExtension(name)) ?? `${ELN_ICON_BASE}/unknown.svg`;
+}
+
+function iconUrlForNode(node: FolderTreeNode): string {
+  switch (node.type) {
+    case "FOLDER":
+      return `${ELN_ICON_BASE}/folder.png`;
+    case "NOTEBOOK":
+      return `${ELN_ICON_BASE}/notebook.png`;
+    case "MEDIA":
+      // Gallery files use the Gallery's own per-type icons (image/pdf/document/...)
+      return galleryIconUrl(node.name);
+    default:
+      // DOCUMENT and any other leaf type use the ELN's generic document icon
+      return `${ELN_ICON_BASE}/unknownDocument.png`;
+  }
+}
+
+/** A node label matching the ELN tree: the node's type icon followed by its name only. */
+function NodeLabel({ node }: { node: FolderTreeNode }): React.ReactElement {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, minHeight: "25px" }}>
+      <Box
+        component="img"
+        src={iconUrlForNode(node)}
+        alt=""
+        aria-hidden
+        sx={{ width: 22, height: 22, objectFit: "contain", flexShrink: 0 }}
+      />
+      <Typography variant="body2" noWrap>
+        {node.name}
+      </Typography>
+    </Box>
+  );
+}
+
+/** Folder/notebook expander arrows, reusing the ELN's served arrow assets. */
+function ExpandArrow(): React.ReactElement {
+  return (
+    <Box
+      component="img"
+      src={`${ELN_ICON_BASE}/RightArrow25.png`}
+      alt=""
+      aria-hidden
+      sx={{ width: 16, height: 16, objectFit: "contain" }}
+    />
+  );
+}
+function CollapseArrow(): React.ReactElement {
+  return (
+    <Box
+      component="img"
+      src={`${ELN_ICON_BASE}/DownArrow25.png`}
+      alt=""
+      aria-hidden
+      sx={{ width: 16, height: 16, objectFit: "contain" }}
+    />
+  );
+}
+
+/**
+ * A single tree node. Folders and notebooks are expandable and lazily load their
+ * own contents (mirroring FolderTree's load strategy); documents render as leaves.
+ */
+function TreeNodeContent({ node }: { node: FolderTreeNode }): React.ReactNode {
+  const { getFolderTree } = useFolders();
+  const [children, setChildren] = React.useState<ReadonlyArray<FolderTreeNode>>([]);
+  const [totalHits, setTotalHits] = React.useState(0);
+  const [currentPage, setCurrentPage] = React.useState(0);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(false);
+
+  const loadChildren = React.useCallback(
+    async (pageNumber: number, append: boolean) => {
+      setLoading(true);
+      setError(false);
+      try {
+        const response = await getFolderTree({
+          id: node.id,
+          typesToInclude: TYPES_TO_INCLUDE,
+          pageNumber,
+        });
+        setChildren((prev) => (append ? [...prev, ...response.records] : response.records));
+        setTotalHits(response.totalHits);
+        setCurrentPage(pageNumber);
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [node.id, getFolderTree],
+  );
+
+  React.useEffect(() => {
+    if (isExpandable(node)) void loadChildren(0, false);
+  }, [loadChildren, node]);
+
+  if (!isExpandable(node)) {
+    return <TreeItem item={node} label={<NodeLabel node={node} />} role="treeitem" />;
+  }
+
+  const hasMorePages = children.length < totalHits;
+
+  return (
+    <TreeItem item={node} label={<NodeLabel node={node} />} role="treeitem">
+      {children.map((child) => (
+        <TreeNodeContent key={child.id} node={child} />
+      ))}
+      {loading && (
+        <Box sx={{ p: 1 }}>
+          <CircularProgress size={16} />
+        </Box>
+      )}
+      {error && (
+        <Box sx={{ p: 1 }}>
+          <Alert severity="error">Failed to load contents</Alert>
+        </Box>
+      )}
+      {hasMorePages && !loading && (
+        <Box sx={{ p: 1 }}>
+          <Button size="small" onClick={() => void loadChildren(currentPage + 1, true)}>
+            Load more
+          </Button>
+        </Box>
+      )}
+    </TreeItem>
+  );
+}
+
+/**
+ * A folder-tree browser for picking an ELN link target. Folders and notebooks can
+ * be expanded to navigate; documents, notebooks and Gallery files can be selected as
+ * the target. Clicking a node both selects it and (for folders and notebooks)
+ * expands it, so a notebook can be opened to reach its entries and still be chosen
+ * itself. Selection alone does not confirm the pick: the browser only reports the
+ * current selection ({@code null} for navigate-only folders) and the host dialog
+ * confirms it with an explicit Choose action. Reuses the workspace folder-tree data
+ * layer ({@link useFolders}), which also surfaces the Gallery, so gallery files can
+ * be picked here as well as via search.
+ */
+export default function ElnFolderBrowser({
+  onSelectionChange,
+}: {
+  onSelectionChange: (selection: ElnTreeSelection | null) => void;
+}): React.ReactElement {
+  const { getFolderTree } = useFolders();
+  const [roots, setRoots] = React.useState<ReadonlyArray<FolderTreeNode>>([]);
+  const [expanded, setExpanded] = React.useState<Array<FolderTreeNode>>([]);
+  const [selected, setSelected] = React.useState<FolderTreeNode | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(false);
+
+  const loadRoots = React.useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const response = await getFolderTree({ typesToInclude: TYPES_TO_INCLUDE });
+      setRoots(response.records);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [getFolderTree]);
+
+  React.useEffect(() => {
+    void loadRoots();
+  }, [loadRoots]);
+
+  return (
+    <Box>
+      {error && (
+        <Alert
+          severity="error"
+          sx={{ mb: 1 }}
+          action={
+            <Button size="small" onClick={() => void loadRoots()}>
+              Retry
+            </Button>
+          }
+        >
+          Failed to load your workspace
+        </Alert>
+      )}
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", my: 2 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
+      <Tree<FolderTreeNode, string>
+        aria-label="Browse the ELN workspace for a link target"
+        getId={(node) => node.id.toString()}
+        itemChildrenIndentation={20}
+        slots={{ expandIcon: ExpandArrow, collapseIcon: CollapseArrow }}
+        sx={{
+          // Compact rows like the ELN tree (fileTreeBrowser.css cannot bind to this
+          // MUI DOM; see ADR 0001). The selected row uses the solid theme primary
+          // colour so the current selection is unmistakable before clicking Choose.
+          // x-tree-view 9 marks state with data attributes on the content row (the
+          // Mui-selected class no longer exists), so the selectors target those.
+          [`& .${treeItemClasses.content}`]: {
+            minHeight: "25px",
+            borderRadius: 0,
+            py: 0,
+          },
+          [`& .${treeItemClasses.content}[data-selected], & .${treeItemClasses.content}[data-selected][data-focused], & .${treeItemClasses.content}[data-selected]:hover`]:
+            {
+              backgroundColor: "primary.main",
+              color: "primary.contrastText",
+            },
+        }}
+        expandedItems={expanded}
+        onExpandedItemsChange={(_event, items) => setExpanded(items)}
+        selectedItems={selected}
+        onSelectedItemsChange={(_event, node) => {
+          setSelected(node);
+          onSelectionChange(
+            node && isPickable(node) ? { globalId: node.globalId, name: node.name, type: node.type } : null,
+          );
+        }}
+      >
+        {roots.map((node) => (
+          <TreeNodeContent key={node.id} node={node} />
+        ))}
+      </Tree>
+      {!loading && !error && roots.length === 0 && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          Nothing to browse here.
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnRecordInfoDialog.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnRecordInfoDialog.tsx
@@ -1,0 +1,166 @@
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Link from "@mui/material/Link";
+import Skeleton from "@mui/material/Skeleton";
+import type React from "react";
+import RecordTypeIcon from "@/components/RecordTypeIcon";
+import { useGetWorkspaceRecordInformationAjaxQuery } from "@/modules/workspace/queries";
+import DocumentSections from "./DocumentSections";
+import GallerySections from "./GallerySections";
+import { iconForGlobalId, openUrlForTarget, prefixOf } from "./iconForGlobalId";
+import { GLOBAL_ID_PATTERN } from "./linkTarget";
+
+export interface ElnRecordInfoDialogProps {
+  open: boolean;
+  globalId: string;
+  /**
+   * When the link is pinned to a specific version of an SD target, the version number
+   * (the `vN` in `SDxxxvN`). null/undefined means the link points at the latest version.
+   */
+  versionPin?: number | null;
+  /**
+   * When the ELN target has been deleted, the Open button is hidden: a deleted
+   * ELN record's route only produces an error page (unlike a deleted Inventory
+   * item, which is still viewable in the trash and so keeps Open). Mirrors the
+   * link card's Open rule.
+   */
+  targetDeleted?: boolean;
+  /**
+   * When the ELN target is not readable by the viewer (e.g. shared then
+   * unshared), the Open button is hidden for the same reason: its route is only
+   * an error page. Together with targetDeleted this matches the link card's
+   * Open rule for ELN targets.
+   */
+  noAccess?: boolean;
+  onClose: () => void;
+}
+
+const UNAVAILABLE_MESSAGE = "This item is not available, or you do not have permission to view it.";
+
+/**
+ * Extract the numeric DB id from a global id (e.g. `SD123` -> 123, `SD123v2` -> 123).
+ * `getRecordInformation` takes the numeric id, not the global-id string.
+ */
+function numericIdOf(globalId: string): number | null {
+  const id = GLOBAL_ID_PATTERN.exec(globalId)?.[2];
+  return id !== undefined ? Number(id) : null;
+}
+
+/**
+ * The per-type body. Runs the record-information query and renders explicitly by
+ * state: a loading skeleton, an inline error Alert, or the matching per-type
+ * sections. A failed load (e.g. 404 / not readable / unknown version) is an
+ * expected outcome handled here from the query's error state, not thrown to an
+ * error boundary. Re-opening the dialog remounts this body, so React Query
+ * refetches a previously-errored query automatically.
+ */
+function DialogBody({
+  globalId,
+  recordId,
+  versionPin,
+}: {
+  globalId: string;
+  recordId: number;
+  versionPin?: number | null;
+}): React.ReactElement {
+  const {
+    data: info,
+    isPending,
+    isError,
+    refetch,
+  } = useGetWorkspaceRecordInformationAjaxQuery({
+    recordId,
+    version: versionPin ?? undefined,
+  });
+
+  if (isPending) {
+    return <Skeleton variant="rectangular" width="100%" height={240} />;
+  }
+
+  if (isError || !info) {
+    // A pinned link that can no longer resolve its version gets a specific message
+    // plus a link to the latest, rather than the generic not-available text.
+    if (versionPin != null) {
+      return (
+        <Alert severity="error">
+          Version {versionPin} of {globalId} is no longer available.{" "}
+          <Link href={`/globalId/${globalId}`} target="_blank" rel="noopener noreferrer">
+            View the latest version
+          </Link>
+          .
+        </Alert>
+      );
+    }
+    return <Alert severity="error">{UNAVAILABLE_MESSAGE}</Alert>;
+  }
+
+  const prefix = prefixOf(globalId);
+  if (prefix === "GL") {
+    return (
+      <GallerySections
+        info={info}
+        onRecordChanged={() => {
+          void refetch();
+        }}
+      />
+    );
+  }
+  return <DocumentSections info={info} isNotebook={prefix === "NB"} pinnedVersion={versionPin} />;
+}
+
+/**
+ * Modal that reproduces the ELN record-info dialog (`#recordInfoDialog`) for an ELN
+ * link target (structured document, notebook or gallery file). It fetches the same
+ * data the ELN info button does via `/workspace/getRecordInformation` and renders the
+ * per-type body (documents/notebooks vs gallery files) to match the ELN exactly.
+ *
+ * Relies on the app-level QueryClient (the Inventory app is mounted under App.tsx's
+ * QueryClientProvider), so it does not provide its own.
+ */
+export default function ElnRecordInfoDialog(props: ElnRecordInfoDialogProps): React.ReactElement | null {
+  if (!props.open) return null;
+
+  const iconData = iconForGlobalId(props.globalId);
+  const recordId = numericIdOf(props.globalId);
+  // Only SD documents are versionable; ignore a pin on any other target (NB/GL).
+  const effectiveVersionPin = prefixOf(props.globalId) === "SD" ? (props.versionPin ?? null) : null;
+
+  return (
+    <Dialog open={props.open} onClose={props.onClose} aria-label={`Info for ${props.globalId}`} fullWidth maxWidth="md">
+      <DialogTitle>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          {iconData && <RecordTypeIcon record={iconData} aria-hidden />}
+          {props.globalId}
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>
+        {recordId === null ? (
+          <Alert severity="error">{UNAVAILABLE_MESSAGE}</Alert>
+        ) : (
+          <DialogBody globalId={props.globalId} recordId={recordId} versionPin={effectiveVersionPin} />
+        )}
+      </DialogContent>
+      <DialogActions>
+        {!(props.targetDeleted || props.noAccess) && (
+          <Button
+            size="small"
+            startIcon={<OpenInNewIcon />}
+            href={openUrlForTarget(props.globalId, effectiveVersionPin)}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open"
+          >
+            Open
+          </Button>
+        )}
+        <Button onClick={props.onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnRecordPicker.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnRecordPicker.tsx
@@ -1,0 +1,65 @@
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import React from "react";
+import ElnFolderBrowser from "./ElnFolderBrowser";
+
+export type ElnRecordPickerResult = {
+  globalId: string;
+  name: string;
+  type: string;
+};
+
+export interface ElnRecordPickerProps {
+  open: boolean;
+  onPick: (target: ElnRecordPickerResult) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Dialog for picking an ELN link target (document, notebook or Gallery file) by browsing the
+ * workspace/Gallery folder tree. Opened from a "Browse ELN" affordance, so it drops straight into
+ * the folder picker with no search/browse mode choice. Clicking a tree node only selects it (and
+ * expands folders/notebooks), so notebooks can be browsed into; the selection is confirmed with
+ * the explicit Choose button, which reports the target via onPick. Decoupled from TinyMCE and
+ * MobX so it can be reused outside the Inventory dialog.
+ */
+export default function ElnRecordPicker(props: ElnRecordPickerProps): React.ReactElement {
+  const [selection, setSelection] = React.useState<ElnRecordPickerResult | null>(null);
+
+  // a reopened dialog must not retain (and offer to Choose) a stale selection
+  React.useEffect(() => {
+    if (props.open) setSelection(null);
+  }, [props.open]);
+
+  return (
+    <Dialog
+      open={props.open}
+      onClose={props.onCancel}
+      fullWidth
+      maxWidth="sm"
+      aria-label="Browse the ELN for a link target"
+    >
+      <DialogTitle>Browse ELN</DialogTitle>
+      <DialogContent dividers sx={{ minHeight: "40vh" }}>
+        <ElnFolderBrowser onSelectionChange={setSelection} />
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="contained"
+          color="callToAction"
+          disableElevation
+          disabled={selection === null}
+          onClick={() => {
+            if (selection) props.onPick(selection);
+          }}
+        >
+          Choose
+        </Button>
+        <Button onClick={props.onCancel}>Cancel</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/GallerySections.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/GallerySections.tsx
@@ -1,0 +1,183 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import Typography from "@mui/material/Typography";
+import type React from "react";
+import { useRef, useState } from "react";
+import { uploadNewGalleryVersion } from "@/modules/workspace/galleryUpload";
+import { getLinkedDocuments } from "@/modules/workspace/linkedRecords";
+import type { LinkedRecords, WorkspaceRecordInformation } from "@/modules/workspace/schema";
+import { formatFileSize } from "@/util/files";
+import { GlobalIdLink, MetaRow } from "./MetaTable";
+import RelatedInventoryItems from "./RelatedInventoryItems";
+
+export interface GallerySectionsProps {
+  info: WorkspaceRecordInformation;
+  /** Called after a successful upload-new-version so the shell can refetch. */
+  onRecordChanged: () => void;
+}
+
+/**
+ * Gallery-file body for {@link ElnRecordInfoDialog}. Mirrors the ELN
+ * `#recordInfoDialog` for GL targets: the core metadata table, an image thumbnail
+ * preview, and the Download / Show-linked-docs / Upload-new-version actions.
+ */
+export default function GallerySections({ info, onRecordChanged }: GallerySectionsProps): React.ReactElement {
+  const isRevisionView = info.revision != null;
+  const isImage = info.type === "Image";
+  // The ELN gates upload on `!isRevisionView && (owner || VIEW_MODE)`. `VIEW_MODE` is
+  // the server's editable signal (returned for owners too), so gating on it covers the
+  // common owner case without wiring bearer-token whoami plumbing into this dialog.
+  const canUpload = !isRevisionView && info.status === "VIEW_MODE";
+
+  const [linked, setLinked] = useState<LinkedRecords | null>(null);
+  const [linkedLoading, setLinkedLoading] = useState(false);
+  // Mounting RelatedInventoryItems triggers its fetch, so deferring the mount
+  // until the user asks for linked docs keeps the dialog itself lazy.
+  const [showRelatedInventory, setShowRelatedInventory] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Cache-buster so the thumbnail refreshes after an upload-new-version.
+  const thumbnailSrc = `/gallery/getThumbnail/${info.id}/${info.modificationDate ?? info.version ?? 0}`;
+  const downloadHref = isRevisionView ? `/Streamfile/${info.id}?revision=${info.revision}` : `/Streamfile/${info.id}`;
+
+  function handleShowLinkedDocs(): void {
+    setShowRelatedInventory(true);
+    setLinkedLoading(true);
+    void getLinkedDocuments(info.id)
+      .then(setLinked)
+      // degrade to the empty state rather than an unhandled rejection
+      .catch(() => setLinked({ readable: [], privateByOwner: [] }))
+      .finally(() => setLinkedLoading(false));
+  }
+
+  function handleFilePicked(event: React.ChangeEvent<HTMLInputElement>): void {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    setUploading(true);
+    setUploadError(null);
+    void uploadNewGalleryVersion({ mediaId: info.id, file })
+      .then(() => {
+        onRecordChanged();
+      })
+      .catch((e: unknown) => {
+        setUploadError(e instanceof Error ? e.message : "Upload failed.");
+      })
+      .finally(() => setUploading(false));
+  }
+
+  return (
+    <Box>
+      <Typography variant="h6" component="div" sx={{ mb: 1 }}>
+        {info.name}
+      </Typography>
+
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        <Box sx={{ flex: "1 1 18rem" }}>
+          <Table size="small">
+            <TableBody>
+              <MetaRow label="Unique Id">
+                <GlobalIdLink globalId={info.oid.idString} />
+              </MetaRow>
+              <MetaRow label="Type">{info.type}</MetaRow>
+              {info.version != null && (info.version > 1 || isRevisionView) ? (
+                <MetaRow label="Version">{info.version}</MetaRow>
+              ) : null}
+              {info.size != null ? <MetaRow label="File size">{formatFileSize(info.size)}</MetaRow> : null}
+              {info.extension ? <MetaRow label="Extension">{info.extension}</MetaRow> : null}
+              <MetaRow label="Owner">{info.ownerFullName}</MetaRow>
+              <MetaRow label="Creation Date">{info.creationDateWithClientTimezoneOffset}</MetaRow>
+              <MetaRow label="Last Modified">{info.modificationDateWithClientTimezoneOffset}</MetaRow>
+              {info.originalImageOid ? (
+                <MetaRow label="Original Image">
+                  <GlobalIdLink globalId={info.originalImageOid.idString} />
+                </MetaRow>
+              ) : null}
+              {info.description ? <MetaRow label="Caption">{info.description}</MetaRow> : null}
+            </TableBody>
+          </Table>
+        </Box>
+
+        {isImage ? (
+          <Box sx={{ flex: "0 0 auto" }}>
+            <Typography variant="subtitle2">Preview</Typography>
+            <Box
+              component="img"
+              src={thumbnailSrc}
+              alt={info.name}
+              sx={{
+                maxWidth: 250,
+                maxHeight: 250,
+                border: "1px solid",
+                borderColor: "divider",
+              }}
+            />
+          </Box>
+        ) : null}
+      </Box>
+
+      <Box sx={{ display: "flex", gap: 1, mt: 1, flexWrap: "wrap" }}>
+        <Button size="small" href={downloadHref} target="_blank" rel="noopener noreferrer">
+          Download
+        </Button>
+        {!isRevisionView ? (
+          <Button size="small" disabled={linkedLoading} onClick={handleShowLinkedDocs}>
+            Show linked docs
+          </Button>
+        ) : null}
+        {canUpload ? (
+          <>
+            <Button size="small" disabled={uploading} onClick={() => fileInputRef.current?.click()}>
+              {uploading ? "Uploading…" : "Upload new version"}
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              data-testid="gallery-upload-input"
+              accept={info.extension ? `.${info.extension}` : undefined}
+              style={{ display: "none" }}
+              onChange={handleFilePicked}
+            />
+          </>
+        ) : null}
+      </Box>
+
+      {uploadError ? (
+        <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+          {uploadError}
+        </Typography>
+      ) : null}
+
+      {linked !== null ? (
+        <Box sx={{ mt: 1 }}>
+          {linked.readable.length === 0 ? (
+            <Typography variant="body2">There are no references to this file.</Typography>
+          ) : (
+            <>
+              <Typography variant="body2">This file is referenced by:</Typography>
+              <List dense disablePadding sx={{ pl: 3, my: 0.5, listStyleType: "disc" }}>
+                {linked.readable.map((r) => (
+                  <ListItem key={r.globalId} disableGutters sx={{ display: "list-item", py: 0 }}>
+                    <GlobalIdLink globalId={r.globalId} />: {r.name}
+                  </ListItem>
+                ))}
+              </List>
+            </>
+          )}
+        </Box>
+      ) : null}
+
+      {showRelatedInventory ? (
+        <Box sx={{ mt: 1 }}>
+          <RelatedInventoryItems globalId={info.oid.idString} recordTypeName="file" />
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/InventoryInfoDialog.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/InventoryInfoDialog.tsx
@@ -1,0 +1,123 @@
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Skeleton from "@mui/material/Skeleton";
+import Typography from "@mui/material/Typography";
+import type React from "react";
+import { useEffect, useState } from "react";
+import ApiService from "../../../../common/InvApiService";
+import type { GlobalId } from "../../../../stores/definitions/BaseRecord";
+import type { InventoryRecord } from "../../../../stores/definitions/InventoryRecord";
+import AlwaysNewFactory from "../../../../stores/models/Factory/AlwaysNewFactory";
+import SidebarBody from "../../MoreInfoSidebar/SidebarBody";
+import { iconForInventoryGlobalId } from "./iconForGlobalId";
+
+export interface InventoryInfoDialogProps {
+  open: boolean;
+  globalId: string;
+  /**
+   * When set, load the historical snapshot at this user-facing version (via the
+   * /versions/{n} endpoint added in RSDEV-1141) rather than the live record.
+   */
+  versionPin?: number | null;
+  onClose: () => void;
+}
+
+import { GLOBAL_ID_PATTERN, INVENTORY_PREFIX_TO_API_PATH } from "./linkTarget";
+
+function recordEndpoint(globalId: string, versionPin?: number | null): string | null {
+  const match = GLOBAL_ID_PATTERN.exec(globalId);
+  if (!match) return null;
+  const segment = INVENTORY_PREFIX_TO_API_PATH[match[1]];
+  if (!segment) return null;
+  const base = `${segment}/${match[2]}`;
+  return versionPin == null ? base : `${base}/versions/${versionPin}`;
+}
+
+type State =
+  | { state: "init" }
+  | { state: "loading" }
+  | { state: "success"; record: InventoryRecord }
+  | { state: "fail"; error: Error };
+
+/**
+ * Modal wrapper that loads an inventory record by globalId and renders the
+ * MoreInfoSidebar body for it. Reuses the same SidebarBody component as the
+ * drawer so both surfaces display identical info.
+ */
+export default function InventoryInfoDialog(props: InventoryInfoDialogProps): React.ReactElement | null {
+  const [state, setState] = useState<State>({ state: "init" });
+  const [factory] = useState(() => new AlwaysNewFactory());
+
+  useEffect(() => {
+    if (!props.open) return;
+    const endpoint = recordEndpoint(props.globalId, props.versionPin);
+    if (!endpoint) {
+      setState({
+        state: "fail",
+        error: new Error(`Cannot resolve endpoint for ${props.globalId}`),
+      });
+      return;
+    }
+    // Guard against out-of-order resolution: if the props change or the dialog
+    // closes before this request resolves, ignore its result so a stale response
+    // cannot overwrite newer state (or update state after the dialog is hidden).
+    let cancelled = false;
+    setState({ state: "loading" });
+    void (async () => {
+      try {
+        const { data } = await ApiService.get<Record<string, unknown> & { globalId: GlobalId }>(endpoint);
+        if (cancelled) return;
+        const record = factory.newRecord(data);
+        setState({ state: "success", record });
+      } catch (e) {
+        if (cancelled) return;
+        setState({ state: "fail", error: e as Error });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [props.open, props.globalId, props.versionPin, factory]);
+
+  if (!props.open) return null;
+  return (
+    <Dialog open={props.open} onClose={props.onClose} aria-label={`Info for ${props.globalId}`} fullWidth maxWidth="sm">
+      <DialogTitle>{props.globalId}</DialogTitle>
+      <DialogContent>
+        {state.state === "loading" && <Skeleton variant="rectangular" width="100%" height={240} />}
+        {state.state === "fail" && <Alert severity="error">{state.error.message}</Alert>}
+        {state.state === "success" && (
+          <>
+            {props.versionPin != null && (
+              <Box
+                role="note"
+                sx={{
+                  border: "1px solid",
+                  borderColor: "warning.main",
+                  borderRadius: 1,
+                  p: 1,
+                  mb: 1,
+                }}
+              >
+                <Typography variant="body2">
+                  The information below describes <strong>version {props.versionPin}</strong> of a{" "}
+                  {iconForInventoryGlobalId(props.globalId)?.recordTypeLabel.toLowerCase() ?? "record"}{" "}
+                  {props.globalId.replace(/v\d+$/, "")}, which may not be the latest version.
+                </Typography>
+              </Box>
+            )}
+            <SidebarBody record={state.record} factory={factory} />
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
@@ -1,0 +1,205 @@
+import HistoryIcon from "@mui/icons-material/History";
+import Autocomplete from "@mui/material/Autocomplete";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import FormHelperText from "@mui/material/FormHelperText";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import type React from "react";
+import { useState } from "react";
+import RecordTypeIcon from "../../../../components/RecordTypeIcon";
+import ElnRecordPicker from "./ElnRecordPicker";
+import { iconForGlobalId } from "./iconForGlobalId";
+import LinkTargetBrowser from "./LinkTargetBrowser";
+import VersionLockDialog from "./VersionLockDialog";
+
+export interface LinkEditorProps {
+  /** Current relation type (controlled). */
+  relationType: string;
+  onRelationTypeChange: (value: string) => void;
+  /** Allowed relation types: a constrained list or the full DataCite set. */
+  relationOptions: ReadonlyArray<string>;
+  /**
+   * When true the relation field accepts free text (extra-field links allow any
+   * DataCite type); when false it is a constrained pick from `relationOptions`
+   * (template-field links restrict to the template's allowed set).
+   */
+  relationFreeSolo: boolean;
+  relationLabel: string;
+  relationError?: boolean;
+  relationHelperText?: string;
+
+  /** Current target Global ID (controlled). */
+  targetGlobalId: string;
+  /** Optional display name shown in the target chip ("GID — name"). */
+  targetName?: string;
+  /** Called for picks, typed edits, and clearing (globalId/name are "" when cleared). */
+  onTargetChange: (globalId: string, name: string) => void;
+  targetError: boolean;
+  targetHelperText: string;
+
+  /** A separate error shown under the target field (e.g. "select both …"). */
+  validationMessage?: string;
+
+  versionPin: number | null;
+  onVersionPinChange: (versionPin: number | null) => void;
+  /** Whether the version-pin affordance is enabled (caller owns target validity). */
+  canPinVersion: boolean;
+}
+
+/**
+ * The shared link-editor UI used by both the extra-field editor (UpdateField)
+ * and the template-field editor (LinkFieldValue): the relation-type field, the
+ * target chip + Browse Inventory/ELN buttons + Target Global ID field, the
+ * version pill and version-pin control, and the three picker/version dialogs.
+ *
+ * Controlled and presentational: it owns only the open-state of its three
+ * dialogs and a neutral vertical layout. All staged values, validation, the
+ * commit buttons, and the commit logic stay with each caller, which differ
+ * (constrained vs free-solo relations, a target name, Box vs Grid placement,
+ * and different model-commit calls).
+ */
+export default function LinkEditor({
+  relationType,
+  onRelationTypeChange,
+  relationOptions,
+  relationFreeSolo,
+  relationLabel,
+  relationError,
+  relationHelperText,
+  targetGlobalId,
+  targetName,
+  onTargetChange,
+  targetError,
+  targetHelperText,
+  validationMessage,
+  versionPin,
+  onVersionPinChange,
+  canPinVersion,
+}: LinkEditorProps): React.ReactElement {
+  const [browserOpen, setBrowserOpen] = useState(false);
+  const [elnOpen, setElnOpen] = useState(false);
+  const [versionDialogOpen, setVersionDialogOpen] = useState(false);
+
+  return (
+    <Box>
+      <Autocomplete
+        freeSolo={relationFreeSolo}
+        options={relationOptions}
+        value={relationFreeSolo ? relationType : relationType === "" ? null : relationType}
+        onChange={relationFreeSolo ? undefined : (_event, value) => onRelationTypeChange(value ?? "")}
+        onInputChange={relationFreeSolo ? (_event, value) => onRelationTypeChange(value) : undefined}
+        renderInput={(params) => {
+          const { slotProps, ...textFieldProps } = params;
+          return (
+            <TextField
+              {...textFieldProps}
+              variant="standard"
+              label={relationLabel}
+              error={relationError}
+              helperText={relationHelperText}
+              slotProps={{
+                ...slotProps,
+                htmlInput: {
+                  ...slotProps.htmlInput,
+                  "aria-label": relationLabel,
+                },
+              }}
+            />
+          );
+        }}
+      />
+      <Stack direction="row" spacing={1} sx={{ mt: 1, flexWrap: "wrap", alignItems: "center" }}>
+        {targetGlobalId
+          ? (() => {
+              const iconData = iconForGlobalId(targetGlobalId);
+              return (
+                <Chip
+                  // Match the committed (non-edit) LinkField pill. size="small"
+                  // gives the same geometry; the pl restores the left padding
+                  // the accented theme strips from deletable chips
+                  // (`&.MuiChip-deletable { padding: 0 }`). Without it the type
+                  // icon — which gets no MuiChip-icon margin because
+                  // RecordTypeIcon wraps it in a tooltip — sits flush against
+                  // the left edge instead of the non-edit pill's 4px
+                  // (spacing(0.5)). The selector is repeated to out-specify the
+                  // theme's two-class `.MuiChip-deletable` rule. The cancel
+                  // button just widens the chip.
+                  size="small"
+                  sx={{ "&.MuiChip-deletable": { pl: 0.5 } }}
+                  icon={iconData ? <RecordTypeIcon record={iconData} aria-hidden /> : undefined}
+                  label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
+                  onDelete={() => onTargetChange("", "")}
+                  data-test-id="LinkTarget-globalId"
+                />
+              );
+            })()
+          : null}
+        <Button size="small" variant="outlined" aria-label="Browse Inventory" onClick={() => setBrowserOpen(true)}>
+          Browse Inventory
+        </Button>
+        <Button size="small" variant="outlined" aria-label="Browse ELN" onClick={() => setElnOpen(true)}>
+          Browse ELN
+        </Button>
+      </Stack>
+      <TextField
+        label="Target Global ID"
+        value={targetGlobalId}
+        onChange={(e) => onTargetChange(e.target.value, "")}
+        fullWidth
+        size="small"
+        variant="standard"
+        sx={{ mt: 1 }}
+        helperText={targetHelperText}
+        error={targetError}
+        slotProps={{ htmlInput: { "aria-label": "Target Global ID" } }}
+      />
+      {validationMessage ? <FormHelperText error>{validationMessage}</FormHelperText> : null}
+      <Stack direction="row" spacing={1} sx={{ mt: 1, alignItems: "center" }}>
+        <Chip
+          size="small"
+          variant="outlined"
+          label={versionPin != null ? `Pinned to v${versionPin}` : "Latest"}
+          data-test-id="LinkEditor-version"
+        />
+        <IconButton
+          size="small"
+          aria-label={targetGlobalId ? `Pin version for ${targetGlobalId}` : "Pin version"}
+          disabled={!canPinVersion}
+          onClick={() => setVersionDialogOpen(true)}
+        >
+          <HistoryIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+
+      <LinkTargetBrowser
+        open={browserOpen}
+        onCancel={() => setBrowserOpen(false)}
+        onPick={(target) => {
+          onTargetChange(target.globalId, target.name);
+          setBrowserOpen(false);
+        }}
+      />
+      <ElnRecordPicker
+        open={elnOpen}
+        onCancel={() => setElnOpen(false)}
+        onPick={(target) => {
+          onTargetChange(target.globalId, target.name);
+          setElnOpen(false);
+        }}
+      />
+      <VersionLockDialog
+        open={versionDialogOpen}
+        globalId={targetGlobalId}
+        currentVersionPin={versionPin}
+        onConfirm={(pin) => {
+          setVersionDialogOpen(false);
+          onVersionPinChange(pin);
+        }}
+        onCancel={() => setVersionDialogOpen(false)}
+      />
+    </Box>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkField.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkField.tsx
@@ -1,0 +1,188 @@
+import EditIcon from "@mui/icons-material/Edit";
+import HistoryIcon from "@mui/icons-material/History";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import type React from "react";
+import { useState } from "react";
+import RecordTypeIcon from "../../../../components/RecordTypeIcon";
+import type { ExtraInventoryLink } from "../../../../stores/definitions/ExtraField";
+import ElnRecordInfoDialog from "./ElnRecordInfoDialog";
+import InventoryInfoDialog from "./InventoryInfoDialog";
+import { iconForGlobalId, isInventoryGlobalId, openUrlForTarget, supportsVersionPin } from "./iconForGlobalId";
+import { GLOBAL_ID_PATTERN } from "./linkTarget";
+import useLinkTargetSummary from "./useLinkTargetSummary";
+
+// Read-only versioned viewer route added in RSDEV-1141 (matches MoreInfoSidebar/VersionHistory's
+// `/inventory/{recordType}/{id}?version=N`). Keyed by inventory Global ID prefix.
+const INVENTORY_PREFIX_TO_ROUTE: Record<string, string> = {
+  SA: "sample",
+  SS: "subsample",
+  IC: "container",
+  IN: "instrument",
+};
+
+/**
+ * The URL the Open action points at, so it can be a plain anchor rather than a
+ * scripted handler. A version-pinned inventory target opens the read-only
+ * versioned viewer added in RSDEV-1141 (`/inventory/{type}/{id}?version=N`);
+ * every other case uses the standard target route (`openUrlForTarget`: the
+ * Gallery item route for GL, `/globalId/<gid>[vN]` for the rest).
+ */
+function openHrefForLink(link: ExtraInventoryLink, targetIsInventory: boolean): string {
+  if (targetIsInventory && link.versionPin != null) {
+    const match = GLOBAL_ID_PATTERN.exec(link.targetGlobalId);
+    const routeType = match ? INVENTORY_PREFIX_TO_ROUTE[match[1]] : undefined;
+    if (match && routeType) {
+      return `/inventory/${routeType}/${match[2]}?version=${link.versionPin}`;
+    }
+  }
+  return openUrlForTarget(link.targetGlobalId, link.versionPin);
+}
+
+export interface LinkFieldProps {
+  /** Field name (the user-supplied label of the ExtraLinkField row) */
+  name: string;
+  link: ExtraInventoryLink;
+  /** When false, the edit affordance is hidden. */
+  editable: boolean;
+  /**
+   * Opens the link editor. Optional: custom (extra) Link fields are edited via
+   * the field's settings cog (consistent with other custom field types), so
+   * they omit this and no inline Edit button is shown. Template Link fields have
+   * no cog, so they pass it and the inline Edit button is their edit affordance.
+   */
+  onEdit?: () => void;
+}
+
+export default function LinkField(props: LinkFieldProps): React.ReactElement {
+  const versionLabel = props.link.versionPin != null ? `Pinned to v${props.link.versionPin}` : "Latest";
+  const iconData = iconForGlobalId(props.link.targetGlobalId);
+  const targetIsInventory = isInventoryGlobalId(props.link.targetGlobalId);
+  const [infoOpen, setInfoOpen] = useState(false);
+  // current state of the target; null while loading or unresolvable, which
+  // renders the card exactly as before the summary existed (no pill, Open on)
+  const targetSummary = useLinkTargetSummary(props.link.targetGlobalId);
+  const targetDeleted = targetSummary?.deleted === true;
+  // ELN targets the viewer cannot read get a "No access" pill; inventory
+  // targets ignore readability because every logged-in user keeps the
+  // limited-read view. A redacted summary always has deleted=false, so the
+  // two pills can never co-occur.
+  const noAccess = targetSummary?.readable === false && !targetIsInventory;
+  // deleted inventory items live on in the trash and their viewer works, so
+  // only deleted or unreadable ELN targets lose Open (their routes are just
+  // error pages)
+  const openBlocked = !targetIsInventory && (targetDeleted || noAccess);
+
+  const openHref = openHrefForLink(props.link, targetIsInventory);
+  return (
+    <Card variant="outlined" aria-label={props.name ? `Link field ${props.name}` : "Link field"}>
+      <CardContent>
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1,
+            flexWrap: "wrap",
+            alignItems: "center",
+          }}
+          data-test-id="LinkField-row"
+        >
+          {props.name && (
+            <Typography variant="subtitle1" component="span" sx={{ fontWeight: 700 }}>
+              {props.name}
+            </Typography>
+          )}
+          <Chip size="small" label={props.link.relationType} data-test-id="LinkField-relation" />
+          <Chip
+            size="small"
+            icon={iconData ? <RecordTypeIcon record={iconData} aria-hidden /> : undefined}
+            label={props.link.targetGlobalId}
+            data-test-id="LinkField-target"
+          />
+          <IconButton
+            size="small"
+            aria-label={`Show info for ${props.link.targetGlobalId}`}
+            // an unreadable ("No access") target has nothing to show and its
+            // info route is just an error page, so grey out info alongside the
+            // (already-disabled) version-pin clock. Recomputed from the target
+            // summary, so changing the link's target clears it and reverting
+            // (e.g. Discard) to the unshared target reimposes it.
+            disabled={noAccess}
+            onClick={() => setInfoOpen(true)}
+          >
+            <InfoOutlinedIcon fontSize="small" />
+          </IconButton>
+          {props.editable && supportsVersionPin(props.link.targetGlobalId) && (
+            // a disabled affordance only: like the other link properties,
+            // the pin is changed in the link editor (Edit) and committed
+            // with Update, not directly from the view card. The tooltip
+            // wrapper says so, since a disabled button cannot.
+            <Tooltip title="Edit the link to change the pinned version">
+              <span>
+                <IconButton size="small" aria-label={`Pin version for ${props.link.targetGlobalId}`} disabled>
+                  <HistoryIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+          <Chip size="small" variant="outlined" label={versionLabel} data-test-id="LinkField-version" />
+          {targetDeleted && (
+            <Chip size="small" color="warning" label="Target deleted" data-test-id="LinkField-targetDeleted" />
+          )}
+          {noAccess && (
+            // no "no longer" in the tooltip: the pill also shows for
+            // viewers who never had access (ADR-0002)
+            <Tooltip title="You do not have permission to view this item">
+              <Chip size="small" color="warning" label="No access" data-test-id="LinkField-noAccess" />
+            </Tooltip>
+          )}
+          {!openBlocked && (
+            <Button
+              size="small"
+              startIcon={<OpenInNewIcon />}
+              href={openHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Open ${props.link.targetGlobalId}`}
+            >
+              Open
+            </Button>
+          )}
+          {props.editable && props.onEdit && (
+            <Button size="small" startIcon={<EditIcon />} onClick={props.onEdit} aria-label="Edit link">
+              Edit
+            </Button>
+          )}
+        </Box>
+      </CardContent>
+      {targetIsInventory ? (
+        <InventoryInfoDialog
+          open={infoOpen}
+          globalId={props.link.targetGlobalId}
+          versionPin={props.link.versionPin}
+          onClose={() => setInfoOpen(false)}
+        />
+      ) : (
+        <ElnRecordInfoDialog
+          open={infoOpen}
+          globalId={props.link.targetGlobalId}
+          versionPin={props.link.versionPin}
+          // a deleted or unreadable ELN target only routes to an error page, so
+          // the dialog drops its Open button (matching the card). Deleted
+          // inventory targets stay viewable in the trash and use
+          // InventoryInfoDialog, which has no Open button.
+          targetDeleted={targetDeleted}
+          noAccess={noAccess}
+          onClose={() => setInfoOpen(false)}
+        />
+      )}
+    </Card>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkTargetBrowser.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkTargetBrowser.tsx
@@ -1,0 +1,88 @@
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import { observer } from "mobx-react-lite";
+import type React from "react";
+import { useEffect, useState } from "react";
+import AlwaysNewWindowNavigationContext from "../../../../components/AlwaysNewWindowNavigationContext";
+import type { InventoryRecord } from "../../../../stores/definitions/InventoryRecord";
+import AlwaysNewFactory from "../../../../stores/models/Factory/AlwaysNewFactory";
+import Search from "../../../../stores/models/Search";
+import InventoryPicker from "../../Picker/Picker";
+
+export interface LinkTargetBrowserProps {
+  open: boolean;
+  onPick: (target: { globalId: string; name: string }) => void;
+  onCancel: () => void;
+}
+
+function LinkTargetBrowser(props: LinkTargetBrowserProps): React.ReactElement {
+  // lazy initializer: Search sets up the store/fetcher chain, which must not
+  // be re-done (and discarded) on every render
+  const [search] = useState(
+    () =>
+      new Search({
+        factory: new AlwaysNewFactory(),
+        fetcherParams: {
+          resultType: "ALL",
+          pageSize: 10,
+          orderBy: "name",
+          order: "asc",
+        },
+        uiConfig: {
+          allowedSearchModules: new Set(["TYPE", "OWNER", "SAVEDSEARCHES", "TAG"]),
+          allowedTypeFilters: new Set(["ALL", "SAMPLE", "SUBSAMPLE", "CONTAINER", "TEMPLATE"]),
+          selectionMode: "SINGLE",
+          // mirror Browse ELN: clicking a result only selects it, and the
+          // picker's Choose button (enabled once a row is selected) confirms
+          instantConfirm: false,
+        },
+      }),
+  );
+
+  useEffect(() => {
+    if (props.open) void search.fetcher.performInitialSearch(null);
+  }, [props.open, search]);
+
+  const handleAddition = (records: Array<InventoryRecord>) => {
+    const [first] = records;
+    if (!first?.globalId) {
+      // defensive: Choose is disabled while nothing is selected, but an empty
+      // confirmation must close the dialog rather than commit an empty pick
+      props.onCancel();
+      return;
+    }
+    props.onPick({
+      globalId: first.globalId,
+      name: first.name ?? "",
+    });
+  };
+
+  return (
+    <Dialog
+      open={props.open}
+      onClose={props.onCancel}
+      fullWidth
+      maxWidth="md"
+      aria-label="Browse Inventory for link target"
+    >
+      <DialogTitle>Browse Inventory</DialogTitle>
+      <DialogContent sx={{ height: "60vh", p: 1 }}>
+        <AlwaysNewWindowNavigationContext>
+          <InventoryPicker
+            search={search}
+            paddingless
+            onAddition={handleAddition}
+            onCancel={props.onCancel}
+            showActions
+            // clear the picker's active result after each pick/cancel so reopening
+            // the dialog starts fresh rather than with the prior selection
+            resetActiveResultOnClose
+          />
+        </AlwaysNewWindowNavigationContext>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default observer(LinkTargetBrowser);

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/MetaTable.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/MetaTable.tsx
@@ -1,0 +1,36 @@
+import Link from "@mui/material/Link";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import type React from "react";
+
+/**
+ * Shared building blocks for the core metadata table rendered by both
+ * {@link DocumentSections} and {@link GallerySections} in the link info dialog.
+ */
+
+/** One label/value row of the core metadata table. */
+export function MetaRow({ label, children }: { label: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <TableRow>
+      <TableCell component="th" scope="row" sx={{ color: "text.secondary", width: "10rem", verticalAlign: "top" }}>
+        {label}
+      </TableCell>
+      <TableCell>{children}</TableCell>
+    </TableRow>
+  );
+}
+
+/** A `/globalId/<id>` link that opens in a new tab. */
+export function GlobalIdLink({
+  globalId,
+  children,
+}: {
+  globalId: string;
+  children?: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <Link href={`/globalId/${globalId}`} target="_blank" rel="noopener noreferrer">
+      {children ?? globalId}
+    </Link>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/RelatedInventoryItems.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/RelatedInventoryItems.tsx
@@ -1,0 +1,60 @@
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import Typography from "@mui/material/Typography";
+import type React from "react";
+import useReferencingInventoryItems from "@/eln/gallery/useReferencingInventoryItems";
+
+/**
+ * The "Related inventory items" section of {@link ElnRecordInfoDialog}: the
+ * Inventory items whose Link field points at the displayed ELN record. The
+ * "Show linked docs" action only covers ELN references, so without this section
+ * an inventory link to the record would be invisible from its info dialog.
+ * Shared by the document/notebook and gallery-file bodies.
+ */
+export default function RelatedInventoryItems({
+  globalId,
+  recordTypeName,
+}: {
+  globalId: string;
+  /** Lower-case noun for the empty message, e.g. "document", "notebook", "file". */
+  recordTypeName: string;
+}): React.ReactElement {
+  const { items, loading, errorMessage } = useReferencingInventoryItems(globalId);
+
+  return (
+    <Box>
+      <Typography variant="subtitle2">Related inventory items</Typography>
+      {loading && <Typography variant="body2">Loading…</Typography>}
+      {errorMessage && (
+        <Typography variant="body2" color="error">
+          {errorMessage}
+        </Typography>
+      )}
+      {!loading && !errorMessage && items.length === 0 && (
+        <Typography variant="body2">No Inventory items link to this {recordTypeName}.</Typography>
+      )}
+      {items.length > 0 && (
+        <List dense disablePadding sx={{ pl: 3, my: 0.5, listStyleType: "disc" }}>
+          {items.map((item, index) => (
+            // one row per link FIELD: a source item linking through two
+            // fields repeats its globalId, so the key needs the index too
+            <ListItem key={`${item.globalId}-${index}`} disableGutters sx={{ display: "list-item", py: 0 }}>
+              <Link href={`/globalId/${item.globalId}`} target="_blank" rel="noopener noreferrer">
+                {item.globalId}
+              </Link>
+              : {item.name}
+              {item.relationType ? (
+                <Typography variant="caption" component="em">
+                  {" "}
+                  ({item.relationType})
+                </Typography>
+              ) : null}
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/VersionLockDialog.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/VersionLockDialog.tsx
@@ -1,0 +1,195 @@
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import React, { useCallback, useEffect, useState } from "react";
+import axios from "@/common/axios";
+import ApiService from "../../../../common/InvApiService";
+import VersionLockPicker, {
+  LATEST_SELECTION,
+  type VersionLockSelection,
+  type VersionRecord,
+} from "../../../../components/VersionLockPicker/VersionLockPicker";
+
+export interface VersionLockDialogProps {
+  open: boolean;
+  globalId: string;
+  /**
+   * Current versionPin on the link. null means "latest" (unpinned).
+   */
+  currentVersionPin: number | null;
+  /** Called with the chosen versionPin (the user-facing version) or null for latest. */
+  onConfirm: (versionPin: number | null) => void;
+  onCancel: () => void;
+}
+
+import { GLOBAL_ID_PATTERN, INVENTORY_PREFIX_TO_API_PATH } from "./linkTarget";
+
+interface ParsedTarget {
+  prefix: string;
+  id: number;
+  /**
+   * Inventory revisions path segment (samples/subSamples/...), or null for ELN targets
+   * (e.g. SD) whose revisions come from the ELN endpoint instead of the inventory API.
+   */
+  inventoryPathSegment: string | null;
+}
+
+function parseGlobalId(globalId: string): ParsedTarget | null {
+  const match = GLOBAL_ID_PATTERN.exec(globalId);
+  if (!match) return null;
+  const prefix = match[1];
+  return {
+    prefix,
+    id: Number(match[2]),
+    inventoryPathSegment: INVENTORY_PREFIX_TO_API_PATH[prefix] ?? null,
+  };
+}
+
+/** Targets whose revision history this dialog can resolve: inventory items and SD documents. */
+function isSupportedTarget(parsed: ParsedTarget): boolean {
+  return parsed.inventoryPathSegment !== null || parsed.prefix === "SD";
+}
+
+interface ApiRevisionEntry {
+  revisionId: number;
+  revisionType: string;
+  record: {
+    // The user-facing version of the item at this audit revision. Several revisions can share
+    // one version (non-version-bumping edits), so callers must group by it, not by revisionId.
+    version?: number | null;
+    lastModified?: string;
+  };
+}
+
+interface ApiRevisionList {
+  revisions: ApiRevisionEntry[];
+  revisionsCount: number;
+}
+
+// ELN revisions endpoint shape (/workspace/revisionHistory/ajax/{id}/versions). Each entry
+// carries the document `version` number (used to pin, e.g. SD123v2) and a separate audit
+// `revision` id. Mirrors tinyMCE/InternalLink.tsx.
+interface ElnRevisionEntry {
+  version: number;
+  revision: number;
+  modificationDate?: string;
+}
+
+interface ElnRevisionHistoryResponse {
+  data: ElnRevisionEntry[];
+}
+
+/**
+ * Modal hosting the shared VersionLockPicker. Used by inventory link fields to
+ * pin a link to a specific revision of the target item, or release it back to
+ * latest.
+ */
+export default function VersionLockDialog(props: VersionLockDialogProps): React.ReactElement | null {
+  const parsed = React.useMemo(() => parseGlobalId(props.globalId), [props.globalId]);
+  const initialSelection: VersionLockSelection =
+    props.currentVersionPin == null ? LATEST_SELECTION : props.currentVersionPin;
+  const [selection, setSelection] = useState<VersionLockSelection>(initialSelection);
+
+  // The component instance stays mounted while closed (open=false renders
+  // null but keeps hook state), so an abandoned selection from a previous
+  // open would otherwise leak into the next one. Re-sync on each open.
+  useEffect(() => {
+    if (props.open) {
+      setSelection(props.currentVersionPin == null ? LATEST_SELECTION : props.currentVersionPin);
+    }
+  }, [props.open, props.currentVersionPin]);
+
+  const fetchVersions = useCallback(async (): Promise<VersionRecord[]> => {
+    if (!parsed) return [];
+    try {
+      if (parsed.prefix === "SD") {
+        // ELN document revisions come from the workspace endpoint, not the inventory
+        // API. Pin to the document version number (entry.version); carry the audit id.
+        const { data } = await axios.get<ElnRevisionHistoryResponse>(
+          `/workspace/revisionHistory/ajax/${parsed.id}/versions`,
+        );
+        // Several audit revisions can share one document version: non-version-bumping
+        // edits, and the soft-delete MOD of a deleted document (a delete does not bump the
+        // version). Collapse to one row per version, keeping the newest revision of each,
+        // so the final version is not listed twice (mirrors the inventory path below).
+        const byVersion = new Map<number, VersionRecord>();
+        for (const entry of [...data.data].sort((a, b) => a.revision - b.revision)) {
+          byVersion.set(entry.version, {
+            version: entry.version,
+            revisionId: entry.revision,
+            modificationDate: entry.modificationDate ?? "",
+          });
+        }
+        return [...byVersion.values()].sort((a, b) => b.version - a.version);
+      }
+      if (parsed.inventoryPathSegment) {
+        const { data } = await ApiService.get<ApiRevisionList>(`${parsed.inventoryPathSegment}/${parsed.id}/revisions`);
+        // Audit rows carry the user-facing record.version; non-version-bumping edits create
+        // several revisions sharing one version. Collapse to one row per version, keeping the
+        // newest revision of each, and pin the user-facing version (mirrors VersionHistory).
+        const byVersion = new Map<number, VersionRecord>();
+        for (const entry of [...data.revisions].sort((a, b) => a.revisionId - b.revisionId)) {
+          const version = entry.record.version;
+          if (version == null) continue;
+          byVersion.set(version, {
+            version,
+            revisionId: entry.revisionId,
+            modificationDate: entry.record.lastModified ?? "",
+          });
+        }
+        return [...byVersion.values()].sort((a, b) => b.version - a.version);
+      }
+      return [];
+    } catch {
+      // A failed revisions fetch degrades to the latest-only view rather than
+      // surfacing an unhandled rejection through the picker.
+      return [];
+    }
+  }, [parsed?.prefix, parsed?.id, parsed?.inventoryPathSegment]);
+
+  if (!props.open) return null;
+  if (!parsed || !isSupportedTarget(parsed)) {
+    return (
+      <Dialog open onClose={props.onCancel} fullWidth maxWidth="sm">
+        <DialogTitle>Version history</DialogTitle>
+        <DialogContent>Cannot resolve version history for {props.globalId}.</DialogContent>
+        <DialogActions>
+          <Button onClick={props.onCancel}>Close</Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog
+      open={props.open}
+      onClose={props.onCancel}
+      aria-label={`Version history for ${props.globalId}`}
+      fullWidth
+      maxWidth="md"
+    >
+      <DialogTitle>Version history for {props.globalId}</DialogTitle>
+      <DialogContent>
+        <VersionLockPicker
+          recordId={parsed.id}
+          currentSelection={selection}
+          fetchVersions={fetchVersions}
+          onChange={setSelection}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onCancel}>Cancel</Button>
+        <Button
+          color="callToAction"
+          disableElevation
+          variant="contained"
+          onClick={() => props.onConfirm(selection === LATEST_SELECTION ? null : selection)}
+        >
+          Lock to selected version
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/DocumentSections.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/DocumentSections.test.tsx
@@ -1,0 +1,231 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@/__tests__/customQueries";
+import type { WorkspaceRecordInformation } from "@/modules/workspace/schema";
+import materialTheme from "../../../../../theme";
+
+const getLinkedByRecords = vi.fn();
+const getPublicLink = vi.fn();
+const useReferencingInventoryItems = vi.fn();
+
+vi.mock("@/modules/workspace/linkedRecords", () => ({
+  getLinkedByRecords: (...args: Array<unknown>) => getLinkedByRecords(...args) as unknown,
+}));
+vi.mock("@/modules/workspace/publicLink", () => ({
+  getPublicLink: (...args: Array<unknown>) => getPublicLink(...args) as unknown,
+}));
+vi.mock("@/eln/gallery/useReferencingInventoryItems", () => ({
+  default: (...args: Array<unknown>) => useReferencingInventoryItems(...args) as unknown,
+}));
+
+import DocumentSections from "../DocumentSections";
+
+const baseInfo: WorkspaceRecordInformation = {
+  id: 123,
+  oid: { idString: "SD123" },
+  name: "My experiment",
+  type: "Structured Document",
+  ownerFullName: "Ada Lovelace",
+  creationDateWithClientTimezoneOffset: "2026-05-01 10:00 +0000",
+  modificationDateWithClientTimezoneOffset: "2026-05-02 10:00 +0000",
+  version: 4,
+  status: "VIEW_MODE",
+  signatureStatus: "UNSIGNED",
+  tags: "alpha,beta",
+  path: "/Workspace/Project",
+  templateFormName: "Basic Document",
+  templateFormId: { idString: "FM7" },
+  templateName: "My template",
+  templateOid: "SD200",
+  linkedByCount: 2,
+  shared: false,
+  implicitlyShared: false,
+};
+
+beforeEach(() => {
+  getLinkedByRecords.mockReset();
+  getPublicLink.mockReset();
+  useReferencingInventoryItems.mockReset();
+  // Sensible defaults; individual tests override.
+  getLinkedByRecords.mockResolvedValue({ readable: [], privateByOwner: [] });
+  getPublicLink.mockResolvedValue(null);
+  useReferencingInventoryItems.mockReturnValue({
+    items: [],
+    loading: false,
+    errorMessage: null,
+  });
+});
+
+afterEach(cleanup);
+
+function renderDoc(props: Partial<React.ComponentProps<typeof DocumentSections>> = {}) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <DocumentSections info={baseInfo} isNotebook={false} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe("DocumentSections (structured document)", () => {
+  it("renders the core metadata table rows", () => {
+    renderDoc();
+    expect(screen.getByText("My experiment")).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("/Workspace/Project")).toBeInTheDocument();
+    // version
+    expect(screen.getByText("4")).toBeInTheDocument();
+    // status maps to a friendly label
+    expect(screen.getByText(/viewable & editable/i)).toBeInTheDocument();
+    // signature status maps to a friendly label
+    expect(screen.getByText(/^unsigned$/i)).toBeInTheDocument();
+    // tags are comma-spaced
+    expect(screen.getByText(/alpha, beta/i)).toBeInTheDocument();
+  });
+
+  it("renders the self link to /globalId/SD123", () => {
+    renderDoc();
+    const selfLink = screen.getByRole("link", { name: /SD123/ });
+    expect(selfLink).toHaveAttribute("href", "/globalId/SD123");
+  });
+
+  it("renders form id and template links", () => {
+    renderDoc();
+    const formLink = screen.getByRole("link", { name: /FM7/ });
+    expect(formLink).toHaveAttribute("href", "/globalId/FM7");
+    const templateLink = screen.getByRole("link", { name: /my template/i });
+    expect(templateLink).toHaveAttribute("href", "/globalId/SD200");
+  });
+
+  it("lazily loads the linked-by docs when 'Show linked docs' is clicked", async () => {
+    getLinkedByRecords.mockResolvedValue({
+      readable: [{ globalId: "SD11", name: "Doc one", ownerFullName: "Ada" }],
+      privateByOwner: [{ ownerFullName: "Grace Hopper", count: 2 }],
+    });
+    const user = userEvent.setup();
+    renderDoc();
+
+    expect(screen.getByText(/linked by 2 docs/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /show linked docs/i }));
+
+    expect(getLinkedByRecords).toHaveBeenCalledWith(123);
+    expect(await screen.findByRole("link", { name: /SD11/ })).toHaveAttribute("href", "/globalId/SD11");
+    expect(screen.getByText(/2 private docs belonging to grace hopper/i)).toBeInTheDocument();
+  });
+
+  it("renders related inventory items from the referencing-items hook", () => {
+    useReferencingInventoryItems.mockReturnValue({
+      items: [
+        {
+          globalId: "SA1",
+          name: "Buffer",
+          type: "SAMPLE",
+          relationType: "IsPartOf",
+          permalinkHref: "/globalId/SA1",
+          linkableRecord: {},
+        },
+      ],
+      loading: false,
+      errorMessage: null,
+    });
+    renderDoc();
+    expect(useReferencingInventoryItems).toHaveBeenCalledWith("SD123");
+    const invLink = screen.getByRole("link", { name: /SA1/ });
+    expect(invLink).toHaveAttribute("href", "/globalId/SA1");
+    expect(screen.getByText(/buffer/i)).toBeInTheDocument();
+  });
+
+  it("shows sharing status when the document is shared", () => {
+    renderDoc({
+      info: {
+        ...baseInfo,
+        shared: true,
+        sharedGroupsAndAccess: { "Lab Group": "READ" },
+      },
+    });
+    expect(screen.getByText(/lab group/i)).toBeInTheDocument();
+  });
+
+  it("shows the public link when the document is published", async () => {
+    getPublicLink.mockResolvedValue("abc-123");
+    renderDoc();
+    expect(getPublicLink).toHaveBeenCalledWith("SD123");
+    const publicLink = await screen.findByRole("link", { name: /public link/i });
+    expect(publicLink).toHaveAttribute("href", expect.stringContaining("/public/publishedView/document/abc-123"));
+  });
+
+  it("routes an unpublished entry in a published notebook to the notebook public view", async () => {
+    // The publiclink endpoint returns <parentLink>?initialRecordToDisplay=<docId>
+    // when the document itself is unpublished but its parent notebook is published;
+    // the ELN routes these to /notebook/, not /document/ (recordInfoPanel.js).
+    getPublicLink.mockResolvedValue("parent-link?initialRecordToDisplay=123");
+    renderDoc();
+    expect(await screen.findByText(/in a published notebook/i)).toBeInTheDocument();
+    const publicLink = screen.getByRole("link", { name: /public link/i });
+    expect(publicLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("/public/publishedView/notebook/parent-link?initialRecordToDisplay=123"),
+    );
+  });
+});
+
+describe("DocumentSections (version-pinned SD)", () => {
+  function renderPinned(props: Partial<React.ComponentProps<typeof DocumentSections>> = {}) {
+    // getRecordInformation?version=N returns a VERSIONED oid (getOidWithVersion()),
+    // so the fixture mirrors production; the component strips the suffix for the
+    // "latest" link and reconstructs the versioned id for the Unique Id row.
+    return renderDoc({
+      info: { ...baseInfo, oid: { idString: "SD599v3" }, version: 3 },
+      pinnedVersion: 3,
+      ...props,
+    });
+  }
+
+  it("shows the 'may not be the latest version' header with the doc id as plain text (no link) when pinned", () => {
+    renderPinned();
+    const note = screen.getByRole("note");
+    expect(note).toHaveTextContent(/describes version 3 of a document SD599, which may not be the latest version/i);
+    // The document id in the warning is plain text, not a link to the latest version.
+    expect(within(note).queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("shows the versioned global id in the Unique Id row when pinned", () => {
+    renderPinned();
+    const uniqueIdLink = screen.getByRole("link", { name: "SD599v3" });
+    expect(uniqueIdLink).toHaveAttribute("href", "/globalId/SD599v3");
+  });
+});
+
+describe("DocumentSections (notebook)", () => {
+  const notebookInfo: WorkspaceRecordInformation = {
+    ...baseInfo,
+    oid: { idString: "NB55" },
+    id: 55,
+    name: "Lab notebook",
+    type: "Notebook",
+    templateFormId: null,
+    templateName: null,
+    templateOid: null,
+  };
+
+  function renderNotebook() {
+    return render(
+      <ThemeProvider theme={materialTheme}>
+        <DocumentSections info={notebookInfo} isNotebook={true} />
+      </ThemeProvider>,
+    );
+  }
+
+  it("does not render the form/template rows for notebooks", () => {
+    renderNotebook();
+    expect(screen.queryByRole("link", { name: /FM7/ })).not.toBeInTheDocument();
+    expect(screen.queryByText(/form id/i)).not.toBeInTheDocument();
+  });
+
+  it("uses notebook wording in the sharing/publication section", async () => {
+    getPublicLink.mockResolvedValue(null);
+    renderNotebook();
+    expect(await screen.findByText(/this notebook is not published/i)).toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnFolderBrowser.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnFolderBrowser.test.tsx
@@ -1,0 +1,170 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { treeItemClasses } from "@mui/x-tree-view/TreeItem";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@/__tests__/customQueries";
+import materialTheme from "../../../../../theme";
+
+const { mockGetFolderTree } = vi.hoisted(() => ({
+  mockGetFolderTree: vi.fn(),
+}));
+
+vi.mock("@/hooks/api/useFolders", () => ({
+  default: () => ({
+    getFolderTree: mockGetFolderTree,
+    getFolder: vi.fn(),
+    createFolder: vi.fn(),
+  }),
+}));
+
+import ElnFolderBrowser from "../ElnFolderBrowser";
+
+type Node = { id: number; globalId: string; name: string; type: string };
+
+const ROOTS: ReadonlyArray<Node> = [
+  { id: 100, globalId: "FL100", name: "Projects", type: "FOLDER" },
+  { id: 200, globalId: "NB200", name: "Lab NB", type: "NOTEBOOK" },
+  { id: 300, globalId: "SD300", name: "Protocol doc", type: "DOCUMENT" },
+  // the folder-tree endpoint bundles Gallery/MEDIA files in with documents
+  { id: 400, globalId: "GL400", name: "lemmings.gif", type: "MEDIA" },
+];
+
+function wireFolderTree() {
+  mockGetFolderTree.mockImplementation(({ id }: { id?: number }) => {
+    let records: ReadonlyArray<Node> = [];
+    if (id === undefined) records = ROOTS;
+    else if (id === 100) records = [{ id: 301, globalId: "SD301", name: "Sub doc", type: "DOCUMENT" }];
+    else if (id === 200) records = [{ id: 201, globalId: "SD201", name: "NB entry", type: "DOCUMENT" }];
+    return Promise.resolve({
+      totalHits: records.length,
+      pageNumber: 0,
+      records,
+    });
+  });
+}
+
+function renderBrowser(onSelectionChange: (s: { globalId: string; name: string; type: string } | null) => void): void {
+  render(
+    <ThemeProvider theme={materialTheme}>
+      <ElnFolderBrowser onSelectionChange={onSelectionChange} />
+    </ThemeProvider>,
+  );
+}
+
+describe("ElnFolderBrowser", () => {
+  beforeEach(() => {
+    mockGetFolderTree.mockReset();
+    wireFolderTree();
+  });
+  afterEach(cleanup);
+
+  it("requests the workspace tree including documents, notebooks and folders", async () => {
+    renderBrowser(vi.fn());
+    await waitFor(() => expect(mockGetFolderTree).toHaveBeenCalled());
+    const firstCallArg = mockGetFolderTree.mock.calls[0][0] as {
+      typesToInclude: Set<string>;
+    };
+    expect([...firstCallArg.typesToInclude].sort()).toEqual(["document", "folder", "notebook"]);
+  });
+
+  it("renders documents, notebooks and folders at the root", async () => {
+    renderBrowser(vi.fn());
+    expect(await screen.findByRole("treeitem", { name: /protocol doc/i })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: /lab nb/i })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: /projects/i })).toBeInTheDocument();
+  });
+
+  it("reports a document selection when its label is clicked", async () => {
+    const onSelectionChange = vi.fn();
+    renderBrowser(onSelectionChange);
+    const user = userEvent.setup();
+    await user.click(await screen.findByText(/protocol doc/i));
+    expect(onSelectionChange).toHaveBeenCalledWith({
+      globalId: "SD300",
+      name: "Protocol doc",
+      type: "DOCUMENT",
+    });
+  });
+
+  it("reports a notebook selection when its label is clicked", async () => {
+    const onSelectionChange = vi.fn();
+    renderBrowser(onSelectionChange);
+    const user = userEvent.setup();
+    await user.click(await screen.findByText(/lab nb/i));
+    expect(onSelectionChange).toHaveBeenCalledWith({
+      globalId: "NB200",
+      name: "Lab NB",
+      type: "NOTEBOOK",
+    });
+  });
+
+  it("reveals a notebook's contents on click and lets an entry be selected", async () => {
+    const onSelectionChange = vi.fn();
+    renderBrowser(onSelectionChange);
+    const user = userEvent.setup();
+
+    // clicking the notebook selects it and expands it to reveal its entries
+    await user.click(await screen.findByText(/lab nb/i));
+    const entry = await screen.findByText(/nb entry/i);
+
+    await user.click(entry);
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      globalId: "SD201",
+      name: "NB entry",
+      type: "DOCUMENT",
+    });
+  });
+
+  it("reports a Gallery file selection when its label is clicked", async () => {
+    const onSelectionChange = vi.fn();
+    renderBrowser(onSelectionChange);
+    const user = userEvent.setup();
+    await user.click(await screen.findByText(/lemmings\.gif/i));
+    expect(onSelectionChange).toHaveBeenCalledWith({
+      globalId: "GL400",
+      name: "lemmings.gif",
+      type: "MEDIA",
+    });
+  });
+
+  it("reports no selection for a folder (navigate-only)", async () => {
+    const onSelectionChange = vi.fn();
+    renderBrowser(onSelectionChange);
+    const user = userEvent.setup();
+    await user.click(await screen.findByText("Projects"));
+    expect(onSelectionChange).toHaveBeenCalledWith(null);
+  });
+});
+
+describe("ElnFolderBrowser selection highlight", () => {
+  beforeEach(() => {
+    mockGetFolderTree.mockReset();
+    wireFolderTree();
+  });
+  afterEach(cleanup);
+
+  it("obviously highlights the selected item with the theme primary colour", async () => {
+    renderBrowser(vi.fn());
+    const user = userEvent.setup();
+    await user.click(await screen.findByText(/protocol doc/i));
+
+    const item = screen.getByRole("treeitem", { name: /protocol doc/i });
+
+    /* eslint-disable testing-library/no-node-access, testing-library/no-container -- inspecting the MUI content row that carries the selection styling, and the emotion style tags that define it */
+    // x-tree-view 9 marks selection with a data-selected attribute on the
+    // content row (the Mui-selected class no longer exists)
+    const content = item.querySelector(`.${treeItemClasses.content}`);
+    expect(content).toHaveAttribute("data-selected");
+
+    // the highlight styling must target that data attribute and use the solid
+    // theme primary colour so the selection is unmistakable
+    const css = Array.from(document.head.querySelectorAll("style"))
+      .map((tag) => tag.textContent ?? "")
+      .join("\n");
+    /* eslint-enable testing-library/no-node-access, testing-library/no-container */
+    const selectedRule =
+      css.match(new RegExp(`\\.${treeItemClasses.content}\\[data-selected\\][^{]*\\{[^}]*\\}`))?.[0] ?? "";
+    expect(selectedRule).toContain("background-color");
+    expect(selectedRule).toContain(materialTheme.palette.primary.main);
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnRecordInfoDialog.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnRecordInfoDialog.test.tsx
@@ -1,0 +1,276 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@/__tests__/customQueries";
+import materialTheme from "../../../../../theme";
+
+// The per-type bodies are exercised by their own tests; here we only assert that
+// the shell fetches record information, branches by global-id prefix, and renders
+// the correct per-type body. Stub both so the shell test stays focused.
+vi.mock("../DocumentSections", () => ({
+  default: ({ info, pinnedVersion }: { info: { oid: { idString: string } }; pinnedVersion?: number | null }) => (
+    <div data-testid="document-sections" data-globalid={info.oid.idString} data-pinned-version={pinnedVersion ?? ""} />
+  ),
+}));
+
+vi.mock("../GallerySections", () => ({
+  default: ({ info }: { info: { oid: { idString: string } } }) => (
+    <div data-testid="gallery-sections" data-globalid={info.oid.idString} />
+  ),
+}));
+
+import ElnRecordInfoDialog from "../ElnRecordInfoDialog";
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+function recordInfoResponse(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    data: {
+      id: 123,
+      oid: { idString: "SD123" },
+      name: "My experiment",
+      type: "Structured Document",
+      ownerFullName: "Ada Lovelace",
+      creationDateWithClientTimezoneOffset: "2026-05-01 10:00 +0000",
+      modificationDateWithClientTimezoneOffset: "2026-05-02 10:00 +0000",
+      ...overrides,
+    },
+    error: null,
+    success: true,
+  });
+}
+
+function renderDialog(props: Partial<React.ComponentProps<typeof ElnRecordInfoDialog>> = {}) {
+  // The dialog relies on an ancestor QueryClient (App.tsx provides one in the
+  // running app); supply a fresh client per render here to mirror that.
+  const queryClient = new QueryClient();
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={materialTheme}>
+          <ElnRecordInfoDialog open globalId="SD123" onClose={vi.fn()} {...props} />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    ),
+    queryClient,
+  };
+}
+
+describe("ElnRecordInfoDialog", () => {
+  it("fetches record information using the numeric id derived from the global id", async () => {
+    fetchMock.mockResponse(recordInfoResponse());
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/workspace/getRecordInformation?recordId=123");
+  });
+
+  it("fetches the pinned version when versionPin is set", async () => {
+    fetchMock.mockResponse(recordInfoResponse({ version: 4 }));
+
+    renderDialog({ globalId: "SD123", versionPin: 4 });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("recordId=123");
+    expect(url).toContain("version=4");
+  });
+
+  it("does not send a version param when the link is not pinned", async () => {
+    fetchMock.mockResponse(recordInfoResponse());
+
+    renderDialog({ globalId: "SD123" });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).not.toContain("version=");
+  });
+
+  it("renders the DocumentSections body for an SD target", async () => {
+    fetchMock.mockResponse(recordInfoResponse());
+
+    renderDialog({ globalId: "SD123" });
+
+    const body = await screen.findByTestId("document-sections");
+    expect(body).toBeInTheDocument();
+    expect(body).toHaveAttribute("data-globalid", "SD123");
+    expect(screen.queryByTestId("gallery-sections")).not.toBeInTheDocument();
+  });
+
+  it("forwards the pinned version into the document body", async () => {
+    fetchMock.mockResponse(recordInfoResponse({ version: 4 }));
+
+    renderDialog({ globalId: "SD123", versionPin: 4 });
+
+    const body = await screen.findByTestId("document-sections");
+    expect(body).toHaveAttribute("data-pinned-version", "4");
+  });
+
+  it("ignores a versionPin on a non-SD (NB) target", async () => {
+    // NB/GL are not versionable; a stray pin must not send version= nor show version view.
+    fetchMock.mockResponse(recordInfoResponse({ oid: { idString: "NB55" }, type: "Notebook" }));
+
+    renderDialog({ globalId: "NB55", versionPin: 9 });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).not.toContain("version=");
+    const body = await screen.findByTestId("document-sections");
+    expect(body).toHaveAttribute("data-pinned-version", "");
+  });
+
+  it("renders the DocumentSections body for a notebook (NB) target", async () => {
+    fetchMock.mockResponse(recordInfoResponse({ oid: { idString: "NB55" }, type: "Notebook" }));
+
+    renderDialog({ globalId: "NB55" });
+
+    const body = await screen.findByTestId("document-sections");
+    expect(body).toBeInTheDocument();
+    expect(body).toHaveAttribute("data-globalid", "NB55");
+  });
+
+  it("renders the GallerySections body for a gallery (GL) target", async () => {
+    fetchMock.mockResponse(recordInfoResponse({ oid: { idString: "GL9" }, type: "Image" }));
+
+    renderDialog({ globalId: "GL9" });
+
+    const body = await screen.findByTestId("gallery-sections");
+    expect(body).toBeInTheDocument();
+    expect(body).toHaveAttribute("data-globalid", "GL9");
+    expect(screen.queryByTestId("document-sections")).not.toBeInTheDocument();
+  });
+
+  it("shows an error message when the record cannot be loaded", async () => {
+    fetchMock.mockResponse(
+      JSON.stringify({
+        data: null,
+        error: { errorMessages: ["Record not found"] },
+        success: false,
+      }),
+      { status: 404, statusText: "Not Found" },
+    );
+
+    renderDialog();
+
+    expect(await screen.findByText(/not available.*permission|could not.*load|not found/i)).toBeInTheDocument();
+  });
+
+  it("shows a version-specific error with a latest link when the pinned version cannot be loaded", async () => {
+    fetchMock.mockResponse(
+      JSON.stringify({
+        data: null,
+        error: { errorMessages: ["Version not found"] },
+        success: false,
+      }),
+      { status: 404, statusText: "Not Found" },
+    );
+
+    renderDialog({ globalId: "SD599", versionPin: 4 });
+
+    expect(await screen.findByText(/version 4 of SD599 is no longer available/i)).toBeInTheDocument();
+    const latestLink = screen.getByRole("link", { name: /latest version/i });
+    expect(latestLink).toHaveAttribute("href", "/globalId/SD599");
+  });
+
+  it("links the Open button to /globalId/<globalId> in a new tab", async () => {
+    fetchMock.mockResponse(recordInfoResponse());
+
+    renderDialog({ globalId: "SD123" });
+
+    const openLink = await screen.findByRole("link", { name: /^open$/i });
+    expect(openLink).toHaveAttribute("href", "/globalId/SD123");
+    expect(openLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("opens a gallery target at its location in the Gallery, not a download", async () => {
+    fetchMock.mockResponse(recordInfoResponse({ oid: { idString: "GL9" }, type: "Image" }));
+
+    renderDialog({ globalId: "GL9" });
+
+    const openLink = await screen.findByRole("link", { name: /^open$/i });
+    expect(openLink).toHaveAttribute("href", "/gallery/item/9");
+  });
+
+  it("hides the Open button when the ELN target has been deleted", async () => {
+    // a deleted ELN record only routes to an error page, so the dialog drops
+    // Open; deleted Inventory targets (still viewable in the trash) keep theirs,
+    // but they render through InventoryInfoDialog, which has no Open button
+    fetchMock.mockResponse(recordInfoResponse());
+
+    renderDialog({ globalId: "SD123", targetDeleted: true });
+
+    // the dialog still renders (Close present), but there is no Open affordance
+    await screen.findByRole("button", { name: /^close$/i });
+    expect(screen.queryByRole("link", { name: /^open$/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the Open button when the ELN target is not readable (no access)", async () => {
+    // an unreadable ELN target (shared then unshared) routes only to an error
+    // page, so Open is dropped for the same reason as a deleted target
+    fetchMock.mockResponse(recordInfoResponse());
+
+    renderDialog({ globalId: "SD123", noAccess: true });
+
+    await screen.findByRole("button", { name: /^close$/i });
+    expect(screen.queryByRole("link", { name: /^open$/i })).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    fetchMock.mockResponse(recordInfoResponse());
+    const { container } = renderDialog({ open: false });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("retries the fetch when reopened after a failure", async () => {
+    // First open fails, second open succeeds; the dialog instance stays mounted.
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        data: null,
+        error: { errorMessages: ["Record not found"] },
+        success: false,
+      }),
+      { status: 404, statusText: "Not Found" },
+    );
+    fetchMock.mockResponse(recordInfoResponse());
+
+    const { rerender, queryClient } = renderDialog({ open: true });
+    expect(await screen.findByText(/not available.*permission|not found/i)).toBeInTheDocument();
+
+    // Close, then reopen the same instance (reusing the same QueryClient, as the
+    // app-level provider would, so the errored query is refetched on remount).
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={materialTheme}>
+          <ElnRecordInfoDialog open={false} globalId="SD123" onClose={vi.fn()} />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    );
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={materialTheme}>
+          <ElnRecordInfoDialog open globalId="SD123" onClose={vi.fn()} />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    );
+
+    // On reopen the body remounts and React Query refetches the errored query,
+    // which now succeeds.
+    expect(await screen.findByTestId("document-sections")).toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnRecordPicker.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnRecordPicker.test.tsx
@@ -1,0 +1,127 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import materialTheme from "../../../../../theme";
+
+// The folder browser has its own tests; stub it so we can drive selection changes
+// without the useFolders/API chain and assert the picker confirms via Choose.
+vi.mock("../ElnFolderBrowser", () => ({
+  default: ({
+    onSelectionChange,
+  }: {
+    onSelectionChange: (s: { globalId: string; name: string; type: string } | null) => void;
+  }) => (
+    <div data-testid="eln-folder-browser">
+      <button
+        type="button"
+        onClick={() =>
+          onSelectionChange({
+            globalId: "SD9",
+            name: "Browsed doc",
+            type: "DOCUMENT",
+          })
+        }
+      >
+        select doc
+      </button>
+      <button type="button" onClick={() => onSelectionChange(null)}>
+        select folder
+      </button>
+    </div>
+  ),
+}));
+
+import ElnRecordPicker from "../ElnRecordPicker";
+
+function renderPicker(props: Partial<React.ComponentProps<typeof ElnRecordPicker>> = {}) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <ElnRecordPicker open onPick={vi.fn()} onCancel={vi.fn()} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe("ElnRecordPicker", () => {
+  afterEach(cleanup);
+
+  it("drops straight into the folder browser with no search/browse mode choice", () => {
+    renderPicker();
+
+    // entered via "Browse ELN", so the file picker shows directly...
+    expect(screen.getByTestId("eln-folder-browser")).toBeInTheDocument();
+    // ...with no Search/Browse tabs or search box to choose between
+    expect(screen.queryByRole("tab", { name: /search/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: /browse/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /search the eln/i })).not.toBeInTheDocument();
+  });
+
+  it("disables Choose until a target is selected", () => {
+    renderPicker();
+    expect(screen.getByRole("button", { name: /choose/i })).toBeDisabled();
+  });
+
+  it("confirms the selected target via Choose rather than on click, so expandable items can be browsed into", async () => {
+    const onPick = vi.fn();
+    const user = userEvent.setup();
+    renderPicker({ onPick });
+
+    await user.click(screen.getByRole("button", { name: /select doc/i }));
+    // selection alone must not close the dialog or report a pick
+    expect(onPick).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /choose/i }));
+    expect(onPick).toHaveBeenCalledWith({
+      globalId: "SD9",
+      name: "Browsed doc",
+      type: "DOCUMENT",
+    });
+  });
+
+  it("disables Choose again when the selection moves to a non-pickable item", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+
+    await user.click(screen.getByRole("button", { name: /select doc/i }));
+    expect(screen.getByRole("button", { name: /choose/i })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: /select folder/i }));
+    expect(screen.getByRole("button", { name: /choose/i })).toBeDisabled();
+  });
+
+  it("forgets the previous selection when reopened", async () => {
+    const onPick = vi.fn();
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ThemeProvider theme={materialTheme}>
+        <ElnRecordPicker open onPick={onPick} onCancel={onCancel} />
+      </ThemeProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /select doc/i }));
+    rerender(
+      <ThemeProvider theme={materialTheme}>
+        <ElnRecordPicker open={false} onPick={onPick} onCancel={onCancel} />
+      </ThemeProvider>,
+    );
+    rerender(
+      <ThemeProvider theme={materialTheme}>
+        <ElnRecordPicker open onPick={onPick} onCancel={onCancel} />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: /choose/i })).toBeDisabled();
+  });
+
+  it("cancels via the Cancel button", async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    renderPicker({ onCancel });
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/GallerySections.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/GallerySections.test.tsx
@@ -1,0 +1,175 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import type { WorkspaceRecordInformation } from "@/modules/workspace/schema";
+import materialTheme from "../../../../../theme";
+
+const getLinkedDocuments = vi.fn();
+const uploadNewGalleryVersion = vi.fn();
+const useReferencingInventoryItems = vi.fn();
+
+vi.mock("@/modules/workspace/linkedRecords", () => ({
+  getLinkedDocuments: (...args: Array<unknown>) => getLinkedDocuments(...args) as unknown,
+}));
+vi.mock("@/modules/workspace/galleryUpload", () => ({
+  uploadNewGalleryVersion: (...args: Array<unknown>) => uploadNewGalleryVersion(...args) as unknown,
+}));
+vi.mock("@/eln/gallery/useReferencingInventoryItems", () => ({
+  default: (...args: Array<unknown>) => useReferencingInventoryItems(...args) as unknown,
+}));
+
+import GallerySections from "../GallerySections";
+
+const imageInfo: WorkspaceRecordInformation = {
+  id: 21,
+  oid: { idString: "GL21" },
+  name: "Microscope.png",
+  type: "Image",
+  ownerFullName: "Ada Lovelace",
+  ownerUsername: "ada",
+  creationDateWithClientTimezoneOffset: "2026-05-01 10:00 +0000",
+  modificationDateWithClientTimezoneOffset: "2026-05-02 10:00 +0000",
+  version: 2,
+  size: 1024,
+  extension: "png",
+  thumbnailId: 301,
+  status: "VIEW_MODE",
+  description: "A microscope image",
+};
+
+beforeEach(() => {
+  getLinkedDocuments.mockReset();
+  uploadNewGalleryVersion.mockReset();
+  useReferencingInventoryItems.mockReset();
+  getLinkedDocuments.mockResolvedValue({ readable: [], privateByOwner: [] });
+  uploadNewGalleryVersion.mockResolvedValue(imageInfo);
+  useReferencingInventoryItems.mockReturnValue({
+    items: [],
+    loading: false,
+    errorMessage: null,
+  });
+});
+
+afterEach(cleanup);
+
+function renderGallery(props: Partial<React.ComponentProps<typeof GallerySections>> = {}) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <GallerySections info={imageInfo} onRecordChanged={vi.fn()} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe("GallerySections", () => {
+  it("renders the gallery metadata rows", () => {
+    renderGallery();
+    expect(screen.getByText("Microscope.png")).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    // file size formatted
+    expect(screen.getByText(/1\.02 kB|1024 B|1 kB/i)).toBeInTheDocument();
+    // extension shown as its own row value (exact match, not the filename)
+    expect(screen.getByText(/^png$/i)).toBeInTheDocument();
+  });
+
+  it("renders an image thumbnail preview for Image targets", () => {
+    renderGallery();
+    const img = screen.getByRole("img", { name: /microscope\.png|preview/i });
+    expect(img).toHaveAttribute("src", expect.stringContaining("/gallery/getThumbnail/21/"));
+  });
+
+  it("links Download to the Streamfile endpoint for the media id", () => {
+    renderGallery();
+    const download = screen.getByRole("link", { name: /download/i });
+    expect(download).toHaveAttribute("href", "/Streamfile/21");
+  });
+
+  it("lazily shows linked documents when 'Show linked docs' is clicked", async () => {
+    getLinkedDocuments.mockResolvedValue({
+      readable: [{ globalId: "SD7", name: "Linked doc", ownerFullName: "Ada" }],
+      privateByOwner: [],
+    });
+    const user = userEvent.setup();
+    renderGallery();
+
+    await user.click(screen.getByRole("button", { name: /show linked docs/i }));
+
+    expect(getLinkedDocuments).toHaveBeenCalledWith(21);
+    expect(await screen.findByRole("link", { name: /SD7/ })).toHaveAttribute("href", "/globalId/SD7");
+  });
+
+  it("hides the related inventory items until 'Show linked docs' is clicked", () => {
+    renderGallery();
+    expect(screen.queryByText("Related inventory items")).not.toBeInTheDocument();
+  });
+
+  it("shows the Inventory items that link to this file on 'Show linked docs'", async () => {
+    // the Gallery's own info panel shows these back-references; this dialog must
+    // too, since the ELN linked-docs lookup does not cover inventory links
+    useReferencingInventoryItems.mockReturnValue({
+      items: [
+        {
+          globalId: "SA42",
+          name: "My sample",
+          type: "SAMPLE",
+          relationType: "References",
+          permalinkHref: "/globalId/SA42",
+          linkableRecord: {},
+        },
+      ],
+      loading: false,
+      errorMessage: null,
+    });
+    const user = userEvent.setup();
+    renderGallery();
+
+    await user.click(screen.getByRole("button", { name: /show linked docs/i }));
+
+    expect(useReferencingInventoryItems).toHaveBeenCalledWith("GL21");
+    expect(await screen.findByText("Related inventory items")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /SA42/ })).toHaveAttribute("href", "/globalId/SA42");
+    expect(screen.getByText(/\(References\)/)).toBeInTheDocument();
+  });
+
+  it("shows an empty message when no Inventory items link to this file", async () => {
+    const user = userEvent.setup();
+    renderGallery();
+
+    await user.click(screen.getByRole("button", { name: /show linked docs/i }));
+
+    expect(await screen.findByText(/no inventory items link to this file/i)).toBeInTheDocument();
+  });
+
+  it("shows the upload-new-version control when the file is editable (VIEW_MODE)", () => {
+    renderGallery();
+    expect(screen.getByRole("button", { name: /upload new version/i })).toBeInTheDocument();
+  });
+
+  it("hides the upload-new-version control for a revision (historical) view", () => {
+    renderGallery({ info: { ...imageInfo, revision: 5 } });
+    expect(screen.queryByRole("button", { name: /upload new version/i })).not.toBeInTheDocument();
+  });
+
+  it("uploads the picked file and notifies the parent on success", async () => {
+    const onRecordChanged = vi.fn();
+    uploadNewGalleryVersion.mockResolvedValue({ ...imageInfo, version: 3 });
+    const user = userEvent.setup();
+    renderGallery({ onRecordChanged });
+
+    const file = new File(["new bytes"], "Microscope.png", {
+      type: "image/png",
+    });
+    // The visible button proxies to a hidden file input.
+    const input = screen.getByTestId("gallery-upload-input");
+    await user.upload(input, file);
+
+    expect(uploadNewGalleryVersion).toHaveBeenCalledWith({
+      mediaId: 21,
+      file,
+    });
+    await vi.waitFor(() => {
+      expect(onRecordChanged).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/InventoryInfoDialog.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/InventoryInfoDialog.test.tsx
@@ -1,0 +1,277 @@
+import { ThemeProvider } from "@mui/material/styles";
+import type { AxiosResponse } from "axios";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import InvApiService from "../../../../../common/InvApiService";
+import materialTheme from "../../../../../theme";
+
+vi.mock("../../../../../common/InvApiService", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../../stores/models/Factory/AlwaysNewFactory", () => {
+  return {
+    default: class TestFactory {
+      newRecord(data: Record<string, unknown>) {
+        return data as unknown;
+      }
+    },
+  };
+});
+
+vi.mock("../../../MoreInfoSidebar/SidebarBody", () => ({
+  default: ({ record }: { record: { globalId: string; created: string } }) => (
+    <div data-testid="sidebar-body" data-globalid={record.globalId} data-created={record.created} />
+  ),
+}));
+
+import InventoryInfoDialog from "../InventoryInfoDialog";
+
+describe("InventoryInfoDialog", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("does not render when closed", () => {
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <InventoryInfoDialog open={false} globalId="SA42" onClose={vi.fn()} />
+      </ThemeProvider>,
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("fetches the target by global id and renders the sidebar body for it", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockImplementation((url) => {
+      if (url === "samples/42") {
+        return Promise.resolve({
+          data: {
+            id: 42,
+            globalId: "SA42",
+            type: "SAMPLE",
+            name: "A sample",
+            created: "2026-05-01T10:00:00Z",
+            lastModified: "2026-05-02T10:00:00Z",
+            extraFields: [],
+            subSamples: [],
+            quantity: { numericValue: 1, unitId: 3 },
+            permittedActions: ["READ"],
+          },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        } as AxiosResponse);
+      }
+      return Promise.reject(new Error(`unexpected url ${String(url)}`));
+    });
+
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <InventoryInfoDialog open globalId="SA42" onClose={vi.fn()} />
+      </ThemeProvider>,
+    );
+
+    const body = await screen.findByTestId("sidebar-body");
+    expect(body).toHaveAttribute("data-globalid", "SA42");
+    expect(body).toHaveAttribute("data-created", "2026-05-01T10:00:00Z");
+    expect(vi.mocked(apiGet)).toHaveBeenCalledWith("samples/42");
+  });
+
+  it("fetches the pinned version snapshot when versionPin is set", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockImplementation((url) => {
+      if (url === "samples/42/versions/3") {
+        return Promise.resolve({
+          data: {
+            id: 42,
+            globalId: "SA42",
+            type: "SAMPLE",
+            name: "A sample (v3)",
+            version: 3,
+            created: "2026-05-01T10:00:00Z",
+            lastModified: "2026-05-03T10:00:00Z",
+            extraFields: [],
+            subSamples: [],
+            quantity: { numericValue: 1, unitId: 3 },
+            permittedActions: ["READ"],
+          },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        } as AxiosResponse);
+      }
+      return Promise.reject(new Error(`unexpected url ${String(url)}`));
+    });
+
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <InventoryInfoDialog open globalId="SA42" versionPin={3} onClose={vi.fn()} />
+      </ThemeProvider>,
+    );
+
+    const body = await screen.findByTestId("sidebar-body");
+    expect(body).toHaveAttribute("data-globalid", "SA42");
+    expect(vi.mocked(apiGet)).toHaveBeenCalledWith("samples/42/versions/3");
+  });
+
+  it("fetches an instrument target by global id (IN prefix)", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockImplementation((url) => {
+      if (url === "instruments/43") {
+        return Promise.resolve({
+          data: {
+            id: 43,
+            globalId: "IN43",
+            type: "INSTRUMENT",
+            name: "A microscope",
+            created: "2026-05-01T10:00:00Z",
+            lastModified: "2026-05-02T10:00:00Z",
+            extraFields: [],
+            permittedActions: ["READ"],
+          },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        } as AxiosResponse);
+      }
+      return Promise.reject(new Error(`unexpected url ${String(url)}`));
+    });
+
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <InventoryInfoDialog open globalId="IN43" onClose={vi.fn()} />
+      </ThemeProvider>,
+    );
+
+    const body = await screen.findByTestId("sidebar-body");
+    expect(body).toHaveAttribute("data-globalid", "IN43");
+    expect(vi.mocked(apiGet)).toHaveBeenCalledWith("instruments/43");
+  });
+
+  it("shows a historic-version note (matching the ELN dialog) when versionPin is set", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockResolvedValue({
+      data: {
+        id: 42,
+        globalId: "SA42",
+        type: "SAMPLE",
+        name: "A sample (v1)",
+        version: 1,
+        created: "2026-05-01T10:00:00Z",
+        lastModified: "2026-05-01T10:00:00Z",
+        extraFields: [],
+        subSamples: [],
+        quantity: { numericValue: 1, unitId: 3 },
+        permittedActions: ["READ"],
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {},
+    } as AxiosResponse);
+
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <InventoryInfoDialog open globalId="SA42" versionPin={1} onClose={vi.fn()} />
+      </ThemeProvider>,
+    );
+
+    await screen.findByTestId("sidebar-body");
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "The information below describes version 1 of a sample SA42, which may not be the latest version.",
+    );
+  });
+
+  it("shows no historic-version note when the link is not pinned", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockResolvedValue({
+      data: {
+        id: 42,
+        globalId: "SA42",
+        type: "SAMPLE",
+        name: "A sample",
+        created: "2026-05-01T10:00:00Z",
+        lastModified: "2026-05-02T10:00:00Z",
+        extraFields: [],
+        subSamples: [],
+        quantity: { numericValue: 1, unitId: 3 },
+        permittedActions: ["READ"],
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {},
+    } as AxiosResponse);
+
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <InventoryInfoDialog open globalId="SA42" onClose={vi.fn()} />
+      </ThemeProvider>,
+    );
+
+    await screen.findByTestId("sidebar-body");
+    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+  });
+
+  it("ignores a stale in-flight response when the target changes before it resolves", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock inspection
+    const apiGet = InvApiService.get;
+    let resolveStale: (r: AxiosResponse) => void = () => {};
+    const stalePending = new Promise<AxiosResponse>((res) => {
+      resolveStale = res;
+    });
+    const okResponse = (globalId: string): AxiosResponse =>
+      ({
+        data: {
+          globalId,
+          type: "SAMPLE",
+          name: globalId,
+          created: "2026-05-01T10:00:00Z",
+        },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {},
+      }) as AxiosResponse;
+    vi.mocked(apiGet).mockImplementation((url) => {
+      if (url === "samples/42") return stalePending; // never resolves until told
+      if (url === "subSamples/7") return Promise.resolve(okResponse("SS7"));
+      return Promise.reject(new Error(`unexpected url ${String(url)}`));
+    });
+
+    const { rerender } = render(
+      <ThemeProvider theme={materialTheme}>
+        <InventoryInfoDialog open globalId="SA42" onClose={vi.fn()} />
+      </ThemeProvider>,
+    );
+    // switch to a new target before the SA42 request resolves
+    rerender(
+      <ThemeProvider theme={materialTheme}>
+        <InventoryInfoDialog open globalId="SS7" onClose={vi.fn()} />
+      </ThemeProvider>,
+    );
+
+    const body = await screen.findByTestId("sidebar-body");
+    expect(body).toHaveAttribute("data-globalid", "SS7");
+
+    // the stale SA42 response now arrives; the cancellation guard must drop it
+    // so it cannot overwrite the current SS7 result
+    resolveStale(okResponse("SA42"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(screen.getByTestId("sidebar-body")).toHaveAttribute("data-globalid", "SS7");
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkField.test.tsx
@@ -1,0 +1,359 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import materialTheme from "../../../../../theme";
+
+vi.mock("../InventoryInfoDialog", () => ({
+  default: ({ open, globalId, versionPin }: { open: boolean; globalId: string; versionPin?: number | null }) =>
+    open ? (
+      <div
+        data-testid="inventory-info-dialog"
+        data-globalid={globalId}
+        data-version-pin={versionPin == null ? "" : String(versionPin)}
+      />
+    ) : null,
+}));
+
+vi.mock("../ElnRecordInfoDialog", () => ({
+  default: ({ open, globalId, versionPin }: { open: boolean; globalId: string; versionPin?: number | null }) =>
+    open ? (
+      <div
+        data-testid="eln-info-dialog"
+        data-globalid={globalId}
+        data-version-pin={versionPin == null ? "" : String(versionPin)}
+      />
+    ) : null,
+}));
+
+const mockUseLinkTargetSummary = vi.hoisted(() => vi.fn());
+vi.mock("../useLinkTargetSummary", () => ({
+  default: (globalId: string) => mockUseLinkTargetSummary(globalId) as unknown,
+}));
+
+import LinkField from "../LinkField";
+
+const baseLink = {
+  relationType: "IsCalibratedBy",
+  targetGlobalId: "SA42",
+  versionPin: null as number | null,
+};
+
+function renderField(props: Partial<React.ComponentProps<typeof LinkField>> = {}) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <LinkField name="Calibration cert" link={baseLink} onEdit={vi.fn()} editable={true} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe("LinkField", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    // default: target state unknown (loading/unresolvable) -> no pill, Open on
+    mockUseLinkTargetSummary.mockReset();
+    mockUseLinkTargetSummary.mockReturnValue(null);
+  });
+
+  it("renders relation type, target global id, and name", () => {
+    renderField();
+    expect(screen.getByText(/calibration cert/i)).toBeInTheDocument();
+    expect(screen.getByText(/iscalibratedby/i)).toBeInTheDocument();
+    expect(screen.getByText(/sa42/i)).toBeInTheDocument();
+  });
+
+  it("shows a bold inline field name and no 'Link' heading", () => {
+    renderField();
+    // the literal "Link" heading was removed; only the field name is shown
+    expect(screen.queryByText(/^link$/i)).not.toBeInTheDocument();
+    const name = screen.getByText(/^calibration cert$/i);
+    // subtitle1 is the larger variant; the name renders bold within the link row
+    expect(name).toHaveClass("MuiTypography-subtitle1");
+    /* eslint-disable testing-library/no-node-access -- asserting the name sits inline in the link row */
+    expect(name.closest('[data-test-id="LinkField-row"]')).toBeInTheDocument();
+    /* eslint-enable testing-library/no-node-access */
+  });
+
+  it("renders the inline Edit action when onEdit is provided (template Link fields, which have no settings cog)", async () => {
+    const onEdit = vi.fn();
+    const user = userEvent.setup();
+    renderField({ editable: true, onEdit });
+
+    const editButton = screen.getByRole("button", { name: /edit link/i });
+    /* eslint-disable testing-library/no-node-access -- asserting Edit sits inline in the link row */
+    expect(editButton.closest('[data-test-id="LinkField-row"]')).toBeInTheDocument();
+    /* eslint-enable testing-library/no-node-access */
+
+    await user.click(editButton);
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the inline Edit button when onEdit is not provided (custom field Link cards are edited via the settings cog)", () => {
+    renderField({ editable: true, onEdit: undefined });
+    expect(screen.queryByRole("button", { name: /edit link/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the Open action as a static link inline with the link chips", () => {
+    renderField();
+
+    // a single consistent, target-qualified Open action ("Open SA42"), never a
+    // separate "Open in Inventory" variant. It is a real anchor (role link) for
+    // accessibility, not a scripted button.
+    const openLink = screen.getByRole("link", { name: /^open sa42$/i });
+    expect(openLink).toHaveAttribute("href", "/globalId/SA42");
+    expect(openLink).toHaveAttribute("target", "_blank");
+    expect(screen.queryByRole("link", { name: /open in inventory/i })).not.toBeInTheDocument();
+
+    /* eslint-disable testing-library/no-node-access -- asserting the Open link sits in the same row as the link chips */
+    expect(openLink.closest('[data-test-id="LinkField-row"]')).toBeInTheDocument();
+    /* eslint-enable testing-library/no-node-access */
+  });
+
+  it("renders pinned version label when versionPin is set", () => {
+    renderField({ link: { ...baseLink, versionPin: 4 } });
+    expect(screen.getByText(/v4|pinned to v4/i)).toBeInTheDocument();
+  });
+
+  it("shows the Target deleted pill and blocks Open for a deleted ELN target", () => {
+    // a deleted ELN record's open route only produces an error page, so the
+    // card must not offer Open
+    mockUseLinkTargetSummary.mockReturnValue({
+      globalId: "SD5",
+      name: "gone doc",
+      type: "DOCUMENT",
+      deleted: true,
+      readable: true,
+    });
+    renderField({ link: { ...baseLink, targetGlobalId: "SD5" } });
+    expect(screen.getByText(/target deleted/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /^open /i })).not.toBeInTheDocument();
+  });
+
+  it("shows the Target deleted pill but keeps Open for a deleted inventory target", () => {
+    // deleted inventory items live on in the trash and their viewer works,
+    // so Open stays available alongside the pill
+    mockUseLinkTargetSummary.mockReturnValue({
+      globalId: "SA42",
+      name: "binned sample",
+      type: "SAMPLE",
+      deleted: true,
+      readable: true,
+    });
+    renderField();
+    expect(screen.getByText(/target deleted/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^open /i })).toBeInTheDocument();
+  });
+
+  it("shows the No access pill and removes Open for an unreadable ELN target", () => {
+    // the server redacts targets the viewer cannot read (unshared, never
+    // shared, nonexistent, or hard-deleted by another owner all look alike);
+    // opening such an ELN target could only produce an error page
+    mockUseLinkTargetSummary.mockReturnValue({
+      globalId: "SD5",
+      name: null,
+      type: null,
+      deleted: false,
+      readable: false,
+    });
+    renderField({ link: { ...baseLink, targetGlobalId: "SD5" } });
+    expect(screen.getByText(/no access/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /^open /i })).not.toBeInTheDocument();
+    // an unreadable target has nothing to show, so info and the version-pin
+    // clock are greyed out; Edit stays as the repair path (retarget or remove)
+    expect(screen.getByRole("button", { name: /show info for sd5/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /pin version for sd5/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /edit link/i })).toBeInTheDocument();
+  });
+
+  it("explains the No access pill with a permission tooltip", async () => {
+    const user = userEvent.setup();
+    mockUseLinkTargetSummary.mockReturnValue({
+      globalId: "SD5",
+      name: null,
+      type: null,
+      deleted: false,
+      readable: false,
+    });
+    renderField({ link: { ...baseLink, targetGlobalId: "SD5" } });
+
+    await user.hover(screen.getByText(/no access/i));
+
+    // no "no longer": viewers who never had access see this pill too
+    expect(await screen.findByText(/you do not have permission to view this item/i)).toBeInTheDocument();
+  });
+
+  it("renders a normal card with Open for an unreadable inventory target", () => {
+    // every logged-in user keeps the limited-read view of inventory items,
+    // so Open still lands somewhere useful and no pill is warranted
+    mockUseLinkTargetSummary.mockReturnValue({
+      globalId: "SA42",
+      name: null,
+      type: null,
+      deleted: false,
+      readable: false,
+    });
+    renderField();
+    expect(screen.queryByText(/no access/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^open /i })).toBeInTheDocument();
+  });
+
+  it("renders no pill and keeps Open while the target state is unknown", () => {
+    // the summary fetch may be in flight or have failed; the card behaves as
+    // it did before the summary existed rather than flashing a wrong state
+    mockUseLinkTargetSummary.mockReturnValue(null);
+    renderField();
+    expect(screen.queryByText(/target deleted/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^open /i })).toBeInTheDocument();
+  });
+
+  it("greys out the clock in view mode: pin changes happen in the link editor", () => {
+    // the version pin is edited like every other link property: click Edit,
+    // change it in the editor, and commit with Update. The view-mode clock is
+    // a disabled affordance only.
+    renderField({ editable: true });
+
+    expect(screen.getByRole("button", { name: /pin version for sa42/i })).toBeDisabled();
+  });
+
+  it("hides the clock entirely when the record is not editable", () => {
+    renderField({ editable: false });
+
+    expect(screen.queryByRole("button", { name: /pin version for sa42/i })).not.toBeInTheDocument();
+  });
+
+  it("links Open to the versioned viewer for a pinned inventory target", () => {
+    renderField({
+      link: { ...baseLink, targetGlobalId: "SA42", versionPin: 3 },
+    });
+
+    // pinned inventory links to the read-only versioned viewer (RSDEV-1141 route),
+    // not the live record.
+    const openLink = screen.getByRole("link", { name: /^open /i });
+    expect(openLink).toHaveAttribute("href", "/inventory/sample/42?version=3");
+    expect(openLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("keeps Open enabled when no versionPin is set", () => {
+    renderField({ link: { ...baseLink, versionPin: null } });
+    expect(screen.getByRole("link", { name: /^open /i })).toHaveAttribute("href", "/globalId/SA42");
+  });
+
+  it("shows a clock icon for version-pinning only when editable", () => {
+    const { rerender } = renderField({ editable: true });
+    expect(screen.getByRole("button", { name: /pin.*version|version.*history/i })).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider theme={materialTheme}>
+        <LinkField name="Calibration cert" link={baseLink} onEdit={vi.fn()} editable={false} />
+      </ThemeProvider>,
+    );
+    expect(screen.queryByRole("button", { name: /pin.*version|version.*history/i })).not.toBeInTheDocument();
+  });
+
+  it("renders an info button next to the chip that opens InventoryInfoDialog for the target", async () => {
+    const user = userEvent.setup();
+    renderField();
+
+    const infoButton = screen.getByRole("button", {
+      name: /show info for sa42/i,
+    });
+    await user.click(infoButton);
+
+    const dialog = screen.getByTestId("inventory-info-dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("data-globalid", "SA42");
+  });
+
+  it("passes the link's versionPin to the inventory record-info dialog", async () => {
+    const user = userEvent.setup();
+    renderField({ link: { ...baseLink, targetGlobalId: "SA42", versionPin: 3 } });
+    await user.click(screen.getByRole("button", { name: /show info for sa42/i }));
+    expect(screen.getByTestId("inventory-info-dialog")).toHaveAttribute("data-version-pin", "3");
+  });
+
+  it("hides the version-pin clock for notebook (NB) targets even when editable", () => {
+    renderField({
+      editable: true,
+      link: { ...baseLink, targetGlobalId: "NB5" },
+    });
+    expect(screen.queryByRole("button", { name: /pin version for/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the version-pin clock for gallery (GL) targets even when editable", () => {
+    renderField({
+      editable: true,
+      link: { ...baseLink, targetGlobalId: "GL9" },
+    });
+    expect(screen.queryByRole("button", { name: /pin version for/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the version-pin clock for document (SD) targets when editable", () => {
+    renderField({
+      editable: true,
+      link: { ...baseLink, targetGlobalId: "SD3" },
+    });
+    expect(screen.getByRole("button", { name: /pin version for sd3/i })).toBeInTheDocument();
+  });
+
+  it("labels the open action 'Open <globalId>' for ELN targets too", () => {
+    renderField({ link: { ...baseLink, targetGlobalId: "SD3" } });
+    expect(screen.getByRole("link", { name: /^open sd3$/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /open in inventory/i })).not.toBeInTheDocument();
+  });
+
+  it("links a version-pinned document (SD) target to its versioned globalId route", () => {
+    renderField({ link: { ...baseLink, targetGlobalId: "SD3", versionPin: 2 } });
+    expect(screen.getByRole("link", { name: /^open /i })).toHaveAttribute("href", "/globalId/SD3v2");
+  });
+
+  it("passes the link's versionPin to the ELN record-info dialog", async () => {
+    const user = userEvent.setup();
+    renderField({ link: { ...baseLink, targetGlobalId: "SD3", versionPin: 2 } });
+    const infoButton = screen.getByRole("button", {
+      name: /show info for sd3/i,
+    });
+    await user.click(infoButton);
+    const dialog = screen.getByTestId("eln-info-dialog");
+    expect(dialog).toHaveAttribute("data-version-pin", "2");
+  });
+
+  it("shows the info button for ELN targets and opens the ELN record-info dialog (not the inventory dialog)", async () => {
+    const user = userEvent.setup();
+    renderField({ link: { ...baseLink, targetGlobalId: "SD3" } });
+
+    const infoButton = screen.getByRole("button", {
+      name: /show info for sd3/i,
+    });
+    await user.click(infoButton);
+
+    const dialog = screen.getByTestId("eln-info-dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("data-globalid", "SD3");
+    expect(screen.queryByTestId("inventory-info-dialog")).not.toBeInTheDocument();
+  });
+
+  it("still shows the info button for inventory targets", () => {
+    renderField({ link: { ...baseLink, targetGlobalId: "SA42" } });
+    expect(screen.getByRole("button", { name: /show info for sa42/i })).toBeInTheDocument();
+  });
+
+  it("renders a type icon inside the target chip for each Inventory prefix", () => {
+    /* eslint-disable testing-library/no-node-access, testing-library/no-container -- inspecting MUI Chip icon child */
+    const { rerender, container } = renderField({
+      link: { ...baseLink, targetGlobalId: "SA42" },
+    });
+    const sampleChip = container.querySelector('[data-test-id="LinkField-target"]');
+    expect(sampleChip?.querySelector("svg")).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider theme={materialTheme}>
+        <LinkField name="x" link={{ ...baseLink, targetGlobalId: "IC9" }} onEdit={vi.fn()} editable={true} />
+      </ThemeProvider>,
+    );
+    const containerChip = container.querySelector('[data-test-id="LinkField-target"]');
+    expect(containerChip?.querySelector("svg")).toBeInTheDocument();
+    /* eslint-enable testing-library/no-node-access, testing-library/no-container */
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkTargetBrowser.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkTargetBrowser.test.tsx
@@ -1,0 +1,107 @@
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/__tests__/customQueries";
+import LinkTargetBrowser from "../LinkTargetBrowser";
+
+// Search pulls in the store/fetcher chain at construction; stub it out (this is a thin wrapper).
+const { searchConstructorArgs } = vi.hoisted(() => ({
+  searchConstructorArgs: [] as Array<unknown>,
+}));
+vi.mock("@/stores/models/Search", () => ({
+  default: class {
+    fetcher = { performInitialSearch: vi.fn(() => Promise.resolve()) };
+    uiConfig = { selectionMode: "SINGLE" };
+
+    constructor(args: unknown) {
+      searchConstructorArgs.push(args);
+    }
+  },
+}));
+vi.mock("@/stores/models/Factory/AlwaysNewFactory", () => ({ default: class {} }));
+vi.mock("@/components/AlwaysNewWindowNavigationContext", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+// Stub the picker so we can assert the props LinkTargetBrowser passes and drive its onAddition.
+vi.mock("@/Inventory/components/Picker/Picker", () => ({
+  default: (props: {
+    resetActiveResultOnClose?: boolean;
+    onAddition: (records: Array<{ globalId: string; name: string }>) => void;
+  }) => (
+    <div data-testid="inventory-picker" data-reset={String(props.resetActiveResultOnClose ?? false)}>
+      <button type="button" onClick={() => props.onAddition([{ globalId: "SA42", name: "Sample 42" }])}>
+        pick SA42
+      </button>
+      <button type="button" onClick={() => props.onAddition([])}>
+        cancel picker
+      </button>
+    </div>
+  ),
+}));
+
+describe("LinkTargetBrowser", () => {
+  it("resets the picker's active result on close so a reopened dialog starts fresh", () => {
+    render(<LinkTargetBrowser open onPick={() => {}} onCancel={() => {}} />);
+    // guards the resetActiveResultOnClose fix: without it, a reused Search model re-emits the
+    // previously-picked item when the dialog is reopened
+    expect(screen.getByTestId("inventory-picker")).toHaveAttribute("data-reset", "true");
+  });
+
+  it("calls onPick with the chosen target's global id and name", async () => {
+    const onPick = vi.fn();
+    const user = userEvent.setup();
+    render(<LinkTargetBrowser open onPick={onPick} onCancel={() => {}} />);
+
+    await user.click(screen.getByRole("button", { name: /pick sa42/i }));
+
+    expect(onPick).toHaveBeenCalledWith({
+      globalId: "SA42",
+      name: "Sample 42",
+    });
+  });
+
+  it("lets sample templates be browsed as link targets", () => {
+    render(<LinkTargetBrowser open onPick={() => {}} onCancel={() => {}} />);
+
+    const args = searchConstructorArgs.at(-1) as {
+      uiConfig: { allowedTypeFilters: Set<string> };
+    };
+    expect([...args.uiConfig.allowedTypeFilters]).toContain("TEMPLATE");
+  });
+
+  it("requires an explicit Choose click instead of confirming on row click", () => {
+    // mirrors Browse ELN: clicking a result only selects it; the picker's
+    // Choose button (enabled once something is selected) confirms the pick.
+    // instantConfirm would instead fire onPick the moment a row is clicked.
+    render(<LinkTargetBrowser open onPick={() => {}} onCancel={() => {}} />);
+
+    const args = searchConstructorArgs.at(-1) as {
+      uiConfig: { instantConfirm?: boolean };
+    };
+    expect(args.uiConfig.instantConfirm).toBe(false);
+  });
+
+  it("constructs the search model once, not on every render", () => {
+    // useState's initializer must be lazy: a Search constructed per render is
+    // discarded by React immediately but still pays the store/fetcher setup
+    // cost (and any MobX side effects) on each render
+    const before = searchConstructorArgs.length;
+    const { rerender } = render(<LinkTargetBrowser open onPick={() => {}} onCancel={() => {}} />);
+    rerender(<LinkTargetBrowser open={false} onPick={() => {}} onCancel={() => {}} />);
+    rerender(<LinkTargetBrowser open onPick={() => {}} onCancel={() => {}} />);
+
+    expect(searchConstructorArgs.length - before).toBe(1);
+  });
+
+  it("treats an empty addition as cancel so the Cancel button closes the dialog", async () => {
+    // defensive: the Choose button is disabled while nothing is selected, but
+    // an empty confirmation must still close rather than commit an empty pick
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    render(<LinkTargetBrowser open onPick={() => {}} onCancel={onCancel} />);
+
+    await user.click(screen.getByRole("button", { name: /cancel picker/i }));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/RelatedInventoryItems.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/RelatedInventoryItems.test.tsx
@@ -1,0 +1,64 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import materialTheme from "../../../../../theme";
+
+const mockUseReferencing = vi.fn();
+vi.mock("@/eln/gallery/useReferencingInventoryItems", () => ({
+  default: (globalId: string | null) => mockUseReferencing(globalId) as unknown,
+}));
+
+import RelatedInventoryItems from "../RelatedInventoryItems";
+
+function renderSection() {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <RelatedInventoryItems globalId="SD1" recordTypeName="document" />
+    </ThemeProvider>,
+  );
+}
+
+describe("RelatedInventoryItems", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders one row per referencing item", () => {
+    mockUseReferencing.mockReturnValue({
+      items: [
+        { globalId: "SA7", name: "sample A", relationType: "References" },
+        { globalId: "IC9", name: "box B", relationType: "Cites" },
+      ],
+      loading: false,
+      errorMessage: null,
+    });
+
+    renderSection();
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByText("SA7")).toBeInTheDocument();
+    expect(screen.getByText("IC9")).toBeInTheDocument();
+  });
+
+  it("keeps row keys unique when one source links to the record twice", () => {
+    // the endpoint returns one row per link FIELD, so a single source item
+    // linking through two fields legitimately repeats its sourceGlobalId;
+    // keying rows on globalId alone would collide
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockUseReferencing.mockReturnValue({
+      items: [
+        { globalId: "SA7", name: "sample A", relationType: "References" },
+        { globalId: "SA7", name: "sample A", relationType: "Cites" },
+      ],
+      loading: false,
+      errorMessage: null,
+    });
+
+    renderSection();
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    const duplicateKeyWarnings = errorSpy.mock.calls.filter((args) => String(args[0]).includes("same key"));
+    expect(duplicateKeyWarnings).toHaveLength(0);
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/VersionLockDialog.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/VersionLockDialog.test.tsx
@@ -1,0 +1,307 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import type { AxiosResponse } from "axios";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import axios from "@/common/axios";
+import InvApiService from "../../../../../common/InvApiService";
+import materialTheme from "../../../../../theme";
+
+vi.mock("../../../../../common/InvApiService", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("@/common/axios", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import VersionLockDialog from "../VersionLockDialog";
+
+// The inventory /revisions endpoint returns Envers audit rows. Each carries the audit
+// `revisionId` AND the user-facing `record.version`. Non-version-bumping edits create several
+// revisions sharing one version (here revisions 10 and 11 are both version 1), so the picker
+// must collapse to one row per user-facing version and pin the version, not the revisionId.
+const revisionsResponse = {
+  data: {
+    revisions: [
+      {
+        revisionId: 10,
+        revisionType: "MOD",
+        record: {
+          id: 42,
+          globalId: "SA42",
+          name: "Sample foo",
+          version: 1,
+          lastModified: "2026-01-15T10:00:00Z",
+        },
+      },
+      {
+        revisionId: 11,
+        revisionType: "MOD",
+        record: {
+          id: 42,
+          globalId: "SA42",
+          name: "Sample foo edited",
+          version: 1,
+          lastModified: "2026-01-20T10:00:00Z",
+        },
+      },
+      {
+        revisionId: 22,
+        revisionType: "MOD",
+        record: {
+          id: 42,
+          globalId: "SA42",
+          name: "Sample foo v2",
+          version: 2,
+          lastModified: "2026-02-15T10:00:00Z",
+        },
+      },
+    ],
+    revisionsCount: 3,
+  },
+  status: 200,
+  statusText: "OK",
+  headers: {},
+  config: {},
+} as AxiosResponse;
+
+// The ELN revisions endpoint (/workspace/revisionHistory/ajax/{id}/versions) returns
+// { data: RevisionRecord[] }, where each record has a document `version` number and a
+// separate audit `revision` id (mirrors tinyMCE/InternalLink.tsx).
+const elnRevisionsResponse = {
+  data: {
+    data: [
+      {
+        version: 1,
+        revision: 101,
+        name: "My document",
+        oid: { idString: "SD55" },
+        ownerId: 1,
+        ownerFullName: "Owner One",
+        modificationDate: "2026-01-10T10:00:00Z",
+      },
+      {
+        version: 2,
+        revision: 202,
+        name: "My document",
+        oid: { idString: "SD55" },
+        ownerId: 1,
+        ownerFullName: "Owner One",
+        modificationDate: "2026-02-10T10:00:00Z",
+      },
+    ],
+  },
+  status: 200,
+  statusText: "OK",
+  headers: {},
+  config: {},
+} as AxiosResponse;
+
+// A soft-deleted SD document's history includes the final content revision AND the
+// soft-delete MOD revision, which share the same document version number (a delete does
+// not bump the version). The endpoint returns both rows, so the picker must collapse them
+// to one row per version (like the inventory path) rather than listing the final version twice.
+const elnDuplicateFinalVersionResponse = {
+  data: {
+    data: [
+      {
+        version: 1,
+        revision: 101,
+        modificationDate: "2026-01-10T10:00:00Z",
+      },
+      {
+        version: 2,
+        revision: 202,
+        modificationDate: "2026-02-10T10:00:00Z",
+      },
+      {
+        // the soft-delete MOD: a later audit revision still at version 2
+        version: 2,
+        revision: 303,
+        modificationDate: "2026-02-11T10:00:00Z",
+      },
+    ],
+  },
+  status: 200,
+  statusText: "OK",
+  headers: {},
+  config: {},
+} as AxiosResponse;
+
+function renderDialog(props: Partial<React.ComponentProps<typeof VersionLockDialog>> = {}) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <VersionLockDialog
+        open
+        globalId="SA42"
+        currentVersionPin={null}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        {...props}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe("VersionLockDialog", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows one row per user-facing version, collapsing multiple revisions of the same version", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockResolvedValue(revisionsResponse);
+    renderDialog();
+    expect(await screen.findByText("Version 1")).toBeInTheDocument();
+    expect(await screen.findByText("Version 2")).toBeInTheDocument();
+    // the raw Envers revision ids must NOT be presented as versions
+    expect(screen.queryByText("Version 10")).not.toBeInTheDocument();
+    expect(screen.queryByText("Version 11")).not.toBeInTheDocument();
+    expect(screen.queryByText("Version 22")).not.toBeInTheDocument();
+    expect(vi.mocked(apiGet)).toHaveBeenCalledWith("samples/42/revisions");
+  });
+
+  it("calls onConfirm with the chosen user-facing version, not the audit revisionId", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockResolvedValue(revisionsResponse);
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    renderDialog({ onConfirm });
+
+    const row = await screen.findByText("Version 2");
+    await user.click(row);
+    await user.click(screen.getByRole("button", { name: /lock to selected/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith(2);
+  });
+
+  it("re-syncs the selection when reopened after an abandoned edit", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockResolvedValue(revisionsResponse);
+    const user = userEvent.setup();
+    const stableProps = {
+      globalId: "SA42",
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+    };
+    const { rerender } = render(
+      <ThemeProvider theme={materialTheme}>
+        <VersionLockDialog open currentVersionPin={null} {...stableProps} />
+      </ThemeProvider>,
+    );
+
+    // abandon an edit: select Version 1, then close without confirming
+    await user.click(await screen.findByText("Version 1"));
+    rerender(
+      <ThemeProvider theme={materialTheme}>
+        <VersionLockDialog open={false} currentVersionPin={null} {...stableProps} />
+      </ThemeProvider>,
+    );
+
+    // reopen after the pin was saved as version 2 elsewhere: the abandoned
+    // selection (Version 1) must not leak into the fresh open
+    rerender(
+      <ThemeProvider theme={materialTheme}>
+        <VersionLockDialog open currentVersionPin={2} {...stableProps} />
+      </ThemeProvider>,
+    );
+
+    // wait for the version rows to load before inspecting the radios
+    expect(await screen.findByText("Version 2")).toBeInTheDocument();
+    const version2Radio = screen.getAllByRole("radio").find((radio) => radio.getAttribute("value") === "2");
+    expect(version2Radio).toBeChecked();
+  });
+
+  it("calls onConfirm with null when the user selects 'latest' after a pin was in place", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockResolvedValue(revisionsResponse);
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    renderDialog({ onConfirm, currentVersionPin: 1 });
+
+    const latestRow = await screen.findByText(/^latest$/i);
+    await user.click(latestRow);
+    await user.click(screen.getByRole("button", { name: /lock to selected/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith(null);
+  });
+});
+
+describe("VersionLockDialog (SD/ELN document target)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("fetches SD revisions from the ELN endpoint and shows a row per version", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const axiosGet = axios.get;
+    vi.mocked(axiosGet).mockResolvedValue(elnRevisionsResponse);
+    renderDialog({ globalId: "SD55" });
+
+    expect(await screen.findByText("Version 1")).toBeInTheDocument();
+    expect(await screen.findByText("Version 2")).toBeInTheDocument();
+    expect(vi.mocked(axiosGet)).toHaveBeenCalledWith("/workspace/revisionHistory/ajax/55/versions");
+  });
+
+  it("pins to the document version number, not the audit revision id", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const axiosGet = axios.get;
+    vi.mocked(axiosGet).mockResolvedValue(elnRevisionsResponse);
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    renderDialog({ globalId: "SD55", onConfirm });
+
+    await user.click(await screen.findByText("Version 2"));
+    await user.click(screen.getByRole("button", { name: /lock to selected/i }));
+
+    // version 2 maps to audit revision 202; the pin must be the version number (2).
+    expect(onConfirm).toHaveBeenCalledWith(2);
+  });
+
+  it("collapses duplicate entries of the same version (a deleted doc's final version listed twice) to one row", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const axiosGet = axios.get;
+    vi.mocked(axiosGet).mockResolvedValue(elnDuplicateFinalVersionResponse);
+    renderDialog({ globalId: "SD55" });
+
+    // wait for the version rows to load (version 1 is unique)
+    expect(await screen.findByText("Version 1")).toBeInTheDocument();
+    // version 2 is returned twice (final edit + soft-delete MOD) but must render once
+    const version2Radios = screen.getAllByRole("radio").filter((radio) => radio.getAttribute("value") === "2");
+    expect(version2Radios).toHaveLength(1);
+  });
+
+  it("still shows the cannot-resolve fallback for unsupported ELN types (NB)", () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const axiosGet = axios.get;
+    renderDialog({ globalId: "NB9" });
+
+    expect(screen.getByText(/cannot resolve version history for NB9/i)).toBeInTheDocument();
+    expect(vi.mocked(axiosGet)).not.toHaveBeenCalled();
+  });
+
+  it("degrades to the latest-only view when the SD revisions fetch fails", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const axiosGet = axios.get;
+    vi.mocked(axiosGet).mockRejectedValue(new Error("network down"));
+    renderDialog({ globalId: "SD55" });
+
+    // SD is a supported target, so this is NOT the cannot-resolve fallback...
+    expect(screen.queryByText(/cannot resolve version history/i)).not.toBeInTheDocument();
+    // ...the picker still renders with the Latest option and no version rows.
+    expect(await screen.findByText(/^latest$/i)).toBeInTheDocument();
+    expect(screen.queryByText("Version 1")).not.toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/dataciteRelationTypes.test.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/dataciteRelationTypes.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { DATACITE_RELATION_TYPES, isValidDataCiteRelationType } from "../dataciteRelationTypes";
+
+describe("dataciteRelationTypes", () => {
+  it("accepts canonical DataCite values", () => {
+    expect(isValidDataCiteRelationType("IsCitedBy")).toBe(true);
+    expect(isValidDataCiteRelationType("References")).toBe(true);
+    expect(isValidDataCiteRelationType("IsPartOf")).toBe(true);
+  });
+
+  it("rejects unknown values", () => {
+    expect(isValidDataCiteRelationType("MadeUpRelation")).toBe(false);
+    expect(isValidDataCiteRelationType("")).toBe(false);
+  });
+
+  it("rejects case variants", () => {
+    expect(isValidDataCiteRelationType("iscitedby")).toBe(false);
+    expect(isValidDataCiteRelationType("ISCITEDBY")).toBe(false);
+  });
+
+  it("includes PIDINST IsCalibratedBy and Calibrates", () => {
+    expect(isValidDataCiteRelationType("IsCalibratedBy")).toBe(true);
+    expect(isValidDataCiteRelationType("Calibrates")).toBe(true);
+  });
+
+  it("contains no duplicate entries", () => {
+    expect(DATACITE_RELATION_TYPES.length).toBe(new Set(DATACITE_RELATION_TYPES).size);
+  });
+
+  it("matches backend vocabulary list", () => {
+    const expectedFromBackend = [
+      "IsCitedBy",
+      "Cites",
+      "IsSupplementTo",
+      "IsSupplementedBy",
+      "IsContinuedBy",
+      "Continues",
+      "IsDescribedBy",
+      "Describes",
+      "HasMetadata",
+      "IsMetadataFor",
+      "HasVersion",
+      "IsVersionOf",
+      "IsNewVersionOf",
+      "IsPreviousVersionOf",
+      "IsPartOf",
+      "HasPart",
+      "IsPublishedIn",
+      "IsReferencedBy",
+      "References",
+      "IsDocumentedBy",
+      "Documents",
+      "IsCompiledBy",
+      "Compiles",
+      "IsVariantFormOf",
+      "IsOriginalFormOf",
+      "IsIdenticalTo",
+      "IsReviewedBy",
+      "Reviews",
+      "IsDerivedFrom",
+      "IsSourceOf",
+      "IsRequiredBy",
+      "Requires",
+      "IsObsoletedBy",
+      "Obsoletes",
+      "IsCollectedBy",
+      "Collects",
+      "IsTranslationOf",
+      "HasTranslation",
+      "IsCalibratedBy",
+      "Calibrates",
+    ];
+    expect([...DATACITE_RELATION_TYPES]).toEqual(expectedFromBackend);
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/iconForGlobalId.test.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/iconForGlobalId.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+import {
+  iconForGlobalId,
+  iconForInventoryGlobalId,
+  isInventoryGlobalId,
+  openUrlForTarget,
+  prefixOf,
+  supportsVersionPin,
+} from "../iconForGlobalId";
+
+describe("iconForInventoryGlobalId", () => {
+  test("maps known Inventory prefixes to RecordTypeIcon data", () => {
+    expect(iconForInventoryGlobalId("SA12")).toEqual({
+      iconName: "sample",
+      recordTypeLabel: "Sample",
+    });
+    expect(iconForInventoryGlobalId("SS9")).toEqual({
+      iconName: "subsample",
+      recordTypeLabel: "Subsample",
+    });
+    expect(iconForInventoryGlobalId("IC1")).toEqual({
+      iconName: "container",
+      recordTypeLabel: "Container",
+    });
+    expect(iconForInventoryGlobalId("IN7")).toEqual({
+      iconName: "container",
+      recordTypeLabel: "Instrument",
+    });
+  });
+
+  test("maps sample templates to the template icon", () => {
+    expect(iconForInventoryGlobalId("IT3")).toEqual({
+      iconName: "template",
+      recordTypeLabel: "Sample template",
+    });
+  });
+
+  test("returns null for ELN and unknown prefixes and malformed ids", () => {
+    expect(iconForInventoryGlobalId("SD1")).toBeNull();
+    expect(iconForInventoryGlobalId("")).toBeNull();
+    expect(iconForInventoryGlobalId("not-a-global-id")).toBeNull();
+  });
+
+  test("tolerates a version pin suffix", () => {
+    expect(iconForInventoryGlobalId("SA12v3")?.iconName).toBe("sample");
+  });
+});
+
+describe("iconForGlobalId (inventory + ELN)", () => {
+  test("maps ELN prefixes to supported RecordTypeIcon names", () => {
+    expect(iconForGlobalId("SD1")).toEqual({
+      iconName: "document",
+      recordTypeLabel: "Document",
+    });
+    // RecordTypeIcon has no dedicated notebook icon, so notebooks reuse the document icon
+    expect(iconForGlobalId("NB5")).toEqual({
+      iconName: "document",
+      recordTypeLabel: "Notebook",
+    });
+    expect(iconForGlobalId("GL9")).toEqual({
+      iconName: "gallery",
+      recordTypeLabel: "Gallery file",
+    });
+  });
+
+  test("still maps inventory prefixes", () => {
+    expect(iconForGlobalId("SA1")?.iconName).toBe("sample");
+  });
+
+  test("returns null for unsupported prefixes", () => {
+    expect(iconForGlobalId("GF1")).toBeNull();
+    expect(iconForGlobalId("not-a-global-id")).toBeNull();
+  });
+});
+
+describe("prefix helpers", () => {
+  test("prefixOf extracts the two-letter prefix, tolerating versions", () => {
+    expect(prefixOf("SD123")).toBe("SD");
+    expect(prefixOf("SD123v5")).toBe("SD");
+    expect(prefixOf("garbage")).toBeNull();
+  });
+
+  test("isInventoryGlobalId is true only for inventory prefixes", () => {
+    expect(isInventoryGlobalId("SA1")).toBe(true);
+    expect(isInventoryGlobalId("IN9")).toBe(true);
+    expect(isInventoryGlobalId("SD1")).toBe(false);
+    expect(isInventoryGlobalId("NB1")).toBe(false);
+  });
+
+  test("supportsVersionPin is true for inventory and SD, false for NB and GL", () => {
+    expect(supportsVersionPin("SA1")).toBe(true);
+    expect(supportsVersionPin("SD1")).toBe(true);
+    expect(supportsVersionPin("NB1")).toBe(false);
+    expect(supportsVersionPin("GL1")).toBe(false);
+  });
+});
+
+describe("openUrlForTarget", () => {
+  test("opens a Gallery file at its location in the Gallery", () => {
+    expect(openUrlForTarget("GL21", null)).toBe("/gallery/item/21");
+  });
+
+  test("keeps the /globalId route for non-Gallery targets", () => {
+    expect(openUrlForTarget("SD5", null)).toBe("/globalId/SD5");
+    expect(openUrlForTarget("SA10", null)).toBe("/globalId/SA10");
+  });
+
+  test("appends the pinned version suffix for non-Gallery targets", () => {
+    expect(openUrlForTarget("SD5", 3)).toBe("/globalId/SD5v3");
+  });
+
+  test("does not double-encode the version when a legacy id already carries a suffix", () => {
+    // rows written before the backend normalised stored ids can hold e.g.
+    // "SS42v7" alongside versionPin 7; the URL must not become /globalId/SS42v7v7
+    expect(openUrlForTarget("SS42v7", 7)).toBe("/globalId/SS42v7");
+  });
+
+  test("strips a legacy suffix when the link is unpinned", () => {
+    expect(openUrlForTarget("SS42v7", null)).toBe("/globalId/SS42");
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/linkTarget.test.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/linkTarget.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { isSelfLink, validateTarget } from "../linkTarget";
+
+describe("validateTarget", () => {
+  test("accepts all inventory prefixes, including sample templates", () => {
+    for (const globalId of ["SA9", "SS9", "IC9", "IN9", "IT9"]) {
+      expect(validateTarget(globalId, "SA1").ok, `${globalId} accepted`).toBe(true);
+    }
+  });
+
+  test("accepts ELN prefixes", () => {
+    for (const globalId of ["SD9", "NB9", "GL9"]) {
+      expect(validateTarget(globalId, "SA1").ok, `${globalId} accepted`).toBe(true);
+    }
+  });
+
+  test("rejects unsupported prefixes", () => {
+    const { ok, reason } = validateTarget("GF9", "SA1");
+    expect(ok).toBe(false);
+    expect(reason).toMatch(/target must be/i);
+  });
+
+  test("rejects malformed and empty ids as 'required'", () => {
+    expect(validateTarget("", "SA1").reason).toMatch(/required/i);
+    expect(validateTarget("not-an-id", "SA1").reason).toMatch(/required/i);
+  });
+
+  test("rejects self-links, ignoring any version suffix", () => {
+    expect(validateTarget("SA1", "SA1").ok).toBe(false);
+    expect(validateTarget("SA1v3", "SA1").ok).toBe(false);
+  });
+
+  test("rejects manually-typed version suffixes: versions are pinned via the clock", () => {
+    const inventory = validateTarget("SA6v1", "SA1");
+    expect(inventory.ok).toBe(false);
+    expect(inventory.reason).toMatch(/clock/i);
+    const eln = validateTarget("SD7v2", "SA1");
+    expect(eln.ok).toBe(false);
+    expect(eln.reason).toMatch(/clock/i);
+    // the base id without a suffix remains valid
+    expect(validateTarget("SA6", "SA1").ok).toBe(true);
+  });
+});
+
+describe("isSelfLink", () => {
+  test("matches only the same prefix and id", () => {
+    expect(isSelfLink("SA1", "SA1")).toBe(true);
+    expect(isSelfLink("SA1", "SS1")).toBe(false);
+    expect(isSelfLink("SA1", "SA2")).toBe(false);
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/linkTargetExists.test.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/linkTargetExists.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGet, mockGetWorkspaceRecordInformationAjax } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockGetWorkspaceRecordInformationAjax: vi.fn(),
+}));
+
+vi.mock("@/common/InvApiService", () => ({
+  default: { get: mockGet },
+}));
+vi.mock("@/modules/workspace/queries", () => ({
+  getWorkspaceRecordInformationAjax: mockGetWorkspaceRecordInformationAjax,
+}));
+
+import { checkLinkTargetExists } from "../linkTargetExists";
+
+describe("checkLinkTargetExists", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockGetWorkspaceRecordInformationAjax.mockReset();
+  });
+
+  it.each([
+    ["SA12", "samples/12"],
+    ["SS34", "subSamples/34"],
+    ["IC56", "containers/56"],
+    ["IN78", "instruments/78"],
+    ["IT90", "sampleTemplates/90"],
+  ])("resolves an inventory target %s through the inventory API", async (globalId, endpoint) => {
+    mockGet.mockResolvedValue({ data: { permittedActions: ["READ"] } });
+    await expect(checkLinkTargetExists(globalId)).resolves.toBe(true);
+    expect(mockGet).toHaveBeenCalledWith(endpoint);
+  });
+
+  it("accepts an editable inventory target (READ alongside UPDATE)", async () => {
+    mockGet.mockResolvedValue({
+      data: { permittedActions: ["READ", "UPDATE", "CHANGE_OWNER"] },
+    });
+    await expect(checkLinkTargetExists("SA12")).resolves.toBe(true);
+  });
+
+  it("reports a missing inventory target as not existing", async () => {
+    mockGet.mockRejectedValue(new Error("404"));
+    await expect(checkLinkTargetExists("SA99999")).resolves.toBe(false);
+  });
+
+  it("treats a limited-read inventory target as not visible", async () => {
+    // the inventory GET succeeds for items any user may see a redacted view
+    // of, but linking requires full READ (the backend rejects the link at
+    // save); reporting it as not-visible gives the same generic message as a
+    // missing id, so existence is not leaked
+    mockGet.mockResolvedValue({
+      data: { permittedActions: ["LIMITED_READ"] },
+    });
+    await expect(checkLinkTargetExists("SA12")).resolves.toBe(false);
+  });
+
+  it("treats an inventory response without READ permission as not visible", async () => {
+    mockGet.mockResolvedValue({ data: { permittedActions: [] } });
+    await expect(checkLinkTargetExists("SA12")).resolves.toBe(false);
+    mockGet.mockResolvedValue({ data: {} });
+    await expect(checkLinkTargetExists("SA12")).resolves.toBe(false);
+  });
+
+  it("resolves an ELN target through the workspace record-information endpoint", async () => {
+    mockGetWorkspaceRecordInformationAjax.mockResolvedValue({
+      id: 42,
+      oid: { idString: "SD42" },
+    });
+    await expect(checkLinkTargetExists("SD42")).resolves.toBe(true);
+    expect(mockGetWorkspaceRecordInformationAjax).toHaveBeenCalledWith({
+      recordId: 42,
+    });
+  });
+
+  it("reports a missing ELN target as not existing", async () => {
+    mockGetWorkspaceRecordInformationAjax.mockRejectedValue(new Error("not found"));
+    await expect(checkLinkTargetExists("NB123")).resolves.toBe(false);
+  });
+
+  it("checks the base record for a version-pinned target", async () => {
+    mockGetWorkspaceRecordInformationAjax.mockResolvedValue({
+      id: 7,
+      oid: { idString: "SD7" },
+    });
+    await expect(checkLinkTargetExists("SD7v3")).resolves.toBe(true);
+    expect(mockGetWorkspaceRecordInformationAjax).toHaveBeenCalledWith({
+      recordId: 7,
+    });
+  });
+
+  it("rejects an ELN target whose resolved record has a different prefix", async () => {
+    // the workspace endpoint resolves by numeric id alone, so "GL150"
+    // resolves whatever record has id 150 (e.g. folder FL150); only an exact
+    // Global ID match counts as existing
+    mockGetWorkspaceRecordInformationAjax.mockResolvedValue({
+      id: 150,
+      oid: { idString: "FL150" },
+    });
+    await expect(checkLinkTargetExists("GL150")).resolves.toBe(false);
+  });
+
+  it("reports unknown prefixes and malformed ids as not existing", async () => {
+    await expect(checkLinkTargetExists("XX5")).resolves.toBe(false);
+    await expect(checkLinkTargetExists("not-an-id")).resolves.toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockGetWorkspaceRecordInformationAjax).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/useLinkTargetSummary.test.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/useLinkTargetSummary.test.ts
@@ -1,0 +1,50 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+
+vi.mock("@/common/InvApiService", () => ({
+  default: { get: mockGet },
+}));
+
+import useLinkTargetSummary from "../useLinkTargetSummary";
+
+describe("useLinkTargetSummary", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+  afterEach(cleanup);
+
+  it("resolves the target's current state from the lazy summary endpoint", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        globalId: "SD5",
+        name: "my doc",
+        type: "DOCUMENT",
+        deleted: true,
+        readable: true,
+      },
+    });
+
+    const { result } = renderHook(() => useLinkTargetSummary("SD5"));
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledWith("linkTargets/SD5/summary");
+    expect(result.current?.deleted).toBe(true);
+    expect(result.current?.name).toBe("my doc");
+    expect(result.current?.readable).toBe(true);
+  });
+
+  it("degrades to null on any resolution failure", async () => {
+    // network failure and malformed ids look the same to the card: no pill,
+    // Open kept, exactly as before the summary existed. (Missing and
+    // unreadable records are not failures: they resolve to a redacted
+    // readable:false summary.)
+    mockGet.mockRejectedValue(new Error("404"));
+
+    const { result } = renderHook(() => useLinkTargetSummary("SD404"));
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/dataciteRelationTypes.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/dataciteRelationTypes.ts
@@ -1,0 +1,55 @@
+/**
+ * Controlled vocabulary of DataCite Metadata Schema 4.7 relationType values, plus the
+ * PIDINST-aligned IsCalibratedBy / Calibrates pair. Kept in lockstep with the backend
+ * com.researchspace.service.inventory.DataCiteRelationType.
+ */
+export const DATACITE_RELATION_TYPES = [
+  "IsCitedBy",
+  "Cites",
+  "IsSupplementTo",
+  "IsSupplementedBy",
+  "IsContinuedBy",
+  "Continues",
+  "IsDescribedBy",
+  "Describes",
+  "HasMetadata",
+  "IsMetadataFor",
+  "HasVersion",
+  "IsVersionOf",
+  "IsNewVersionOf",
+  "IsPreviousVersionOf",
+  "IsPartOf",
+  "HasPart",
+  "IsPublishedIn",
+  "IsReferencedBy",
+  "References",
+  "IsDocumentedBy",
+  "Documents",
+  "IsCompiledBy",
+  "Compiles",
+  "IsVariantFormOf",
+  "IsOriginalFormOf",
+  "IsIdenticalTo",
+  "IsReviewedBy",
+  "Reviews",
+  "IsDerivedFrom",
+  "IsSourceOf",
+  "IsRequiredBy",
+  "Requires",
+  "IsObsoletedBy",
+  "Obsoletes",
+  "IsCollectedBy",
+  "Collects",
+  "IsTranslationOf",
+  "HasTranslation",
+  "IsCalibratedBy",
+  "Calibrates",
+] as const;
+
+export type DataCiteRelationType = (typeof DATACITE_RELATION_TYPES)[number];
+
+const RELATION_TYPE_SET: ReadonlySet<string> = new Set(DATACITE_RELATION_TYPES);
+
+export function isValidDataCiteRelationType(value: string): value is DataCiteRelationType {
+  return value !== "" && RELATION_TYPE_SET.has(value);
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/iconForGlobalId.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/iconForGlobalId.ts
@@ -1,0 +1,82 @@
+import type { RecordIconData } from "../../../../stores/definitions/BaseRecord";
+
+import { GLOBAL_ID_PATTERN } from "./linkTarget";
+
+export const INVENTORY_PREFIX_ICON_DATA: Record<string, RecordIconData> = {
+  SA: { iconName: "sample", recordTypeLabel: "Sample" },
+  SS: { iconName: "subsample", recordTypeLabel: "Subsample" },
+  IC: { iconName: "container", recordTypeLabel: "Container" },
+  IN: { iconName: "container", recordTypeLabel: "Instrument" },
+  IT: { iconName: "template", recordTypeLabel: "Sample template" },
+};
+
+// RecordTypeIcon supports "document" and "gallery" but has no dedicated notebook
+// icon, so notebooks reuse the document icon (with a Notebook label).
+const ELN_PREFIX_ICON_DATA: Record<string, RecordIconData> = {
+  SD: { iconName: "document", recordTypeLabel: "Document" },
+  NB: { iconName: "document", recordTypeLabel: "Notebook" },
+  GL: { iconName: "gallery", recordTypeLabel: "Gallery file" },
+};
+
+/** Returns the two-letter prefix of a Global ID (ignoring any version suffix), or null. */
+export function prefixOf(globalId: string): string | null {
+  const match = GLOBAL_ID_PATTERN.exec(globalId);
+  return match ? match[1] : null;
+}
+
+/**
+ * Returns the RecordTypeIcon data appropriate for the supplied Inventory Global ID, or null when
+ * the prefix is not an inventory item.
+ */
+export function iconForInventoryGlobalId(globalId: string): RecordIconData | null {
+  const prefix = prefixOf(globalId);
+  return prefix ? (INVENTORY_PREFIX_ICON_DATA[prefix] ?? null) : null;
+}
+
+/**
+ * Returns RecordTypeIcon data for any supported link target (Inventory item or ELN document,
+ * notebook or gallery file), or null when the prefix is not a supported target. Only ever returns
+ * iconName values that RecordTypeIcon knows about, since that component throws on unknown names.
+ */
+export function iconForGlobalId(globalId: string): RecordIconData | null {
+  const prefix = prefixOf(globalId);
+  if (!prefix) return null;
+  return INVENTORY_PREFIX_ICON_DATA[prefix] ?? ELN_PREFIX_ICON_DATA[prefix] ?? null;
+}
+
+/** True when the Global ID is an Inventory item (sample, subsample, container, instrument). */
+export function isInventoryGlobalId(globalId: string): boolean {
+  const prefix = prefixOf(globalId);
+  return prefix != null && prefix in INVENTORY_PREFIX_ICON_DATA;
+}
+
+/**
+ * Targets that support version pinning in the link UI: Inventory items and ELN documents (SD).
+ * Notebooks (NB) and gallery files (GL) do not, so the version-pin affordance must not be rendered
+ * for them.
+ */
+export function supportsVersionPin(globalId: string): boolean {
+  return isInventoryGlobalId(globalId) || prefixOf(globalId) === "SD";
+}
+
+/**
+ * URL to OPEN a link target in a new tab. A Gallery file (GL) opens at its
+ * location in the Gallery (/gallery/item/<id>) rather than downloading via
+ * /globalId, which is the misleading default the backend resolves to Streamfile.
+ * Every other target keeps the existing /globalId/<gid>[v<n>] behaviour, which
+ * the backend resolves per type (e.g. SD documents, inventory items). GL cannot
+ * be version-pinned (see supportsVersionPin), so the gallery route ignores
+ * versionPin by design.
+ */
+export function openUrlForTarget(globalId: string, versionPin: number | null): string {
+  const match = GLOBAL_ID_PATTERN.exec(globalId);
+  if (match && match[1] === "GL") {
+    return `/gallery/item/${match[2]}`;
+  }
+  // rebuild from the parsed base id: rows written before the backend
+  // normalised stored ids can already carry a "vN" suffix, which must not be
+  // doubly encoded (e.g. /globalId/SS42v7v7)
+  const base = match ? `${match[1]}${match[2]}` : globalId;
+  const versionSuffix = versionPin != null ? `v${versionPin}` : "";
+  return `/globalId/${base}${versionSuffix}`;
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/linkTarget.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/linkTarget.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared client-side validation for link targets, used by both the extra-field
+ * link editor (UpdateField) and the template-field link editor (LinkFieldValue).
+ * Mirrors the backend's InventoryLinkValidator: syntactic Global ID parse, a
+ * supported target prefix, and no self-links. Existence checks require a server
+ * round-trip and live in checkLinkTargetExists.
+ */
+
+// Inventory items (SA/SS/IC/IN, plus IT sample templates) and ELN documents (SD),
+// notebooks (NB) and gallery files (GL).
+export const ALLOWED_TARGET_PREFIXES: ReadonlySet<string> = new Set(["SA", "SS", "IC", "IN", "IT", "SD", "NB", "GL"]);
+
+export const GLOBAL_ID_PATTERN = /^([A-Z]{2})(\d+)(?:v(\d+))?$/;
+
+/**
+ * Inventory Global-ID prefix -> REST API path segment, shared so the map cannot
+ * drift between the existence check, the info/version dialogs and the
+ * back-reference panels (IT was missing from some copies before).
+ */
+export const INVENTORY_PREFIX_TO_API_PATH: Record<string, string> = {
+  SA: "samples",
+  SS: "subSamples",
+  IC: "containers",
+  IN: "instruments",
+  IT: "sampleTemplates",
+};
+
+/** True when target points at the same item as source, ignoring any version suffix. */
+export function isSelfLink(sourceGlobalId: string, targetGlobalId: string): boolean {
+  const source = GLOBAL_ID_PATTERN.exec(sourceGlobalId);
+  const target = GLOBAL_ID_PATTERN.exec(targetGlobalId);
+  return Boolean(source && target && source[1] === target[1] && source[2] === target[2]);
+}
+
+/** Validates only the target Global ID; relation-type validity is reported on its own field. */
+export function validateTarget(targetGlobalId: string, sourceGlobalId: string): { ok: boolean; reason: string } {
+  const parsed = GLOBAL_ID_PATTERN.exec(targetGlobalId);
+  if (!parsed) return { ok: false, reason: "Target Global ID is required" };
+  if (!ALLOWED_TARGET_PREFIXES.has(parsed[1]))
+    return {
+      ok: false,
+      reason: "Target must be an Inventory item or an ELN document, notebook or gallery file",
+    };
+  if (parsed[3] !== undefined)
+    // versions are pinned through the version dialog, never typed: the dialog
+    // only offers versions the target actually has, and pinning also captures
+    // the matching audit revision
+    return {
+      ok: false,
+      reason: "Enter the Global ID without a version. To pin the link to a version, use the clock icon.",
+    };
+  if (isSelfLink(sourceGlobalId, targetGlobalId)) return { ok: false, reason: "An item cannot link to itself." };
+  return { ok: true, reason: "" };
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/linkTargetExists.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/linkTargetExists.ts
@@ -1,0 +1,46 @@
+import { getWorkspaceRecordInformationAjax } from "@/modules/workspace/queries";
+import ApiService from "../../../../common/InvApiService";
+import { GLOBAL_ID_PATTERN, INVENTORY_PREFIX_TO_API_PATH } from "./linkTarget";
+
+const ELN_PREFIXES = new Set(["SD", "NB", "GL"]);
+
+/**
+ * Reports whether a link target Global ID resolves to a real record the current
+ * user can read, mirroring the backend's create-time existence check so typed
+ * Global IDs can be rejected before the record is saved. A version suffix is
+ * ignored: only the base record needs to exist. Any resolution failure (not
+ * found, no permission, network error) is reported as "does not exist".
+ *
+ * For inventory targets a 200 response is not enough: the inventory GET also
+ * succeeds for items the user may only see a redacted "limited read" view of,
+ * while linking requires full READ permission (the backend's
+ * LinkTargetResolver rejects the link at save otherwise). So the response's
+ * permittedActions must include READ; anything less is reported as
+ * not-visible, giving the same generic message as a missing id so existence
+ * is not leaked.
+ */
+export async function checkLinkTargetExists(globalId: string): Promise<boolean> {
+  const parsed = GLOBAL_ID_PATTERN.exec(globalId);
+  if (!parsed) return false;
+  const [, prefix, dbId] = parsed;
+  try {
+    const inventoryPath = INVENTORY_PREFIX_TO_API_PATH[prefix];
+    if (inventoryPath) {
+      const { data } = await ApiService.get<{ permittedActions?: unknown }>(`${inventoryPath}/${dbId}`);
+      const permittedActions = data?.permittedActions;
+      return Array.isArray(permittedActions) && permittedActions.includes("READ");
+    }
+    if (ELN_PREFIXES.has(prefix)) {
+      const info = await getWorkspaceRecordInformationAjax({
+        recordId: Number(dbId),
+      });
+      // the workspace endpoint resolves by numeric id alone, so a typed id
+      // can resolve a different record kind sharing the number (e.g. "GL150"
+      // resolves folder FL150): only an exact Global ID match counts
+      return info.oid.idString === `${prefix}${dbId}`;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/useLinkTargetSummary.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/useLinkTargetSummary.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import ApiService from "../../../../common/InvApiService";
+
+/**
+ * Current state of a link target as reported by the lazy summary endpoint
+ * (RSDEV-1182). Unreadable targets are redacted server-side to a
+ * globalId-only summary, so name/type can be null even on success.
+ */
+export type LinkTargetSummary = {
+  globalId: string | null;
+  name: string | null;
+  type: string | null;
+  deleted: boolean;
+  /**
+   * False when the viewer cannot read the target. Deliberately conflates
+   * unshared, never-shared, nonexistent, and hard-deleted-by-another-owner:
+   * all are redacted identically (ADR-0002), so false never discloses
+   * whether the record exists.
+   */
+  readable: boolean;
+};
+
+/**
+ * Resolves the current state of a link target for the link card. Returns null
+ * while loading and on any failure (network error, malformed id): the card
+ * then renders no state pill and keeps its Open action, the same as before
+ * the summary existed. Missing and unreadable targets are not failures: the
+ * server resolves them to a redacted summary with readable false.
+ */
+export default function useLinkTargetSummary(globalId: string): LinkTargetSummary | null {
+  const [summary, setSummary] = useState<LinkTargetSummary | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSummary(null);
+    // No target (empty field, or callers that only want a summary while editing)
+    // has nothing to resolve; skip the request rather than hitting the endpoint
+    // with a blank id.
+    if (!globalId) {
+      return;
+    }
+    ApiService.get<LinkTargetSummary>(`linkTargets/${encodeURIComponent(globalId)}/summary`).then(
+      ({ data }) => {
+        if (!cancelled) setSummary(data);
+      },
+      () => {
+        if (!cancelled) setSummary(null);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [globalId]);
+
+  return summary;
+}

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/LatestTemplateActions.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/LatestTemplateActions.tsx
@@ -12,11 +12,16 @@ type LatestTemplateActionsArgs = {
 };
 
 function LatestTemplateActions({ record }: LatestTemplateActionsArgs): React.ReactNode {
-  if (!(record instanceof TemplateModel) || record.historicalVersion) return null;
+  // Only offer the update when the template actually has samples to update:
+  // samples created from an older version of it (samplesToUpdateCount). Merely
+  // being a link target (e.g. a sample links to this template) is not something
+  // to update, so the button must stay hidden in that case.
+  if (!(record instanceof TemplateModel) || record.historicalVersion || record.samplesToUpdateCount <= 0) return null;
 
   return (
-    <FormControl component="fieldset">
+    <FormControl component="fieldset" sx={{ alignItems: "flex-start" }}>
       <FormLabel component="legend">Update Samples</FormLabel>
+      {/* width is unified across the sidebar's action buttons in SidebarBody */}
       <FormGroup>
         <Button
           variant="outlined"

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/LinkedDocuments.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/LinkedDocuments.tsx
@@ -8,6 +8,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import FormControl from "@mui/material/FormControl";
 import FormGroup from "@mui/material/FormGroup";
 import FormLabel from "@mui/material/FormLabel";
+import Grid from "@mui/material/Grid";
 import Skeleton from "@mui/material/Skeleton";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -28,11 +29,152 @@ import type { Document, DocumentAttrs } from "../../../stores/definitions/Docume
 import type { Factory } from "../../../stores/definitions/Factory";
 import RsSet, { unionWith } from "../../../util/set";
 
+type ReferencingItem = {
+  sourceGlobalId: string;
+  sourceName: string;
+  sourceType: string;
+  relationType: string;
+  versionPin: number | null;
+};
+
 type State =
   | { state: "init" }
   | { state: "loading" }
-  | { state: "success"; documents: RsSet<Document> }
+  | {
+      state: "success";
+      documents: RsSet<Document>;
+      referencingItems: ReferencingItem[];
+    }
   | { state: "fail"; error: Error };
+
+import { GLOBAL_ID_PATTERN, INVENTORY_PREFIX_TO_API_PATH } from "@/Inventory/components/Fields/Link/linkTarget";
+
+function referencingItemsEndpoint(globalId: string): string | null {
+  const match = GLOBAL_ID_PATTERN.exec(globalId);
+  if (!match) return null;
+  // sample templates have no typed referencingItems endpoint; use the
+  // generic by-Global-ID route instead
+  if (match[1] === "IT") return `referencingItems/${globalId}`;
+  const segment = INVENTORY_PREFIX_TO_API_PATH[match[1]];
+  if (segment) return `${segment}/${match[2]}/referencingItems`;
+  return null;
+}
+
+function ReferencingItemsTable({ items }: { items: ReferencingItem[] }): React.ReactElement {
+  return (
+    <Table size="small" aria-label="Inventory items linking to this item">
+      <TableHead>
+        <TableRow>
+          <TableCell>Name</TableCell>
+          <TableCell>Global ID</TableCell>
+          <TableCell>Relation</TableCell>
+          {/* Which version of THIS item the linking item points at (not a version
+              of the linking item itself). */}
+          <TableCell>Linked version</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {items.map((item, index) => (
+          // one item can link to the same target through several fields, so
+          // the global id alone is not a unique row key
+          <TableRow key={`${item.sourceGlobalId}-${index}`}>
+            <TableCell>{item.sourceName}</TableCell>
+            <TableCell>
+              <a href={`/globalId/${item.sourceGlobalId}`} rel="noreferrer" target="_blank">
+                {item.sourceGlobalId}
+              </a>
+            </TableCell>
+            <TableCell>{item.relationType}</TableCell>
+            <TableCell>{item.versionPin != null ? `v${item.versionPin}` : "Latest"}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function DocumentsTable({ documents }: { documents: RsSet<Document> }): React.ReactElement {
+  return (
+    <Table aria-label="Documents containing this item">
+      <TableHead>
+        <TableRow>
+          <TableCell>Name</TableCell>
+          <TableCell>Global ID</TableCell>
+          <TableCell>Owner</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {documents.map((document) => (
+          <TableRow key={document.globalId}>
+            <TableCell>{document.name}</TableCell>
+            <TableCell>
+              <GlobalIdLink record={document} />
+            </TableCell>
+            <TableCell>
+              {document.owner ? (
+                <UserDetails
+                  userId={document.owner.id}
+                  fullName={document.owner.fullName}
+                  position={["bottom", "right"]}
+                />
+              ) : (
+                <>-</>
+              )}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function DialogContents({ state }: { state: State }): React.ReactNode {
+  if (state.state === "loading") return <Skeleton variant="rectangular" width={210} height={118} />;
+  if (state.state === "fail") return <Alert severity="error">{state.error.message}</Alert>;
+  if (state.state === "success") {
+    const { documents, referencingItems } = state;
+    const bothEmpty = documents.size === 0 && referencingItems.length === 0;
+    return (
+      <>
+        <Box>
+          <Typography variant="subtitle1" gutterBottom>
+            Documents containing this item
+          </Typography>
+          {documents.size > 0 ? <DocumentsTable documents={documents} /> : <NoValue label="No documents" />}
+        </Box>
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle1" gutterBottom>
+            Inventory items linking to this item
+          </Typography>
+          {referencingItems.length > 0 ? (
+            <ReferencingItemsTable items={referencingItems} />
+          ) : (
+            <NoValue label="No inventory links" />
+          )}
+        </Box>
+        {bothEmpty && (
+          <>
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="body1">
+                Adding this item to a document&apos;s{" "}
+                <a href={docLinks.listOfMaterials} rel="noreferrer" target="_blank">
+                  List of Materials
+                </a>{" "}
+                will add an entry for the document in this panel.
+              </Typography>
+            </Box>
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="body1">
+                Other Inventory items that link to this item through a Link custom field will also be listed here.
+              </Typography>
+            </Box>
+          </>
+        )}
+      </>
+    );
+  }
+  return null;
+}
 
 type LinkedDocumentsArgs = {
   globalId: GlobalId;
@@ -49,9 +191,17 @@ function LinkedDocuments({ globalId, factory }: LinkedDocumentsArgs): React.Reac
       setState({ state: "loading" });
       void (async () => {
         try {
-          const { data } = await ApiService.get<Array<{ elnDocument: DocumentAttrs }>>(
+          const docsRequest = ApiService.get<Array<{ elnDocument: DocumentAttrs }>>(
             `listOfMaterials/forInventoryItem/${globalId}`,
           );
+          const refsEndpoint = referencingItemsEndpoint(globalId);
+          const refsRequest = refsEndpoint
+            ? ApiService.get<{ referencingItems: ReferencingItem[] }>(refsEndpoint)
+            : Promise.resolve({
+                data: { referencingItems: [] },
+              } as { data: { referencingItems: ReferencingItem[] } });
+
+          const [docsResponse, refsResponse] = await Promise.all([docsRequest, refsRequest]);
 
           // always use a new factory so that closing and reopening the
           // dialog uses the newly fetched data
@@ -59,11 +209,9 @@ function LinkedDocuments({ globalId, factory }: LinkedDocumentsArgs): React.Reac
 
           setState({
             state: "success",
-            // take the union of the documents, where id defines equality, to
-            // only show each document in the table once
             documents: unionWith(
               ({ id }: Document) => id,
-              data.map(
+              docsResponse.data.map(
                 ({ elnDocument: { globalId: docGlobalId, name, id, owner } }: { elnDocument: DocumentAttrs }) =>
                   new RsSet([
                     newFactory.newDocument({
@@ -75,6 +223,7 @@ function LinkedDocuments({ globalId, factory }: LinkedDocumentsArgs): React.Reac
                   ]),
               ),
             ),
+            referencingItems: refsResponse.data.referencingItems ?? [],
           });
         } catch (e) {
           setState({ state: "fail", error: e as Error });
@@ -84,77 +233,32 @@ function LinkedDocuments({ globalId, factory }: LinkedDocumentsArgs): React.Reac
   }, [open]);
 
   return (
-    <FormControl component="fieldset" sx={{ alignItems: "flex-start" }}>
-      <FormLabel component="legend">Linked Documents</FormLabel>
-      <FormGroup>
-        <Button
-          variant="outlined"
-          disableElevation
-          onClick={() => {
-            setOpen(true);
-          }}
-          disabled={!factory}
-        >
-          Show Linked Documents
-        </Button>
-        <Dialog open={open} onClose={() => setOpen(false)}>
-          <DialogTitle>Linked Documents</DialogTitle>
-          <DialogContent>
-            {state.state === "loading" && <Skeleton variant="rectangular" width={210} height={118} />}
-            {state.state === "fail" && <Alert severity="error">{state.error.message}</Alert>}
-            {state.state === "success" && state.documents.size === 0 && (
-              <>
-                <NoValue label="None" />
-                <Box sx={{ mt: 1 }}>
-                  <Typography variant="body1">
-                    Adding this item to a document&apos;s{" "}
-                    <a href={docLinks.listOfMaterials} rel="noreferrer" target="_blank">
-                      List of Materials
-                    </a>{" "}
-                    will add an entry for the document in this panel.
-                  </Typography>
-                </Box>
-              </>
-            )}
-            {state.state === "success" && state.documents.size > 0 && (
-              <Table>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Name</TableCell>
-                    <TableCell>Global ID</TableCell>
-                    <TableCell>Owner</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {state.documents.map((document) => (
-                    <TableRow key={document.globalId}>
-                      <TableCell>{document.name}</TableCell>
-                      <TableCell>
-                        <GlobalIdLink record={document} />
-                      </TableCell>
-                      <TableCell>
-                        {document.owner ? (
-                          <UserDetails
-                            userId={document.owner.id}
-                            fullName={document.owner.fullName}
-                            position={["bottom", "right"]}
-                          />
-                        ) : (
-                          <>&emdash;</>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setOpen(false)}>Close</Button>
-          </DialogActions>
-        </Dialog>
-      </FormGroup>
-    </FormControl>
+    <Grid>
+      <FormControl component="fieldset" style={{ alignItems: "flex-start" }}>
+        <FormLabel component="legend">Linked Documents</FormLabel>
+        <FormGroup>
+          <Button
+            variant="outlined"
+            disableElevation
+            onClick={() => {
+              setOpen(true);
+            }}
+            disabled={!factory}
+          >
+            Show Linked Documents
+          </Button>
+          <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="sm">
+            <DialogTitle>Linked Documents</DialogTitle>
+            <DialogContent>
+              <DialogContents state={state} />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setOpen(false)}>Close</Button>
+            </DialogActions>
+          </Dialog>
+        </FormGroup>
+      </FormControl>
+    </Grid>
   );
 }
 

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/SidebarBody.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/SidebarBody.tsx
@@ -1,0 +1,55 @@
+import { buttonClasses } from "@mui/material/Button";
+import { formGroupClasses } from "@mui/material/FormGroup";
+import Stack from "@mui/material/Stack";
+import { observer } from "mobx-react-lite";
+import type React from "react";
+import type { Factory } from "../../../stores/definitions/Factory";
+import type { InventoryRecord } from "../../../stores/definitions/InventoryRecord";
+// biome-ignore lint/suspicious/noShadowRestrictedNames: initial biome migration
+import Date from "./Date";
+import GlobalId from "./GlobalId";
+import LatestTemplateActions from "./LatestTemplateActions";
+import LinkedDocuments from "./LinkedDocuments";
+import VersionHistory from "./VersionHistory";
+
+type SidebarBodyArgs = {
+  record: InventoryRecord;
+  factory: Factory | null;
+};
+
+/**
+ * Presentational body of the MoreInfo side panel. Renders the labelled fields
+ * for an inventory record. Used by the main Sidebar drawer and by the
+ * InventoryInfoDialog modal so both surfaces share one implementation.
+ */
+function SidebarBody({ record, factory }: SidebarBodyArgs): React.ReactNode {
+  return (
+    <Stack
+      spacing={2}
+      // Give every action button (version history, update samples, linked
+      // documents) a shared minimum width so they line up, while still letting
+      // a longer label grow past it. These are the only FormGroup-wrapped
+      // buttons in the panel; the dialog Close buttons they render are portaled
+      // out of this subtree.
+      sx={{
+        [`& .${formGroupClasses.root} .${buttonClasses.root}`]: {
+          minWidth: "220px",
+        },
+      }}
+    >
+      <GlobalId record={record} />
+      <Date label="Created" date={record.created} />
+      <Date label="Last Modified" date={record.lastModified} />
+      <VersionHistory record={record} />
+      <LatestTemplateActions record={record} />
+      {/* templates cannot appear in a List of Materials, but they are valid
+          link targets, so the linked-documents dialog (which also lists the
+          inventory items linking here) applies to them like every other type */}
+      {(record.usableInLoM || record.recordType === "sampleTemplate") && record.globalId && (
+        <LinkedDocuments globalId={record.globalId} factory={factory} />
+      )}
+    </Stack>
+  );
+}
+
+export default observer(SidebarBody);

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/LatestTemplateActions.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/LatestTemplateActions.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const mockRootStore = {
+  uiStore: { confirm: vi.fn(() => Promise.resolve(true)), addAlert: vi.fn() },
+  unitStore: { getUnit: () => ({ label: "ml" }) },
+};
+vi.mock("../../../../stores/stores/RootStore", () => ({
+  default: () => mockRootStore,
+}));
+vi.mock("../../../../common/InvApiService", () => ({
+  default: { post: vi.fn(), get: vi.fn() },
+}));
+
+import { ThemeProvider } from "@mui/material/styles";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import { makeMockTemplate } from "../../../../stores/models/__tests__/TemplateModel/mocking";
+import materialTheme from "../../../../theme";
+import LatestTemplateActions from "../LatestTemplateActions";
+
+function renderFor(record: unknown) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <LatestTemplateActions record={record as never} />
+    </ThemeProvider>,
+  );
+}
+
+describe("LatestTemplateActions", () => {
+  afterEach(cleanup);
+
+  test("hides the Update Samples button when no samples need updating", () => {
+    renderFor(makeMockTemplate({ samplesToUpdateCount: 0 }));
+    expect(screen.queryByRole("button", { name: /update samples/i })).not.toBeInTheDocument();
+  });
+
+  test("shows the Update Samples button when samples need updating", () => {
+    renderFor(makeMockTemplate({ samplesToUpdateCount: 2 }));
+    expect(screen.getByRole("button", { name: /update samples/i })).toBeInTheDocument();
+  });
+
+  test("stays hidden for a historical version even when samples need updating", () => {
+    renderFor(makeMockTemplate({ samplesToUpdateCount: 2, historicalVersion: true }));
+    expect(screen.queryByRole("button", { name: /update samples/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/MoreInfoLinkedDocuments.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/MoreInfoLinkedDocuments.test.tsx
@@ -18,6 +18,39 @@ describe("LinkedDocuments", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
+  test("fetches a template's back-references via the generic referencingItems endpoint", async () => {
+    // there is no typed /sampleTemplates/{id}/referencingItems endpoint, so
+    // IT targets use the generic /referencingItems/{globalId} route
+    const spy = vi.spyOn(InvApiService, "get").mockImplementation((url) => {
+      if (String(url).startsWith("referencingItems/")) {
+        return Promise.resolve({
+          data: {
+            referencingItems: [
+              {
+                sourceGlobalId: "SA1",
+                sourceName: "A sample",
+                sourceType: "SAMPLE",
+                relationType: "References",
+                versionPin: null,
+              },
+            ],
+          },
+        } as AxiosResponse);
+      }
+      return Promise.resolve({ data: [] } as AxiosResponse);
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkedDocuments factory={mockFactory()} globalId="IT5" />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
+
+    expect(await screen.findByText("A sample")).toBeVisible();
+    expect(spy).toHaveBeenCalledWith("listOfMaterials/forInventoryItem/IT5");
+    expect(spy).toHaveBeenCalledWith("referencingItems/IT5");
+  });
+
   test("Assert that correct API endpoint is called with Global ID", async () => {
     const spy = vi.spyOn(InvApiService, "get").mockImplementation(() => Promise.reject(new Error("An error")));
     render(<LinkedDocuments factory={mockFactory()} globalId="IC1" />);
@@ -57,14 +90,16 @@ describe("LinkedDocuments", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
     expect(within(await screen.findByRole("table")).getAllByRole("row")).toHaveLength(3);
     expect(
-      // @ts-expect-error findTableCell exists in the customized within function
+      // @ts-expect-error findTableCell exists on the custom within function
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       await within(screen.getByRole("table")).findTableCell({
         columnHeading: "Name",
         rowIndex: 0,
       }),
     ).toHaveTextContent("Foo");
     expect(
-      // @ts-expect-error findTableCell exists in the customized within function
+      // @ts-expect-error findTableCell exists on the custom within function
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       await within(screen.getByRole("table")).findTableCell({
         columnHeading: "Name",
         rowIndex: 1,
@@ -99,12 +134,86 @@ describe("LinkedDocuments", () => {
 
     expect(rows).toHaveLength(2);
     expect(
-      // @ts-expect-error findTableCell exists in the customized within function
+      // @ts-expect-error findTableCell exists on the custom within function
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       await within(screen.getByRole("table")).findTableCell({
         columnHeading: "Name",
         rowIndex: 0,
       }),
     ).toHaveTextContent("Foo");
+  });
+  test.each([
+    ["SS9", "subSamples/9/referencingItems"],
+    ["IC5", "containers/5/referencingItems"],
+    ["IN3", "instruments/3/referencingItems"],
+  ])("Maps Global ID %s to %s for the referencingItems endpoint", async (globalId, expectedUrl) => {
+    const spy = vi.spyOn(InvApiService, "get").mockImplementation((url) => {
+      if (typeof url === "string" && url.endsWith("/referencingItems")) {
+        return Promise.resolve({
+          data: { referencingItems: [] },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        } as AxiosResponse);
+      }
+      return Promise.resolve({
+        data: [],
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {},
+      } as AxiosResponse);
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkedDocuments factory={mockFactory()} globalId={globalId} />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
+    await screen.findByRole("button", { name: "Close" });
+    expect(spy).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  test("Does not call referencingItems for an unknown Global ID prefix", async () => {
+    const spy = vi.spyOn(InvApiService, "get").mockImplementation(() => {
+      return Promise.resolve({
+        data: [],
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {},
+      } as AxiosResponse);
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkedDocuments factory={mockFactory()} globalId="ZZ1" />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
+    await screen.findByRole("button", { name: "Close" });
+    const calls = spy.mock.calls.map(([url]) => url);
+    expect(calls.some((url) => typeof url === "string" && url.endsWith("/referencingItems"))).toBe(false);
+  });
+
+  test("When no documents link to the item, the empty-state mentions both List of Materials and inventory links", async () => {
+    vi.spyOn(InvApiService, "get").mockImplementation(() => {
+      return Promise.resolve({
+        data: [],
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {},
+      } as AxiosResponse);
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkedDocuments factory={mockFactory()} globalId="IC1" />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
+    expect(await screen.findByText(/List of Materials/i)).toBeVisible();
+    expect(await screen.findByText(/other inventory items? that link/i)).toBeVisible();
   });
   test("Opening the dialog twice should trigger two network calls", async () => {
     const spy = vi.spyOn(InvApiService, "get").mockImplementation(() => {
@@ -117,6 +226,137 @@ describe("LinkedDocuments", () => {
     await screen.findByRole("button", { name: "Show Linked Documents" });
     fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
     expect(await screen.findByText("An error")).toBeVisible();
-    expect(spy).toHaveBeenCalledTimes(2);
+    // 2 opens, each open triggers 2 calls (documents + referencing items)
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+
+  test("Calls the referencingItems endpoint for the matching item kind", async () => {
+    const spy = vi.spyOn(InvApiService, "get").mockImplementation((url) => {
+      if (typeof url === "string" && url.endsWith("/referencingItems")) {
+        return Promise.resolve({
+          data: { referencingItems: [] },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        } as AxiosResponse);
+      }
+      return Promise.resolve({
+        data: [],
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {},
+      } as AxiosResponse);
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkedDocuments factory={mockFactory()} globalId="SA42" />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
+    // wait for the dialog to settle
+    await screen.findByRole("button", { name: "Close" });
+    expect(spy).toHaveBeenCalledWith("samples/42/referencingItems");
+  });
+
+  test("Renders a row per referencing Inventory item", async () => {
+    vi.spyOn(InvApiService, "get").mockImplementation((url) => {
+      if (typeof url === "string" && url.endsWith("/referencingItems")) {
+        return Promise.resolve({
+          data: {
+            referencingItems: [
+              {
+                sourceGlobalId: "SA10",
+                sourceName: "Calibrator A",
+                sourceType: "SAMPLE",
+                relationType: "IsCalibratedBy",
+                versionPin: null,
+                modifiedAtMillis: 0,
+              },
+              {
+                sourceGlobalId: "IC5",
+                sourceName: "Box 5",
+                sourceType: "CONTAINER",
+                relationType: "References",
+                versionPin: 3,
+                modifiedAtMillis: 0,
+              },
+            ],
+          },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        } as AxiosResponse);
+      }
+      return Promise.resolve({
+        data: [],
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {},
+      } as AxiosResponse);
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkedDocuments factory={mockFactory()} globalId="IC1" />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
+    expect(await screen.findByText("Calibrator A")).toBeVisible();
+    expect(screen.getByText("Box 5")).toBeVisible();
+    expect(screen.getByText("IsCalibratedBy")).toBeVisible();
+    expect(screen.getByText("References")).toBeVisible();
+  });
+
+  test("shows which version of THIS item each referencing item links to, not as a suffix on the source Global ID", async () => {
+    vi.spyOn(InvApiService, "get").mockImplementation((url) => {
+      if (typeof url === "string" && url.endsWith("/referencingItems")) {
+        return Promise.resolve({
+          data: {
+            referencingItems: [
+              {
+                sourceGlobalId: "SA10",
+                sourceName: "Unpinned source",
+                sourceType: "SAMPLE",
+                relationType: "References",
+                versionPin: null,
+              },
+              {
+                sourceGlobalId: "IC5",
+                sourceName: "Pinned source",
+                sourceType: "CONTAINER",
+                relationType: "References",
+                versionPin: 3,
+              },
+            ],
+          },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        } as AxiosResponse);
+      }
+      return Promise.resolve({
+        data: [],
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {},
+      } as AxiosResponse);
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkedDocuments factory={mockFactory()} globalId="IC1" />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
+    // The source's Global ID is shown bare: the version pin is NOT a version of the source.
+    expect(await screen.findByText("IC5")).toBeVisible();
+    expect(screen.queryByText("IC5v3")).not.toBeInTheDocument();
+    // Each row shows, separately, which version of THIS item the source links to.
+    expect(screen.getByText("v3")).toBeVisible();
+    expect(screen.getByText("Latest")).toBeVisible();
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/SidebarBody.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/SidebarBody.test.tsx
@@ -1,0 +1,119 @@
+// matchMedia is not implemented by jsdom; the shared per-file mock supplies it
+// (must be imported before any source module that reads it at evaluation time).
+import "@/__tests__/__mocks__/matchMedia";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../GlobalId", () => ({
+  default: ({ record }: { record: { globalId: string | null } }) => (
+    <div data-testid="globalid" data-value={record.globalId ?? ""} />
+  ),
+}));
+
+vi.mock("../Date", () => ({
+  default: ({ label, date }: { label: string; date: string }) => (
+    <div data-testid={`date-${label.replace(/\s+/g, "-").toLowerCase()}`} data-value={date} />
+  ),
+}));
+
+vi.mock("../VersionHistory", () => ({
+  default: () => <div data-testid="version-history" />,
+}));
+
+vi.mock("../LatestTemplateActions", () => ({
+  default: () => <div data-testid="latest-template-actions" />,
+}));
+
+vi.mock("../LinkedDocuments", () => ({
+  default: ({ globalId }: { globalId: string | null }) => (
+    <div data-testid="linked-documents" data-globalid={globalId ?? ""} />
+  ),
+}));
+
+import { ThemeProvider } from "@mui/material/styles";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import materialTheme from "../../../../theme";
+import SidebarBody from "../SidebarBody";
+
+function makeRecord(
+  overrides: Partial<{
+    globalId: string | null;
+    created: string;
+    lastModified: string;
+    usableInLoM: boolean;
+    recordType: string;
+  }> = {},
+) {
+  return {
+    globalId: "SA42",
+    created: "2026-01-01T00:00:00Z",
+    lastModified: "2026-02-02T00:00:00Z",
+    usableInLoM: true,
+    recordType: "sample",
+    ...overrides,
+  };
+}
+
+describe("SidebarBody", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders Global ID, Created and Last Modified for the supplied record", () => {
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <SidebarBody record={makeRecord() as never} factory={null} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("globalid")).toHaveAttribute("data-value", "SA42");
+    expect(screen.getByTestId("date-created")).toHaveAttribute("data-value", "2026-01-01T00:00:00Z");
+    expect(screen.getByTestId("date-last-modified")).toHaveAttribute("data-value", "2026-02-02T00:00:00Z");
+  });
+
+  it("includes LinkedDocuments when the record is usable in a List of Materials and has a Global ID", () => {
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <SidebarBody record={makeRecord() as never} factory={null} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("linked-documents")).toHaveAttribute("data-globalid", "SA42");
+  });
+
+  it("omits LinkedDocuments when the record is not usable in a List of Materials", () => {
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <SidebarBody record={makeRecord({ usableInLoM: false }) as never} factory={null} />
+      </ThemeProvider>,
+    );
+    expect(screen.queryByTestId("linked-documents")).not.toBeInTheDocument();
+  });
+
+  it("includes LinkedDocuments for a sample template", () => {
+    // templates cannot appear in a List of Materials (usableInLoM is false),
+    // but they are valid link targets, so "what links to this" applies and
+    // the Show Linked Documents button must be present like all other types
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <SidebarBody
+          record={
+            makeRecord({
+              usableInLoM: false,
+              recordType: "sampleTemplate",
+              globalId: "IT5",
+            }) as never
+          }
+          factory={null}
+        />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("linked-documents")).toHaveAttribute("data-globalid", "IT5");
+  });
+
+  it("omits LinkedDocuments when the record has no Global ID yet", () => {
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <SidebarBody record={makeRecord({ globalId: null }) as never} factory={null} />
+      </ThemeProvider>,
+    );
+    expect(screen.queryByTestId("linked-documents")).not.toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/index.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/index.tsx
@@ -5,18 +5,12 @@ import CardContent from "@mui/material/CardContent";
 import Divider from "@mui/material/Divider";
 import Drawer from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
-import Stack from "@mui/material/Stack";
 import { observer } from "mobx-react-lite";
 import type React from "react";
 import type { Factory } from "../../../stores/definitions/Factory";
 import useStores from "../../../stores/use-stores";
 import { useIsSingleColumnLayout } from "../Layout/Layout2x1";
-// biome-ignore lint/suspicious/noShadowRestrictedNames: initial biome migration
-import Date from "./Date";
-import GlobalId from "./GlobalId";
-import LatestTemplateActions from "./LatestTemplateActions";
-import LinkedDocuments from "./LinkedDocuments";
-import VersionHistory from "./VersionHistory";
+import SidebarBody from "./SidebarBody";
 
 type SidebarArgs = {
   factory: Factory | null;
@@ -51,16 +45,7 @@ function Sidebar({ factory }: SidebarArgs): React.ReactNode {
         </CardActions>
         <Divider />
         <CardContent sx={{ overflowX: "hidden" }}>
-          <Stack spacing={5}>
-            <GlobalId record={activeResult} />
-            <Date label="Created" date={activeResult.created} />
-            <Date label="Last Modified" date={activeResult.lastModified} />
-            <VersionHistory record={activeResult} />
-            <LatestTemplateActions record={activeResult} />
-            {activeResult.usableInLoM && activeResult.globalId && (
-              <LinkedDocuments globalId={activeResult.globalId} factory={factory} />
-            )}
-          </Stack>
+          <SidebarBody record={activeResult} factory={factory} />
         </CardContent>
       </Card>
     </Drawer>

--- a/src/main/webapp/ui/src/components/Inputs/FieldLabel.tsx
+++ b/src/main/webapp/ui/src/components/Inputs/FieldLabel.tsx
@@ -1,6 +1,7 @@
 import FormLabel from "@mui/material/FormLabel";
 import type { SxProps, Theme } from "@mui/material/styles";
 import type React from "react";
+import { mergeSx } from "@/modules/common/utils/styles";
 import { Heading } from "../DynamicHeadingLevel";
 
 /**
@@ -84,14 +85,17 @@ export default function FieldLabel({
       ? "legend"
       : "label";
 
+  // Reset styles added by the browser when setting the `component` prop, then
+  // merge any caller overrides on top.
+  const mergedSx: SxProps<Theme> = mergeSx({ mt: 0, textAlign: "left" }, sx);
+
   return (
     <FormLabel
       id={id}
       component={component}
       classes={classes}
       required={required}
-      // reset styles added by the browser when setting the component prop
-      sx={[{ mt: 0, textAlign: "left" }, ...(Array.isArray(sx) ? sx : [sx])]}
+      sx={mergedSx}
       {...(!disabled && !asFieldset && typeof htmlFor === "string" ? { htmlFor } : {})}
     >
       {children}

--- a/src/main/webapp/ui/src/components/Inputs/FormField.tsx
+++ b/src/main/webapp/ui/src/components/Inputs/FormField.tsx
@@ -249,6 +249,27 @@ export type FormFieldArgs<T> = {
   doNotAttachIdToLabel?: boolean;
 
   sx?: SxProps<Theme>;
+
+  /**
+   * When true the label stays in the DOM (so screen readers and the
+   * `aria-labelledby` wiring still find it) but is hidden visually. Use this
+   * where the field's name is presented elsewhere in the input itself - e.g. a
+   * Link field renders its name inside the link card, so the duplicate label
+   * above the card is suppressed.
+   */
+  hideLabel?: boolean;
+};
+
+const VISUALLY_HIDDEN: SxProps<Theme> = {
+  border: 0,
+  clip: "rect(0 0 0 0)",
+  height: "1px",
+  margin: "-1px",
+  overflow: "hidden",
+  padding: 0,
+  position: "absolute",
+  whiteSpace: "nowrap",
+  width: "1px",
 };
 
 export default function FormField<T>({
@@ -265,6 +286,7 @@ export default function FormField<T>({
   asFieldset,
   doNotAttachIdToLabel,
   sx,
+  hideLabel,
 }: FormFieldArgs<T>): React.ReactNode {
   const inputId = React.useId();
   const labelId = React.useId();
@@ -295,6 +317,7 @@ export default function FormField<T>({
         disabled={disabled}
         asFieldset={asFieldset}
         htmlFor={doNotAttachIdToLabel ? undefined : inputId}
+        sx={hideLabel ? VISUALLY_HIDDEN : undefined}
       >
         {label}
       </FieldLabel>

--- a/src/main/webapp/ui/src/components/VersionLockPicker/VersionLockPicker.tsx
+++ b/src/main/webapp/ui/src/components/VersionLockPicker/VersionLockPicker.tsx
@@ -1,0 +1,93 @@
+import Radio from "@mui/material/Radio";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import type React from "react";
+import { useEffect, useState } from "react";
+
+export const LATEST_SELECTION = "__latest__" as const;
+
+export interface VersionRecord {
+  version: number;
+  revisionId: number;
+  modificationDate: string;
+}
+
+export type VersionLockSelection = number | typeof LATEST_SELECTION;
+
+export interface VersionLockPickerProps {
+  recordId: number;
+  currentSelection: VersionLockSelection;
+  fetchVersions: (recordId: number) => Promise<VersionRecord[]>;
+  onChange: (selection: VersionLockSelection) => void;
+}
+
+export default function VersionLockPicker(props: VersionLockPickerProps): React.ReactElement {
+  const [versions, setVersions] = useState<VersionRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    props.fetchVersions(props.recordId).then(
+      (rows) => {
+        if (!cancelled) {
+          setVersions(rows);
+        }
+      },
+      () => {
+        // a failed fetch degrades to the latest-only view; the rejection must
+        // not escape the component as an unhandled promise rejection
+        if (!cancelled) {
+          setVersions([]);
+        }
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [props.recordId, props.fetchVersions]);
+
+  const isLatest = props.currentSelection === LATEST_SELECTION;
+
+  return (
+    <TableContainer>
+      <Table size="small" aria-label="version-lock-picker">
+        <TableHead>
+          <TableRow>
+            <TableCell padding="checkbox" />
+            <TableCell>Version</TableCell>
+            <TableCell>Modified</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow hover onClick={() => props.onChange(LATEST_SELECTION)} data-test-id="VersionLockPicker-latest">
+            <TableCell padding="checkbox">
+              <Radio checked={isLatest} value={LATEST_SELECTION} />
+            </TableCell>
+            <TableCell>Latest</TableCell>
+            <TableCell />
+          </TableRow>
+          {versions.map((v) => {
+            const checked = !isLatest && props.currentSelection === v.version;
+            return (
+              <TableRow
+                key={v.version}
+                hover
+                onClick={() => props.onChange(v.version)}
+                data-test-id={`VersionLockPicker-row-${v.version}`}
+              >
+                <TableCell padding="checkbox">
+                  <Radio checked={checked} value={v.version} />
+                </TableCell>
+                <TableCell>{`Version ${v.version}`}</TableCell>
+                <TableCell>{v.modificationDate}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/main/webapp/ui/src/components/VersionLockPicker/__tests__/VersionLockPicker.test.tsx
+++ b/src/main/webapp/ui/src/components/VersionLockPicker/__tests__/VersionLockPicker.test.tsx
@@ -1,0 +1,107 @@
+import { ThemeProvider } from "@mui/material/styles";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/__tests__/customQueries";
+import materialTheme from "../../../theme";
+import VersionLockPicker, { LATEST_SELECTION, type VersionRecord } from "../VersionLockPicker";
+
+const revisions: VersionRecord[] = [
+  { version: 1, revisionId: 11, modificationDate: "2024-01-01T00:00:00Z" },
+  { version: 2, revisionId: 22, modificationDate: "2024-02-01T00:00:00Z" },
+  { version: 3, revisionId: 33, modificationDate: "2024-03-01T00:00:00Z" },
+];
+
+function renderComponent(props: {
+  currentSelection: number | typeof LATEST_SELECTION;
+  onChange: (s: number | typeof LATEST_SELECTION) => void;
+}) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <VersionLockPicker
+        recordId={42}
+        currentSelection={props.currentSelection}
+        fetchVersions={() => Promise.resolve(revisions)}
+        onChange={props.onChange}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe("VersionLockPicker", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders a row for each revision and a 'latest' row", async () => {
+    renderComponent({ currentSelection: LATEST_SELECTION, onChange: vi.fn() });
+    expect(await screen.findByText(/version 1/i)).toBeInTheDocument();
+    expect(await screen.findByText(/version 2/i)).toBeInTheDocument();
+    expect(await screen.findByText(/version 3/i)).toBeInTheDocument();
+    expect(screen.getByText(/latest/i)).toBeInTheDocument();
+  });
+
+  it("calls onChange with the version number when a row is selected", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderComponent({ currentSelection: LATEST_SELECTION, onChange });
+
+    const row = await screen.findByText(/version 2/i);
+    await user.click(row);
+
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it("calls onChange with LATEST_SELECTION when the latest row is selected", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderComponent({ currentSelection: 1, onChange });
+
+    const latestRow = await screen.findByText(/latest/i);
+    await user.click(latestRow);
+
+    expect(onChange).toHaveBeenCalledWith(LATEST_SELECTION);
+  });
+
+  it("marks the current selection as the checked radio", async () => {
+    renderComponent({ currentSelection: 2, onChange: vi.fn() });
+
+    // wait for rows to load
+    await screen.findByText(/version 2/i);
+    const radios = screen.getAllByRole("radio");
+    const checkedRadios = radios.filter((r) => (r as HTMLInputElement).checked);
+    expect(checkedRadios).toHaveLength(1);
+  });
+
+  it("degrades to the latest-only view when fetchVersions rejects", async () => {
+    // the fetchVersions contract does not promise to never reject; a failing
+    // versions endpoint must leave the picker in a known state (no version
+    // rows) without an unhandled promise rejection escaping the component
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <VersionLockPicker
+            recordId={42}
+            currentSelection={LATEST_SELECTION}
+            fetchVersions={() => Promise.reject(new Error("versions endpoint down"))}
+            onChange={vi.fn()}
+          />
+        </ThemeProvider>,
+      );
+
+      expect(await screen.findByText(/latest/i)).toBeInTheDocument();
+      // let the rejection cross a macrotask boundary so node's
+      // unhandled-rejection detection has run
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(screen.queryByText(/version \d/i)).not.toBeInTheDocument();
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useReferencingInventoryItems.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useReferencingInventoryItems.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAxiosGet } = vi.hoisted(() => ({ mockAxiosGet: vi.fn() }));
+
+vi.mock("@/common/axios", () => ({
+  default: { get: mockAxiosGet },
+}));
+
+import useReferencingInventoryItems from "../useReferencingInventoryItems";
+
+describe("useReferencingInventoryItems", () => {
+  beforeEach(() => {
+    mockAxiosGet.mockReset();
+  });
+  afterEach(cleanup);
+
+  it("requests the generic referencingItems endpoint with the record's global id", async () => {
+    mockAxiosGet.mockResolvedValue({ data: { referencingItems: [] } });
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockAxiosGet).toHaveBeenCalledWith("/workspace/getReferencingInventoryItems/GL5");
+  });
+
+  it("url-encodes the global id in the request path", async () => {
+    // a global id is normally path-safe, but encoding guards against any
+    // future id format that introduces characters that would otherwise alter
+    // the request path
+    mockAxiosGet.mockResolvedValue({ data: { referencingItems: [] } });
+
+    const { result } = renderHook(() => useReferencingInventoryItems("SA1 2#3"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockAxiosGet).toHaveBeenCalledWith("/workspace/getReferencingInventoryItems/SA1%202%233");
+  });
+
+  it("maps referencing items into rows with a linkable inventory record", async () => {
+    mockAxiosGet.mockResolvedValue({
+      data: {
+        referencingItems: [
+          {
+            sourceGlobalId: "SA1",
+            sourceName: "My sample",
+            sourceType: "SAMPLE",
+            relationType: "IsPartOf",
+            versionPin: null,
+            modifiedAt: null,
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toHaveLength(1);
+    const row = result.current.items[0];
+    expect(row.globalId).toBe("SA1");
+    expect(row.name).toBe("My sample");
+    expect(row.relationType).toBe("IsPartOf");
+    expect(row.linkableRecord.iconName).toBe("sample");
+    expect(row.linkableRecord.permalinkURL).toBe("/globalId/SA1");
+  });
+
+  it("renders a row whose relationType is missing rather than dropping it", async () => {
+    // the relation column is nullable on the server; the legacy panel renders
+    // such rows with a blank relation and this hook must agree
+    mockAxiosGet.mockResolvedValue({
+      data: {
+        referencingItems: [
+          {
+            sourceGlobalId: "SA2",
+            sourceName: "No relation",
+            sourceType: "SAMPLE",
+            versionPin: null,
+            modifiedAt: null,
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].globalId).toBe("SA2");
+    expect(result.current.items[0].relationType).toBe("");
+  });
+
+  it("does not call the endpoint and reports empty when given a null global id", async () => {
+    const { result } = renderHook(() => useReferencingInventoryItems(null));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockAxiosGet).not.toHaveBeenCalled();
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("surfaces an error message when the request fails", async () => {
+    mockAxiosGet.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.errorMessage).toMatch(/related inventory items/i);
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("clears a stale error when the global id becomes null", async () => {
+    // a failure for one record must not leave its error showing once the hook
+    // is pointed at no record at all (the early-return path)
+    mockAxiosGet.mockRejectedValue(new Error("boom"));
+
+    const initialProps: { id: string | null } = { id: "GL5" };
+    const { result, rerender } = renderHook(({ id }: { id: string | null }) => useReferencingInventoryItems(id), {
+      initialProps,
+    });
+
+    await waitFor(() => expect(result.current.errorMessage).not.toBeNull());
+
+    rerender({ id: null });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.items).toHaveLength(0);
+  });
+});

--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.tsx
@@ -33,6 +33,7 @@ import { usePdfPreview } from "./CallablePdfPreview";
 import { useSnapGenePreview } from "./CallableSnapGenePreview";
 import { useSnippetPreview } from "./CallableSnippetPreview";
 import { useFolderOpen } from "./OpenFolderProvider";
+import { ReferencingInventoryItemsPanel } from "./ReferencingInventoryItemsPanel";
 
 /**
  * The height, in pixels, of the region that responds to touch/pointer events
@@ -578,6 +579,7 @@ const InfoPanelContent = observer(
           />
         </Box>
         {file.linkedDocuments}
+        <ReferencingInventoryItemsPanel file={file} />
       </Stack>
     );
   },

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.spec.tsx
@@ -315,6 +315,13 @@ feature.beforeEach(async ({ router }) => {
       }),
     });
   });
+  await router.route("/workspace/getReferencingInventoryItems/*", (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ referencingItems: [] }),
+    });
+  });
   await router.route(
     "/gallery/getUploadedFiles?mediatype=Images&currentFolderId=1&name=&pageNumber=0&sortOrder=ASC&orderBy=name&foldersOnly=false",
     (route) => {

--- a/src/main/webapp/ui/src/eln/gallery/components/ReferencingInventoryItemsPanel.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/ReferencingInventoryItemsPanel.tsx
@@ -1,0 +1,102 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { DataGrid, useGridApiRef } from "@mui/x-data-grid";
+import React from "react";
+import GlobalId from "../../../components/GlobalId";
+import AnalyticsContext from "../../../stores/contexts/Analytics";
+import { DataGridColumn } from "../../../util/table";
+import type { GalleryFile } from "../useGalleryListing";
+import useReferencingInventoryItems, { type ReferencingInventoryItem } from "../useReferencingInventoryItems";
+
+/**
+ * One grid row per link FIELD: a source item linking through two fields
+ * repeats its globalId, so each row carries its own synthetic unique id.
+ */
+type ReferencingItemRow = ReferencingInventoryItem & { rowId: string };
+
+/**
+ * Lists the Inventory items (samples, subsamples, containers, instruments) whose
+ * Link extra-field points at this GalleryFile. The mirror image of
+ * {@link LinkedDocumentsPanel}: where that shows ELN documents linking in, this
+ * shows Inventory items linking in. The relation is displayed with the Inventory
+ * item as the subject (e.g. "SA1 IsPartOf this file").
+ *
+ * @param file The GalleryFile that can be referenced by Inventory items.
+ */
+export function ReferencingInventoryItemsPanel({ file }: { file: GalleryFile }): React.ReactNode {
+  const apiRef = useGridApiRef();
+  const referencing = useReferencingInventoryItems(typeof file.globalId === "string" ? file.globalId : null);
+  const { trackEvent } = React.useContext(AnalyticsContext);
+
+  React.useEffect(() => {
+    setTimeout(() => {
+      void apiRef.current?.autosizeColumns({
+        includeHeaders: true,
+        includeOutliers: true,
+      });
+    }, 10); // 10ms for react to re-render
+  }, [referencing.items, apiRef]);
+
+  return (
+    <Box component="section" sx={{ mt: 0.5, "--DataGrid-overlayHeight": "40px", flexGrow: 1 }}>
+      <Typography variant="h4" component="h4">
+        Related inventory items
+      </Typography>
+      <DataGrid
+        columns={[
+          DataGridColumn.newColumnWithFieldName<"name", ReferencingItemRow>("name", {
+            headerName: "Name",
+            flex: 1,
+            sortable: false,
+            resizable: true,
+          }),
+          DataGridColumn.newColumnWithFieldName<"relationType", ReferencingItemRow>("relationType", {
+            headerName: "Relation",
+            flex: 0,
+            sortable: false,
+            resizable: true,
+          }),
+          DataGridColumn.newColumnWithFieldName<"globalId", ReferencingItemRow>("globalId", {
+            headerName: "Global ID",
+            flex: 0,
+            resizable: true,
+            sortable: false,
+            renderCell: ({ row }) => (
+              <GlobalId
+                record={row.linkableRecord}
+                onClick={() => {
+                  trackEvent("user:click:globalId:galleryReferencingInventoryItems");
+                }}
+              />
+            ),
+          }),
+        ]}
+        rows={referencing.items.map((item, index) => ({
+          ...item,
+          // one row per link FIELD: a source item linking through two fields
+          // repeats its globalId, so the grid row id needs the index too
+          rowId: `${item.globalId}-${index}`,
+        }))}
+        initialState={{
+          columns: {},
+        }}
+        density="compact"
+        disableColumnFilter
+        hideFooter
+        autoHeight
+        apiRef={apiRef}
+        slots={{
+          pagination: null,
+        }}
+        localeText={{
+          noRowsLabel: referencing.errorMessage ?? "No related inventory items",
+        }}
+        loading={referencing.loading}
+        getRowId={(row) => row.rowId}
+        sx={{
+          ml: 2,
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/main/webapp/ui/src/eln/gallery/useReferencingInventoryItems.ts
+++ b/src/main/webapp/ui/src/eln/gallery/useReferencingInventoryItems.ts
@@ -1,0 +1,98 @@
+import React from "react";
+import axios from "@/common/axios";
+import { INVENTORY_PREFIX_ICON_DATA, prefixOf } from "@/Inventory/components/Fields/Link/iconForGlobalId";
+import type { LinkableRecord } from "../../stores/definitions/LinkableRecord";
+import * as Parsers from "../../util/parsers";
+import Result from "../../util/result";
+
+/**
+ * An Inventory item that links to the current ELN record, to the extent the
+ * Gallery info panel needs to render a back-reference row.
+ */
+export type ReferencingInventoryItem = {
+  globalId: string;
+  name: string;
+  type: string;
+  relationType: string;
+  permalinkHref: string;
+  linkableRecord: LinkableRecord;
+};
+
+/**
+ * Given an ELN record's Global ID (e.g. a gallery file GLnnn), fetch the Inventory
+ * items whose Link extra-field points at it. Backs the "Related inventory items"
+ * section on the ELN side. The endpoint is permission-filtered server-side, so the
+ * caller only ever receives items the user may read. Mirrors {@link useLinkedDocuments}.
+ */
+export default function useReferencingInventoryItems(globalId: string | null): {
+  items: ReadonlyArray<ReferencingInventoryItem>;
+  loading: boolean;
+  errorMessage: string | null;
+} {
+  const [loading, setLoading] = React.useState(true);
+  const [items, setItems] = React.useState<ReadonlyArray<ReferencingInventoryItem>>([]);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  const fetchReferencingItems = React.useCallback(async (): Promise<void> => {
+    if (!globalId) {
+      setItems([]);
+      setErrorMessage(null);
+      setLoading(false);
+      return;
+    }
+    setItems([]);
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const { data } = await axios.get<unknown>(
+        `/workspace/getReferencingInventoryItems/${encodeURIComponent(globalId)}`,
+      );
+      const rows: Array<ReferencingInventoryItem> = [];
+      Parsers.objectPath(["referencingItems"], data)
+        .flatMap(Parsers.isArray)
+        .do((arr) => {
+          for (const item of arr) {
+            Parsers.isObject(item)
+              .flatMap(Parsers.isNotNull)
+              .flatMap((obj) => {
+                const sourceGlobalId = Parsers.getValueWithKey("sourceGlobalId")(obj).flatMap(Parsers.isString);
+                const name = Parsers.getValueWithKey("sourceName")(obj).flatMap(Parsers.isString);
+                const type = Parsers.getValueWithKey("sourceType")(obj).flatMap(Parsers.isString);
+                // relationType is nullable on the server; a row without one
+                // must still render (as the legacy panel does) rather than be
+                // silently dropped
+                const relationType = Parsers.getValueWithKey("relationType")(obj).flatMap(Parsers.isString).orElse("");
+                return Result.all(sourceGlobalId, name, type).map(([g, n, t]) => ({
+                  globalId: g,
+                  name: n,
+                  type: t,
+                  relationType,
+                  permalinkHref: `/globalId/${g}`,
+                  linkableRecord: {
+                    id: parseInt(g.replace(/^[A-Z]{2}/, ""), 10) || null,
+                    globalId: g,
+                    name: n,
+                    recordTypeLabel: INVENTORY_PREFIX_ICON_DATA[prefixOf(g) ?? ""]?.recordTypeLabel ?? "Item",
+                    iconName: INVENTORY_PREFIX_ICON_DATA[prefixOf(g) ?? ""]?.iconName ?? "container",
+                    permalinkURL: `/globalId/${g}`,
+                  },
+                }));
+              })
+              .do((row) => rows.push(row));
+          }
+        });
+      setItems(rows);
+    } catch (e) {
+      console.error(e);
+      setErrorMessage("Error loading related inventory items.");
+    } finally {
+      setLoading(false);
+    }
+  }, [globalId]);
+
+  React.useEffect(() => {
+    void fetchReferencingItems();
+  }, [fetchReferencingItems]);
+
+  return { items, loading, errorMessage };
+}

--- a/src/main/webapp/ui/src/modules/workspace/__tests__/galleryUpload.test.ts
+++ b/src/main/webapp/ui/src/modules/workspace/__tests__/galleryUpload.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadNewGalleryVersion } from "@/modules/workspace/galleryUpload";
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+  vi.clearAllMocks();
+});
+
+function makeFile(): File {
+  return new File(["new bytes"], "replacement.png", { type: "image/png" });
+}
+
+describe("uploadNewGalleryVersion", () => {
+  it("posts multipart form data with the file and selectedMediaId to the upload endpoint", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        data: { id: 55, oid: { idString: "GL55" }, name: "replacement.png", type: "Image" },
+        error: null,
+        success: true,
+      }),
+    );
+
+    await uploadNewGalleryVersion({ mediaId: 55, file: makeFile() });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/gallery/ajax/uploadFile");
+    expect(init).toMatchObject({ method: "POST" });
+    const body = (init as RequestInit).body as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get("selectedMediaId")).toBe("55");
+    expect(body.get("xfile")).toBeInstanceOf(File);
+  });
+
+  it("returns the updated record information on success", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        data: { id: 55, oid: { idString: "GL55" }, name: "replacement.png", type: "Image", version: 3 },
+        error: null,
+        success: true,
+      }),
+    );
+
+    const result = await uploadNewGalleryVersion({ mediaId: 55, file: makeFile() });
+
+    expect(result.oid.idString).toBe("GL55");
+    expect(result.version).toBe(3);
+  });
+
+  it("throws the endpoint error message when the upload fails", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        data: null,
+        error: { errorMessages: ["File too large"] },
+        success: false,
+      }),
+      { status: 400, statusText: "Bad Request" },
+    );
+
+    await expect(uploadNewGalleryVersion({ mediaId: 55, file: makeFile() })).rejects.toThrow("File too large");
+  });
+});

--- a/src/main/webapp/ui/src/modules/workspace/__tests__/linkedRecords.test.ts
+++ b/src/main/webapp/ui/src/modules/workspace/__tests__/linkedRecords.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getLinkedByRecords, getLinkedDocuments } from "@/modules/workspace/linkedRecords";
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+  vi.clearAllMocks();
+});
+
+describe("getLinkedByRecords", () => {
+  it("requests the linked-by endpoint with the numeric target record id", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ data: [], error: null, success: true }));
+
+    await getLinkedByRecords(123);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/workspace/getLinkedByRecords?targetRecordId=123",
+      expect.objectContaining({
+        method: "GET",
+        headers: { "X-Requested-With": "XMLHttpRequest" },
+      }),
+    );
+  });
+
+  it("splits readable rows from private rows and aggregates private docs by owner", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        data: [
+          { id: 11, oid: { idString: "SD11" }, name: "Doc one", ownerFullName: "Ada Lovelace" },
+          { id: 12, oid: { idString: "SD12" }, name: "Doc two", ownerFullName: "Grace Hopper" },
+          { ownerFullName: "Grace Hopper", ownerUsername: "grace" },
+          { ownerFullName: "Grace Hopper", ownerUsername: "grace" },
+          { ownerFullName: "Ada Lovelace", ownerUsername: "ada" },
+        ],
+        error: null,
+        success: true,
+      }),
+    );
+
+    const result = await getLinkedByRecords(123);
+
+    expect(result.readable).toEqual([
+      { globalId: "SD11", name: "Doc one", ownerFullName: "Ada Lovelace" },
+      { globalId: "SD12", name: "Doc two", ownerFullName: "Grace Hopper" },
+    ]);
+    expect(result.privateByOwner).toEqual([
+      { ownerFullName: "Grace Hopper", count: 2 },
+      { ownerFullName: "Ada Lovelace", count: 1 },
+    ]);
+  });
+
+  it("throws the endpoint error message for non-OK responses", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        data: null,
+        error: { errorMessages: ["Record not found"] },
+        success: false,
+      }),
+      { status: 404, statusText: "Not Found" },
+    );
+
+    await expect(getLinkedByRecords(99)).rejects.toThrow("Record not found");
+  });
+});
+
+describe("getLinkedDocuments", () => {
+  it("requests the gallery linked-documents endpoint with the media id", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ data: [], error: null, success: true }));
+
+    await getLinkedDocuments(55);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/gallery/ajax/getLinkedDocuments/55",
+      expect.objectContaining({
+        method: "GET",
+        headers: { "X-Requested-With": "XMLHttpRequest" },
+      }),
+    );
+  });
+
+  it("returns readable linked documents as global-id rows", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        data: [{ id: 7, oid: { idString: "SD7" }, name: "Linked doc", ownerFullName: "Ada Lovelace" }],
+        error: null,
+        success: true,
+      }),
+    );
+
+    const result = await getLinkedDocuments(55);
+
+    expect(result.readable).toEqual([{ globalId: "SD7", name: "Linked doc", ownerFullName: "Ada Lovelace" }]);
+    expect(result.privateByOwner).toEqual([]);
+  });
+});

--- a/src/main/webapp/ui/src/modules/workspace/__tests__/publicLink.test.ts
+++ b/src/main/webapp/ui/src/modules/workspace/__tests__/publicLink.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPublicLink } from "@/modules/workspace/publicLink";
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+  vi.clearAllMocks();
+});
+
+describe("getPublicLink", () => {
+  it("requests the public link endpoint with the global id", async () => {
+    fetchMock.mockResponseOnce("");
+
+    await getPublicLink("SD123");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/public/publishedView/publiclink?globalId=SD123",
+      expect.objectContaining({
+        method: "GET",
+        headers: { "X-Requested-With": "XMLHttpRequest" },
+      }),
+    );
+  });
+
+  it("returns the public link when the record is published", async () => {
+    fetchMock.mockResponseOnce("/public/publishedView/document/abc-123");
+
+    const result = await getPublicLink("SD123");
+
+    expect(result).toBe("/public/publishedView/document/abc-123");
+  });
+
+  it("returns null when the endpoint returns an empty body", async () => {
+    fetchMock.mockResponseOnce("");
+
+    const result = await getPublicLink("SD123");
+
+    expect(result).toBeNull();
+  });
+
+  it("throws when the response is not OK", async () => {
+    fetchMock.mockResponseOnce("nope", { status: 500, statusText: "Server Error" });
+
+    await expect(getPublicLink("SD123")).rejects.toThrow();
+  });
+});

--- a/src/main/webapp/ui/src/modules/workspace/galleryUpload.ts
+++ b/src/main/webapp/ui/src/modules/workspace/galleryUpload.ts
@@ -1,0 +1,50 @@
+import { parseOrThrow } from "@/modules/common/queries/parseOrThrow";
+import {
+  WorkspaceGetRecordInformationResponseSchema,
+  type WorkspaceRecordInformation,
+} from "@/modules/workspace/schema";
+import { toWorkspaceError } from "@/modules/workspace/utils";
+
+const GALLERY_UPLOAD_URL = "/gallery/ajax/uploadFile";
+
+export type UploadNewGalleryVersionParams = {
+  mediaId: number;
+  file: File;
+};
+
+/**
+ * Replace a gallery media file with a new version, via multipart
+ * `POST /gallery/ajax/uploadFile` with `xfile` (the new file) and
+ * `selectedMediaId` (the existing media id). Returns the updated record information.
+ * Callers should invalidate the record-info query for this id on success.
+ */
+export async function uploadNewGalleryVersion({
+  mediaId,
+  file,
+}: UploadNewGalleryVersionParams): Promise<WorkspaceRecordInformation> {
+  const formData = new FormData();
+  formData.set("xfile", file);
+  formData.set("selectedMediaId", String(mediaId));
+
+  const response = await fetch(GALLERY_UPLOAD_URL, {
+    method: "POST",
+    headers: {
+      "X-Requested-With": "XMLHttpRequest",
+    },
+    body: formData,
+  });
+
+  const data: unknown = await response.json();
+
+  if (!response.ok) {
+    throw toWorkspaceError(data, `Failed to upload new version: ${response.statusText || response.status}`);
+  }
+
+  const parsed = parseOrThrow(WorkspaceGetRecordInformationResponseSchema, data);
+
+  if (parsed.data === null) {
+    throw toWorkspaceError(parsed, "No record information was returned.");
+  }
+
+  return parsed.data;
+}

--- a/src/main/webapp/ui/src/modules/workspace/linkedRecords.ts
+++ b/src/main/webapp/ui/src/modules/workspace/linkedRecords.ts
@@ -1,0 +1,91 @@
+import { parseOrThrow } from "@/modules/common/queries/parseOrThrow";
+import {
+  type LinkedRecords,
+  type PrivateLinkedRecordsByOwner,
+  type ReadableLinkedRecord,
+  type WorkspaceLinkedRecord,
+  WorkspaceLinkedRecordsResponseSchema,
+} from "@/modules/workspace/schema";
+import { toWorkspaceError, WORKSPACE_API_BASE_URL } from "@/modules/workspace/utils";
+
+const GALLERY_API_BASE_URL = "/gallery";
+
+/**
+ * Reduce a raw `getLinkedByRecords` / `getLinkedDocuments` list into the readable rows
+ * and the per-owner count of unreadable ("private") rows. A row is readable iff it
+ * carries an `id` (the server omits id/oid for records the caller cannot read and
+ * returns only the owner's name). Mirrors the aggregation in `recordInfoPanel.js`.
+ */
+function splitLinkedRecords(rows: ReadonlyArray<WorkspaceLinkedRecord>): LinkedRecords {
+  const readable: Array<ReadableLinkedRecord> = [];
+  const privateCounts = new Map<string, number>();
+
+  for (const row of rows) {
+    if (row.id != null && row.oid) {
+      readable.push({
+        globalId: row.oid.idString,
+        name: row.name ?? "",
+        ownerFullName: row.ownerFullName ?? null,
+      });
+    } else {
+      const owner = row.ownerFullName ?? "";
+      privateCounts.set(owner, (privateCounts.get(owner) ?? 0) + 1);
+    }
+  }
+
+  const privateByOwner: Array<PrivateLinkedRecordsByOwner> = [];
+  for (const [ownerFullName, count] of privateCounts) {
+    privateByOwner.push({ ownerFullName, count });
+  }
+
+  return { readable, privateByOwner };
+}
+
+async function fetchLinkedRecords(url: string, fallbackMessage: string): Promise<LinkedRecords> {
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "X-Requested-With": "XMLHttpRequest",
+    },
+  });
+
+  const data: unknown = await response.json();
+
+  if (!response.ok) {
+    throw toWorkspaceError(data, fallbackMessage);
+  }
+
+  const parsed = parseOrThrow(WorkspaceLinkedRecordsResponseSchema, data);
+
+  if (parsed.data === null) {
+    throw toWorkspaceError(parsed, fallbackMessage);
+  }
+
+  return splitLinkedRecords(parsed.data);
+}
+
+/**
+ * Fetch the ELN documents that link TO the given record, via
+ * `GET /workspace/getLinkedByRecords?targetRecordId={id}`. The id is the numeric DB id
+ * (strip the global-id prefix before calling).
+ */
+export function getLinkedByRecords(targetRecordId: number): Promise<LinkedRecords> {
+  const searchParams = new URLSearchParams();
+  searchParams.set("targetRecordId", String(targetRecordId));
+  return fetchLinkedRecords(
+    `${WORKSPACE_API_BASE_URL}/getLinkedByRecords?${searchParams.toString()}`,
+    "Failed to fetch linked-by records.",
+  );
+}
+
+/**
+ * Fetch the ELN documents that reference the given gallery media file, via
+ * `GET /gallery/ajax/getLinkedDocuments/{mediaId}`. The id is the numeric DB id of the
+ * gallery file.
+ */
+export function getLinkedDocuments(mediaId: number): Promise<LinkedRecords> {
+  return fetchLinkedRecords(
+    `${GALLERY_API_BASE_URL}/ajax/getLinkedDocuments/${mediaId}`,
+    "Failed to fetch linked documents.",
+  );
+}

--- a/src/main/webapp/ui/src/modules/workspace/publicLink.ts
+++ b/src/main/webapp/ui/src/modules/workspace/publicLink.ts
@@ -1,0 +1,26 @@
+const PUBLIC_API_BASE_URL = "/public";
+
+/**
+ * Fetch the public-view link for a published ELN record (or its published parent), via
+ * `GET /public/publishedView/publiclink?globalId={globalId}`. The endpoint returns a
+ * bare string body: the link when published, or an empty string when the record is not
+ * published. Returns `null` for the empty-string (not-published) case.
+ */
+export async function getPublicLink(globalId: string): Promise<string | null> {
+  const searchParams = new URLSearchParams();
+  searchParams.set("globalId", globalId);
+
+  const response = await fetch(`${PUBLIC_API_BASE_URL}/publishedView/publiclink?${searchParams.toString()}`, {
+    method: "GET",
+    headers: {
+      "X-Requested-With": "XMLHttpRequest",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch public link: ${response.statusText || response.status}`);
+  }
+
+  const link = (await response.text()).trim();
+  return link.length > 0 ? link : null;
+}

--- a/src/main/webapp/ui/src/modules/workspace/queries.ts
+++ b/src/main/webapp/ui/src/modules/workspace/queries.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { parseOrThrow } from "@/modules/common/queries/parseOrThrow";
 import {
   WorkspaceGetRecordInformationResponseSchema,
@@ -55,7 +55,10 @@ export async function getWorkspaceRecordInformationAjax({
 }
 
 export function useGetWorkspaceRecordInformationAjaxQuery(params: GetWorkspaceRecordInformationParams) {
-  return useSuspenseQuery({
+  // A plain (non-suspense) query so callers can handle a failed load explicitly
+  // from the returned error state, rather than the query throwing into a React
+  // error boundary. A 404 / not-readable record is an expected outcome here.
+  return useQuery({
     queryKey: workspaceQueryKeys.recordInformation(params),
     queryFn: () => getWorkspaceRecordInformationAjax(params),
     retry: false,

--- a/src/main/webapp/ui/src/modules/workspace/schema.ts
+++ b/src/main/webapp/ui/src/modules/workspace/schema.ts
@@ -86,3 +86,51 @@ export const WorkspaceGetRecordInformationResponseSchema = v.objectWithRest(
   v.unknown(),
 );
 export type WorkspaceGetRecordInformationResponse = v.InferOutput<typeof WorkspaceGetRecordInformationResponseSchema>;
+
+/**
+ * A single row from `getLinkedByRecords` / gallery `getLinkedDocuments`. The server
+ * returns the full {@link WorkspaceRecordInformation} for records the caller may read,
+ * but for records the caller cannot read it returns ONLY the owner's name/username (no
+ * `id`/`oid`). The presence of `id` is therefore the readable-vs-private discriminator.
+ */
+export const WorkspaceLinkedRecordSchema = v.objectWithRest(
+  {
+    id: v.optional(v.nullable(v.number())),
+    oid: v.optional(v.nullable(WorkspaceRecordOidSchema)),
+    name: v.optional(v.nullable(v.string())),
+    ownerFullName: v.optional(v.nullable(v.string())),
+    ownerUsername: v.optional(v.nullable(v.string())),
+  },
+  v.unknown(),
+);
+export type WorkspaceLinkedRecord = v.InferOutput<typeof WorkspaceLinkedRecordSchema>;
+
+export const WorkspaceLinkedRecordsResponseSchema = v.objectWithRest(
+  {
+    data: v.nullable(v.array(WorkspaceLinkedRecordSchema)),
+    error: v.optional(v.nullable(v.unknown())),
+    errorMsg: v.optional(v.nullable(v.unknown())),
+    success: v.optional(v.boolean()),
+  },
+  v.unknown(),
+);
+export type WorkspaceLinkedRecordsResponse = v.InferOutput<typeof WorkspaceLinkedRecordsResponseSchema>;
+
+/** An ELN record the caller can read, reduced to what a link row renders. */
+export type ReadableLinkedRecord = {
+  globalId: string;
+  name: string;
+  ownerFullName: string | null;
+};
+
+/** Count of unreadable ("private") linked records grouped by their owner. */
+export type PrivateLinkedRecordsByOwner = {
+  ownerFullName: string;
+  count: number;
+};
+
+/** The readable/private split that the linked-by and linked-docs sections render. */
+export type LinkedRecords = {
+  readable: ReadonlyArray<ReadableLinkedRecord>;
+  privateByOwner: ReadonlyArray<PrivateLinkedRecordsByOwner>;
+};

--- a/src/main/webapp/ui/src/stores/definitions/ExtraField.ts
+++ b/src/main/webapp/ui/src/stores/definitions/ExtraField.ts
@@ -2,20 +2,27 @@ import type { ValidationResult } from "../../components/ValidatingSubmitButton";
 import type { GlobalId, Id } from "./BaseRecord";
 import type { InventoryRecord } from "./InventoryRecord";
 
-export type ExtraFieldType = "Text" | "Number";
+export type ExtraFieldType = "Text" | "Number" | "Link";
+
+export type ExtraInventoryLink = {
+  relationType: string;
+  targetGlobalId: string;
+  versionPin: number | null;
+};
 
 export type ExtraFieldAttrs = {
   id: Id;
   globalId: GlobalId | null;
   name: string;
   lastModified: string | null;
-  type: "text" | "number";
+  type: "text" | "number" | "link";
   content: string;
   parentGlobalId: GlobalId | null;
   editable?: boolean;
   editing?: boolean;
   initial?: boolean;
   newFieldRequest?: boolean;
+  link?: ExtraInventoryLink | null;
 };
 
 /**
@@ -30,6 +37,12 @@ export interface ExtraField {
   content: string; // the value of the key-value pair
   owner: InventoryRecord;
   initial: boolean;
+
+  /*
+   * For Link-typed fields, the inventory/ELN link payload; null for non-Link
+   * fields (and for a Link field that has not yet been given a target).
+   */
+  readonly link: ExtraInventoryLink | null;
 
   /*
    * When set, subsequent API calls to store modifications MUST ensure that the

--- a/src/main/webapp/ui/src/stores/definitions/Field.ts
+++ b/src/main/webapp/ui/src/stores/definitions/Field.ts
@@ -13,9 +13,20 @@ export type FieldType =
   | "uri"
   | "time"
   | "reference"
-  | "attachment";
+  | "attachment"
+  | "link";
 
 export type OptionValue = string;
+
+/**
+ * The value of a link field: a single link to another Inventory item or ELN record, with a
+ * DataCite relationship type and an optional pinned version.
+ */
+export type FieldLink = {
+  relationType: string;
+  targetGlobalId: string;
+  versionPin: number | null;
+};
 
 export type Option = {
   value: OptionValue;
@@ -38,6 +49,15 @@ export interface Field extends BaseRecord {
   content: string | number | Date;
   selectedOptions: Array<string> | null;
   options: Array<Option>;
+
+  /**
+   * For link template fields: the whitelist of permitted DataCite relation types. An empty array
+   * means all relation types are allowed.
+   */
+  allowedRelationTypes: Array<string>;
+
+  /** For link fields: the single link value, or null when unset. */
+  link: FieldLink | null;
 
   readonly paramsForBackend: object;
   readonly hasContent: boolean;

--- a/src/main/webapp/ui/src/stores/definitions/InventoryRecord.ts
+++ b/src/main/webapp/ui/src/stores/definitions/InventoryRecord.ts
@@ -222,7 +222,6 @@ export interface InventoryRecord extends Record, Editable, HasChildren, CreateFr
    * When new data is available, typically by making a GET request, the
    * instance of InventoryRecord can be repopulated with this method.
    */
-
   // biome-ignore lint/suspicious/noExplicitAny: initial biome migration
   populateFromJson(factory: Factory, params: any, defaultParams: any | null): void;
 
@@ -295,7 +294,6 @@ export interface InventoryRecord extends Record, Editable, HasChildren, CreateFr
    * MUST always be JSON serialisable, and it is advisable to write a unit test
    * to assert as such for each implementation.
    */
-
   // biome-ignore lint/suspicious/noExplicitAny: initial biome migration
   readonly paramsForBackend: any;
 
@@ -314,7 +312,6 @@ export interface InventoryRecord extends Record, Editable, HasChildren, CreateFr
    * InventoryRecord at once whilst also setting a dirty flag to signify to
    * various UI elements that the user has made changes.
    */
-
   // biome-ignore lint/correctness/noEmptyPattern: initial biome migration
   setAttributesDirty({}): void;
 
@@ -348,7 +345,18 @@ export interface InventoryRecord extends Record, Editable, HasChildren, CreateFr
    */
   extraFields: Array<ExtraField>;
   addExtraField(newExtraFieldAttrs: ExtraFieldAttrs): void;
-  updateExtraField(oldFieldName: string, updatedField: { name: string; type: string }): void;
+  updateExtraField(
+    oldFieldName: string,
+    updatedField: {
+      name: string;
+      type: string;
+      link?: {
+        relationType: string;
+        targetGlobalId: string;
+        versionPin: number | null;
+      };
+    },
+  ): void;
   removeExtraField(id: number | null, index: number): void;
   readonly visibleExtraFields: Array<ExtraField>;
   readonly hasUnsavedExtraField: boolean;

--- a/src/main/webapp/ui/src/stores/definitions/Template.ts
+++ b/src/main/webapp/ui/src/stores/definitions/Template.ts
@@ -3,6 +3,11 @@ import type { Sample } from "./Sample";
 
 export interface Template extends Sample {
   version: number;
+  /**
+   * How many of the current user's samples were created from an older version
+   * of this template and could therefore be updated to its latest version.
+   */
+  samplesToUpdateCount: number;
   defaultUnitId: number;
   getLatest(): void;
   historicalVersion: boolean;

--- a/src/main/webapp/ui/src/stores/models/ExtraFieldModel.ts
+++ b/src/main/webapp/ui/src/stores/models/ExtraFieldModel.ts
@@ -1,7 +1,7 @@
 import { action, computed, makeObservable, observable } from "mobx";
 import { IsInvalid, IsValid, type ValidationResult } from "../../components/ValidatingSubmitButton";
 import type { GlobalId, Id } from "../definitions/BaseRecord";
-import type { ExtraField, ExtraFieldAttrs, ExtraFieldType } from "../definitions/ExtraField";
+import type { ExtraField, ExtraFieldAttrs, ExtraFieldType, ExtraInventoryLink } from "../definitions/ExtraField";
 import type { InventoryRecord } from "../definitions/InventoryRecord";
 import type InventoryBaseRecord from "./InventoryBaseRecord";
 
@@ -33,6 +33,7 @@ export default class ExtraFieldModel implements ExtraField {
   // @ts-expect-error Set by the call to setAttributes
   owner: InventoryRecord;
   invalidInput: boolean;
+  link: ExtraInventoryLink | null = null;
 
   constructor(attrs: ExtraFieldAttrs, owner: InventoryBaseRecord) {
     makeObservable(this, {
@@ -47,8 +48,11 @@ export default class ExtraFieldModel implements ExtraField {
       initial: observable,
       owner: observable,
       invalidInput: observable,
+      link: observable,
       setAttributesDirty: action,
       setAttributes: action,
+      setEditing: action,
+      setInvalidInput: action,
       isValid: computed,
       hasContent: computed,
     });
@@ -56,7 +60,8 @@ export default class ExtraFieldModel implements ExtraField {
     this.setAttributes({
       ...attrs,
       owner,
-      type: attrs.type === "text" ? "Text" : "Number",
+      type: typeNameFromApi(attrs.type),
+      link: attrs.link ?? null,
     });
     this.invalidInput = false;
   }
@@ -79,6 +84,16 @@ export default class ExtraFieldModel implements ExtraField {
   }
 
   get isValid(): ValidationResult {
+    // an open editor holds mid-edit values that the model does not have yet;
+    // saving the record now would silently drop them, so Save stays greyed
+    // until the edit is committed or abandoned
+    if (this.editing && !this.deleteFieldRequest) {
+      return IsInvalid(
+        this.initial
+          ? "A new field is being added. Apply or discard it before saving."
+          : `The field "${this.name}" is being edited. Update or cancel the edit before saving.`,
+      );
+    }
     if (!this.name) return IsInvalid("Names of extra fields cannot be empty.");
     if (this.name.length > 255) return IsInvalid("Names of extra fields cannot exceed 255 characters.");
     if (this.type === "Text") {
@@ -88,13 +103,36 @@ export default class ExtraFieldModel implements ExtraField {
       return IsValid();
     }
     if (this.type === "Number") {
-      if (this.invalidInput) return IsInvalid("The content of numberical extra fields must be a valid number.");
+      if (this.invalidInput) return IsInvalid("The content of numerical extra fields must be a valid number.");
+      return IsValid();
+    }
+    if (this.type === "Link") {
+      if (this.invalidInput)
+        return IsInvalid(
+          `The link field "${this.name}" needs its Target Global ID set. Set a target or cancel the edit.`,
+        );
+      // an absent payload is the legitimate "No link set" empty state (the
+      // backend allows payload-less Link extra-fields), so it must not block
+      // record-level Save; only a half-set payload is invalid
+      if (!this.link) return IsValid();
+      if (!this.link.relationType || !this.link.targetGlobalId) {
+        return IsInvalid("Link fields require a relation type and target.");
+      }
       return IsValid();
     }
     return IsInvalid("Invalid field type");
   }
 
   get hasContent(): boolean {
+    if (this.type === "Link") {
+      return Boolean(this.link?.targetGlobalId);
+    }
     return Boolean(this.content);
   }
+}
+
+function typeNameFromApi(t: "text" | "number" | "link"): ExtraFieldType {
+  if (t === "text") return "Text";
+  if (t === "number") return "Number";
+  return "Link";
 }

--- a/src/main/webapp/ui/src/stores/models/FieldModel.ts
+++ b/src/main/webapp/ui/src/stores/models/FieldModel.ts
@@ -7,7 +7,7 @@ import type { URL as URLType } from "../../util/types";
 import { pick } from "../../util/unsafeUtils";
 import type { Attachment } from "../definitions/Attachment";
 import type { GlobalId, Id } from "../definitions/BaseRecord";
-import type { Field, FieldType, Option, OptionValue } from "../definitions/Field";
+import type { Field, FieldLink, FieldType, Option, OptionValue } from "../definitions/Field";
 import type { Sample } from "../definitions/Sample";
 import { type AttachmentJson, newAttachment, newExistingAttachment, newGalleryAttachment } from "./AttachmentModel";
 import { apiStringToFieldType, type FieldType as FieldTypeSymbol } from "./FieldTypes";
@@ -38,6 +38,8 @@ export type FieldModelAttrs = {
   columnIndex: number | null;
   attachment: AttachmentJson | null;
   mandatory: boolean;
+  allowedRelationTypes?: Array<string> | null;
+  link?: FieldLink | null;
 };
 
 export default class FieldModel implements Field {
@@ -69,6 +71,10 @@ export default class FieldModel implements Field {
   // @ts-expect-error Initialised by setAttributes
   mandatory: boolean;
   error: boolean;
+  /** Link template fields: permitted DataCite relation types; empty = all allowed. */
+  allowedRelationTypes: Array<string> = [];
+  /** Link fields: the single link value, or null when unset. */
+  link: FieldLink | null = null;
 
   constructor(_params: FieldModelAttrs, owner: InventoryBaseRecord) {
     makeObservable(this, {
@@ -89,6 +95,8 @@ export default class FieldModel implements Field {
       attachment: observable,
       mandatory: observable,
       error: observable,
+      allowedRelationTypes: observable,
+      link: observable,
       setAttributesDirty: action,
       setAttributes: action,
       setEditing: action,
@@ -109,6 +117,8 @@ export default class FieldModel implements Field {
       "name",
       "initial",
       "mandatory",
+      "allowedRelationTypes",
+      "link",
     )(_params) as object & {
       content: string | number | Date;
       type: FieldType;
@@ -116,9 +126,13 @@ export default class FieldModel implements Field {
       attachment?: AttachmentJson;
       owner: InventoryBaseRecord;
       options: Array<OptionValue> | Array<Option>;
+      allowedRelationTypes?: Array<string> | null;
+      link?: FieldLink | null;
     };
 
     params.initial = params.initial ?? false;
+    params.allowedRelationTypes = params.allowedRelationTypes ?? [];
+    params.link = params.link ?? null;
 
     if (_params.definition) {
       params = {
@@ -223,6 +237,8 @@ export default class FieldModel implements Field {
     }
     if (this.mandatory && this.owner.enforceMandatoryFields && !this.hasContent)
       return IsInvalid(`The mandatory custom field "${this.name}" must have a valid value.`);
+    if (this.type === "link" && this.error)
+      return IsInvalid(`Apply or discard the link changes in "${this.name}" before saving.`);
     if (this.error) return IsInvalid(`There is an error with the custom field, "${this.name}".`);
     return IsValid();
   }
@@ -230,6 +246,7 @@ export default class FieldModel implements Field {
   get hasContent(): boolean {
     if (hasOptions(this.type)) return Boolean(this.selectedOptions?.length);
     if (this.type === "number") return this.content !== "";
+    if (this.type === "link") return Boolean(this.link?.targetGlobalId);
     return Boolean(this.content);
   }
 
@@ -284,10 +301,9 @@ export default class FieldModel implements Field {
         ret.content = ret.content ?? "";
         break;
     }
-    return pick(
+    const keys = [
       "id",
       "name",
-      hasOptions(ret.type) ? "selectedOptions" : "content",
       "type",
       "definition",
       "newFieldRequest",
@@ -295,6 +311,15 @@ export default class FieldModel implements Field {
       "deleteFieldOnSampleUpdate",
       "columnIndex",
       "mandatory",
-    )(ret) as object;
+    ];
+    if (ret.type === "link") {
+      // link fields carry their permitted relation-type whitelist and the
+      // chosen link value; their data column is unused, so no content is sent
+      // (the backend's mandatory check rejects empty content)
+      keys.push("allowedRelationTypes", "link");
+    } else {
+      keys.push(hasOptions(ret.type) ? "selectedOptions" : "content");
+    }
+    return pick(...keys)(ret) as object;
   }
 }

--- a/src/main/webapp/ui/src/stores/models/FieldTypes.tsx
+++ b/src/main/webapp/ui/src/stores/models/FieldTypes.tsx
@@ -21,6 +21,7 @@ export const FieldTypes: { [fieldName: string]: symbol } = {
   uri: Symbol.for("uri"),
   reference: Symbol.for("reference"),
   attachment: Symbol.for("attachment"),
+  link: Symbol.for("link"),
 };
 
 export type FieldType = (typeof FieldTypes)[keyof typeof FieldTypes];
@@ -49,6 +50,7 @@ export const fieldTypeToApiString = (fieldType: FieldType): string => {
     [FieldTypes.time]: "time",
     [FieldTypes.reference]: "reference",
     [FieldTypes.attachment]: "attachment",
+    [FieldTypes.link]: "link",
   };
   if (!map[fieldType]) throw new Error(`Invalid field type: Symbol(${Symbol.keyFor(fieldType)})`);
   return map[fieldType];
@@ -66,6 +68,7 @@ export const apiStringToFieldType = (apiString: string): FieldType => {
     time: FieldTypes.time,
     reference: FieldTypes.reference,
     attachment: FieldTypes.attachment,
+    link: FieldTypes.link,
   };
   if (!map[apiString]) throw new Error(`Invalid api string '${apiString}'; not a valid field type.`);
   return map[apiString];
@@ -85,6 +88,7 @@ export const FIELD_LABEL: { [fieldName: FieldType]: string } = {
   [FieldTypes.time]: "Time",
   [FieldTypes.attachment]: "Attachment",
   [FieldTypes.reference]: "Reference",
+  [FieldTypes.link]: "Link",
 };
 
 export const FIELD_ICON: { [fieldName: FieldType]: React.ReactNode } = {
@@ -97,6 +101,7 @@ export const FIELD_ICON: { [fieldName: FieldType]: React.ReactNode } = {
   [FieldTypes.uri]: <LinkOutlinedIcon />,
   [FieldTypes.time]: <QueryBuilderOutlinedIcon />,
   [FieldTypes.attachment]: <AttachFileOutlinedIcon />,
+  [FieldTypes.link]: <LinkOutlinedIcon />,
 };
 
 export const FIELD_HELP_TEXT: { [fieldName: FieldType]: string } = {
@@ -110,6 +115,7 @@ export const FIELD_HELP_TEXT: { [fieldName: FieldType]: string } = {
   [FieldTypes.time]: "A time of day.",
   [FieldTypes.attachment]: "A single file, e.g. document, or chemistry file.",
   [FieldTypes.reference]: "",
+  [FieldTypes.link]: "A link to another Inventory item or ELN record.",
 };
 
 export const SUPPORTED_TYPES: Set<FieldType> = new Set<FieldType>([
@@ -122,6 +128,7 @@ export const SUPPORTED_TYPES: Set<FieldType> = new Set<FieldType>([
   FieldTypes.uri,
   FieldTypes.time,
   FieldTypes.attachment,
+  FieldTypes.link,
 ]);
 
 export const FIELD_DATA: {

--- a/src/main/webapp/ui/src/stores/models/InventoryBaseRecord.tsx
+++ b/src/main/webapp/ui/src/stores/models/InventoryBaseRecord.tsx
@@ -519,14 +519,41 @@ export default class InventoryBaseRecord
    * serialised and any changes here should be reflect in each of those.
    */
   get paramsForBackend(): Record<string, unknown> {
-    const extraFields = this.extraFields.map((ef) => ({
-      name: ef.name,
-      content: ef.content,
-      id: ef.id,
-      type: ef.type === "Text" ? "text" : "number",
-      newFieldRequest: ef.newFieldRequest,
-      deleteFieldRequest: ef.deleteFieldRequest,
-    }));
+    const apiTypeFor = (t: ExtraField["type"]): "text" | "number" | "link" => {
+      if (t === "Text") return "text";
+      if (t === "Number") return "number";
+      return "link";
+    };
+    const extraFields = this.extraFields.map((ef) => {
+      const base: {
+        name: string;
+        content: string;
+        id: ExtraField["id"];
+        type: "text" | "number" | "link";
+        newFieldRequest: boolean;
+        deleteFieldRequest: boolean;
+        link?: {
+          relationType: string;
+          targetGlobalId: string;
+          versionPin: number | null;
+        };
+      } = {
+        name: ef.name,
+        content: ef.content,
+        id: ef.id,
+        type: apiTypeFor(ef.type),
+        newFieldRequest: ef.newFieldRequest,
+        deleteFieldRequest: ef.deleteFieldRequest,
+      };
+      if (ef.type === "Link" && ef.link) {
+        base.link = {
+          relationType: ef.link.relationType,
+          targetGlobalId: ef.link.targetGlobalId,
+          versionPin: ef.link.versionPin ?? null,
+        };
+      }
+      return base;
+    });
 
     const params: {
       id: Id;
@@ -1279,18 +1306,52 @@ export default class InventoryBaseRecord
     }
   }
 
-  updateExtraField(oldFieldName: string, updatedField: { name: string; type: string }) {
+  updateExtraField(
+    oldFieldName: string,
+    updatedField: {
+      name: string;
+      type: string;
+      link?: {
+        relationType: string;
+        targetGlobalId: string;
+        versionPin: number | null;
+      };
+    },
+  ) {
     const field = this.extraFields.find((ef) => ef.name === oldFieldName);
 
     if (field) {
-      const attrs = {
-        ...updatedField,
+      const typeChanged = field.type !== updatedField.type;
+      const attrs: Record<string, unknown> = {
+        name: updatedField.name,
+        type: updatedField.type,
         editing: false,
         initial: false,
-        content: field.type !== updatedField.type ? "" : field.content,
+        content: typeChanged ? "" : field.content,
       };
+      if (updatedField.type === "Link") {
+        // Only overwrite the link when the caller actually supplies one. Omitting
+        // it (a rename-only edit, or discardChanges restoring name/type) must
+        // preserve the existing link rather than wipe it, since setAttributes
+        // merges via Object.assign.
+        if (updatedField.link !== undefined) {
+          attrs.link = updatedField.link;
+        }
+      } else if (typeChanged) {
+        attrs.link = null;
+      }
       const justNameAndType = pick("name", "type");
-      const areEqual = sameKeysAndValues(justNameAndType(field), justNameAndType(updatedField));
+      const existingLink = field.link;
+      const incomingLink = updatedField.link;
+      const linkUnchanged =
+        updatedField.type !== "Link" ||
+        incomingLink === undefined ||
+        (existingLink !== null &&
+          existingLink.relationType === incomingLink.relationType &&
+          existingLink.targetGlobalId === incomingLink.targetGlobalId &&
+          (existingLink.versionPin ?? null) === (incomingLink.versionPin ?? null));
+      const areEqual =
+        sameKeysAndValues(justNameAndType(field) as object, justNameAndType(updatedField) as object) && linkUnchanged;
       if (areEqual) {
         field.setAttributes(attrs);
       } else {

--- a/src/main/webapp/ui/src/stores/models/TemplateModel.tsx
+++ b/src/main/webapp/ui/src/stores/models/TemplateModel.tsx
@@ -35,6 +35,7 @@ export type TemplateAttrs = Omit<SampleAttrs, "quantity"> & {
   defaultUnitId: number | null;
   historicalVersion: boolean;
   version: number;
+  samplesToUpdateCount: number;
   quantity: null;
 };
 
@@ -68,6 +69,7 @@ const DEFAULT_TEMPLATE: TemplateAttrs = {
   defaultUnitId: 3,
   version: 0,
   historicalVersion: false,
+  samplesToUpdateCount: 0,
   barcodes: [],
   identifiers: [],
   sharingMode: "OWNER_GROUPS",
@@ -86,6 +88,7 @@ export default class TemplateModel extends SampleModel implements Template {
   // The inherited number | null is narrowed to number to satisfy the Template
   // interface: the API contract guarantees every sample template has a version.
   declare version: number;
+  samplesToUpdateCount: number = 0;
   latest: Template | null = null;
   icon: string | null = null;
 
@@ -93,6 +96,7 @@ export default class TemplateModel extends SampleModel implements Template {
     super(factory, params as unknown as SampleAttrs);
     makeObservable(this, {
       defaultUnitId: observable,
+      samplesToUpdateCount: observable,
       latest: observable,
       icon: observable,
       addField: action,
@@ -139,9 +143,12 @@ export default class TemplateModel extends SampleModel implements Template {
 
   populateFromJson(factory: Factory, params: object, defaultParams: object = {}) {
     super.populateFromJson(factory, params, defaultParams);
-    params = { ...defaultParams, ...params };
-    // @ts-expect-error We assume that params has this property
-    this.defaultUnitId = params.defaultUnitId ?? 3;
+    const merged = { ...defaultParams, ...params } as {
+      defaultUnitId?: number;
+      samplesToUpdateCount?: number;
+    };
+    this.defaultUnitId = merged.defaultUnitId ?? 3;
+    this.samplesToUpdateCount = merged.samplesToUpdateCount ?? 0;
     // version and historicalVersion are populated by the base class
   }
 

--- a/src/main/webapp/ui/src/stores/models/__tests__/ExtraFieldModel.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/ExtraFieldModel.test.ts
@@ -1,0 +1,139 @@
+import { isAction } from "mobx";
+import { describe, expect, it, vi } from "vitest";
+import ExtraFieldModel from "../ExtraFieldModel";
+// SampleModel must load before the ExtraFieldModel -> RootStore import chain,
+// otherwise the TemplateModel/SampleModel module cycle hits an uninitialised
+// SAMPLE_FIELDS during module evaluation
+import { makeMockSample } from "./SampleModel/mocking";
+
+vi.mock("../../../common/InvApiService", () => ({ default: {} }));
+// cut the RootStore -> SearchStore -> TemplateModel module cycle, which is not
+// exercised by these model-level tests
+vi.mock("../../stores/getRootStore", () => ({
+  default: () => ({
+    unitStore: { getUnit: () => ({ label: "ml" }) },
+  }),
+}));
+
+function makeLinkField(
+  link: {
+    relationType: string;
+    targetGlobalId: string;
+    versionPin: number | null;
+  } | null,
+): ExtraFieldModel {
+  return new ExtraFieldModel(
+    {
+      id: 7,
+      globalId: "EF7",
+      name: "Related item",
+      lastModified: null,
+      type: "link",
+      content: "",
+      parentGlobalId: "SA1",
+      link,
+    },
+    makeMockSample(),
+  );
+}
+
+describe("ExtraFieldModel link validation", () => {
+  it("is valid for a complete link", () => {
+    const field = makeLinkField({
+      relationType: "References",
+      targetGlobalId: "SA2",
+      versionPin: null,
+    });
+    expect(field.isValid.isOk).toBe(true);
+  });
+
+  it("is invalid while an in-progress edit has cleared the target", () => {
+    // the editor flags the model when its staged link state is incomplete, so
+    // a record-level Save cannot silently revert the removed target
+    const field = makeLinkField({
+      relationType: "References",
+      targetGlobalId: "SA2",
+      versionPin: null,
+    });
+    field.setInvalidInput(true);
+
+    expect(field.isValid.isOk).toBe(false);
+    const message = field.isValid.orElseGet((errors) => errors.map((e) => e.message).join(" "));
+    expect(message).toMatch(/target global id/i);
+  });
+
+  it("treats an unset link as a valid empty field rather than blocking Save", () => {
+    // the backend allows Link extra-fields with no payload (API-created or
+    // migrated records) and the card renders them as "No link set"; that
+    // empty view state must not block record-level Save, since no editor is
+    // open and there is nothing for the user to correct
+    const field = makeLinkField(null);
+    expect(field.isValid.isOk).toBe(true);
+  });
+
+  it("is invalid when the link is half-set", () => {
+    // a payload missing its relation or target is corrupt, unlike an absent
+    // payload, which is the legitimate "No link set" empty state
+    const field = makeLinkField({
+      relationType: "",
+      targetGlobalId: "SA2",
+      versionPin: null,
+    });
+    expect(field.isValid.isOk).toBe(false);
+  });
+});
+
+describe("ExtraFieldModel editing blocks record save", () => {
+  it("is invalid while the field editor is open, so Save is greyed out", () => {
+    // mid-edit values live in the editor, not the model: saving now would
+    // silently drop them. Save stays greyed until Update or Cancel is clicked.
+    const field = makeLinkField({
+      relationType: "References",
+      targetGlobalId: "SA2",
+      versionPin: null,
+    });
+    expect(field.isValid.isOk).toBe(true);
+
+    field.setEditing(true);
+
+    expect(field.isValid.isOk).toBe(false);
+    const message = field.isValid.orElseGet((errors) => errors.map((e) => e.message).join(" "));
+    expect(message).toMatch(/update or cancel/i);
+
+    field.setEditing(false);
+    expect(field.isValid.isOk).toBe(true);
+  });
+
+  it("is invalid while a brand-new field is unapplied, so Save is greyed out", () => {
+    const field = new ExtraFieldModel(
+      {
+        id: null,
+        globalId: null,
+        name: "",
+        lastModified: null,
+        type: "text",
+        content: "",
+        parentGlobalId: "SA1",
+        editing: true,
+        initial: true,
+      } as unknown as ConstructorParameters<typeof ExtraFieldModel>[0],
+      makeMockSample(),
+    );
+
+    expect(field.isValid.isOk).toBe(false);
+    const message = field.isValid.orElseGet((errors) => errors.map((e) => e.message).join(" "));
+    expect(message).toMatch(/apply or discard/i);
+  });
+});
+
+describe("ExtraFieldModel actions", () => {
+  it("mutates observable state only through MobX actions", () => {
+    // setInvalidInput and setEditing modify observed observables; if they are
+    // not actions, MobX strict mode logs an error on every editor interaction
+    const field = makeLinkField(null);
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- isAction inspects the function itself
+    const { setInvalidInput, setEditing } = field;
+    expect(isAction(setInvalidInput)).toBe(true);
+    expect(isAction(setEditing)).toBe(true);
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/__tests__/FieldModel/backendParams.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/FieldModel/backendParams.test.ts
@@ -36,4 +36,29 @@ describe("computed: paramsForBackend", () => {
       expect(JSON.stringify(field.paramsForBackend)).toEqual(expect.any(String));
     });
   });
+
+  describe("link fields", () => {
+    test("carry the link payload and relation whitelist but no content", () => {
+      const field = makeMockField({
+        type: "link",
+        allowedRelationTypes: ["References"],
+        link: {
+          relationType: "References",
+          targetGlobalId: "SA2",
+          versionPin: null,
+        },
+      });
+
+      const params = field.paramsForBackend as Record<string, unknown>;
+      expect(params.link).toEqual({
+        relationType: "References",
+        targetGlobalId: "SA2",
+        versionPin: null,
+      });
+      expect(params.allowedRelationTypes).toEqual(["References"]);
+      // a link field's value lives in its link, not the data column; sending
+      // (empty) content trips the backend's mandatory-field content check
+      expect(params).not.toHaveProperty("content");
+    });
+  });
 });

--- a/src/main/webapp/ui/src/stores/models/__tests__/FieldModel/validate.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/FieldModel/validate.test.ts
@@ -25,4 +25,35 @@ describe("method: validState", () => {
     field.setError(true);
     expect(field.validate().isOk).toBe(false);
   });
+
+  test("A link field with unapplied editor changes reports a link-specific reason.", () => {
+    const field = new FieldModel(
+      {
+        attachment: null,
+        columnIndex: 1,
+        content: "",
+        definition: null,
+        globalId: "SF20",
+        id: 20,
+        mandatory: false,
+        name: "Related item",
+        selectedOptions: null,
+        type: "link",
+        link: {
+          relationType: "References",
+          targetGlobalId: "SA2",
+          versionPin: null,
+        },
+      },
+      makeMockSample(),
+    );
+
+    // the link editor flags the model while its staged state is unapplied
+    field.setError(true);
+
+    const result = field.validate();
+    expect(result.isOk).toBe(false);
+    const message = result.orElseGet((errors) => errors.map((e) => e.message).join(" "));
+    expect(message).toMatch(/apply or discard/i);
+  });
 });

--- a/src/main/webapp/ui/src/stores/models/__tests__/FieldTypes.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/FieldTypes.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { apiStringToFieldType, FIELD_LABEL, FieldTypes, fieldTypeToApiString } from "../FieldTypes";
+
+describe("FieldTypes - link", () => {
+  it("maps the link symbol to and from the 'link' api string", () => {
+    expect(fieldTypeToApiString(FieldTypes.link)).toBe("link");
+    expect(apiStringToFieldType("link")).toBe(FieldTypes.link);
+  });
+
+  it("has a human-readable label for the link field type", () => {
+    expect(FIELD_LABEL[FieldTypes.link]).toBe("Link");
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/__tests__/SampleModel/paramsForBackend.linkExtraField.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/SampleModel/paramsForBackend.linkExtraField.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test, vi } from "vitest";
+import { makeMockSample } from "./mocking";
+
+vi.mock("../../../use-stores", () => () => {});
+vi.mock("../../../../stores/stores/getRootStore", () => ({
+  default: () => ({
+    unitStore: {
+      getUnit: () => ({ label: "ml" }),
+    },
+  }),
+}));
+
+describe("paramsForBackend with a Link extra-field", () => {
+  test("emits link.versionPin when the link is pinned to a revision", () => {
+    const sample = makeMockSample();
+    sample.currentlyEditableFields.add("extraFields");
+    sample.addExtraField({
+      id: 5,
+      globalId: null,
+      name: "Linked sample",
+      lastModified: null,
+      type: "link",
+      content: "",
+      parentGlobalId: sample.globalId,
+      editing: false,
+      initial: false,
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: 7,
+      },
+    });
+    const params = sample.paramsForBackend as {
+      extraFields?: Array<Record<string, unknown>>;
+    };
+    expect(params.extraFields?.[0].link).toEqual({
+      relationType: "References",
+      targetGlobalId: "SA42",
+      versionPin: 7,
+    });
+  });
+
+  test("does NOT include a link key on Text or Number extra-fields", () => {
+    const sample = makeMockSample();
+    sample.currentlyEditableFields.add("extraFields");
+    sample.addExtraField({
+      id: 1,
+      globalId: null,
+      name: "Note",
+      lastModified: null,
+      type: "text",
+      content: "hi",
+      parentGlobalId: sample.globalId,
+      editing: false,
+      initial: false,
+    });
+    sample.addExtraField({
+      id: 2,
+      globalId: null,
+      name: "Yield",
+      lastModified: null,
+      type: "number",
+      content: "12.5",
+      parentGlobalId: sample.globalId,
+      editing: false,
+      initial: false,
+    });
+    const params = sample.paramsForBackend as {
+      extraFields?: Array<Record<string, unknown>>;
+    };
+    const fields = params.extraFields ?? [];
+    expect(fields).toHaveLength(2);
+    expect("link" in fields[0]).toBe(false);
+    expect("link" in fields[1]).toBe(false);
+  });
+
+  test("serialises a mix of Text, Number and Link fields side by side", () => {
+    const sample = makeMockSample();
+    sample.currentlyEditableFields.add("extraFields");
+    sample.addExtraField({
+      id: 1,
+      globalId: null,
+      name: "Note",
+      lastModified: null,
+      type: "text",
+      content: "hi",
+      parentGlobalId: sample.globalId,
+      editing: false,
+      initial: false,
+    });
+    sample.addExtraField({
+      id: 2,
+      globalId: null,
+      name: "Linked sample",
+      lastModified: null,
+      type: "link",
+      content: "",
+      parentGlobalId: sample.globalId,
+      editing: false,
+      initial: false,
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: null,
+      },
+    });
+    const params = sample.paramsForBackend as {
+      extraFields?: Array<Record<string, unknown>>;
+    };
+    expect(params.extraFields).toHaveLength(2);
+    expect(params.extraFields?.[0].type).toBe("text");
+    expect(params.extraFields?.[1].type).toBe("link");
+    expect(params.extraFields?.[1].link).toEqual({
+      relationType: "References",
+      targetGlobalId: "SA42",
+      versionPin: null,
+    });
+  });
+
+  test("emits type=link and the link payload, not content", () => {
+    const sample = makeMockSample();
+    sample.currentlyEditableFields.add("extraFields");
+    sample.addExtraField({
+      id: null,
+      globalId: null,
+      name: "Linked sample",
+      lastModified: null,
+      type: "link",
+      content: "",
+      parentGlobalId: sample.globalId,
+      editing: false,
+      initial: false,
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: null,
+      },
+    });
+
+    const params = sample.paramsForBackend as {
+      extraFields?: Array<Record<string, unknown>>;
+    };
+    expect(params.extraFields).toHaveLength(1);
+    const linkField = (params.extraFields ?? [])[0];
+    expect(linkField.type).toBe("link");
+    expect(linkField.link).toEqual({
+      relationType: "References",
+      targetGlobalId: "SA42",
+      versionPin: null,
+    });
+    expect(linkField.content).toBe("");
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/__tests__/SampleModel/updateExtraField.link.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/SampleModel/updateExtraField.link.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, vi } from "vitest";
+import { makeMockSample } from "./mocking";
+
+vi.mock("../../../use-stores", () => () => {});
+vi.mock("../../../../stores/stores/getRootStore", () => ({
+  default: () => ({
+    unitStore: {
+      getUnit: () => ({ label: "ml" }),
+    },
+  }),
+}));
+
+describe("InventoryBaseRecord.updateExtraField with a link payload", () => {
+  function seedLinkField(versionPin: number | null = null) {
+    const sample = makeMockSample();
+    sample.currentlyEditableFields.add("extraFields");
+    sample.addExtraField({
+      id: 1,
+      globalId: "EF1",
+      name: "linked sample",
+      lastModified: null,
+      type: "link",
+      content: "",
+      parentGlobalId: sample.globalId,
+      editing: false,
+      initial: false,
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin,
+      },
+    });
+    return sample;
+  }
+
+  test("applies the supplied link payload onto the existing Link field", () => {
+    const sample = seedLinkField(null);
+    sample.updateExtraField("linked sample", {
+      name: "linked sample",
+      type: "Link",
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: 7,
+      },
+    });
+    const ef = sample.extraFields[0] as (typeof sample.extraFields)[0] & {
+      link: {
+        relationType: string;
+        targetGlobalId: string;
+        versionPin: number | null;
+      };
+    };
+    expect(ef.link.versionPin).toBe(7);
+    expect(ef.editing).toBe(false);
+    expect(ef.initial).toBe(false);
+  });
+
+  test("clears the link when the type is switched away from Link", () => {
+    const sample = seedLinkField(7);
+    sample.updateExtraField("linked sample", {
+      name: "linked sample",
+      type: "Text",
+    });
+    const ef = sample.extraFields[0] as (typeof sample.extraFields)[0] & {
+      link: unknown;
+    };
+    expect(ef.type).toBe("Text");
+    expect(ef.link).toBeNull();
+  });
+
+  test("dirties the record when only the link payload changes, even though name/type are the same", () => {
+    const sample = seedLinkField(null);
+    // baseline: not dirty after seed because addExtraField sets us through setAttributesDirty,
+    // so the dirty flag is already raised. Clear by calling submitDirtyChanges-equivalent: we
+    // can't easily do that here, so instead we assert that the link change went through the
+    // dirty path by checking the underlying field's link was actually updated.
+    sample.updateExtraField("linked sample", {
+      name: "linked sample",
+      type: "Link",
+      link: {
+        relationType: "IsCalibratedBy",
+        targetGlobalId: "SA42",
+        versionPin: null,
+      },
+    });
+    const ef = sample.extraFields[0] as (typeof sample.extraFields)[0] & {
+      link: { relationType: string };
+    };
+    expect(ef.link.relationType).toBe("IsCalibratedBy");
+  });
+
+  test("preserves the existing link when a Link update omits the link payload", () => {
+    // Reproduces the discardChanges/partial-update path: the caller passes only
+    // name + type (no link), which must NOT wipe the field's existing link.
+    const sample = seedLinkField(5);
+    sample.updateExtraField("linked sample", {
+      name: "linked sample",
+      type: "Link",
+    });
+    const ef = sample.extraFields[0] as (typeof sample.extraFields)[0] & {
+      link: {
+        relationType: string;
+        targetGlobalId: string;
+        versionPin: number | null;
+      } | null;
+    };
+    expect(ef.link).not.toBeNull();
+    expect(ef.link?.relationType).toBe("References");
+    expect(ef.link?.targetGlobalId).toBe("SA42");
+    expect(ef.link?.versionPin).toBe(5);
+  });
+
+  test("does not dirty the field when an identical Link update is applied", () => {
+    const sample = seedLinkField(3);
+    const ef = sample.extraFields[0];
+    const dirtySpy = vi.spyOn(ef, "setAttributesDirty");
+    sample.updateExtraField("linked sample", {
+      name: "linked sample",
+      type: "Link",
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: 3,
+      },
+    });
+    expect(dirtySpy).not.toHaveBeenCalled();
+    const updated = ef as typeof ef & {
+      link: { versionPin: number | null } | null;
+    };
+    expect(updated.link?.versionPin).toBe(3);
+  });
+
+  test("ignores link payload when the new type is not Link", () => {
+    const sample = seedLinkField(7);
+    sample.updateExtraField("linked sample", {
+      name: "linked sample",
+      type: "Number",
+      link: {
+        relationType: "References",
+        targetGlobalId: "SA42",
+        versionPin: 99,
+      },
+    });
+    const ef = sample.extraFields[0] as (typeof sample.extraFields)[0] & {
+      link: unknown;
+    };
+    expect(ef.type).toBe("Number");
+    // type changed -> the implementation clears link to null regardless of incoming payload
+    expect(ef.link).toBeNull();
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/__tests__/TemplateModel/mocking.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/TemplateModel/mocking.ts
@@ -42,6 +42,7 @@ export const templateAttrs = (attrs?: Partial<TemplateAttrs>): TemplateAttrs => 
   defaultUnitId: 3,
   historicalVersion: false,
   version: 1,
+  samplesToUpdateCount: 0,
   barcodes: [],
   identifiers: [],
   sharingMode: "OWNER_GROUPS",

--- a/src/test/java/com/researchspace/api/v1/controller/CreateSampleWithLinkMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/CreateSampleWithLinkMVCIT.java
@@ -1,0 +1,92 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiExtraField;
+import com.researchspace.api.v1.model.ApiSample;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.service.inventory.SampleApiManager;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage for RSDEV-1131 "create item and link at the same time": a brand-new Sample
+ * created in a single POST whose extra-fields already carry a Link must persist that link.
+ *
+ * <p>Regression being guarded: the create path built the {@code ExtraLinkField} (name, type,
+ * content) but never created its {@code InventoryLink} from the incoming {@code link} payload, so
+ * the link was silently dropped on save even though the field itself was applied. The update (PUT)
+ * path did not have this gap, so the bug only showed when the link was created together with the
+ * sample rather than added afterwards.
+ *
+ * <p>Authored as part of the bug fix; not run automatically (extends a real-transaction MVC base).
+ */
+@WebAppConfiguration
+public class CreateSampleWithLinkMVCIT extends API_MVC_InventoryTestBase {
+
+  private @Autowired SampleApiManager sampleApiManager;
+
+  private User anyUser;
+  private String apiKey;
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+    anyUser = createInitAndLoginAnyUser();
+    apiKey = createNewApiKeyForUser(anyUser);
+  }
+
+  @Test
+  public void linkInExtraFieldIsPersistedWhenSampleIsCreatedInOnePost() throws Exception {
+    // a separate sample to be the link target (a different record, so the self-link guard,
+    // which the not-yet-created source could not trip anyway, is plainly not the thing under test)
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+
+    // create a brand-new sample whose extra-fields already carry a link to the target, in the
+    // SAME POST - i.e. the user adds a custom Link field while creating the item and saves once
+    String createJson =
+        "{\"name\":\"sample created with a link\","
+            + "\"extraFields\":[{"
+            + "\"name\":\"Related items\","
+            + "\"type\":\"link\","
+            + "\"newFieldRequest\":true,"
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + target.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+
+    MvcResult result =
+        mockMvc
+            .perform(createBuilderForPostWithJSONBody(apiKey, "/samples", anyUser, createJson))
+            // the samples POST returns 201 Created (see SamplesApiControllerMVCIT)
+            .andExpect(status().is2xxSuccessful())
+            .andReturn();
+    ApiSampleWithFullSubSamples created =
+        getFromJsonResponseBody(result, ApiSampleWithFullSubSamples.class);
+
+    // the link round-trips in the create response ...
+    ApiExtraField responseLink = findLinkField(created.getExtraFields());
+    assertNotNull(responseLink, "the link extra-field should be present in the create response");
+    assertEquals(target.getGlobalId(), responseLink.getLink().getTargetGlobalId());
+    assertEquals("References", responseLink.getLink().getRelationType());
+
+    // ... and is actually persisted: re-read the sample fresh from the database. Before the fix the
+    // ExtraLinkField was saved with a null InventoryLink, so this is where the bug surfaced.
+    ApiSample reloaded = sampleApiManager.getApiSampleById(created.getId(), anyUser);
+    ApiExtraField persistedLink = findLinkField(reloaded.getExtraFields());
+    assertNotNull(persistedLink, "the link must be saved with the new sample, not dropped on save");
+    assertEquals(target.getGlobalId(), persistedLink.getLink().getTargetGlobalId());
+    assertEquals("References", persistedLink.getLink().getRelationType());
+  }
+
+  private ApiExtraField findLinkField(List<ApiExtraField> extraFields) {
+    return extraFields.stream().filter(ef -> ef.getLink() != null).findFirst().orElse(null);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryLinkExtraFieldUpdateMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryLinkExtraFieldUpdateMVCIT.java
@@ -1,0 +1,264 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiExtraField;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end MVC coverage for editing an existing Link extra-field. The frontend ships versionPin
+ * (and relationType) changes via PUT alongside the existing extra-field id; we verify that those
+ * round-trip back through a subsequent GET, which guards against the bug where
+ * applyChangesToDatabaseExtraField was previously dropping the link payload silently.
+ */
+public class InventoryLinkExtraFieldUpdateMVCIT extends API_MVC_InventoryTestBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void updatesVersionPinOnExistingLinkExtraField() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+
+    // first PUT: create the Link extra-field on the source
+    String createJson =
+        buildLinkExtraFieldCreate(target.getGlobalId(), "References", /* versionPin */ null);
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, createJson))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiSampleWithFullSubSamples created =
+        getFromJsonResponseBody(createResult, ApiSampleWithFullSubSamples.class);
+    ApiExtraField createdLinkField = findLinkExtraField(created);
+    assertNotNull(createdLinkField, "link extra-field should be present after create");
+    assertNull(createdLinkField.getLink().getVersionPin(), "initial versionPin should be null");
+    Long extraFieldId = createdLinkField.getId();
+
+    // second PUT: update only the versionPin
+    String updateJson =
+        buildLinkExtraFieldUpdate(
+            extraFieldId, target.getGlobalId(), "References", /* versionPin */ 7L);
+    MvcResult updateResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, updateJson))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiSampleWithFullSubSamples updated =
+        getFromJsonResponseBody(updateResult, ApiSampleWithFullSubSamples.class);
+    ApiExtraField updatedField = findLinkExtraField(updated);
+    assertNotNull(updatedField);
+    assertEquals(
+        Long.valueOf(7L),
+        updatedField.getLink().getVersionPin(),
+        "versionPin should now be 7 after the update PUT");
+
+    // and a fresh GET should also see the new pin
+    MvcResult getResult =
+        mockMvc
+            .perform(
+                createBuilderForGet(API_VERSION.ONE, apiKey, "/samples/{id}", user, source.getId()))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleWithFullSubSamples fetched =
+        getFromJsonResponseBody(getResult, ApiSampleWithFullSubSamples.class);
+    ApiExtraField fetchedField = findLinkExtraField(fetched);
+    assertNotNull(fetchedField);
+    assertEquals(Long.valueOf(7L), fetchedField.getLink().getVersionPin());
+  }
+
+  @Test
+  public void clearsVersionPinWhenSetToNull() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+
+    // create with a versionPin already set
+    String createJson =
+        buildLinkExtraFieldCreate(target.getGlobalId(), "References", /* versionPin */ 3L);
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, createJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleWithFullSubSamples created =
+        getFromJsonResponseBody(createResult, ApiSampleWithFullSubSamples.class);
+    ApiExtraField createdLinkField = findLinkExtraField(created);
+    Long extraFieldId = createdLinkField.getId();
+    assertEquals(Long.valueOf(3L), createdLinkField.getLink().getVersionPin());
+
+    // update with versionPin omitted -> should clear to null
+    String updateJson =
+        buildLinkExtraFieldUpdate(
+            extraFieldId, target.getGlobalId(), "References", /* versionPin */ null);
+    MvcResult updateResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, updateJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleWithFullSubSamples updated =
+        getFromJsonResponseBody(updateResult, ApiSampleWithFullSubSamples.class);
+    ApiExtraField updatedField = findLinkExtraField(updated);
+    assertNull(
+        updatedField.getLink().getVersionPin(),
+        "versionPin should be null after explicitly setting it to null");
+  }
+
+  @Test
+  public void updatesTargetOnExistingLinkExtraField() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+    ApiSampleWithFullSubSamples firstTarget = createBasicSampleForUser(user);
+    ApiSampleWithFullSubSamples secondTarget = createBasicSampleForUser(user);
+
+    String createJson =
+        buildLinkExtraFieldCreate(firstTarget.getGlobalId(), "References", /* versionPin */ null);
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, createJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    Long extraFieldId =
+        findLinkExtraField(getFromJsonResponseBody(createResult, ApiSampleWithFullSubSamples.class))
+            .getId();
+
+    // retarget the existing link to a different record; previously this was
+    // silently ignored and the response (and any later GET) kept the old target
+    String updateJson =
+        buildLinkExtraFieldUpdate(
+            extraFieldId, secondTarget.getGlobalId(), "References", /* versionPin */ null);
+    MvcResult updateResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, updateJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleWithFullSubSamples updated =
+        getFromJsonResponseBody(updateResult, ApiSampleWithFullSubSamples.class);
+    assertEquals(
+        secondTarget.getGlobalId(), findLinkExtraField(updated).getLink().getTargetGlobalId());
+
+    // a fresh GET also sees the new target
+    MvcResult getResult =
+        mockMvc
+            .perform(
+                createBuilderForGet(API_VERSION.ONE, apiKey, "/samples/{id}", user, source.getId()))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleWithFullSubSamples fetched =
+        getFromJsonResponseBody(getResult, ApiSampleWithFullSubSamples.class);
+    assertEquals(
+        secondTarget.getGlobalId(), findLinkExtraField(fetched).getLink().getTargetGlobalId());
+  }
+
+  @Test
+  public void updatesRelationTypeOnExistingLinkExtraField() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+
+    String createJson =
+        buildLinkExtraFieldCreate(target.getGlobalId(), "References", /* versionPin */ null);
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, createJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    Long extraFieldId =
+        findLinkExtraField(getFromJsonResponseBody(createResult, ApiSampleWithFullSubSamples.class))
+            .getId();
+
+    String updateJson =
+        buildLinkExtraFieldUpdate(
+            extraFieldId, target.getGlobalId(), "IsCalibratedBy", /* versionPin */ null);
+    MvcResult updateResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, updateJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleWithFullSubSamples updated =
+        getFromJsonResponseBody(updateResult, ApiSampleWithFullSubSamples.class);
+    ApiExtraField updatedField = findLinkExtraField(updated);
+    assertEquals("IsCalibratedBy", updatedField.getLink().getRelationType());
+  }
+
+  private ApiExtraField findLinkExtraField(ApiSampleWithFullSubSamples sample) {
+    return sample.getExtraFields().stream()
+        .filter(ef -> ef.getLink() != null)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private String buildLinkExtraFieldCreate(
+      String targetGlobalId, String relationType, Long versionPin) {
+    String versionPinFragment = versionPin == null ? "null" : versionPin.toString();
+    return "{\"extraFields\":[{"
+        + "\"name\":\"Linked sample\","
+        + "\"type\":\"link\","
+        + "\"newFieldRequest\":true,"
+        + "\"link\":{\"relationType\":\""
+        + relationType
+        + "\",\"targetGlobalId\":\""
+        + targetGlobalId
+        + "\",\"versionPin\":"
+        + versionPinFragment
+        + "}"
+        + "}]}";
+  }
+
+  private String buildLinkExtraFieldUpdate(
+      Long extraFieldId, String targetGlobalId, String relationType, Long versionPin) {
+    // updates an existing extra-field: id is required, newFieldRequest is omitted/false.
+    String versionPinFragment = versionPin == null ? "null" : versionPin.toString();
+    return "{\"extraFields\":[{"
+        + "\"id\":"
+        + extraFieldId
+        + ","
+        + "\"name\":\"Linked sample\","
+        + "\"type\":\"link\","
+        + "\"link\":{\"relationType\":\""
+        + relationType
+        + "\",\"targetGlobalId\":\""
+        + targetGlobalId
+        + "\",\"versionPin\":"
+        + versionPinFragment
+        + "}"
+        + "}]}";
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryLinkTargetApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryLinkTargetApiControllerMVCIT.java
@@ -1,0 +1,107 @@
+package com.researchspace.api.v1.controller;
+
+import static com.researchspace.core.testutil.CoreTestUtils.getRandomName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.Constants;
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.model.Group;
+import com.researchspace.model.RecordGroupSharing;
+import com.researchspace.model.User;
+import com.researchspace.model.record.StructuredDocument;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage of the link-target summary endpoint's permission freshness: an unshare must
+ * be visible on the sharee's very next summary fetch, without a server restart. The unshare
+ * notifies the sharee to refresh their cached Shiro authorisation ({@code
+ * RecordSharingManagerImpl.doUnshare}) and the resolver applies pending notifications before
+ * checking readability ({@code LinkTargetResolverImpl}).
+ */
+public class InventoryLinkTargetApiControllerMVCIT extends API_MVC_InventoryTestBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void unshareIsReflectedInSummaryWithoutServerRestart() throws Exception {
+    User owner = createAndSaveUser("pi" + getRandomName(8), Constants.PI_ROLE);
+    User viewer = createAndSaveUser(getRandomName(10));
+    initUsers(owner, viewer);
+    Group group = createGroupForPiAndUsers(owner, new User[] {owner, viewer});
+
+    logoutAndLoginAs(owner);
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(owner, "shared target");
+    RecordGroupSharing share = shareRecordWithGroup(owner, group, doc);
+    String docGlobalId = doc.getOid().getIdString();
+    String viewerKey = createNewApiKeyForUser(viewer);
+
+    // while shared, the viewer's summary is a full, readable one
+    ApiInventoryLinkTargetSummary shared = fetchSummary(viewerKey, viewer, docGlobalId);
+    assertTrue(shared.isReadable(), "shared target must be readable by the group member");
+    assertNotNull(shared.getName());
+    assertEquals("DOCUMENT", shared.getType());
+
+    // the owner unshares; the viewer is NOT logged out and the server NOT restarted
+    logoutAndLoginAs(owner);
+    sharingHandler.unshare(share.getId(), owner);
+
+    // the viewer's very next fetch must already see the redacted summary: the
+    // unshare notification + refreshCacheIfNotified clear the viewer's stale
+    // cached RECORD:READ grant on this request, not at some later restart
+    ApiInventoryLinkTargetSummary unshared = fetchSummary(viewerKey, viewer, docGlobalId);
+    assertFalse(unshared.isReadable(), "unshared target must stop being readable immediately");
+    assertNull(unshared.getName(), "redacted summary must not disclose the name");
+    assertNull(unshared.getType(), "redacted summary must not disclose the type");
+    assertFalse(unshared.isDeleted(), "redacted summary must not disclose state");
+    assertEquals(docGlobalId, unshared.getGlobalId());
+  }
+
+  @Test
+  public void reShareRestoresReadableSummaryWithoutServerRestart() throws Exception {
+    User owner = createAndSaveUser("pi" + getRandomName(8), Constants.PI_ROLE);
+    User viewer = createAndSaveUser(getRandomName(10));
+    initUsers(owner, viewer);
+    Group group = createGroupForPiAndUsers(owner, new User[] {owner, viewer});
+
+    logoutAndLoginAs(owner);
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(owner, "reshared target");
+    RecordGroupSharing share = shareRecordWithGroup(owner, group, doc);
+    String docGlobalId = doc.getOid().getIdString();
+    String viewerKey = createNewApiKeyForUser(viewer);
+
+    assertTrue(fetchSummary(viewerKey, viewer, docGlobalId).isReadable());
+
+    logoutAndLoginAs(owner);
+    sharingHandler.unshare(share.getId(), owner);
+    assertFalse(fetchSummary(viewerKey, viewer, docGlobalId).isReadable());
+
+    // sharing again must restore the viewer's readable summary just as promptly
+    logoutAndLoginAs(owner);
+    shareRecordWithGroup(owner, group, doc);
+    ApiInventoryLinkTargetSummary reshared = fetchSummary(viewerKey, viewer, docGlobalId);
+    assertTrue(reshared.isReadable(), "re-shared target must be readable again without restart");
+    assertNotNull(reshared.getName());
+  }
+
+  private ApiInventoryLinkTargetSummary fetchSummary(String apiKey, User user, String globalId)
+      throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE, apiKey, "/linkTargets/{globalId}/summary", user, globalId))
+            .andExpect(status().isOk())
+            .andReturn();
+    return getFromJsonResponseBody(result, ApiInventoryLinkTargetSummary.class);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryLinkTargetApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryLinkTargetApiControllerTest.java
@@ -1,0 +1,31 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.model.User;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryLinkTargetApiControllerTest {
+
+  @Mock private InventoryLinkManager inventoryLinkManager;
+  @InjectMocks private InventoryLinkTargetApiController controller;
+
+  @Test
+  void returnsTheManagerResolvedSummaryForTheRequestedGlobalId() {
+    User user = new User("any");
+    ApiInventoryLinkTargetSummary summary = new ApiInventoryLinkTargetSummary();
+    summary.setGlobalId("SA42");
+    summary.setDeleted(true);
+    when(inventoryLinkManager.getTargetSummary("SA42", user)).thenReturn(summary);
+
+    assertSame(summary, controller.getLinkTargetSummary("SA42", user));
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryLinkTemplateTargetMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryLinkTemplateTargetMVCIT.java
@@ -1,0 +1,83 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiExtraField;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.units.RSUnitDef;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage for linking to a sample template (RSDEV-1131): an IT Global ID is a valid
+ * link target, accepted by the create-time validation and round-tripping through the API.
+ *
+ * <p>Authored as part of the bug fix; not run automatically (extends a real-transaction MVC base).
+ */
+public class InventoryLinkTemplateTargetMVCIT extends API_MVC_InventoryTestBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void createsExtraFieldLinkTargetingASampleTemplate() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+    ApiSampleTemplate template = createBasicTemplate(apiKey, user);
+
+    String createJson =
+        "{\"extraFields\":[{"
+            + "\"name\":\"Made with template\","
+            + "\"type\":\"link\","
+            + "\"newFieldRequest\":true,"
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + template.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, createJson))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiSampleWithFullSubSamples updated =
+        getFromJsonResponseBody(result, ApiSampleWithFullSubSamples.class);
+    ApiExtraField linkField =
+        updated.getExtraFields().stream()
+            .filter(ef -> ef.getLink() != null)
+            .findFirst()
+            .orElse(null);
+    assertNotNull(linkField, "the link extra-field should have been created");
+    assertEquals(template.getGlobalId(), linkField.getLink().getTargetGlobalId());
+    assertEquals("References", linkField.getLink().getRelationType());
+  }
+
+  private ApiSampleTemplate createBasicTemplate(String apiKey, User user) throws Exception {
+    ApiSampleTemplatePost templatePost = new ApiSampleTemplatePost();
+    templatePost.setName("link target template");
+    templatePost.setDefaultUnitId(RSUnitDef.GRAM.getId());
+    templatePost.setSampleSource(SampleSource.LAB_CREATED);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(apiKey, "/sampleTemplates", user, templatePost))
+            // the sampleTemplates POST returns 201 Created (see SampleTemplatesApiControllerMVCIT)
+            .andExpect(status().is2xxSuccessful())
+            .andReturn();
+    return getFromJsonResponseBody(result, ApiSampleTemplate.class);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryReferencingItemsApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryReferencingItemsApiControllerMVCIT.java
@@ -1,0 +1,195 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.model.record.StructuredDocument;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class InventoryReferencingItemsApiControllerMVCIT extends API_MVC_InventoryTestBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void referencingItemsEndpointReturnsEmptyListForUnusedTarget() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE,
+                    apiKey,
+                    "/samples/{id}/referencingItems",
+                    user,
+                    target.getId()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertNotNull(body);
+    assertEquals(0, body.getReferencingItems().size());
+  }
+
+  @Test
+  public void referencingItemsEndpointSurfacesSourcesLinkingToTarget() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+
+    String updateJson = buildLinkExtraFieldUpdate(target.getGlobalId(), "IsCalibratedBy");
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(apiKey, "/samples/" + source.getId(), user, updateJson))
+        .andExpect(status().isOk());
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE,
+                    apiKey,
+                    "/samples/{id}/referencingItems",
+                    user,
+                    target.getId()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(1, body.getReferencingItems().size());
+    assertEquals("IsCalibratedBy", body.getReferencingItems().get(0).getRelationType());
+    assertEquals(source.getGlobalId(), body.getReferencingItems().get(0).getSourceGlobalId());
+  }
+
+  @Test
+  public void referencingItemsHidesItemsNotReadableByCaller() throws Exception {
+    User owner = createInitAndLoginAnyUser();
+    String ownerKey = createNewApiKeyForUser(owner);
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(owner);
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(owner);
+
+    String updateJson = buildLinkExtraFieldUpdate(target.getGlobalId(), "References");
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(
+                ownerKey, "/samples/" + source.getId(), owner, updateJson))
+        .andExpect(status().isOk());
+
+    User other = createInitAndLoginAnyUser();
+    String otherKey = createNewApiKeyForUser(other);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE,
+                    otherKey,
+                    "/samples/{id}/referencingItems",
+                    other,
+                    target.getId()))
+            .andReturn();
+
+    if (result.getResponse().getStatus() == 200) {
+      ApiInventoryReferencingItems body =
+          getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+      assertEquals(
+          0,
+          body.getReferencingItems().size(),
+          "items the requester cannot read should not appear in the back-ref list");
+    }
+  }
+
+  @Test
+  public void genericEndpointSurfacesInventorySourceLinkingToElnDocument() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+    StructuredDocument target = createBasicDocumentInRootFolderWithText(user, "linkable doc");
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+
+    String updateJson = buildLinkExtraFieldUpdate(target.getOid().getIdString(), "References");
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(apiKey, "/samples/" + source.getId(), user, updateJson))
+        .andExpect(status().isOk());
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE,
+                    apiKey,
+                    "/referencingItems/{globalId}",
+                    user,
+                    target.getOid().getIdString()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(1, body.getReferencingItems().size());
+    assertEquals(source.getGlobalId(), body.getReferencingItems().get(0).getSourceGlobalId());
+  }
+
+  @Test
+  public void genericEndpointMatchesVersionPinnedLinksOnTheBaseRecord() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+    StructuredDocument target = createBasicDocumentInRootFolderWithText(user, "pinned target doc");
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+
+    // pin the link to a specific version of the document (vN suffix)
+    String updateJson =
+        buildLinkExtraFieldUpdate(target.getOid().getIdString() + "v1", "References");
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(apiKey, "/samples/" + source.getId(), user, updateJson))
+        .andExpect(status().isOk());
+
+    // querying the base (unversioned) global id must still surface the pinned link
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE,
+                    apiKey,
+                    "/referencingItems/{globalId}",
+                    user,
+                    target.getOid().getIdString()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(1, body.getReferencingItems().size());
+  }
+
+  private String buildLinkExtraFieldUpdate(String targetGlobalId, String relationType) {
+    // hand-build JSON: newFieldRequest is WRITE_ONLY on the DTO so Jackson would drop it on output.
+    return "{\"extraFields\":[{"
+        + "\"name\":\"Link\","
+        + "\"type\":\"link\","
+        + "\"newFieldRequest\":true,"
+        + "\"link\":{\"relationType\":\""
+        + relationType
+        + "\",\"targetGlobalId\":\""
+        + targetGlobalId
+        + "\"}"
+        + "}]}";
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryReferencingItemsApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryReferencingItemsApiControllerTest.java
@@ -1,0 +1,66 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
+import com.researchspace.model.User;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryReferencingItemsApiControllerTest {
+
+  @Mock private InventoryLinkManager inventoryLinkManager;
+  @InjectMocks private InventoryReferencingItemsApiController controller;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("viewer");
+  }
+
+  @Test
+  void genericEndpointDelegatesWithRawGlobalId() {
+    List<ApiInventoryReferencingItem> rows = List.of(new ApiInventoryReferencingItem());
+    when(inventoryLinkManager.findReferencingItems("SD123", user)).thenReturn(rows);
+
+    assertSame(
+        rows, controller.getReferencingItemsForGlobalId("SD123", user).getReferencingItems());
+  }
+
+  @Test
+  void genericEndpointPassesElnGlobalIdThrough() {
+    when(inventoryLinkManager.findReferencingItems("NB9", user)).thenReturn(List.of());
+
+    controller.getReferencingItemsForGlobalId("NB9", user);
+
+    verify(inventoryLinkManager).findReferencingItems("NB9", user);
+  }
+
+  @Test
+  void typedSampleEndpointDelegatesWithSamplePrefixedGlobalId() {
+    when(inventoryLinkManager.findReferencingItems("SA42", user)).thenReturn(List.of());
+
+    controller.getReferencingItemsForSample(42L, user);
+
+    verify(inventoryLinkManager).findReferencingItems("SA42", user);
+  }
+
+  @Test
+  void wrapsManagerResultInResponseObject() {
+    when(inventoryLinkManager.findReferencingItems("SD1", user)).thenReturn(List.of());
+
+    assertEquals(
+        0, controller.getReferencingItemsForGlobalId("SD1", user).getReferencingItems().size());
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplateLinkFieldMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplateLinkFieldMVCIT.java
@@ -1,0 +1,183 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.api.v1.model.ApiSample;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.units.RSUnitDef;
+import com.researchspace.service.inventory.SampleApiManager;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage for the structured Link template field (RSDEV-1131): a Sample template can
+ * define a Link field carrying an allowed-relation-types whitelist; that whitelist round-trips
+ * through the API and is inherited by samples created from the template; and a sample cannot set a
+ * relation type outside the template's whitelist.
+ *
+ * <p>Authored as part of the feature; not run automatically (extends a real-transaction MVC base).
+ */
+@WebAppConfiguration
+public class SampleTemplateLinkFieldMVCIT extends API_MVC_InventoryTestBase {
+
+  private @Autowired SampleApiManager sampleApiManager;
+
+  private User anyUser;
+  private String apiKey;
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+    anyUser = createInitAndLoginAnyUser();
+    apiKey = createNewApiKeyForUser(anyUser);
+  }
+
+  @Test
+  public void templateLinkFieldWhitelistRoundTripsAndIsInheritedBySample() throws Exception {
+    ApiSampleTemplate savedTemplate = createTemplateWithLinkField();
+
+    ApiInventoryEntityField savedLinkField = findLinkField(savedTemplate.getFields());
+    assertNotNull(savedLinkField, "saved template should contain a link field");
+    assertEquals(ApiFieldType.LINK, savedLinkField.getType());
+    assertEquals(List.of("References", "IsDerivedFrom"), savedLinkField.getAllowedRelationTypes());
+
+    // instantiate a sample from the template: it inherits the link field + whitelist (shallowCopy)
+    ApiSampleWithFullSubSamples apiSample =
+        new ApiSampleWithFullSubSamples("sample from link template");
+    apiSample.setTemplateId(savedTemplate.getId());
+    ApiSampleWithFullSubSamples created = sampleApiManager.createNewApiSample(apiSample, anyUser);
+    ApiSample fetched = sampleApiManager.getApiSampleById(created.getId(), anyUser);
+
+    ApiInventoryEntityField inheritedLinkField = findLinkField(fetched.getFields());
+    assertNotNull(inheritedLinkField, "sample should inherit the template's link field");
+    assertEquals(ApiFieldType.LINK, inheritedLinkField.getType());
+    assertEquals(
+        List.of("References", "IsDerivedFrom"), inheritedLinkField.getAllowedRelationTypes());
+  }
+
+  @Test
+  public void rejectsRelationTypeOutsideTemplateWhitelist() throws Exception {
+    ApiSampleTemplate savedTemplate = createTemplateWithLinkField();
+    ApiSampleWithFullSubSamples apiSample =
+        new ApiSampleWithFullSubSamples("sample with out-of-set relation");
+    apiSample.setTemplateId(savedTemplate.getId());
+    ApiSampleWithFullSubSamples created = sampleApiManager.createNewApiSample(apiSample, anyUser);
+    ApiSample fetched = sampleApiManager.getApiSampleById(created.getId(), anyUser);
+    Long linkFieldId = findLinkField(fetched.getFields()).getId();
+
+    // link to a different record (not the sample itself) so the self-link guard does not fire
+    // first; the rejection under test is the relation-type whitelist, not the self-link rule.
+    ApiSampleWithFullSubSamples linkTarget = createBasicSampleForUser(anyUser);
+
+    // attempt to set a relation type that is a valid DataCite type but not in the whitelist
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setRelationType("IsCitedBy");
+    apiLink.setTargetGlobalId(linkTarget.getGlobalId());
+    ApiInventoryEntityField linkUpdate = new ApiInventoryEntityField();
+    linkUpdate.setId(linkFieldId);
+    linkUpdate.setType(ApiFieldType.LINK);
+    linkUpdate.setLink(apiLink);
+    ApiSampleWithFullSubSamples update =
+        new ApiSampleWithFullSubSamples("sample with out-of-set relation");
+    update.setId(created.getId());
+    update.setFields(List.of(linkUpdate));
+
+    // an out-of-whitelist relation type is rejected as a 422 ApiRuntimeException carrying the
+    // relationTypeNotPermitted key (not a raw IllegalArgumentException, which would surface as 500)
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class, () -> sampleApiManager.updateApiSample(update, anyUser));
+    assertEquals("errors.inventory.field.link.relationTypeNotPermitted", ex.getErrorCode());
+  }
+
+  @Test
+  public void mandatoryLinkFieldFilledViaApiPutDoesNotTripMandatoryContentCheck() throws Exception {
+    // a sample created from a template with a mandatory link field starts with the
+    // link unfilled (the same state "update all samples" leaves pre-existing samples in)
+    ApiSampleTemplate savedTemplate = createTemplateWithLinkField(true);
+    ApiSampleWithFullSubSamples apiSample =
+        new ApiSampleWithFullSubSamples("sample with mandatory link field");
+    apiSample.setTemplateId(savedTemplate.getId());
+    ApiSampleWithFullSubSamples created = sampleApiManager.createNewApiSample(apiSample, anyUser);
+    ApiSample fetched = sampleApiManager.getApiSampleById(created.getId(), anyUser);
+    Long linkFieldId = findLinkField(fetched.getFields()).getId();
+
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+
+    // the UI ships the field with empty content alongside the filled link payload; the
+    // content-apply path must leave link fields alone instead of failing the mandatory
+    // content check with "[] is invalid for field type Link" (RSDEV-1131 bug)
+    String updateJson =
+        "{\"fields\":[{"
+            + "\"id\":"
+            + linkFieldId
+            + ","
+            + "\"type\":\"link\","
+            + "\"content\":\"\","
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + target.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + created.getId(), anyUser, updateJson))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiSampleWithFullSubSamples updated =
+        getFromJsonResponseBody(result, ApiSampleWithFullSubSamples.class);
+    ApiInventoryEntityField updatedField = findLinkField(updated.getFields());
+    assertNotNull(updatedField.getLink(), "the mandatory link should now be filled");
+    assertEquals(target.getGlobalId(), updatedField.getLink().getTargetGlobalId());
+  }
+
+  private ApiSampleTemplate createTemplateWithLinkField() throws Exception {
+    return createTemplateWithLinkField(false);
+  }
+
+  private ApiSampleTemplate createTemplateWithLinkField(boolean mandatory) throws Exception {
+    ApiSampleTemplatePost templatePost = new ApiSampleTemplatePost();
+    templatePost.setName("template with link field");
+    templatePost.setDefaultUnitId(RSUnitDef.GRAM.getId());
+    templatePost.setSampleSource(SampleSource.LAB_CREATED);
+    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
+    linkField.setName("Related items");
+    linkField.setType(ApiFieldType.LINK);
+    linkField.setMandatory(mandatory);
+    linkField.setAllowedRelationTypes(List.of("References", "IsDerivedFrom"));
+    templatePost.setFields(List.of(linkField));
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(apiKey, "/sampleTemplates", anyUser, templatePost))
+            // the sampleTemplates POST returns 201 Created (see SampleTemplatesApiControllerMVCIT)
+            .andExpect(status().is2xxSuccessful())
+            .andReturn();
+    return getFromJsonResponseBody(result, ApiSampleTemplate.class);
+  }
+
+  private ApiInventoryEntityField findLinkField(List<ApiInventoryEntityField> fields) {
+    return fields.stream()
+        .filter(f -> ApiFieldType.LINK.equals(f.getType()))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplateUpdatableSamplesCountMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplateUpdatableSamplesCountMVCIT.java
@@ -1,0 +1,142 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.units.RSUnitDef;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage for {@code ApiSampleTemplate.samplesToUpdateCount} (RSDEV-1131): the count
+ * exposed on a template GET reflects only the requesting user's samples that were created from an
+ * older version of the template, and is what the UI gates the "Update Samples" action on.
+ *
+ * <p>The regression this guards: linking a sample to a template (a link extra-field whose target is
+ * the template) must not make the template look like it has samples to update - the linking sample
+ * is not created from the template, so the count stays 0 and the action stays hidden.
+ *
+ * <p>Authored as part of the bug fix; not run automatically (extends a real-transaction MVC base).
+ */
+@WebAppConfiguration
+public class SampleTemplateUpdatableSamplesCountMVCIT extends API_MVC_InventoryTestBase {
+
+  private User anyUser;
+  private String apiKey;
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+    anyUser = createInitAndLoginAnyUser();
+    apiKey = createNewApiKeyForUser(anyUser);
+  }
+
+  @Test
+  public void countTracksSamplesCreatedFromAnOlderTemplateVersion() throws Exception {
+    ApiSampleTemplate template = createBasicTemplate("counted-samples template");
+
+    // a sample created from the template's current version: nothing to update yet
+    ApiSampleWithFullSubSamples sample = new ApiSampleWithFullSubSamples("sample from template v1");
+    sample.setTemplateId(template.getId());
+    sampleApiMgr.createNewApiSample(sample, anyUser);
+    assertEquals(0, retrieveSampleTemplate(template.getId()).getSamplesToUpdateCount());
+
+    // bump the template version: the existing sample is now behind and counts as updatable
+    ApiSampleTemplate bumped =
+        putSampleTemplate("{\"name\":\"counted-samples template v2\"}", template.getId());
+    assertEquals(2, bumped.getVersion());
+    assertEquals(1, retrieveSampleTemplate(template.getId()).getSamplesToUpdateCount());
+
+    // once the sample is brought up to date there is again nothing to update
+    mockMvc
+        .perform(
+            createBuilderForPost(
+                API_VERSION.ONE,
+                apiKey,
+                "/sampleTemplates/"
+                    + template.getId()
+                    + "/actions/updateSamplesToLatestTemplateVersion",
+                anyUser))
+        .andExpect(status().isOk())
+        .andReturn();
+    assertEquals(0, retrieveSampleTemplate(template.getId()).getSamplesToUpdateCount());
+  }
+
+  @Test
+  public void linkingASampleToATemplateDoesNotCountAsSomethingToUpdate() throws Exception {
+    ApiSampleTemplate template = createBasicTemplate("link-target template");
+
+    // a sample that is NOT created from the template, then linked to it via a link extra-field
+    ApiSampleWithFullSubSamples linkingSample = createBasicSampleForUser(anyUser);
+    String linkJson =
+        "{\"extraFields\":[{"
+            + "\"name\":\"Made with template\","
+            + "\"type\":\"link\","
+            + "\"newFieldRequest\":true,"
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + template.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    MvcResult linkResult =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + linkingSample.getId(), anyUser, linkJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleWithFullSubSamples linked =
+        getFromJsonResponseBody(linkResult, ApiSampleWithFullSubSamples.class);
+    assertNotNull(
+        linked.getExtraFields().stream()
+            .filter(ef -> ef.getLink() != null)
+            .findFirst()
+            .orElse(null),
+        "the link extra-field should have been created");
+
+    // the link must not make the template look like it has samples to update
+    assertEquals(0, retrieveSampleTemplate(template.getId()).getSamplesToUpdateCount());
+  }
+
+  private ApiSampleTemplate createBasicTemplate(String name) throws Exception {
+    ApiSampleTemplatePost templatePost = new ApiSampleTemplatePost();
+    templatePost.setName(name);
+    templatePost.setDefaultUnitId(RSUnitDef.GRAM.getId());
+    templatePost.setSampleSource(SampleSource.LAB_CREATED);
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(apiKey, "/sampleTemplates", anyUser, templatePost))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn();
+    return getFromJsonResponseBody(result, ApiSampleTemplate.class);
+  }
+
+  private ApiSampleTemplate putSampleTemplate(String json, Long templateId) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/sampleTemplates/" + templateId, anyUser, json))
+            .andExpect(status().isOk())
+            .andReturn();
+    return getFromJsonResponseBody(result, ApiSampleTemplate.class);
+  }
+
+  private ApiSampleTemplate retrieveSampleTemplate(Long id) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForGet(API_VERSION.ONE, apiKey, "/sampleTemplates/" + id, anyUser))
+            .andExpect(status().isOk())
+            .andReturn();
+    return getFromJsonResponseBody(result, ApiSampleTemplate.class);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/model/ApiExtraFieldLinkUpdateTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiExtraFieldLinkUpdateTest.java
@@ -1,0 +1,191 @@
+package com.researchspace.api.v1.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.ExtraTextField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.realm.SimpleAccountRealm;
+import org.apache.shiro.util.ThreadContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pure unit tests for {@link ApiExtraField#applyChangesToDatabaseExtraField} when applied to a
+ * pre-existing Link extra-field. The DTO apply loop reconciles relationType only; target and
+ * version-pin changes are applied in the service layer (ApiExtraFieldsHelper through
+ * InventoryLinkManager#updateLink), which validates the target and recaptures the pinned audit
+ * revision. Applying a pin here in the DTO would leave the stored targetRevisionId stale.
+ */
+public class ApiExtraFieldLinkUpdateTest {
+
+  private User user;
+
+  @Before
+  public void setUp() {
+    // A prior unit test in the same fork can leave a Subject bound to this thread
+    // (Shiro's ThreadContext is shared, thread-local state). Without clearing it,
+    // getSubject() below would return that stale subject, tied to the prior test's
+    // SecurityManager/realm, and login() would throw AuthenticationException because
+    // that realm has no "tester" account. Clear it so getSubject() builds a fresh
+    // subject from the in-memory realm we set up next.
+    ThreadContext.remove();
+    user = new User();
+    user.setUsername("tester");
+    // setModifiedBy(..., CHECK_OPERATE_AS) consults the Shiro SecurityManager;
+    // for these pure-unit tests we wire up a trivial in-memory subject.
+    SimpleAccountRealm realm = new SimpleAccountRealm("test");
+    realm.addAccount("tester", "pw");
+    DefaultSecurityManager sm = new DefaultSecurityManager(realm);
+    SecurityUtils.setSecurityManager(sm);
+    SecurityUtils.getSubject().login(new UsernamePasswordToken("tester", "pw"));
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      SecurityUtils.getSubject().logout();
+    } catch (Exception ignored) {
+      // pass
+    }
+    ThreadContext.unbindSubject();
+    ThreadContext.unbindSecurityManager();
+    SecurityUtils.setSecurityManager(null);
+  }
+
+  private ExtraLinkField dbLinkField(Long versionPin) {
+    InventoryLink link = new InventoryLink();
+    link.setRelationType("References");
+    link.setTargetGlobalId("SA42");
+    link.setVersionPin(versionPin);
+    ExtraLinkField field = new ExtraLinkField();
+    field.setName("link to sample");
+    field.setLink(link);
+    return field;
+  }
+
+  private ApiExtraField apiLinkField(String relationType, Long versionPin) {
+    ApiExtraField api = new ApiExtraField(ExtraFieldTypeEnum.LINK);
+    api.setId(1L);
+    api.setName("link to sample");
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setRelationType(relationType);
+    apiLink.setTargetGlobalId("SA42");
+    apiLink.setVersionPin(versionPin);
+    api.setLink(apiLink);
+    return api;
+  }
+
+  @Test
+  public void leavesVersionPinChangeToTheServiceLayer() {
+    ExtraLinkField dbField = dbLinkField(null);
+    ApiExtraField apiField = apiLinkField("References", 7L);
+
+    boolean changed = apiField.applyChangesToDatabaseExtraField(dbField, user);
+
+    // a pin applied here would not recapture targetRevisionId, so the DTO must
+    // leave it to ApiExtraFieldsHelper/InventoryLinkManager.updateLink
+    assertEquals(false, changed);
+    assertNull(dbField.getLink().getVersionPin());
+  }
+
+  @Test
+  public void leavesVersionPinClearToTheServiceLayer() {
+    ExtraLinkField dbField = dbLinkField(7L);
+    ApiExtraField apiField = apiLinkField("References", null);
+
+    boolean changed = apiField.applyChangesToDatabaseExtraField(dbField, user);
+
+    assertEquals(false, changed);
+    assertEquals(Long.valueOf(7L), dbField.getLink().getVersionPin());
+  }
+
+  @Test
+  public void appliesUpdatedRelationTypeOntoExistingLink() {
+    ExtraLinkField dbField = dbLinkField(null);
+    ApiExtraField apiField = apiLinkField("IsCalibratedBy", null);
+
+    boolean changed = apiField.applyChangesToDatabaseExtraField(dbField, user);
+
+    assertTrue(changed);
+    assertEquals("IsCalibratedBy", dbField.getLink().getRelationType());
+  }
+
+  @Test
+  public void ignoresLinkPayloadWhenDbFieldIsNotALinkField() {
+    ExtraTextField dbField = new ExtraTextField();
+    dbField.setName("note");
+    dbField.setData("hello");
+
+    ApiExtraField apiField = new ApiExtraField(ExtraFieldTypeEnum.TEXT);
+    apiField.setId(1L);
+    apiField.setName("note");
+    apiField.setContent("hello"); // no content change so no audit bump
+    // a malformed payload carrying a link on a text field should be ignored,
+    // not throw
+    ApiInventoryLink badLink = new ApiInventoryLink();
+    badLink.setRelationType("References");
+    badLink.setTargetGlobalId("SA42");
+    badLink.setVersionPin(7L);
+    apiField.setLink(badLink);
+
+    boolean changed = apiField.applyChangesToDatabaseExtraField(dbField, user);
+
+    assertEquals(false, changed);
+    assertEquals("hello", dbField.getData());
+  }
+
+  @Test
+  public void noNullPointerWhenIncomingLinkIsNullOnLinkField() {
+    ExtraLinkField dbField = dbLinkField(7L);
+
+    ApiExtraField apiField = new ApiExtraField(ExtraFieldTypeEnum.LINK);
+    apiField.setId(1L);
+    apiField.setName("link to sample");
+    // explicit: no link payload
+    apiField.setLink(null);
+
+    boolean changed = apiField.applyChangesToDatabaseExtraField(dbField, user);
+
+    // unchanged because name and content match and no link payload was given
+    assertEquals(false, changed);
+    assertEquals(Long.valueOf(7L), dbField.getLink().getVersionPin());
+  }
+
+  @Test
+  public void noNullPointerWhenDbLinkIsNullOnLinkField() {
+    ExtraLinkField dbField = new ExtraLinkField();
+    dbField.setName("link to sample");
+    // do not call setLink, leaving the underlying InventoryLink null
+
+    ApiExtraField apiField = apiLinkField("References", 7L);
+
+    // this should not throw, even though the dbField has no underlying
+    // InventoryLink to apply changes onto. In practice this can happen if a
+    // Link extra-field row is being created in the same request and arrives
+    // via the update path; defensive handling keeps the API resilient.
+    boolean changed = apiField.applyChangesToDatabaseExtraField(dbField, user);
+
+    assertEquals(false, changed);
+  }
+
+  @Test
+  public void noChangeWhenLinkUnmodified() {
+    ExtraLinkField dbField = dbLinkField(3L);
+    ApiExtraField apiField = apiLinkField("References", 3L);
+
+    boolean changed = apiField.applyChangesToDatabaseExtraField(dbField, user);
+
+    assertEquals(false, changed);
+    assertEquals(Long.valueOf(3L), dbField.getLink().getVersionPin());
+    assertEquals("References", dbField.getLink().getRelationType());
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/model/ApiFieldToModelFieldFactoryTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiFieldToModelFieldFactoryTest.java
@@ -1,10 +1,14 @@
 package com.researchspace.api.v1.model;
 
 import static com.researchspace.core.testutil.CoreTestUtils.assertIllegalArgumentException;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInventoryEntityField.ApiInventoryFieldDef;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import java.util.Arrays;
 import java.util.EnumSet;
 import org.junit.Test;
@@ -95,6 +99,21 @@ public class ApiFieldToModelFieldFactoryTest {
   @Test
   public void identifierField() {
     assertValues("10.12345/sdfg-kooo", "11.12345/sdfg-kooo", ApiFieldType.IDENTIFIER);
+  }
+
+  @Test
+  public void linkField() {
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setName("Related items");
+    apiField.setAllowedRelationTypes(Arrays.asList("References", "IsDerivedFrom"));
+
+    InventoryEntityField model = factory.apiInventoryFieldToModelField(apiField);
+
+    assertTrue(model instanceof InventoryLinkField);
+    // the allowed-relation whitelist is stored pipe-delimited on the model field
+    assertEquals(
+        "References|IsDerivedFrom", ((InventoryLinkField) model).getAllowedRelationTypes());
   }
 
   private void assertValues(String valid, String invalid, ApiFieldType type) {

--- a/src/test/java/com/researchspace/api/v1/model/ApiInventoryEntityFieldLinkContentTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiInventoryEntityFieldLinkContentTest.java
@@ -1,0 +1,57 @@
+package com.researchspace.api.v1.model;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.model.inventory.field.InventoryTextField;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A link field's value lives in its InventoryLink (applied via the service-layer
+ * InventoryLinkManager), not in the {@code data} column, so the DTO content-apply path must leave
+ * link fields alone. Before this rule, updating a sample whose mandatory link field was added by a
+ * template ("update all samples") failed with "[] is invalid for field type Link: Field is
+ * mandatory, but no content is provided" because the client's empty content string was pushed into
+ * setFieldData.
+ */
+class ApiInventoryEntityFieldLinkContentTest {
+
+  @Test
+  void contentChangesAreNotAppliedToMandatoryLinkFields() {
+    InventoryLinkField dbField = new InventoryLinkField();
+    dbField.setName("ALL");
+    dbField.setMandatory(true);
+
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setContent("");
+
+    assertDoesNotThrow(() -> apiField.applyChangesToDatabaseField(dbField, null));
+    assertFalse(apiField.applyChangesToDatabaseField(dbField, null));
+  }
+
+  @Test
+  void contentChangesAreNotAppliedToOptionalLinkFields() {
+    InventoryLinkField dbField = new InventoryLinkField();
+    dbField.setName("related");
+
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setContent("some stray content");
+
+    assertFalse(apiField.applyChangesToDatabaseField(dbField, null));
+    assertEquals(null, dbField.getData());
+  }
+
+  @Test
+  void contentChangesStillApplyToNonLinkFields() {
+    InventoryTextField dbField = new InventoryTextField("notes");
+
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setContent("updated text");
+
+    assertTrue(apiField.applyChangesToDatabaseField(dbField, null));
+    assertEquals("updated text", dbField.getData());
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/model/ApiInventoryLinkTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiInventoryLinkTest.java
@@ -1,0 +1,53 @@
+package com.researchspace.api.v1.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class ApiInventoryLinkTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void serializesRelationTypeAndTarget() throws Exception {
+    ApiInventoryLink link = new ApiInventoryLink();
+    link.setRelationType("IsCalibratedBy");
+    link.setTargetGlobalId("SA123");
+
+    String json = mapper.writeValueAsString(link);
+
+    assertEquals(
+        "{\"relationType\":\"IsCalibratedBy\",\"targetGlobalId\":\"SA123\",\"versionPin\":null}",
+        json);
+  }
+
+  @Test
+  void versionPinDerivedFromGlobalIdSuffix() {
+    ApiInventoryLink link = new ApiInventoryLink();
+    link.setTargetGlobalId("SA123v3");
+
+    assertEquals(Long.valueOf(3), link.derivedVersionPin());
+  }
+
+  @Test
+  void noVersionPinWhenGlobalIdHasNoSuffix() {
+    ApiInventoryLink link = new ApiInventoryLink();
+    link.setTargetGlobalId("SA123");
+
+    assertNull(link.derivedVersionPin());
+  }
+
+  @Test
+  void roundTripJsonPreservesValues() throws Exception {
+    String json =
+        "{\"relationType\":\"References\",\"targetGlobalId\":\"SS42v7\",\"versionPin\":7}";
+    ApiInventoryLink parsed = mapper.readValue(json, ApiInventoryLink.class);
+    assertEquals("References", parsed.getRelationType());
+    assertEquals("SS42v7", parsed.getTargetGlobalId());
+    assertEquals(Long.valueOf(7), parsed.getVersionPin());
+    assertNotNull(parsed);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/model/ApiInventoryReferencingItemsTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiInventoryReferencingItemsTest.java
@@ -1,0 +1,56 @@
+package com.researchspace.api.v1.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ApiInventoryReferencingItemsTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void emptyListSerializes() throws Exception {
+    ApiInventoryReferencingItems wrapper = new ApiInventoryReferencingItems();
+    wrapper.setReferencingItems(List.of());
+
+    String json = mapper.writeValueAsString(wrapper);
+
+    assertTrue(json.contains("\"referencingItems\":[]"));
+  }
+
+  @Test
+  void rowSerializesAllFields() throws Exception {
+    ApiInventoryReferencingItem row = new ApiInventoryReferencingItem();
+    row.setSourceGlobalId("SA77");
+    row.setSourceName("Calibration aliquot");
+    row.setSourceType("SAMPLE");
+    row.setRelationType("IsCalibratedBy");
+    row.setVersionPin(null);
+    row.setModifiedAtMillis(0L);
+
+    ApiInventoryReferencingItems wrapper = new ApiInventoryReferencingItems();
+    wrapper.setReferencingItems(List.of(row));
+
+    String json = mapper.writeValueAsString(wrapper);
+
+    assertTrue(json.contains("\"sourceGlobalId\":\"SA77\""));
+    assertTrue(json.contains("\"relationType\":\"IsCalibratedBy\""));
+    assertTrue(json.contains("\"sourceType\":\"SAMPLE\""));
+    assertTrue(json.contains("\"modifiedAt\":\"1970-01-01"));
+  }
+
+  @Test
+  void roundTripPreservesRow() throws Exception {
+    String json =
+        "{\"referencingItems\":[{\"sourceGlobalId\":\"SS9\",\"sourceName\":\"x\","
+            + "\"sourceType\":\"SUBSAMPLE\",\"relationType\":\"References\","
+            + "\"versionPin\":null,\"modifiedAt\":\"1970-01-01T00:00:00.000Z\"}]}";
+    ApiInventoryReferencingItems parsed =
+        mapper.readValue(json, ApiInventoryReferencingItems.class);
+    assertEquals(1, parsed.getReferencingItems().size());
+    assertEquals("SS9", parsed.getReferencingItems().get(0).getSourceGlobalId());
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/service/ApiFieldsHelperTest.java
+++ b/src/test/java/com/researchspace/api/v1/service/ApiFieldsHelperTest.java
@@ -1,0 +1,70 @@
+package com.researchspace.api.v1.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.validation.Errors;
+import org.springframework.validation.MapBindingResult;
+
+/**
+ * Unit tests for {@link ApiFieldsHelper#validateMandatoryFieldsForEntityPost} focused on the
+ * structured Link field (RSDEV-1131). A Link field carries its value in the incoming field's {@code
+ * link} object, not in its (always-empty) {@code content} string, so the mandatory check must read
+ * the incoming link's target rather than the content. Regression guard for the bug where a
+ * user-provided link on a mandatory Link field was rejected as "mandatory, but provided value was
+ * empty".
+ */
+public class ApiFieldsHelperTest {
+
+  private final ApiFieldsHelper helper = new ApiFieldsHelper();
+
+  private InventoryLinkField mandatoryLinkTemplateField() {
+    InventoryLinkField templateField = new InventoryLinkField();
+    templateField.setName("Related items");
+    templateField.setMandatory(true);
+    return templateField;
+  }
+
+  @Test
+  public void mandatoryLinkFieldSatisfiedByIncomingLinkTarget() {
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setRelationType("References");
+    apiLink.setTargetGlobalId("SD123");
+    ApiInventoryEntityField incoming = new ApiInventoryEntityField();
+    incoming.setType(ApiFieldType.LINK);
+    incoming.setLink(apiLink);
+
+    Errors errors = new MapBindingResult(new HashMap<>(), "sample");
+    helper.validateMandatoryFieldsForEntityPost(
+        "sample",
+        List.of(incoming),
+        List.<InventoryEntityField>of(mandatoryLinkTemplateField()),
+        errors);
+
+    assertFalse(errors.hasErrors(), "a provided link target must satisfy the mandatory link field");
+  }
+
+  @Test
+  public void mandatoryLinkFieldRejectedWhenNoLinkProvided() {
+    ApiInventoryEntityField incoming = new ApiInventoryEntityField();
+    incoming.setType(ApiFieldType.LINK);
+    // no link object provided
+
+    Errors errors = new MapBindingResult(new HashMap<>(), "sample");
+    helper.validateMandatoryFieldsForEntityPost(
+        "sample",
+        List.of(incoming),
+        List.<InventoryEntityField>of(mandatoryLinkTemplateField()),
+        errors);
+
+    assertTrue(errors.hasErrors(), "a mandatory link field with no link must be rejected");
+  }
+}

--- a/src/test/java/com/researchspace/dao/hibernate/InventoryLinkDaoHibernateTest.java
+++ b/src/test/java/com/researchspace/dao/hibernate/InventoryLinkDaoHibernateTest.java
@@ -1,0 +1,35 @@
+package com.researchspace.dao.hibernate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.testutils.SpringTransactionalTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class InventoryLinkDaoHibernateTest extends SpringTransactionalTest {
+
+  @Autowired private InventoryLinkDao dao;
+
+  @Test
+  public void saveAndGenerateId() {
+    InventoryLink link = newLink("SA123", GlobalIdPrefix.SA, 123L, "References");
+    InventoryLink saved = dao.save(link);
+
+    assertNotNull(saved.getId());
+    assertNotNull(saved.getCreatedAt());
+    assertNotNull(saved.getModifiedAt());
+  }
+
+  private InventoryLink newLink(
+      String globalId, GlobalIdPrefix prefix, Long dbId, String relationType) {
+    InventoryLink link = new InventoryLink();
+    link.setTargetGlobalId(globalId);
+    link.setTargetPrefix(prefix);
+    link.setTargetDbId(dbId);
+    link.setRelationType(relationType);
+    return link;
+  }
+}

--- a/src/test/java/com/researchspace/service/impl/RecordSharingManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/RecordSharingManagerImplTest.java
@@ -14,6 +14,7 @@ import com.researchspace.dao.UserDao;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.RecordGroupSharing;
 import com.researchspace.model.User;
+import com.researchspace.model.dtos.ShareConfigElement;
 import com.researchspace.model.field.ErrorList;
 import com.researchspace.model.permissions.ConstraintBasedPermission;
 import com.researchspace.model.permissions.DefaultPermissionFactory;
@@ -22,16 +23,22 @@ import com.researchspace.model.permissions.PermissionDomain;
 import com.researchspace.model.permissions.PermissionFactory;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.record.BaseRecord;
+import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.BaseRecordManager;
+import com.researchspace.service.CommunicationManager;
+import com.researchspace.service.DocumentSharedStateCalculator;
 import com.researchspace.testutils.TestFactory;
 import java.util.List;
+import java.util.Optional;
 import org.apache.shiro.authz.Permission;
+import org.apache.shiro.subject.Subject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -48,6 +55,8 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
   @Mock RecordDao recordDao;
   @Mock UserDao userDao;
   @Mock GroupDao grpDao;
+  @Mock DocumentSharedStateCalculator docSharedStatusCalculator;
+  @Mock CommunicationManager commMgr;
 
   private Long docId01 = 75567L;
   private Long docId02 = 74205L;
@@ -440,5 +449,46 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
         recordSharingManager.listSharesForRecordsAndUser(
             List.of(docId01), new PaginationCriteria<>(), u);
     assertEquals(1, shares.getHits().intValue());
+  }
+
+  @Test
+  public void unsharingNotifiesShareeToRefreshPermissionsCache() {
+    // the sharee's Shiro authorisation cache still grants RECORD:READ after an
+    // unshare; without a notification it serves stale permissions (and e.g. the
+    // link card's "No access" pill) until the server restarts
+    User alice = TestFactory.createAnyUser("alice");
+    alice.setId(7L);
+    User bob = TestFactory.createAnyUser("bob");
+    bob.setId(8L);
+    StructuredDocument doc = TestFactory.createAnySDForUser(TestFactory.createAnyForm(), alice);
+    doc.setId(docId02);
+
+    Subject subject = Mockito.mock(Subject.class);
+    when(subject.getPrincipal()).thenReturn("alice");
+    ShiroTestUtils shiroUtils = new ShiroTestUtils();
+    shiroUtils.setSubject(subject);
+    try {
+      RecordGroupSharing bobShare = new RecordGroupSharing();
+      bobShare.setSharee(bob);
+      bobShare.setShared(doc);
+      when(recordDao.getSafeNull(docId02)).thenReturn(Optional.of(doc));
+      when(userDao.get(8L)).thenReturn(bob);
+      when(userDao.getUserByUsername("alice")).thenReturn(alice);
+      when(docSharedStatusCalculator.canShare(bob, doc, alice)).thenReturn(false);
+      when(permissnUtils.isPermitted(doc, PermissionType.SHARE, alice)).thenReturn(true);
+      when(permissnUtils.createFromString("read")).thenReturn(PermissionType.READ);
+      when(groupshareRecordDao.findByRecordAndUserOrGroup(8L, docId02))
+          .thenReturn(Optional.of(bobShare));
+      when(folderDao.getUserSharedFolder(bob)).thenReturn(null);
+
+      ShareConfigElement cfg = new ShareConfigElement();
+      cfg.setUserId(8L);
+      cfg.setOperation("read");
+      recordSharingManager.unshareRecord(alice, docId02, new ShareConfigElement[] {cfg});
+
+      Mockito.verify(permissnUtils).notifyUserOrGroupToRefreshCache(bob);
+    } finally {
+      shiroUtils.clearSubject();
+    }
   }
 }

--- a/src/test/java/com/researchspace/service/inventory/ApiExtraFieldsHelperLinkDeleteTest.java
+++ b/src/test/java/com/researchspace/service/inventory/ApiExtraFieldsHelperLinkDeleteTest.java
@@ -1,0 +1,102 @@
+package com.researchspace.service.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.researchspace.api.v1.model.ApiExtraField;
+import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.field.FieldType;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.field.ExtraField;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.record.RecordFactory;
+import com.researchspace.testutils.TestFactory;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Deleting a Link extra-field must also soft-delete its backing {@link InventoryLink} through the
+ * service-layer {@link InventoryLinkManager}. A field soft-delete only flips the field's {@code
+ * deleted} flag, which neither dereferences the link nor cascades to it, so without this the link
+ * row lingered with {@code deleted=false} (orphaned) while its parent field was gone.
+ */
+@ExtendWith(MockitoExtension.class)
+class ApiExtraFieldsHelperLinkDeleteTest {
+
+  @Mock private InventoryLinkManager inventoryLinkManager;
+  private ApiExtraFieldsHelper helper;
+  private User user;
+  private InventoryRecord parent;
+
+  @BeforeEach
+  void setUp() {
+    helper = new ApiExtraFieldsHelper(new RecordFactory());
+    // the manager is field-autowired in production; wire the mock in directly
+    ReflectionTestUtils.setField(helper, "inventoryLinkManager", inventoryLinkManager);
+    user = TestFactory.createAnyUser("any");
+    parent = mock(InventoryRecord.class);
+  }
+
+  private ApiExtraField deleteRequest(Long id) {
+    ApiExtraField apiField = new ApiExtraField(ExtraFieldTypeEnum.LINK);
+    apiField.setId(id);
+    apiField.setDeleteFieldRequest(true);
+    return apiField;
+  }
+
+  @Test
+  void deletingALinkExtraFieldAlsoSoftDeletesItsLink() {
+    InventoryLink dbLink = new InventoryLink();
+    dbLink.setRelationType("References");
+    dbLink.setTargetGlobalId("SA2");
+    dbLink.setTargetPrefix(GlobalIdPrefix.SA);
+    dbLink.setTargetDbId(2L);
+    ExtraLinkField dbField = new ExtraLinkField();
+    dbField.setId(5L);
+    dbField.setLink(dbLink);
+
+    boolean changed =
+        helper.createDeleteRequestedExtraFields(
+            List.of(deleteRequest(5L)), List.of(dbField), parent, user);
+
+    assertTrue(changed);
+    assertTrue(dbField.isDeleted());
+    verify(inventoryLinkManager).deleteLink(dbLink, user);
+  }
+
+  @Test
+  void deletingALinkFieldWithNoLinkYetDoesNotCallDeleteLink() {
+    ExtraLinkField dbField = new ExtraLinkField();
+    dbField.setId(5L);
+    dbField.setLink(null);
+
+    helper.createDeleteRequestedExtraFields(
+        List.of(deleteRequest(5L)), List.of(dbField), parent, user);
+
+    assertTrue(dbField.isDeleted());
+    verify(inventoryLinkManager, never()).deleteLink(any(), any());
+  }
+
+  @Test
+  void deletingANonLinkExtraFieldDoesNotCallDeleteLink() {
+    ExtraField dbField = new RecordFactory().createExtraField(FieldType.TEXT);
+    dbField.setId(7L);
+
+    helper.createDeleteRequestedExtraFields(
+        List.of(deleteRequest(7L)), List.of(dbField), parent, user);
+
+    assertTrue(dbField.isDeleted());
+    verify(inventoryLinkManager, never()).deleteLink(any(), any());
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/ApiExtraFieldsHelperLinkUpdateTest.java
+++ b/src/test/java/com/researchspace/service/inventory/ApiExtraFieldsHelperLinkUpdateTest.java
@@ -1,0 +1,192 @@
+package com.researchspace.service.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiExtraField;
+import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.record.RecordFactory;
+import com.researchspace.testutils.TestFactory;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The DTO apply loop treats an existing link's target as immutable, so target (and version pin)
+ * changes must be applied through the service-layer {@link InventoryLinkManager}, which validates
+ * existence/readability and recaptures the audit revision. Without this, editing a link to a
+ * different target saved successfully but silently kept the previous target.
+ */
+@ExtendWith(MockitoExtension.class)
+class ApiExtraFieldsHelperLinkUpdateTest {
+
+  @Mock private InventoryLinkManager inventoryLinkManager;
+  private ApiExtraFieldsHelper helper;
+
+  private User user;
+  private ExtraLinkField dbField;
+  private InventoryLink dbLink;
+
+  @BeforeEach
+  void setUp() {
+    helper = new ApiExtraFieldsHelper(new RecordFactory());
+    // the manager is field-autowired in production; wire the mock in directly
+    ReflectionTestUtils.setField(helper, "inventoryLinkManager", inventoryLinkManager);
+    user = TestFactory.createAnyUser("any");
+    dbLink = new InventoryLink();
+    dbLink.setRelationType("References");
+    dbLink.setTargetGlobalId("SA2");
+    dbLink.setTargetPrefix(GlobalIdPrefix.SA);
+    dbLink.setTargetDbId(2L);
+    dbField = new ExtraLinkField();
+    dbField.setId(5L);
+    dbField.setLink(dbLink);
+  }
+
+  private ApiExtraField incomingLinkField(Long id, String targetGlobalId, Long versionPin) {
+    ApiExtraField apiField = new ApiExtraField(ExtraFieldTypeEnum.LINK);
+    apiField.setId(id);
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setRelationType("References");
+    apiLink.setTargetGlobalId(targetGlobalId);
+    apiLink.setVersionPin(versionPin);
+    apiField.setLink(apiLink);
+    return apiField;
+  }
+
+  @Test
+  void retargetIsAppliedThroughTheLinkManager() {
+    ApiExtraField apiField = incomingLinkField(5L, "SA3", null);
+
+    boolean changed =
+        helper.applyExistingLinkFieldChanges(List.of(apiField), List.of(dbField), user);
+
+    assertTrue(changed);
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+  }
+
+  @Test
+  void versionPinChangeIsAppliedThroughTheLinkManagerSoTheRevisionIsRecaptured() {
+    ApiExtraField apiField = incomingLinkField(5L, "SA2", 4L);
+
+    boolean changed =
+        helper.applyExistingLinkFieldChanges(List.of(apiField), List.of(dbField), user);
+
+    assertTrue(changed);
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+  }
+
+  @Test
+  void unchangedLinkIsLeftAlone() {
+    ApiExtraField apiField = incomingLinkField(5L, "SA2", null);
+
+    boolean changed =
+        helper.applyExistingLinkFieldChanges(List.of(apiField), List.of(dbField), user);
+
+    assertFalse(changed);
+    verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+  }
+
+  @Test
+  void anEmptyLinkFieldGainsItsFirstLinkViaCreate() {
+    dbField.setLink(null);
+    InventoryLink created = new InventoryLink();
+    ApiExtraField apiField = incomingLinkField(5L, "SA3", null);
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    boolean changed =
+        helper.applyExistingLinkFieldChanges(List.of(apiField), List.of(dbField), user);
+
+    assertTrue(changed);
+    assertSame(created, dbField.getLink());
+  }
+
+  @Test
+  void newAndDeleteFlaggedFieldsAndBlankTargetsAreSkipped() {
+    ApiExtraField newField = incomingLinkField(null, "SA3", null);
+    newField.setNewFieldRequest(true);
+    ApiExtraField deleteField = incomingLinkField(5L, "SA3", null);
+    deleteField.setDeleteFieldRequest(true);
+    ApiExtraField blankTarget = incomingLinkField(5L, "", null);
+
+    boolean changed =
+        helper.applyExistingLinkFieldChanges(
+            List.of(newField, deleteField, blankTarget), List.of(dbField), user);
+
+    assertFalse(changed);
+    verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+    verify(inventoryLinkManager, never()).createLink(any(), any());
+  }
+
+  @Test
+  void selfLinkViaUpdatePathIsRejected() {
+    // the controller-layer validator can be bypassed by omitting "type", so
+    // the service-layer apply must enforce no-self-links itself
+    ExtraLinkField selfField = org.mockito.Mockito.mock(ExtraLinkField.class);
+    org.mockito.Mockito.lenient().when(selfField.getId()).thenReturn(5L);
+    org.mockito.Mockito.lenient().when(selfField.getLink()).thenReturn(dbLink);
+    org.mockito.Mockito.lenient()
+        .when(selfField.getConnectedRecordGlobalIdentifier())
+        .thenReturn("SA9");
+    ApiExtraField apiField = incomingLinkField(5L, "SA9", null);
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        com.researchspace.api.v1.auth.ApiRuntimeException.class,
+        () -> helper.applyExistingLinkFieldChanges(List.of(apiField), List.of(selfField), user));
+    verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+    verify(inventoryLinkManager, never()).createLink(any(), any());
+  }
+
+  @Test
+  void suffixPinnedTargetEqualToStoredPinIsNotASpuriousUpdate() {
+    // a raw client may pin via the "vN" suffix with versionPin null; that is
+    // the same link as base-target + stored pin and must not churn the row
+    dbLink.setVersionPin(4L);
+    ApiExtraField apiField = incomingLinkField(5L, "SA2v4", null);
+
+    boolean changed =
+        helper.applyExistingLinkFieldChanges(List.of(apiField), List.of(dbField), user);
+
+    assertFalse(changed);
+    verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+  }
+
+  @Test
+  void invalidRelationTypeViaUpdatePathIsRejected() {
+    // a relation-type-only change does not route through updateLink, and the
+    // controller-layer validator is bypassed when "type" is omitted, so the
+    // service-layer apply must reject a non-DataCite relation itself
+    ApiExtraField apiField = incomingLinkField(5L, "SA2", null);
+    apiField.getLink().setRelationType("NotADataCiteRelation");
+
+    com.researchspace.api.v1.auth.ApiRuntimeException ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            com.researchspace.api.v1.auth.ApiRuntimeException.class,
+            () -> helper.applyExistingLinkFieldChanges(List.of(apiField), List.of(dbField), user));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        "errors.inventory.field.link.relationTypeInvalid", ex.getErrorCode());
+    verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+    verify(inventoryLinkManager, never()).createLink(any(), any());
+  }
+
+  @Test
+  void emptyIncomingListIsANoop() {
+    assertFalse(
+        helper.applyExistingLinkFieldChanges(Collections.emptyList(), List.of(dbField), user));
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/DataCiteRelationTypeTest.java
+++ b/src/test/java/com/researchspace/service/inventory/DataCiteRelationTypeTest.java
@@ -1,0 +1,46 @@
+package com.researchspace.service.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class DataCiteRelationTypeTest {
+
+  @Test
+  void isValidAcceptsCanonicalDataCiteValue() {
+    assertTrue(DataCiteRelationType.isValid("IsCitedBy"));
+    assertTrue(DataCiteRelationType.isValid("References"));
+    assertTrue(DataCiteRelationType.isValid("IsPartOf"));
+  }
+
+  @Test
+  void isValidRejectsUnknownValue() {
+    assertFalse(DataCiteRelationType.isValid("MadeUpRelation"));
+    assertFalse(DataCiteRelationType.isValid(""));
+    assertFalse(DataCiteRelationType.isValid(null));
+  }
+
+  @Test
+  void isValidIsCaseSensitive() {
+    assertFalse(DataCiteRelationType.isValid("iscitedby"));
+    assertFalse(DataCiteRelationType.isValid("ISCITEDBY"));
+  }
+
+  @Test
+  void vocabularyIncludesIsCalibratedByForPidinst() {
+    assertTrue(DataCiteRelationType.isValid("IsCalibratedBy"));
+    assertTrue(DataCiteRelationType.isValid("Calibrates"));
+  }
+
+  @Test
+  void vocabularyExposesAllValues() {
+    assertTrue(DataCiteRelationType.allValues().contains("IsCitedBy"));
+    assertTrue(DataCiteRelationType.allValues().contains("HasPart"));
+    assertEquals(
+        DataCiteRelationType.allValues().size(),
+        DataCiteRelationType.allValues().stream().distinct().count(),
+        "vocabulary must have no duplicate entries");
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/InventoryLinkValidatorTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryLinkValidatorTest.java
@@ -1,0 +1,142 @@
+package com.researchspace.service.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import org.junit.jupiter.api.Test;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+
+class InventoryLinkValidatorTest {
+
+  private final InventoryLinkValidator validator = new InventoryLinkValidator();
+
+  @Test
+  void blankTargetIsRejectedAsNotFound() {
+    ApiInventoryLink link = buildLink("References", "   ");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA1", errors);
+
+    assertTrue(errors.hasFieldErrors("targetGlobalId"));
+    assertEquals(
+        "errors.inventory.field.link.targetNotFound",
+        errors.getFieldError("targetGlobalId").getCode());
+  }
+
+  @Test
+  void rejectsUnknownRelationType() {
+    ApiInventoryLink link = buildLink("MadeUpRelation", "SA1");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA1", errors);
+
+    assertTrue(errors.hasFieldErrors("relationType"));
+    assertEquals(
+        "errors.inventory.field.link.relationTypeInvalid",
+        errors.getFieldError("relationType").getCode());
+  }
+
+  @Test
+  void rejectsTargetWithUnsupportedPrefix() {
+    ApiInventoryLink link = buildLink("References", "GF1");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertTrue(errors.hasFieldErrors("targetGlobalId"));
+    assertEquals(
+        "errors.inventory.field.link.targetKindUnsupported",
+        errors.getFieldError("targetGlobalId").getCode());
+  }
+
+  @Test
+  void rejectsMalformedTargetGlobalId() {
+    ApiInventoryLink link = buildLink("References", "not-a-global-id");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertTrue(errors.hasFieldErrors("targetGlobalId"));
+  }
+
+  @Test
+  void rejectsSelfLink() {
+    ApiInventoryLink link = buildLink("References", "SA42");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertTrue(errors.hasFieldErrors("targetGlobalId"));
+    assertEquals(
+        "errors.inventory.field.link.selfLinkForbidden",
+        errors.getFieldError("targetGlobalId").getCode());
+  }
+
+  @Test
+  void rejectsSelfLinkIgnoringVersionSuffix() {
+    ApiInventoryLink link = buildLink("References", "SA42v2");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertTrue(errors.hasFieldErrors("targetGlobalId"));
+    assertEquals(
+        "errors.inventory.field.link.selfLinkForbidden",
+        errors.getFieldError("targetGlobalId").getCode());
+  }
+
+  @Test
+  void acceptsValidInventoryLink() {
+    ApiInventoryLink link = buildLink("IsCalibratedBy", "SA99");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertFalse(errors.hasErrors());
+  }
+
+  @Test
+  void acceptsAllFourInventoryPrefixes() {
+    for (String prefix : new String[] {"SA", "SS", "IC", "IN"}) {
+      ApiInventoryLink link = buildLink("References", prefix + "1");
+      Errors errors = errorsFor(link);
+      validator.validate(link, "SA42", errors);
+      assertFalse(errors.hasErrors(), "expected " + prefix + " prefix to be accepted");
+    }
+  }
+
+  @Test
+  void acceptsSampleTemplateTarget() {
+    ApiInventoryLink link = buildLink("References", "IT12");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertFalse(errors.hasErrors(), "expected IT (sample template) prefix to be accepted");
+  }
+
+  @Test
+  void acceptsElnTargetPrefixes() {
+    for (String prefix : new String[] {"SD", "NB", "GL"}) {
+      ApiInventoryLink link = buildLink("References", prefix + "1");
+      Errors errors = errorsFor(link);
+      validator.validate(link, "SA42", errors);
+      assertFalse(errors.hasErrors(), "expected " + prefix + " (ELN) prefix to be accepted");
+    }
+  }
+
+  @Test
+  void rejectsNullRelationType() {
+    ApiInventoryLink link = buildLink(null, "SA1");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertTrue(errors.hasFieldErrors("relationType"));
+  }
+
+  private ApiInventoryLink buildLink(String relationType, String targetGlobalId) {
+    ApiInventoryLink l = new ApiInventoryLink();
+    l.setRelationType(relationType);
+    l.setTargetGlobalId(targetGlobalId);
+    return l;
+  }
+
+  private Errors errorsFor(ApiInventoryLink link) {
+    return new BeanPropertyBindingResult(link, "link");
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplReferencingTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplReferencingTest.java
@@ -1,0 +1,176 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.service.inventory.InventoryPermissionUtils;
+import com.researchspace.service.inventory.LinkTargetResolver;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryLinkManagerImplReferencingTest {
+
+  @Mock private InventoryLinkDao linkDao;
+  @Mock private InventoryPermissionUtils permissionUtils;
+  @Mock private LinkTargetResolver linkTargetResolver;
+  @InjectMocks private InventoryLinkManagerImpl manager;
+
+  private User actor;
+
+  @BeforeEach
+  void setUp() {
+    actor = new User("viewer");
+    // these tests cover the source query, so the target read-permission gate is open;
+    // InventoryLinkManagerImplUnitTest covers the gate itself
+    lenient().when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+  }
+
+  @Test
+  void queriesByParsedPrefixAndDbIdForElnTarget() {
+    when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L))
+        .thenReturn(Collections.emptyList());
+
+    assertTrue(manager.findReferencingItems("SD123", actor).isEmpty());
+
+    verify(linkDao).findReferencingLinkFields(GlobalIdPrefix.SD, 123L);
+  }
+
+  @Test
+  void stripsVersionSuffixSoPinnedLinksMatchTheBaseRecord() {
+    when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L))
+        .thenReturn(Collections.emptyList());
+
+    manager.findReferencingItems("SD123v5", actor);
+
+    verify(linkDao).findReferencingLinkFields(GlobalIdPrefix.SD, 123L);
+  }
+
+  @Test
+  void queriesByPrefixAndDbIdForInventoryTarget() {
+    when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SA, 42L))
+        .thenReturn(Collections.emptyList());
+
+    assertEquals(0, manager.findReferencingItems("SA42", actor).size());
+
+    verify(linkDao).findReferencingLinkFields(GlobalIdPrefix.SA, 42L);
+  }
+
+  private InventoryRecord parent(String globalIdString, String name, boolean deleted) {
+    InventoryRecord rec = mock(InventoryRecord.class, org.mockito.Mockito.RETURNS_DEEP_STUBS);
+    org.mockito.Mockito.lenient()
+        .when(rec.getOid())
+        .thenReturn(new com.researchspace.model.core.GlobalIdentifier(globalIdString));
+    org.mockito.Mockito.lenient().when(rec.getName()).thenReturn(name);
+    org.mockito.Mockito.lenient().when(rec.isDeleted()).thenReturn(deleted);
+    return rec;
+  }
+
+  private ExtraLinkField extraFieldRow(InventoryRecord rec, InventoryLink link) {
+    ExtraLinkField field = mock(ExtraLinkField.class);
+    org.mockito.Mockito.lenient().when(field.getInventoryRecord()).thenReturn(rec);
+    org.mockito.Mockito.lenient().when(field.getLink()).thenReturn(link);
+    return field;
+  }
+
+  private InventoryLink linkWith(String relation, Long pin, Date modifiedAt) {
+    InventoryLink link = new InventoryLink();
+    link.setRelationType(relation);
+    link.setVersionPin(pin);
+    link.setModifiedAt(modifiedAt);
+    return link;
+  }
+
+  @Test
+  void buildsRowsOnlyForSourcesTheActorCanRead() {
+    // inverting or dropping this filter would leak names/ids of items the
+    // caller may not read into the back-links panels
+    InventoryRecord readable = parent("SA10", "visible sample", false);
+    InventoryRecord hidden = parent("SA11", "secret sample", false);
+    InventoryLink linkA = linkWith("References", 2L, new Date(1700000000000L));
+    InventoryLink linkB = linkWith("Cites", null, null);
+    // build the field mocks BEFORE stubbing linkDao: stubbing inside thenReturn
+    // arguments trips Mockito's unfinished-stubbing detection
+    ExtraLinkField readableRow = extraFieldRow(readable, linkA);
+    ExtraLinkField hiddenRow = extraFieldRow(hidden, linkB);
+    when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L))
+        .thenReturn(List.of(readableRow, hiddenRow));
+    when(permissionUtils.canUserReadInventoryRecord(readable, actor)).thenReturn(true);
+    when(permissionUtils.canUserReadInventoryRecord(hidden, actor)).thenReturn(false);
+
+    List<ApiInventoryReferencingItem> rows = manager.findReferencingItems("SD123", actor);
+
+    assertEquals(1, rows.size());
+    ApiInventoryReferencingItem row = rows.get(0);
+    assertEquals("SA10", row.getSourceGlobalId());
+    assertEquals("visible sample", row.getSourceName());
+    assertEquals("References", row.getRelationType());
+    assertEquals(Long.valueOf(2L), row.getVersionPin());
+    assertEquals(Long.valueOf(1700000000000L), row.getModifiedAtMillis());
+  }
+
+  @Test
+  void skipsSoftDeletedSourceRecords() {
+    InventoryRecord deleted = parent("SA12", "binned sample", true);
+    ExtraLinkField row = extraFieldRow(deleted, linkWith("References", null, null));
+    when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L)).thenReturn(List.of(row));
+
+    assertTrue(manager.findReferencingItems("SD123", actor).isEmpty());
+  }
+
+  @Test
+  void toleratesRowWithoutModificationDate() {
+    InventoryRecord rec = parent("SA13", "no date", false);
+    ExtraLinkField row = extraFieldRow(rec, linkWith("References", null, null));
+    when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L)).thenReturn(List.of(row));
+    when(permissionUtils.canUserReadInventoryRecord(rec, actor)).thenReturn(true);
+
+    List<ApiInventoryReferencingItem> rows = manager.findReferencingItems("SD123", actor);
+
+    assertEquals(1, rows.size());
+    org.junit.jupiter.api.Assertions.assertNull(rows.get(0).getModifiedAtMillis());
+  }
+
+  @Test
+  void includesStructuredTemplateLinkFieldsAsSources() {
+    // template-defined link fields are first-class links; a sample linking to
+    // the target through one must appear in the back-references like an
+    // extra-field link does
+    InventoryRecord sample = parent("SA20", "templated sample", false);
+    InventoryLink link = linkWith("IsPartOf", null, null);
+    InventoryLinkField structured = mock(InventoryLinkField.class);
+    org.mockito.Mockito.lenient().when(structured.getInventoryRecord()).thenReturn(sample);
+    org.mockito.Mockito.lenient().when(structured.getLink()).thenReturn(link);
+    when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L))
+        .thenReturn(java.util.Collections.emptyList());
+    when(linkDao.findReferencingStructuredLinkFields(GlobalIdPrefix.SD, 123L))
+        .thenReturn(List.of(structured));
+    when(permissionUtils.canUserReadInventoryRecord(sample, actor)).thenReturn(true);
+
+    List<ApiInventoryReferencingItem> rows = manager.findReferencingItems("SD123", actor);
+
+    assertEquals(1, rows.size());
+    assertEquals("SA20", rows.get(0).getSourceGlobalId());
+    assertEquals("IsPartOf", rows.get(0).getRelationType());
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplTest.java
@@ -1,0 +1,146 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.testutils.SpringTransactionalTest;
+import java.util.List;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class InventoryLinkManagerImplTest extends SpringTransactionalTest {
+
+  @Autowired private InventoryLinkManager linkManager;
+  @Autowired private InventoryLinkDao linkDao;
+
+  @Test
+  public void createLinkPersistsRowWithParsedPrefixAndDbId() {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+
+    ApiInventoryLink api = new ApiInventoryLink();
+    api.setRelationType("IsCalibratedBy");
+    api.setTargetGlobalId(target.getGlobalId());
+
+    InventoryLink saved = linkManager.createLink(api, user);
+
+    assertNotNull(saved.getId());
+    assertEquals(GlobalIdPrefix.SA, saved.getTargetPrefix());
+    assertEquals(target.getId(), saved.getTargetDbId());
+    assertEquals("IsCalibratedBy", saved.getRelationType());
+    assertNull(saved.getVersionPin());
+  }
+
+  @Test
+  public void createLinkToElnDocumentResolvesAndPersists() {
+    User user = createInitAndLoginAnyUser();
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(user, "linkable doc");
+
+    ApiInventoryLink api = new ApiInventoryLink();
+    api.setRelationType("References");
+    api.setTargetGlobalId(doc.getOid().getIdString());
+
+    InventoryLink saved = linkManager.createLink(api, user);
+
+    assertNotNull(saved.getId());
+    assertEquals(GlobalIdPrefix.SD, saved.getTargetPrefix());
+    assertEquals(doc.getId(), saved.getTargetDbId());
+  }
+
+  @Test
+  public void createLinkExtractsVersionPinFromTargetSuffix() {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+
+    ApiInventoryLink api = new ApiInventoryLink();
+    api.setRelationType("References");
+    api.setTargetGlobalId(target.getGlobalId() + "v5");
+
+    InventoryLink saved = linkManager.createLink(api, user);
+
+    assertEquals(Long.valueOf(5), saved.getVersionPin());
+    assertEquals(target.getId(), saved.getTargetDbId());
+  }
+
+  @Test
+  public void updateLinkChangesRelationAndPreservesCreatedAt() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples target1 = createBasicSampleForUser(user, "target1");
+    ApiSampleWithFullSubSamples target2 = createBasicSampleForUser(user, "target2");
+
+    ApiInventoryLink api = new ApiInventoryLink();
+    api.setRelationType("References");
+    api.setTargetGlobalId(target1.getGlobalId());
+    InventoryLink saved = linkManager.createLink(api, user);
+    java.util.Date originalCreated = saved.getCreatedAt();
+
+    Thread.sleep(5);
+    ApiInventoryLink update = new ApiInventoryLink();
+    update.setRelationType("IsCalibratedBy");
+    update.setTargetGlobalId(target2.getGlobalId());
+    InventoryLink updated = linkManager.updateLink(saved, update, user);
+
+    assertEquals("IsCalibratedBy", updated.getRelationType());
+    assertEquals(target2.getGlobalId(), updated.getTargetGlobalId());
+    assertEquals(target2.getId(), updated.getTargetDbId());
+    assertEquals(originalCreated, updated.getCreatedAt());
+  }
+
+  @Test
+  public void deleteLinkSoftDeletes() {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+
+    ApiInventoryLink api = new ApiInventoryLink();
+    api.setRelationType("References");
+    api.setTargetGlobalId(target.getGlobalId());
+    InventoryLink saved = linkManager.createLink(api, user);
+
+    linkManager.deleteLink(saved, user);
+
+    InventoryLink reloaded = linkDao.get(saved.getId());
+    assertTrue(reloaded.isDeleted());
+  }
+
+  @Test
+  public void findReferencingItemsReturnsEmptyWhenNoSources() {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(user);
+
+    List<ApiInventoryReferencingItem> rows =
+        linkManager.findReferencingItems(target.getGlobalId(), user);
+
+    assertEquals(0, rows.size());
+  }
+
+  @Test
+  public void findReferencingItemsRejectsTargetTheCallerCannotRead() {
+    User owner = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(owner);
+    User stranger = createInitAndLoginAnyUser();
+
+    // same error as a missing record, so the response does not confirm the target exists
+    assertThrows(
+        ApiRuntimeException.class,
+        () -> linkManager.findReferencingItems(target.getGlobalId(), stranger));
+  }
+
+  @Test
+  public void findReferencingItemsRejectsMissingTarget() {
+    User user = createInitAndLoginAnyUser();
+    assertThrows(ApiRuntimeException.class, () -> linkManager.findReferencingItems("SA9999", user));
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplUnitTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplUnitTest.java
@@ -1,0 +1,160 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.service.inventory.InventoryPermissionUtils;
+import com.researchspace.service.inventory.LinkTargetResolver;
+import com.researchspace.service.inventory.LinkTargetSnapshotResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Pure unit tests for the write path of {@link InventoryLinkManagerImpl}: a pinned link captures
+ * the resolved Envers revision; a "latest" link leaves it null. The Spring-transactional {@code
+ * InventoryLinkManagerImplTest} covers the DB-backed behaviour.
+ */
+@ExtendWith(MockitoExtension.class)
+class InventoryLinkManagerImplUnitTest {
+
+  @Mock private InventoryLinkDao linkDao;
+  @Mock private InventoryPermissionUtils permissionUtils;
+  @Mock private LinkTargetResolver linkTargetResolver;
+  @Mock private LinkTargetSnapshotResolver snapshotResolver;
+  @InjectMocks private InventoryLinkManagerImpl linkManager;
+
+  private final User actor = mock(User.class);
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+    lenient().when(linkDao.save(any())).thenAnswer(inv -> inv.getArgument(0));
+  }
+
+  @Test
+  void createLinkCapturesResolvedRevisionForPinnedTarget() {
+    when(snapshotResolver.resolveRevisionForVersion(GlobalIdPrefix.SD, 42L, 3L)).thenReturn(99L);
+    ApiInventoryLink api = new ApiInventoryLink();
+    api.setRelationType("References");
+    api.setTargetGlobalId("SD42v3");
+
+    InventoryLink saved = linkManager.createLink(api, actor);
+
+    assertEquals(Long.valueOf(3), saved.getVersionPin());
+    assertEquals(Long.valueOf(99), saved.getTargetRevisionId());
+  }
+
+  @Test
+  void createLinkLeavesRevisionNullForLatestTarget() {
+    ApiInventoryLink api = new ApiInventoryLink();
+    api.setRelationType("References");
+    api.setTargetGlobalId("SD42");
+
+    InventoryLink saved = linkManager.createLink(api, actor);
+
+    assertNull(saved.getVersionPin());
+    assertNull(saved.getTargetRevisionId());
+    verify(snapshotResolver, never()).resolveRevisionForVersion(any(), any(), any());
+  }
+
+  @Test
+  void updateLinkClearsRevisionWhenRepointedToLatest() {
+    InventoryLink existing = new InventoryLink();
+    existing.setVersionPin(3L);
+    existing.setTargetRevisionId(99L);
+    ApiInventoryLink update = new ApiInventoryLink();
+    update.setRelationType("References");
+    update.setTargetGlobalId("SD42");
+
+    InventoryLink updated = linkManager.updateLink(existing, update, actor);
+
+    assertNull(updated.getVersionPin());
+    assertNull(updated.getTargetRevisionId());
+    verify(snapshotResolver, never()).resolveRevisionForVersion(any(), any(), any());
+  }
+
+  @Test
+  void updateLinkRecapturesRevisionWhenRepointedToPinnedTarget() {
+    when(snapshotResolver.resolveRevisionForVersion(GlobalIdPrefix.SD, 42L, 7L)).thenReturn(55L);
+    InventoryLink existing = new InventoryLink();
+    ApiInventoryLink update = new ApiInventoryLink();
+    update.setRelationType("References");
+    update.setTargetGlobalId("SD42v7");
+
+    InventoryLink updated = linkManager.updateLink(existing, update, actor);
+
+    assertEquals(Long.valueOf(7), updated.getVersionPin());
+    assertEquals(Long.valueOf(55), updated.getTargetRevisionId());
+  }
+
+  @Test
+  void findReferencingItemsRejectsTargetTheCallerCannotReadWithoutQuerying() {
+    // unreadable and missing targets deliberately produce the same error, so the
+    // response does not confirm to a guessing caller that the record exists
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(false);
+
+    assertThrows(ApiRuntimeException.class, () -> linkManager.findReferencingItems("SA42", actor));
+    verify(linkDao, never()).findReferencingLinkFields(any(), any());
+  }
+
+  @Test
+  void findReferencingItemsQueriesSourcesWhenTargetIsReadable() {
+    when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SA, 42L))
+        .thenReturn(java.util.Collections.emptyList());
+
+    assertEquals(0, linkManager.findReferencingItems("SA42", actor).size());
+  }
+
+  @Test
+  void findReferencingItemsRejectsMalformedGlobalId() {
+    assertThrows(
+        ApiRuntimeException.class, () -> linkManager.findReferencingItems("not-a-gid", actor));
+    verify(linkDao, never()).findReferencingLinkFields(any(), any());
+  }
+
+  @Test
+  void targetSummaryForGlobalIdResolvesCurrentStateOfTheBaseRecord() {
+    // the summary backs the "Target deleted" pill, which must reflect the
+    // record as it is NOW: the pin/revision are deliberately not consulted,
+    // and a version suffix on the id is ignored
+    ApiInventoryLinkTargetSummary expected = new ApiInventoryLinkTargetSummary();
+    expected.setGlobalId("SD42");
+    expected.setDeleted(true);
+    when(snapshotResolver.resolveSummary(GlobalIdPrefix.SD, 42L, null, null, actor))
+        .thenReturn(expected);
+
+    assertSame(expected, linkManager.getTargetSummary("SD42v3", actor));
+  }
+
+  @Test
+  void targetSummaryRejectsMalformedAndUnsupportedIdsWithWritePathErrors() {
+    ApiRuntimeException malformed =
+        assertThrows(
+            ApiRuntimeException.class, () -> linkManager.getTargetSummary("not-a-gid", actor));
+    assertEquals("errors.inventory.field.link.targetNotFound", malformed.getErrorCode());
+
+    // FL is not an allowed link target kind, so its summary must not resolve
+    ApiRuntimeException unsupported =
+        assertThrows(ApiRuntimeException.class, () -> linkManager.getTargetSummary("FL3", actor));
+    assertEquals("errors.inventory.field.link.targetKindUnsupported", unsupported.getErrorCode());
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplValidationTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplValidationTest.java
@@ -1,0 +1,164 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.service.inventory.InventoryPermissionUtils;
+import com.researchspace.service.inventory.LinkTargetResolver;
+import com.researchspace.service.inventory.LinkTargetSnapshotResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryLinkManagerImplValidationTest {
+
+  @Mock private InventoryLinkDao linkDao;
+  @Mock private InventoryPermissionUtils permissionUtils;
+  @Mock private LinkTargetResolver linkTargetResolver;
+  @Mock private LinkTargetSnapshotResolver snapshotResolver;
+  @InjectMocks private InventoryLinkManagerImpl manager;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("actor");
+  }
+
+  private void targetReadable(boolean readable) {
+    when(linkTargetResolver.targetExistsAndIsReadable(any(GlobalIdentifier.class), any(User.class)))
+        .thenReturn(readable);
+  }
+
+  private ApiInventoryLink apiLink(String relationType, String targetGlobalId) {
+    ApiInventoryLink api = new ApiInventoryLink();
+    api.setRelationType(relationType);
+    api.setTargetGlobalId(targetGlobalId);
+    return api;
+  }
+
+  @Test
+  void createLinkRejectsMalformedTargetWithCleanError() {
+    // the validator can be bypassed (e.g. an extra-field update omitting
+    // "type"), so the manager itself must reject bad payloads with a clean
+    // 422 error instead of letting a raw parse exception become a 500
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class,
+            () -> manager.createLink(apiLink("References", "not-a-gid"), user));
+    assertEquals("errors.inventory.field.link.targetNotFound", ex.getErrorCode());
+    verify(linkDao, never()).save(any());
+  }
+
+  @Test
+  void createLinkRejectsUnsupportedTargetKind() {
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class,
+            () -> manager.createLink(apiLink("References", "FL12"), user));
+    assertEquals("errors.inventory.field.link.targetKindUnsupported", ex.getErrorCode());
+    verify(linkDao, never()).save(any());
+  }
+
+  @Test
+  void createLinkRejectsRelationTypeOutsideDataCiteVocabulary() {
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class,
+            () -> manager.createLink(apiLink("NotARelation", "SD123"), user));
+    assertEquals("errors.inventory.field.link.relationTypeInvalid", ex.getErrorCode());
+    verify(linkDao, never()).save(any());
+  }
+
+  @Test
+  void updateLinkRejectsMalformedTargetWithCleanError() {
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class,
+            () -> manager.updateLink(new InventoryLink(), apiLink("References", "ZZ99"), user));
+    // ZZ is not a known prefix, so the id fails to parse at all
+    assertEquals("errors.inventory.field.link.targetNotFound", ex.getErrorCode());
+    verify(linkDao, never()).save(any());
+  }
+
+  @Test
+  void createLinkPersistsWhenTargetReadable() {
+    targetReadable(true);
+    when(linkDao.save(any(InventoryLink.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    InventoryLink saved = manager.createLink(apiLink("References", "SD123"), user);
+
+    assertEquals(GlobalIdPrefix.SD, saved.getTargetPrefix());
+    assertEquals(Long.valueOf(123), saved.getTargetDbId());
+    verify(linkDao).save(any(InventoryLink.class));
+  }
+
+  @Test
+  void createLinkPersistsUnsuffixedGlobalIdAndDerivesPinFromVersionSuffix() {
+    targetReadable(true);
+    when(linkDao.save(any(InventoryLink.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(snapshotResolver.resolveRevisionForVersion(GlobalIdPrefix.SA, 456L, 5L)).thenReturn(77L);
+
+    InventoryLink saved = manager.createLink(apiLink("References", "SA456v5"), user);
+
+    // the suffix becomes the pin and the stored Global ID is the unsuffixed
+    // base, so the version is never doubly encoded in the persisted row
+    assertEquals("SA456", saved.getTargetGlobalId());
+    assertEquals(Long.valueOf(5), saved.getVersionPin());
+    assertEquals(GlobalIdPrefix.SA, saved.getTargetPrefix());
+    assertEquals(Long.valueOf(456), saved.getTargetDbId());
+    assertEquals(Long.valueOf(77), saved.getTargetRevisionId());
+  }
+
+  @Test
+  void createLinkRejectsUnreadableTargetWithI18nCodeAndDoesNotPersist() {
+    targetReadable(false);
+
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class,
+            () -> manager.createLink(apiLink("References", "SD404"), user));
+
+    assertEquals("errors.inventory.field.link.targetNotFound", ex.getErrorCode());
+    verify(linkDao, never()).save(any(InventoryLink.class));
+  }
+
+  @Test
+  void updateLinkPersistsWhenTargetReadable() {
+    targetReadable(true);
+    when(linkDao.save(any(InventoryLink.class))).thenAnswer(inv -> inv.getArgument(0));
+    InventoryLink existing = new InventoryLink();
+
+    InventoryLink updated = manager.updateLink(existing, apiLink("IsCalibratedBy", "NB9"), user);
+
+    assertEquals("IsCalibratedBy", updated.getRelationType());
+    assertEquals(GlobalIdPrefix.NB, updated.getTargetPrefix());
+  }
+
+  @Test
+  void updateLinkRejectsUnreadableTargetAndDoesNotPersist() {
+    targetReadable(false);
+    InventoryLink existing = new InventoryLink();
+
+    assertThrows(
+        ApiRuntimeException.class,
+        () -> manager.updateLink(existing, apiLink("References", "SD404"), user));
+
+    verify(linkDao, never()).save(any(InventoryLink.class));
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/LinkTargetResolverImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/LinkTargetResolverImplTest.java
@@ -1,0 +1,202 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.permissions.IPermissionUtils;
+import com.researchspace.model.record.BaseRecord;
+import com.researchspace.service.BaseRecordManager;
+import com.researchspace.service.inventory.InventoryPermissionUtils;
+import java.util.Collections;
+import java.util.List;
+import javax.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectRetrievalFailureException;
+
+@ExtendWith(MockitoExtension.class)
+class LinkTargetResolverImplTest {
+
+  @Mock private InventoryPermissionUtils inventoryPermissionUtils;
+  @Mock private BaseRecordManager baseRecordManager;
+  @Mock private IPermissionUtils permissionUtils;
+  @InjectMocks private LinkTargetResolverImpl resolver;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    user = new User("any");
+  }
+
+  @Test
+  void resolutionAppliesPendingPermissionCacheRefreshBeforeChecking() {
+    // an unshare notifies the affected user to refresh their cached Shiro
+    // authorisation; resolution must apply that pending refresh first, or the
+    // viewer keeps the stale read grant (and a working Open with no pill)
+    // until the server restarts
+    when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
+        .thenReturn(Collections.emptyList());
+
+    resolver.targetExistsAndIsReadable(new GlobalIdentifier("SD42"), user);
+
+    InOrder inOrder = inOrder(permissionUtils, baseRecordManager);
+    inOrder.verify(permissionUtils).refreshCacheIfNotified();
+    inOrder.verify(baseRecordManager).getByGlobalIdsAndReadPermission(any(), eq(user));
+  }
+
+  @Test
+  void inventoryResolutionAlsoAppliesPendingPermissionCacheRefreshFirst() {
+    when(inventoryPermissionUtils.canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user)))
+        .thenReturn(true);
+
+    resolver.targetExistsAndIsReadable(new GlobalIdentifier("SA42"), user);
+
+    InOrder inOrder = inOrder(permissionUtils, inventoryPermissionUtils);
+    inOrder.verify(permissionUtils).refreshCacheIfNotified();
+    inOrder
+        .verify(inventoryPermissionUtils)
+        .canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user));
+  }
+
+  @Test
+  void inventoryTargetReadableResolvesTrue() {
+    when(inventoryPermissionUtils.canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user)))
+        .thenReturn(true);
+
+    assertTrue(resolver.targetExistsAndIsReadable(new GlobalIdentifier("SA42"), user));
+  }
+
+  @Test
+  void inventoryTargetNotReadableResolvesFalse() {
+    when(inventoryPermissionUtils.canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user)))
+        .thenReturn(false);
+
+    assertFalse(resolver.targetExistsAndIsReadable(new GlobalIdentifier("SA42"), user));
+  }
+
+  @Test
+  void inventoryLinkingRequiresFullReadNotLimitedRead() {
+    // the inventory API grants any logged-in user a redacted "limited read"
+    // view of items, but that must never be enough to link to them: the
+    // resolver consults the full READ check only, so an unreadable target is
+    // rejected exactly like a missing one and existence is not disclosed
+    when(inventoryPermissionUtils.canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user)))
+        .thenReturn(false);
+
+    assertFalse(resolver.targetExistsAndIsReadable(new GlobalIdentifier("SA42"), user));
+    verify(inventoryPermissionUtils, never())
+        .canUserLimitedReadInventoryRecord(any(GlobalIdentifier.class), eq(user));
+  }
+
+  @Test
+  void inventoryTargetNotFoundResolvesFalse() {
+    when(inventoryPermissionUtils.canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user)))
+        .thenThrow(new NotFoundException("no such record"));
+
+    assertFalse(resolver.targetExistsAndIsReadable(new GlobalIdentifier("SA9999"), user));
+  }
+
+  @Test
+  void elnDocumentTargetReadableResolvesTrue() {
+    BaseRecord document = org.mockito.Mockito.mock(BaseRecord.class);
+    when(document.getOid()).thenReturn(new GlobalIdentifier("SD123"));
+    when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
+        .thenReturn(List.of(document));
+
+    assertTrue(resolver.targetExistsAndIsReadable(new GlobalIdentifier("SD123"), user));
+  }
+
+  @Test
+  void elnTargetNotReadableResolvesFalse() {
+    when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
+        .thenReturn(Collections.emptyList());
+
+    assertFalse(resolver.targetExistsAndIsReadable(new GlobalIdentifier("SD123"), user));
+  }
+
+  @Test
+  void elnTargetNotFoundResolvesFalse() {
+    when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
+        .thenThrow(new ObjectRetrievalFailureException("BaseRecord", 123L));
+
+    assertFalse(resolver.targetExistsAndIsReadable(new GlobalIdentifier("SD123"), user));
+  }
+
+  @Test
+  void notebookAndGalleryTargetsResolveViaBaseRecordManager() {
+    BaseRecord notebook = org.mockito.Mockito.mock(BaseRecord.class);
+    when(notebook.getOid()).thenReturn(new GlobalIdentifier("NB7"));
+    BaseRecord galleryFile = org.mockito.Mockito.mock(BaseRecord.class);
+    when(galleryFile.getOid()).thenReturn(new GlobalIdentifier("GL55"));
+    when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
+        .thenReturn(List.of(notebook), List.of(galleryFile));
+
+    assertTrue(resolver.targetExistsAndIsReadable(new GlobalIdentifier("NB7"), user));
+    assertTrue(resolver.targetExistsAndIsReadable(new GlobalIdentifier("GL55"), user));
+  }
+
+  @Test
+  void versionSuffixIsStrippedBeforeResolving() {
+    ArgumentCaptor<List<GlobalIdentifier>> captor = ArgumentCaptor.forClass(List.class);
+    when(baseRecordManager.getByGlobalIdsAndReadPermission(captor.capture(), eq(user)))
+        .thenReturn(List.of(org.mockito.Mockito.mock(BaseRecord.class)));
+
+    resolver.targetExistsAndIsReadable(new GlobalIdentifier("SD123v5"), user);
+
+    GlobalIdentifier resolved = captor.getValue().get(0);
+    assertFalse(resolved.hasVersionId(), "version suffix should be stripped before resolving");
+    assertEquals(Long.valueOf(123), resolved.getDbId());
+    assertEquals(GlobalIdPrefix.SD, resolved.getPrefix());
+  }
+
+  @Test
+  void elnTargetMustMatchRequestedPrefixNotJustDbId() {
+    // the workspace loader resolves by numeric id alone, so "GL150" loads
+    // whatever record has id 150 (e.g. folder FL150); only a record whose own
+    // oid prefix matches the requested one may count as the link target
+    BaseRecord folder = org.mockito.Mockito.mock(BaseRecord.class);
+    when(folder.getOid()).thenReturn(new GlobalIdentifier("FL150"));
+    when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
+        .thenReturn(List.of(folder));
+
+    assertFalse(resolver.targetExistsAndIsReadable(new GlobalIdentifier("GL150"), user));
+  }
+
+  @Test
+  void unsupportedPrefixResolvesFalse() {
+    assertFalse(resolver.targetExistsAndIsReadable(new GlobalIdentifier("FM3"), user));
+  }
+
+  @Test
+  void folderTargetResolvesFalseWithoutQuerying() {
+    // FL is not an allowed link target kind (InventoryLinkValidator rejects it),
+    // so the resolver must not treat readable folders as resolvable: doing so
+    // would let the referencing-items endpoint return an empty list instead of
+    // the uniform not-found error, disclosing folder readability via a
+    // side-channel
+    assertFalse(resolver.targetExistsAndIsReadable(new GlobalIdentifier("FL3"), user));
+    verify(baseRecordManager, never()).getByGlobalIdsAndReadPermission(any(), eq(user));
+  }
+
+  @Test
+  void nullTargetResolvesFalse() {
+    assertFalse(resolver.targetExistsAndIsReadable(null, user));
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverIT.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverIT.java
@@ -1,0 +1,92 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.service.inventory.LinkTargetSnapshotResolver;
+import com.researchspace.testutils.RealTransactionSpringTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * End-to-end Envers test for {@link LinkTargetSnapshotResolverImpl}, exercising real audit data:
+ * the user-facing version -> Envers REV mapping, the newest-revision "latest" resolution, and
+ * loading a pinned revision into a summary.
+ *
+ * <p>Author-only: NOT run during implementation (see project test policy). Envers only writes audit
+ * rows on a real commit, so this extends {@link RealTransactionSpringTestBase} (real commits, *IT
+ * suffix) rather than the auto-rolled-back transactional base.
+ */
+public class LinkTargetSnapshotResolverIT extends RealTransactionSpringTestBase {
+
+  private @Autowired LinkTargetSnapshotResolver snapshotResolver;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+  }
+
+  @Test
+  public void resolvesUserVersionToRevisionForNewlyCreatedSample() {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples sample = createBasicSampleForUser(user);
+
+    Long revision =
+        snapshotResolver.resolveRevisionForVersion(GlobalIdPrefix.SA, sample.getId(), 1L);
+
+    assertNotNull("version 1 of a sample should map to an Envers revision", revision);
+  }
+
+  @Test
+  public void resolvesLatestSnapshotFromNewestRevision() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples sample = createBasicSampleForUser(user);
+
+    // resolveSummary is non-transactional by design: in production it runs inside the calling
+    // *Manager's transaction. Its Envers reads and lazy entity hydration need a thread-bound
+    // session, so the IT supplies one rather than calling the resolver bare.
+    ApiInventoryLinkTargetSummary summary =
+        doInTransaction(
+            () -> {
+              return snapshotResolver.resolveSummary(
+                  GlobalIdPrefix.SA, sample.getId(), null, null, user);
+            });
+
+    assertEquals("SA" + sample.getId(), summary.getGlobalId());
+    assertEquals(sample.getName(), summary.getName());
+    assertEquals("SAMPLE", summary.getType());
+    assertFalse(summary.isDeleted());
+  }
+
+  @Test
+  public void resolvesPinnedSnapshotAtStoredRevision() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples sample = createBasicSampleForUser(user);
+    Long revision =
+        snapshotResolver.resolveRevisionForVersion(GlobalIdPrefix.SA, sample.getId(), 1L);
+
+    // see resolvesLatestSnapshotFromNewestRevision: resolveSummary needs an active transaction
+    ApiInventoryLinkTargetSummary summary =
+        doInTransaction(
+            () -> {
+              return snapshotResolver.resolveSummary(
+                  GlobalIdPrefix.SA, sample.getId(), 1L, revision, user);
+            });
+
+    assertEquals("SA" + sample.getId() + "v1", summary.getGlobalId());
+    assertEquals(sample.getName(), summary.getName());
+    assertEquals("SAMPLE", summary.getType());
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImplTest.java
@@ -1,0 +1,295 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
+import com.researchspace.model.User;
+import com.researchspace.model.audit.AuditedEntity;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.record.Folder;
+import com.researchspace.model.record.StructuredDocument;
+import com.researchspace.service.AuditManager;
+import com.researchspace.service.inventory.LinkTargetResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Pure unit tests for {@link LinkTargetSnapshotResolverImpl}. Collaborators (the audit manager,
+ * permission checks) are mocked; the real Envers behaviour is exercised by an author-only IT.
+ */
+@ExtendWith(MockitoExtension.class)
+class LinkTargetSnapshotResolverImplTest {
+
+  @Mock private AuditManager auditManager;
+  @Mock private LinkTargetResolver linkTargetResolver;
+  @Mock private User user;
+  @InjectMocks private LinkTargetSnapshotResolverImpl resolver;
+
+  @Test
+  void resolvesRevisionForPinnedStructuredDocumentVersion() {
+    when(auditManager.findRevisionNumberForDocumentVersion(42L, 3L)).thenReturn(99);
+
+    Long rev = resolver.resolveRevisionForVersion(GlobalIdPrefix.SD, 42L, 3L);
+
+    assertEquals(Long.valueOf(99), rev);
+  }
+
+  @Test
+  void resolvesRevisionForPinnedGalleryFileVersion() {
+    when(auditManager.findRevisionNumberForMediaFileVersion(7L, 2L)).thenReturn(50);
+
+    Long rev = resolver.resolveRevisionForVersion(GlobalIdPrefix.GL, 7L, 2L);
+
+    assertEquals(Long.valueOf(50), rev);
+  }
+
+  @Test
+  void returnsNullForDocumentVersionWithNoAuditRowWithoutCallingTheThrowingLookup() {
+    // A version with no audit row (e.g. a freshly created target whose creation revision predates
+    // that user-facing version) must degrade to null via the non-throwing lookup. The resolver must
+    // NOT call the throwing getRevisionNumberForDocumentVersion, whose IllegalArgumentException -
+    // crossing the transactional AuditManager boundary - would mark the caller's transaction
+    // rollback-only and fail the whole link save with a 500.
+    when(auditManager.findRevisionNumberForDocumentVersion(42L, 1L)).thenReturn(null);
+
+    assertNull(resolver.resolveRevisionForVersion(GlobalIdPrefix.SD, 42L, 1L));
+    verify(auditManager, never()).getRevisionNumberForDocumentVersion(anyLong(), any());
+  }
+
+  @Test
+  void returnsNullForGalleryFileVersionWithNoAuditRowWithoutCallingTheThrowingLookup() {
+    when(auditManager.findRevisionNumberForMediaFileVersion(7L, 1L)).thenReturn(null);
+
+    assertNull(resolver.resolveRevisionForVersion(GlobalIdPrefix.GL, 7L, 1L));
+    verify(auditManager, never()).getRevisionNumberForMediaFileVersion(anyLong(), any());
+  }
+
+  @Test
+  void resolvesRevisionForPinnedSampleVersionViaInventoryAuditLookup() {
+    when(auditManager.getRevisionNumberForInventoryRecordVersion(Sample.class, 10L, 4L))
+        .thenReturn(77);
+
+    Long rev = resolver.resolveRevisionForVersion(GlobalIdPrefix.SA, 10L, 4L);
+
+    assertEquals(Long.valueOf(77), rev);
+  }
+
+  @Test
+  void resolvesRevisionForSampleTemplateViaSampleClass() {
+    when(auditManager.getRevisionNumberForInventoryRecordVersion(Sample.class, 20L, 2L))
+        .thenReturn(33);
+
+    Long rev = resolver.resolveRevisionForVersion(GlobalIdPrefix.IT, 20L, 2L);
+
+    assertEquals(Long.valueOf(33), rev);
+  }
+
+  @Test
+  void returnsNullForNotebookTargetWhichHasNoUserFacingVersion() {
+    assertNull(resolver.resolveRevisionForVersion(GlobalIdPrefix.NB, 5L, 1L));
+  }
+
+  @Test
+  void returnsNullWhenVersionIsNull() {
+    assertNull(resolver.resolveRevisionForVersion(GlobalIdPrefix.SD, 42L, null));
+  }
+
+  @Test
+  void resolveSummaryDegradesToGlobalIdOnlyWhenNoAuditSnapshotExists() {
+    // old databases may hold links whose audit rows were purged; the summary
+    // must degrade to the globalId rather than NPE on the missing snapshot
+    when(auditManager.getNewestRevisionForEntity(Sample.class, 10L)).thenReturn(null);
+
+    ApiInventoryLinkTargetSummary summary =
+        resolver.resolveSummary(GlobalIdPrefix.SA, 10L, null, null, user);
+
+    assertEquals("SA10", summary.getGlobalId());
+    assertNull(summary.getName());
+    assertFalse(summary.isReadable());
+  }
+
+  @Test
+  void resolveSummaryDegradesToGlobalIdOnlyForUnsupportedPrefix() {
+    ApiInventoryLinkTargetSummary summary =
+        resolver.resolveSummary(GlobalIdPrefix.FL, 7L, null, null, user);
+
+    assertEquals("FL7", summary.getGlobalId());
+    assertNull(summary.getName());
+    verify(auditManager, never()).getNewestRevisionForEntity(any(), any());
+  }
+
+  @Test
+  void resolveSummaryLoadsPinnedRevisionAndBuildsVersionedSummary() {
+    Sample rec = mock(Sample.class);
+    when(rec.getName()).thenReturn("Buffer");
+    when(rec.isDeleted()).thenReturn(false);
+    when(auditManager.getObjectForRevision(Sample.class, 10L, 99L))
+        .thenReturn(new AuditedEntity<>(rec, 99));
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+
+    ApiInventoryLinkTargetSummary s =
+        resolver.resolveSummary(GlobalIdPrefix.SA, 10L, 3L, 99L, user);
+
+    assertEquals("SA10v3", s.getGlobalId());
+    assertEquals("Buffer", s.getName());
+    assertEquals("SAMPLE", s.getType());
+    assertFalse(s.isDeleted());
+    assertTrue(s.isReadable());
+    verify(auditManager, never()).getNewestRevisionForEntity(any(), any());
+  }
+
+  @Test
+  void resolveSummaryUsesNewestRevisionForLatestLink() {
+    Sample rec = mock(Sample.class);
+    when(rec.getName()).thenReturn("Buffer");
+    when(auditManager.getNewestRevisionForEntity(Sample.class, 10L))
+        .thenReturn(new AuditedEntity<>(rec, 120));
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+
+    ApiInventoryLinkTargetSummary s =
+        resolver.resolveSummary(GlobalIdPrefix.SA, 10L, null, null, user);
+
+    assertEquals("SA10", s.getGlobalId());
+    assertEquals("Buffer", s.getName());
+    verify(auditManager, never()).getObjectForRevision(any(), any(), any());
+  }
+
+  @Test
+  void resolveSummaryReportsDeletedWhenSnapshotIsSoftDeleted() {
+    Sample rec = mock(Sample.class);
+    when(rec.getName()).thenReturn("Old buffer");
+    when(rec.isDeleted()).thenReturn(true);
+    when(auditManager.getNewestRevisionForEntity(Sample.class, 10L))
+        .thenReturn(new AuditedEntity<>(rec, 120));
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+
+    ApiInventoryLinkTargetSummary s =
+        resolver.resolveSummary(GlobalIdPrefix.SA, 10L, null, null, user);
+
+    assertTrue(s.isDeleted());
+  }
+
+  @Test
+  void resolveSummaryRedactsNameWhenActorCannotReadTarget() {
+    Sample rec = mock(Sample.class);
+    User owner = mock(User.class);
+    when(owner.getUsername()).thenReturn("alice");
+    when(rec.getOwner()).thenReturn(owner);
+    when(auditManager.getNewestRevisionForEntity(Sample.class, 10L))
+        .thenReturn(new AuditedEntity<>(rec, 120));
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(false);
+    when(user.getUsername()).thenReturn("bob");
+
+    ApiInventoryLinkTargetSummary s =
+        resolver.resolveSummary(GlobalIdPrefix.SA, 10L, null, null, user);
+
+    assertEquals("SA10", s.getGlobalId());
+    assertNull(s.getName());
+    assertNull(s.getType());
+    assertFalse(s.isReadable());
+  }
+
+  @Test
+  void resolveSummaryMakesUnreadableTargetIndistinguishableFromNonexistent() {
+    // Non-disclosure invariant (ADR-0002): a target the actor cannot read must
+    // produce a payload field-for-field identical to one for a record that does
+    // not exist, so probing the summary endpoint with guessed ids learns nothing.
+    Sample rec = mock(Sample.class);
+    User owner = mock(User.class);
+    when(owner.getUsername()).thenReturn("alice");
+    when(rec.getOwner()).thenReturn(owner);
+    when(auditManager.getNewestRevisionForEntity(Sample.class, 10L))
+        .thenReturn(null)
+        .thenReturn(new AuditedEntity<>(rec, 120));
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(false);
+    when(user.getUsername()).thenReturn("bob");
+
+    ApiInventoryLinkTargetSummary nonexistent =
+        resolver.resolveSummary(GlobalIdPrefix.SA, 10L, null, null, user);
+    ApiInventoryLinkTargetSummary unreadable =
+        resolver.resolveSummary(GlobalIdPrefix.SA, 10L, null, null, user);
+
+    assertEquals(nonexistent, unreadable);
+  }
+
+  @Test
+  void resolveSummaryBuildsSummaryForElnDocumentTarget() {
+    StructuredDocument doc = mock(StructuredDocument.class);
+    when(doc.getName()).thenReturn("My doc");
+    when(doc.isDeleted()).thenReturn(false);
+    when(auditManager.getNewestRevisionForEntity(StructuredDocument.class, 42L))
+        .thenReturn(new AuditedEntity<>(doc, 5));
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+
+    ApiInventoryLinkTargetSummary s =
+        resolver.resolveSummary(GlobalIdPrefix.SD, 42L, null, null, user);
+
+    assertEquals("SD42", s.getGlobalId());
+    assertEquals("My doc", s.getName());
+    assertEquals("DOCUMENT", s.getType());
+    assertFalse(s.isDeleted());
+    assertTrue(s.isReadable());
+  }
+
+  @Test
+  void resolveSummaryForDeletedNotebookOwnerReportsDeletedWithoutThrowingLiveCheck() {
+    // Notebooks are persisted as Folder rows and Envers audits Folder, not Notebook, so the
+    // resolver queries Folder.class (querying Notebook.class threw NotAuditedException). For the
+    // owner, readability comes from snapshot ownership and the throwing live folder lookup is
+    // skipped: that lookup loads the folder with includeDeleted=false and throws for a deleted
+    // folder, which - crossing a transactional boundary - marked the summary transaction
+    // rollback-only and 500d it, so the deleted notebook showed no "Target deleted" pill and kept
+    // Open. A deleted notebook owned by the viewer must report deleted=true.
+    Folder notebook = mock(Folder.class);
+    User owner = mock(User.class);
+    when(owner.getUsername()).thenReturn("bob");
+    when(notebook.getOwner()).thenReturn(owner);
+    when(notebook.getName()).thenReturn("Lab notebook");
+    when(notebook.isDeleted()).thenReturn(true);
+    when(auditManager.getNewestRevisionForEntity(Folder.class, 7L))
+        .thenReturn(new AuditedEntity<>(notebook, 12));
+    when(user.getUsername()).thenReturn("bob");
+
+    ApiInventoryLinkTargetSummary s =
+        resolver.resolveSummary(GlobalIdPrefix.NB, 7L, null, null, user);
+
+    assertEquals("NB7", s.getGlobalId());
+    assertEquals("Lab notebook", s.getName());
+    assertEquals("NOTEBOOK", s.getType());
+    assertTrue(s.isDeleted());
+    assertTrue(s.isReadable());
+    verify(linkTargetResolver, never()).targetExistsAndIsReadable(any(), any());
+  }
+
+  @Test
+  void resolveSummaryPermitsSnapshotOwnerWhenOnlyAuditDataRemains() {
+    Sample rec = mock(Sample.class);
+    User owner = mock(User.class);
+    when(owner.getUsername()).thenReturn("bob");
+    when(rec.getOwner()).thenReturn(owner);
+    when(rec.getName()).thenReturn("Buffer");
+    when(auditManager.getNewestRevisionForEntity(Sample.class, 10L))
+        .thenReturn(new AuditedEntity<>(rec, 120));
+    when(user.getUsername()).thenReturn("bob");
+
+    ApiInventoryLinkTargetSummary s =
+        resolver.resolveSummary(GlobalIdPrefix.SA, 10L, null, null, user);
+
+    // the snapshot owner is permitted from ownership alone; the live read check is not consulted
+    assertEquals("Buffer", s.getName());
+    verify(linkTargetResolver, never()).targetExistsAndIsReadable(any(), any());
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
@@ -1,0 +1,249 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.testutils.TestFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Applying a structured link-field value must not leak InventoryLink rows: an unchanged payload is
+ * a no-op, a changed payload updates the existing row in place (which also revalidates the target
+ * and recaptures the pinned audit revision), and clearing the value soft-deletes the old row
+ * through the manager. Creating a fresh row on every save left the previous row in the DB with
+ * {@code deleted=false} and nothing pointing at it.
+ *
+ * <p>Likewise, soft-deleting a structured link field (a template link-field delete, or its
+ * propagation to child samples via {@code Sample#updateToLatestTemplateVersion}) must soft-delete
+ * the field's link, otherwise the link row lingers with {@code deleted=false} after the field is
+ * gone.
+ */
+@ExtendWith(MockitoExtension.class)
+class SampleApiManagerImplLinkFieldTest {
+
+  @Mock private InventoryLinkManager inventoryLinkManager;
+  private SampleApiManagerImpl manager;
+
+  private User user;
+  private InventoryLinkField dbField;
+  private InventoryLink dbLink;
+
+  @BeforeEach
+  void setUp() {
+    manager = new SampleApiManagerImpl();
+    // the manager is field-autowired in production; wire the mock in directly
+    ReflectionTestUtils.setField(manager, "inventoryLinkManager", inventoryLinkManager);
+    user = TestFactory.createAnyUser("any");
+    dbLink = new InventoryLink();
+    dbLink.setRelationType("References");
+    dbLink.setTargetGlobalId("SA2");
+    dbLink.setTargetPrefix(GlobalIdPrefix.SA);
+    dbLink.setTargetDbId(2L);
+    dbField = new InventoryLinkField();
+    dbField.setName("related sample");
+    dbField.setLink(dbLink);
+  }
+
+  private ApiInventoryEntityField apiLinkField(
+      String targetGlobalId, String relationType, Long versionPin) {
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setTargetGlobalId(targetGlobalId);
+    apiLink.setRelationType(relationType);
+    apiLink.setVersionPin(versionPin);
+    apiField.setLink(apiLink);
+    return apiField;
+  }
+
+  @Test
+  void unchangedLinkLeavesTheExistingRowAlone() {
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void pinnedSuffixedTargetMatchingStoredBaseIdIsUnchanged() {
+    // the stored row holds the base id ("SA2") with the pin in versionPin; an
+    // incoming suffixed id ("SA2v4") carrying the same effective pin must
+    // compare equal, not fire a spurious update (and Envers revision) on
+    // every save
+    dbLink.setVersionPin(4L);
+    ApiInventoryEntityField apiField = apiLinkField("SA2v4", "References", null);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void retargetUpdatesTheExistingRowInPlace() {
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "References", null);
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+    verify(inventoryLinkManager, never()).createLink(any(), any());
+  }
+
+  @Test
+  void versionPinChangeUpdatesTheExistingRowInPlace() {
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", 4L);
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+  }
+
+  @Test
+  void relationTypeChangeUpdatesTheExistingRowInPlace() {
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "IsCitedBy", null);
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+  }
+
+  @Test
+  void clearingTheValueDereferencesTheRowForOrphanRemoval() {
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    // no link payload at all: the field's value is being cleared. The field's
+    // orphanRemoval mapping hard-deletes the dereferenced row at flush (with a
+    // DEL revision in InventoryLink_AUD); an extra soft-delete write would be
+    // collapsed away by Envers and is deliberately not attempted.
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    assertNull(dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void invalidRelationTypeIsRejectedWithCleanError() {
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "NotARelation", null);
+
+    com.researchspace.api.v1.auth.ApiRuntimeException ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            com.researchspace.api.v1.auth.ApiRuntimeException.class,
+            () -> manager.applyLinkFieldValue(dbField, apiField, user));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        "errors.inventory.field.link.relationTypeInvalid", ex.getErrorCode());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void relationOutsideTemplateWhitelistIsRejected() {
+    dbField.setAllowedRelationTypes("References|IsPartOf");
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "Cites", null);
+
+    com.researchspace.api.v1.auth.ApiRuntimeException ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            com.researchspace.api.v1.auth.ApiRuntimeException.class,
+            () -> manager.applyLinkFieldValue(dbField, apiField, user));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        "errors.inventory.field.link.relationTypeNotPermitted", ex.getErrorCode());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void relationInsideTemplateWhitelistIsAccepted() {
+    dbField.setAllowedRelationTypes("References|IsPartOf");
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "IsPartOf", null);
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    assertTrue(manager.applyLinkFieldValue(dbField, apiField, user));
+  }
+
+  @Test
+  void clearingAnAlreadyEmptyFieldIsANoop() {
+    dbField.setLink(null);
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertFalse(changed);
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void anEmptyFieldGainsItsFirstLinkViaCreate() {
+    dbField.setLink(null);
+    InventoryLink created = new InventoryLink();
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "References", null);
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    assertSame(created, dbField.getLink());
+    verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+  }
+
+  @Test
+  void deletingALinkFieldSoftDeletesItsLinkThroughTheManager() {
+    dbField.setDeleted(true);
+
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verify(inventoryLinkManager).deleteLink(dbLink, user);
+  }
+
+  @Test
+  void aDeletedLinkFieldWithNoLinkLeavesTheManagerUntouched() {
+    dbField.setLink(null);
+    dbField.setDeleted(true);
+
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aDeletedLinkFieldWhoseLinkIsAlreadyDeletedLeavesTheManagerUntouched() {
+    dbLink.setDeleted(true);
+    dbField.setDeleted(true);
+
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aLiveLinkFieldIsLeftAlone() {
+    // field not deleted (default): a live field keeps its link
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verifyNoInteractions(inventoryLinkManager);
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplSamplesToUpdateCountTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplSamplesToUpdateCountTest.java
@@ -1,0 +1,73 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.dao.SampleDao;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.testutils.TestFactory;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The outgoing template DTO carries how many of the requesting user's samples were created from an
+ * older version of the template (and so could be updated to its latest version). Only that genuine
+ * "behind" count drives the UI's "Update Samples" affordance; a sample that merely links to the
+ * template via a link field is not created from it, is not counted, and so must not surface the
+ * action.
+ */
+@ExtendWith(MockitoExtension.class)
+class SampleApiManagerImplSamplesToUpdateCountTest {
+
+  @Mock private SampleDao sampleDao;
+  private SampleApiManagerImpl manager;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    manager = new SampleApiManagerImpl();
+    ReflectionTestUtils.setField(manager, "sampleDao", sampleDao);
+    user = TestFactory.createAnyUser("any");
+  }
+
+  private Sample templateWith(Long id, Long version) {
+    Sample template = mock(Sample.class);
+    lenient().when(template.getId()).thenReturn(id);
+    lenient().when(template.getVersion()).thenReturn(version);
+    return template;
+  }
+
+  @Test
+  void countReflectsSamplesCreatedFromAnOlderVersion() {
+    Sample template = templateWith(7L, 3L);
+    when(sampleDao.getSamplesLinkingOlderTemplateVersionForUser(7L, 3L, user))
+        .thenReturn(Arrays.asList(mock(Sample.class), mock(Sample.class)));
+
+    ApiSampleTemplate api = new ApiSampleTemplate();
+    manager.setSamplesToUpdateCount(api, template, user);
+
+    assertEquals(2, api.getSamplesToUpdateCount());
+  }
+
+  @Test
+  void countIsZeroWhenNoSampleIsBehind() {
+    Sample template = templateWith(7L, 3L);
+    when(sampleDao.getSamplesLinkingOlderTemplateVersionForUser(7L, 3L, user))
+        .thenReturn(Collections.emptyList());
+
+    ApiSampleTemplate api = new ApiSampleTemplate();
+    manager.setSamplesToUpdateCount(api, template, user);
+
+    assertEquals(0, api.getSamplesToUpdateCount());
+  }
+}

--- a/src/test/java/com/researchspace/testutils/DatabaseCleaner.java
+++ b/src/test/java/com/researchspace/testutils/DatabaseCleaner.java
@@ -130,6 +130,8 @@ public class DatabaseCleaner {
             "DigitalObjectIdentifier",
             "ExtraField",
             "InventoryEntityField",
+            // after BOTH field tables: their link_id FKs point at InventoryLink
+            "InventoryLink",
             "SubSampleNote",
             "SubSample",
             "Sample",

--- a/src/test/java/com/researchspace/webapp/controller/ElnInfoDialogContractMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/ElnInfoDialogContractMVCIT.java
@@ -1,0 +1,174 @@
+package com.researchspace.webapp.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.controller.API_MVC_InventoryTestBase;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.EcatImage;
+import com.researchspace.model.User;
+import com.researchspace.model.record.DetailedRecordInformation;
+import com.researchspace.model.record.Notebook;
+import com.researchspace.model.record.StructuredDocument;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end MVC contract test for the RSDEV-1131 "ELN-fidelity info button" dialog. The dialog is
+ * a React/MUI component in the Inventory module that opens when a user clicks the info button on an
+ * Inventory Link field whose target is an ELN record (SD document, NB notebook, GL gallery file).
+ * It adds no new backend endpoint; instead it reuses the SAME session-authenticated endpoints the
+ * ELN record-info panel uses:
+ *
+ * <ul>
+ *   <li>{@code GET /workspace/getRecordInformation?recordId={numericId}} -> the core metadata table
+ *       (name, global id, type, owner, dates) that the dialog renders, and
+ *   <li>{@code GET /workspace/getReferencingInventoryItems/{globalId}} -> the "Related inventory
+ *       items" section, which must list the Inventory item(s) that link to the ELN record.
+ * </ul>
+ *
+ * <p>This test drives both endpoints with a browser-session principal (as the SPA does, via
+ * same-origin cookies), having first created the Inventory -> ELN links through the API. It asserts
+ * the slice of the contract the dialog actually depends on, for each supported ELN target type.
+ */
+public class ElnInfoDialogContractMVCIT extends API_MVC_InventoryTestBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void documentInfoEndpointReturnsFieldsTheDialogRenders() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(user, "linkable doc");
+
+    MvcResult result = getRecordInformation(doc.getId(), user);
+    DetailedRecordInformation info =
+        getFromJsonAjaxReturnObject(result, DetailedRecordInformation.class);
+
+    // core metadata table fields the dialog renders for a document
+    assertNotNull("dialog needs the core record info", info);
+    assertEquals(doc.getId(), info.getId());
+    assertEquals(doc.getName(), info.getName());
+    assertEquals("Structured Document", info.getType());
+    assertEquals(doc.getGlobalIdentifier(), info.getOid().toString());
+    assertEquals(user.getUsername(), info.getOwnerUsername());
+    assertEquals(user.getFullName(), info.getOwnerFullName());
+    assertNotNull("dialog renders the created date", info.getCreationDate());
+    assertNotNull("dialog renders the modified date", info.getModificationDate());
+  }
+
+  @Test
+  public void referencingItemsEndpointReturnsTheInventorySourceForADocumentTarget()
+      throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(user, "linkable doc");
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+
+    linkInventoryItemToElnTarget(user, apiKey, source, doc.getGlobalIdentifier());
+
+    assertReferencingItem(user, doc.getGlobalIdentifier(), source);
+  }
+
+  @Test
+  public void referencingItemsEndpointReturnsTheInventorySourceForANotebookTarget()
+      throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+    Notebook notebook =
+        createNotebookWithNEntries(
+            folderMgr.getRootFolderForUser(user).getId(), "linkable notebook", 1, user);
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+
+    linkInventoryItemToElnTarget(user, apiKey, source, notebook.getGlobalIdentifier());
+
+    assertReferencingItem(user, notebook.getGlobalIdentifier(), source);
+  }
+
+  @Test
+  public void referencingItemsEndpointReturnsTheInventorySourceForAGalleryFileTarget()
+      throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+    EcatImage galleryFile = addImageToGallery(user);
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+
+    linkInventoryItemToElnTarget(user, apiKey, source, galleryFile.getGlobalIdentifier());
+
+    assertReferencingItem(user, galleryFile.getGlobalIdentifier(), source);
+  }
+
+  /**
+   * Reproduces the dialog's record-info call: a session-authenticated GET against the
+   * WorkspaceController endpoint, keyed by the numeric DB id (the SPA derives this by stripping the
+   * global-id prefix).
+   */
+  private MvcResult getRecordInformation(Long recordId, User user) throws Exception {
+    return mockMvc
+        .perform(
+            get("/workspace/getRecordInformation")
+                .param("recordId", recordId.toString())
+                .principal(user::getUsername))
+        .andExpect(status().isOk())
+        .andReturn();
+  }
+
+  /**
+   * Creates the Inventory -> ELN link through the API (which requires the API key), mirroring the
+   * way a user attaches a Link extra-field to an Inventory item.
+   */
+  private void linkInventoryItemToElnTarget(
+      User user, String apiKey, ApiSampleWithFullSubSamples source, String targetGlobalId)
+      throws Exception {
+    String updateJson = buildLinkExtraFieldUpdate(targetGlobalId, "References");
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(apiKey, "/samples/" + source.getId(), user, updateJson))
+        .andExpect(status().isOk());
+  }
+
+  /**
+   * Reproduces the dialog's "Related inventory items" call: a session-authenticated GET against the
+   * reverse-lookup endpoint, keyed by the ELN record's global-id string.
+   */
+  private void assertReferencingItem(
+      User user, String targetGlobalId, ApiSampleWithFullSubSamples expectedSource)
+      throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/workspace/getReferencingInventoryItems/" + targetGlobalId)
+                    .principal(user::getUsername))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(1, body.getReferencingItems().size());
+    assertEquals(
+        expectedSource.getGlobalId(), body.getReferencingItems().get(0).getSourceGlobalId());
+    assertEquals("References", body.getReferencingItems().get(0).getRelationType());
+    assertTrue(body.getReferencingItems().get(0).getSourceName() != null);
+  }
+
+  private String buildLinkExtraFieldUpdate(String targetGlobalId, String relationType) {
+    // newFieldRequest is WRITE_ONLY on the DTO so Jackson would drop it on output; build by hand.
+    return "{\"extraFields\":[{"
+        + "\"name\":\"Link\","
+        + "\"type\":\"link\","
+        + "\"newFieldRequest\":true,"
+        + "\"link\":{\"relationType\":\""
+        + relationType
+        + "\",\"targetGlobalId\":\""
+        + targetGlobalId
+        + "\"}"
+        + "}]}";
+  }
+}

--- a/src/test/java/com/researchspace/webapp/controller/ReferencingInventoryItemsControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/ReferencingInventoryItemsControllerMVCIT.java
@@ -1,0 +1,90 @@
+package com.researchspace.webapp.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.controller.API_MVC_InventoryTestBase;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.model.record.StructuredDocument;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Integration test for the session-authenticated reverse-lookup endpoint used by the ELN-side
+ * "Related inventory items" panels. Unlike the {@code /api/inventory/v1} endpoint (which requires
+ * an API key / OAuth bearer), this is reached with the browser session, so the test drives it with
+ * a session principal rather than an API key.
+ */
+public class ReferencingInventoryItemsControllerMVCIT extends API_MVC_InventoryTestBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void sessionEndpointReturnsInventorySourcesLinkingToElnDocument() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+    StructuredDocument target = createBasicDocumentInRootFolderWithText(user, "linkable doc");
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+
+    // create the inventory -> document link via the API (needs the API key)
+    String updateJson = buildLinkExtraFieldUpdate(target.getOid().getIdString(), "References");
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(apiKey, "/samples/" + source.getId(), user, updateJson))
+        .andExpect(status().isOk());
+
+    // read it back through the SESSION endpoint (no API key), as the ELN panels do
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/workspace/getReferencingInventoryItems/" + target.getOid().getIdString())
+                    .principal(user::getUsername))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(1, body.getReferencingItems().size());
+    assertEquals(source.getGlobalId(), body.getReferencingItems().get(0).getSourceGlobalId());
+    assertEquals("References", body.getReferencingItems().get(0).getRelationType());
+  }
+
+  @Test
+  public void sessionEndpointReturnsEmptyForUnreferencedRecord() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    StructuredDocument target = createBasicDocumentInRootFolderWithText(user, "lonely doc");
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/workspace/getReferencingInventoryItems/" + target.getOid().getIdString())
+                    .principal(user::getUsername))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(0, body.getReferencingItems().size());
+  }
+
+  private String buildLinkExtraFieldUpdate(String targetGlobalId, String relationType) {
+    // newFieldRequest is WRITE_ONLY on the DTO so Jackson would drop it on output; build by hand.
+    return "{\"extraFields\":[{"
+        + "\"name\":\"Link\","
+        + "\"type\":\"link\","
+        + "\"newFieldRequest\":true,"
+        + "\"link\":{\"relationType\":\""
+        + relationType
+        + "\",\"targetGlobalId\":\""
+        + targetGlobalId
+        + "\"}"
+        + "}]}";
+  }
+}

--- a/src/test/java/com/researchspace/webapp/controller/ReferencingInventoryItemsControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/ReferencingInventoryItemsControllerTest.java
@@ -1,0 +1,81 @@
+package com.researchspace.webapp.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.model.User;
+import com.researchspace.model.field.ErrorList;
+import com.researchspace.service.MessageSourceUtils;
+import com.researchspace.service.UserManager;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import java.security.Principal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class ReferencingInventoryItemsControllerTest {
+
+  @Mock private InventoryLinkManager inventoryLinkManager;
+  @Mock private UserManager userManager;
+  @Mock private MessageSourceUtils messageSource;
+  @InjectMocks private ReferencingInventoryItemsController controller;
+
+  @Test
+  void resolvesSessionUserAndDelegatesToManager() {
+    User user = new User("bob");
+    when(userManager.getUserByUsername("bob")).thenReturn(user);
+    List<ApiInventoryReferencingItem> rows = List.of(new ApiInventoryReferencingItem());
+    when(inventoryLinkManager.findReferencingItems("SD123", user)).thenReturn(rows);
+    Principal principal = () -> "bob";
+
+    ResponseEntity<?> response = controller.getReferencingInventoryItems("SD123", principal);
+
+    assertSame(rows, ((ApiInventoryReferencingItems) response.getBody()).getReferencingItems());
+    verify(inventoryLinkManager).findReferencingItems(eq("SD123"), eq(user));
+  }
+
+  @Test
+  void passesElnNotebookGlobalIdThrough() {
+    User user = new User("alice");
+    when(userManager.getUserByUsername("alice")).thenReturn(user);
+    when(inventoryLinkManager.findReferencingItems("NB9", user)).thenReturn(List.of());
+    Principal principal = () -> "alice";
+
+    controller.getReferencingInventoryItems("NB9", principal);
+
+    verify(inventoryLinkManager).findReferencingItems("NB9", user);
+  }
+
+  @Test
+  void malformedGlobalIdReturnsJsonNotFoundInsteadOfEscaping() {
+    // findReferencingItems throws ApiRuntimeException for a malformed globalId; no
+    // @ControllerAdvice
+    // applies to this @Controller, so it must translate the error to a structured JSON 4xx itself
+    // rather than letting it escape as an HTML 500.
+    User user = new User("bob");
+    when(userManager.getUserByUsername("bob")).thenReturn(user);
+    when(inventoryLinkManager.findReferencingItems("bad!", user))
+        .thenThrow(new ApiRuntimeException("errors.inventory.field.link.targetNotFound", "bad!"));
+    when(messageSource.getMessage(eq("errors.inventory.field.link.targetNotFound"), any()))
+        .thenReturn("bad! does not exist, or you do not have permission to view it.");
+    Principal principal = () -> "bob";
+
+    ResponseEntity<?> response = controller.getReferencingInventoryItems("bad!", principal);
+
+    assertEquals(404, response.getStatusCode().value());
+    assertTrue(response.getBody() instanceof ErrorList);
+  }
+}

--- a/src/test/java/com/researchspace/webapp/controller/StructuredDocumentControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/StructuredDocumentControllerTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -25,9 +26,11 @@ import com.researchspace.core.testutil.CoreTestUtils;
 import com.researchspace.core.testutil.Invokable;
 import com.researchspace.core.util.TransformerUtils;
 import com.researchspace.document.importer.ExternalFileImporter;
+import com.researchspace.linkedelements.RichTextUpdater;
 import com.researchspace.model.EcatComment;
 import com.researchspace.model.EcatCommentItem;
 import com.researchspace.model.User;
+import com.researchspace.model.audit.AuditedRecord;
 import com.researchspace.model.audittrail.AuditTrailService;
 import com.researchspace.model.audittrail.RenameAuditEvent;
 import com.researchspace.model.dtos.IControllerInputValidator;
@@ -80,6 +83,8 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.orm.ObjectRetrievalFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ExtendedModelMap;
 import org.springframework.web.multipart.MultipartFile;
 
 public class StructuredDocumentControllerTest {
@@ -102,6 +107,7 @@ public class StructuredDocumentControllerTest {
   @Mock ExternalFileImporter fileimporter;
   @Mock FolderManager fMgr;
   @Mock IControllerInputValidator validator;
+  @Mock private RichTextUpdater updater;
   private StructuredDocumentController strucDocCtrller;
 
   private Principal mockPrincipal;
@@ -199,6 +205,64 @@ public class StructuredDocumentControllerTest {
     // indicates success
     assertNotNull(rc.getErrorMsg());
     verifyNoInteractions(auditTrail);
+  }
+
+  @Test
+  public void getDocumentVersionResolvesRevisionForDeletedTargetRatherThanNull() {
+    // RSDEV-1131: a link pinned to a version of a now-deleted ELN document. Clicking its
+    // versioned global id (e.g. SD297v3) must redirect to the audit view with the real audit
+    // revision for that version. The deleted branch previously used restoredDeletedForView,
+    // whose AuditedRecord carries a null revision, yielding "...&revision=null" which then
+    // failed to bind to the Integer 'revision' param on the target endpoint. Envers retains the
+    // version history of soft-deleted documents, so the version->revision lookup works
+    // regardless of the current deletion state.
+    StructuredDocument deleted = TestFactory.createAnySD();
+    deleted.setId(297L);
+    deleted.setRecordDeleted(true);
+    when(userMgr.getUserByUsername(eq(user.getUsername()))).thenReturn(user);
+    when(recordMgr.get(297L)).thenReturn(deleted);
+    when(permissionUtils.isPermitted(eq(deleted), eq(PermissionType.READ), eq(user)))
+        .thenReturn(true);
+    when(auditMgr.getRevisionNumberForDocumentVersion(297L, 3L)).thenReturn(3);
+
+    String redirect = strucDocCtrller.getDocumentVersion("SD297v3", mockPrincipal);
+
+    assertEquals(
+        "redirect:/workspace/editor/structuredDocument/audit/view?recordId=297&revision=3",
+        redirect);
+    // the null-revision restored-deleted view must not be used to build the redirect
+    verify(auditMgr, never()).restoredDeletedForView(anyLong());
+  }
+
+  @Test
+  public void getDocumentRevisionLoadsRequestedRevisionContentForDeletedDocument() {
+    // RSDEV-1131: viewing a pinned version of a now-deleted ELN document must render THAT
+    // version's audited content. The deleted branch previously used restoredDeletedForView, which
+    // returns the live deletion-point row and ignores the requested revision, so every pinned
+    // version of a deleted document rendered the same (latest) content. Envers retains each
+    // revision's content regardless of deletion state, so resolve it the same way as for a live
+    // document.
+    StructuredDocument deleted = TestFactory.createAnySD();
+    deleted.setId(297L);
+    deleted.setRecordDeleted(true);
+    StructuredDocument contentAtRevision3 = TestFactory.createAnySD();
+    contentAtRevision3.setId(297L);
+    // updater is @Autowired with no setter; inject a no-op mock so link rewriting does not NPE
+    ReflectionTestUtils.setField(strucDocCtrller, "updater", updater);
+    when(userMgr.getUserByUsername(eq(user.getUsername()))).thenReturn(user);
+    when(recordMgr.get(297L)).thenReturn(deleted);
+    when(permissionUtils.isPermitted(eq(deleted), eq(PermissionType.READ), eq(user)))
+        .thenReturn(true);
+    when(auditMgr.getDocumentRevisionOrVersion(deleted, 3, null))
+        .thenReturn(new AuditedRecord(contentAtRevision3, 3));
+
+    ExtendedModelMap model = new ExtendedModelMap();
+    strucDocCtrller.getDocumentRevision(297L, 3, null, model, mockPrincipal, session);
+
+    // the model carries the requested revision's audited content, not the live deletion-point row
+    assertSame(contentAtRevision3, model.get("structuredDocument"));
+    verify(auditMgr).getDocumentRevisionOrVersion(deleted, 3, null);
+    verify(auditMgr, never()).restoredDeletedForView(anyLong());
   }
 
   @NotNull


### PR DESCRIPTION
## Description

Implements RSDEV-1131: (**which contains a full test plan**): structured **"Related Items" Link fields** for Inventory, so inventory items and sample templates can hold typed, versioned links to other records. 45 commits, ~150 files (roughly two thirds frontend, one third backend plus a Liquibase migration).

**Note - NO linking to version history of Gallery Items as yet - this requires developing a UI to display version history of Gallery Items first.**

Note - the changes to permissions notifications on unshare were due to a caching issue where user was not notified of unshare events.

### What users get

- **Link fields on inventory items**: a new "Link" extra-field type alongside Text and Number. Each link has a relationship type (full DataCite 4.7 vocabulary plus the PIDINST `IsCalibratedBy`/`Calibrates` pair, 40 values), a target Global ID, and an optional version pin.
- **Supported targets**: Inventory items (samples, subsamples, containers, instruments, sample templates) and ELN records (documents, notebooks, gallery files). Self-links are rejected.
- **Link editor** with three ways to set a target: Browse Inventory picker, Browse ELN tree picker (folders expand, notebooks expand and select, documents and gallery files are pickable leaves), or typing a Global ID. Typed ids are validated server-side against the exact Global ID on Apply.
- **Version pinning**: a link can pin a specific user-facing version of its target (samples, subsamples, containers, templates, ELN documents). Pins are edited inside the link editor via a version-history dialog; pinned info dialogs and Open honour the pinned version. Notebooks and gallery files are not pinnable.
- **Link card** rendering one inline row: relation chip, target chip with type icon, info button, version pill, Open, and Edit when editable.
- **Info dialogs** for both target kinds: inventory targets show the MoreInfo record body (historical snapshot when pinned, with a "may not be the latest version" notice); ELN targets show a document/gallery body with preview, Download, Upload new version, and back-references.
- **Target-state pills** resolved lazily per card from a new summary endpoint: **"Target deleted"** for soft-deleted targets and **"No access"** for ELN targets the viewer cannot read. Open is removed for deleted or unreadable ELN targets (their routes only produce error pages) but kept for deleted Inventory targets (the trash viewer works) and for unreadable Inventory targets (every logged-in user keeps the limited-read view).
- **Back-references both ways**: "Inventory items linking to this item" on inventory records (name, Global ID, relation, linked version) and "Related inventory items" on ELN documents, notebooks, and gallery files (in the React info panels and the legacy record-info panel). Both lists are permission-filtered server-side.
- **Templates**: sample templates can define Link fields with an optional whitelist of allowed relationship types; samples created from the template are constrained to it, and "Update all samples" propagates new link fields (including mandatory ones) without erroring on empty values.
- **Editor/Save lifecycle**: record-level Save is blocked with an explanatory message while any field editor is open or holds unapplied link changes, so in-progress edits are never silently discarded.

### API surface (`/api/inventory/v1`)

- `GET /linkTargets/{globalId}/summary` (new): current state of a link target {globalId, name, type, deleted, readable}, permission-redacted per viewer.
- `GET /{samples|subSamples|containers|sampleTemplates}/{id}/referencingItems` and a generic Global ID variant for ELN targets (new): permission-filtered back-references. Requests for targets the caller cannot read are rejected with the same "not found" error a nonexistent id produces.
- `ApiExtraField` gains the `link` payload {relationType, targetGlobalId, versionPin}; sample/template field DTOs gain the relation-type whitelist.

### Backend

- `InventoryLink` entity rows (in `rspace-core-model`) with Hibernate Envers auditing; `InventoryLinkDao`/`InventoryLinkManager`/`InventoryLinkValidator` follow the existing controller, manager, DAO layering.
- `LinkTargetResolver` (live existence and read-permission checks, exact prefix match) and `LinkTargetSnapshotResolver` (Envers-based version and snapshot resolution for pinned links and the summary endpoint).
- Liquibase migration `changeLog-rsdev1131-step1.xml`: `InventoryLink` and `InventoryEntityField` tables plus `ExtraField` columns, each with `_AUD` counterparts.
- User-facing validation messages are externalized to `bundles/inventory/inventory.properties`.

### Frontend

- Inventory side under `src/Inventory/components/Fields/Link/` (card, editors, pickers, info dialogs, version dialog, target-summary hook) and `ExtraFields/`; template fields under `src/Inventory/Sample|Template/Fields/`.
- ELN side: `useReferencingInventoryItems` hook and `ReferencingInventoryItemsPanel` in the Gallery info panel, plus the legacy `recordInfoPanel` table.

## Design decisions

- **Lazy target summaries** (RSDEV-1182): the summary is fetched per rendered card, not serialized eagerly on every LIST response, to keep list endpoints cheap. Decision recorded in the ticket.
- **Non-disclosure invariant** (`DevDocs/adr/0002-link-target-state-non-disclosure.md`): unreadable targets are redacted to a globalId-only summary that is field-for-field identical to a nonexistent target's, so the endpoint cannot be used to probe which records exist. This is why the pill says "No access" rather than "Item unshared", and why the two pills can never co-occur. A unit test pins the invariant. Ubiquitous language is in `DevDocs/CONTEXT.md`.
- **Exact Global ID validation**: both validation layers require the stored prefix to match the requested one, so e.g. `GL150` is rejected when only folder `FL150` shares the number; existence is never confirmed for unreadable records.
- **Pin semantics**: a pin belongs to a specific target, so retargeting resets the staged pin to Latest; pins only take effect on Update/Apply; unpinned links follow the latest version. Saving a record without touching its link never rewrites the link (no spurious audit revisions).
- **`rspace-core-model` is temporarily pinned to this feature's branch build** (`RSDEV-1131-Inventory-link-related-items-4a3efa575b-1`). It will be repointed to a released version before merge; the two open review threads track this deliberately.

## Testing notes

- Backend: pure unit tests for the validators, managers, resolvers, and DTOs (`mvn test -Dfast=true`); author-run `*IT` coverage for the Envers snapshot paths; MVC ITs for the referencing-items endpoints and template link fields.
- Frontend: Vitest suites for the link card, both editors, both pickers, the version dialog, info dialogs, hooks, and the workspace/gallery panels.
- A 17-section manual test plan (pickers, validation, pinning, pills, back-references, permissions, persistence/audit, editor/save lifecycle, regression sweep) lives in the RSDEV-1131 description.
- **Deferred**: Instruments are fully supported by the backend and plumbing but cannot be exercised end-to-end until an Instruments UI exists; there is no versioned viewer for sample templates (a pinned template link opens the live template while its info dialog shows the pinned snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
