### PR TITLE
RSDEV-1123: update DSW app page link to guide.ds-wizard.org

### DIFF
--- a/src/main/webapp/ui/src/eln-dmp-integration/DSW/DSWImportDialog.tsx
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DSW/DSWImportDialog.tsx
@@ -230,7 +230,7 @@ function DSWImportDialogContent({
               it available to view and reference as a DMP within RSpace.
             </Typography>
             <Typography variant="body2">
-              See <Link href="https://researchers.dsw.elixir-europe.org">researchers.dsw.elixir-europe.org</Link> and our{" "}
+              See <Link href="https://guide.ds-wizard.org/en/latest/">guide.ds-wizard.org/en/latest/</Link> and our{" "}
               <Link href={docLinks.dsw}>DSW / FAIR Wizard integration docs</Link> for
               more.
             </Typography>

--- a/src/main/webapp/ui/src/eln/apps/integrations/DSW.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/DSW.tsx
@@ -510,7 +510,7 @@ function DSW({
                 update({ mode: newMode, credentials: integrationState.credentials })
             }
             helpLinkText="DSW integration docs"
-            website="researchers.dsw.elixir-europe.org"
+            website="guide.ds-wizard.org/en/latest/"
             docLink="dsw"
             usageText="You can import projects from Data Stewardship Wizard or FAIR Wizard into RSpace, and associate them as Data Management Plans with repository exports."
             setupSection={


### PR DESCRIPTION
  ## Description ##
  - Updates the DSW / FAIR Wizard website link from
  `researchers.dsw.elixir-europe.org`
    to `https://guide.ds-wizard.org/en/latest/` in two places:
    - The Apps page integration card (`DSW.tsx`)
    - The DSW import dialog (`DSWImportDialog.tsx`)
    
  ## Design decisions
  ***OPTIONAL***
  
  ## Testing notes
  ***OPTIONAL***
  - Navigate to the Apps page, open the DSW / FAIR Wizard integration card, and
  verify
    the website link points to `https://guide.ds-wizard.org/en/latest/`
  - Open the DSW import dialog and verify the same link is updated there