### PR TITLE
RSDEV-1158: Gate frontend (Vite) build behind opt-in generateReactDistFiles profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,13 @@ npm run serve  # Vite dev server
 ### Full Build (no tests)
 
 ```bash
-mvn clean package -DskipTests=true
+mvn clean package -DgenerateReactDist -DskipTests=true
 ```
+
+The `-DgenerateReactDist` flag activates the `generateReactDistFiles` profile that
+runs `npm ci` and the Vite production build and bundles `dist/` into the WAR. It is
+opt-in: omit it and `mvn compile`/`test`/`package` skip the frontend build entirely
+(useful for fast backend-only builds, but the resulting WAR has no frontend).
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,13 @@ npm run serve  # Vite dev server
 ### Full Build (no tests)
 
 ```bash
-mvn clean package -DskipTests=true
+mvn clean package -DgenerateReactDist -DskipTests=true
 ```
+
+The `-DgenerateReactDist` flag activates the `generateReactDistFiles` profile that
+runs `npm ci` and the Vite production build and bundles `dist/` into the WAR. It is
+opt-in: omit it and `mvn compile`/`test`/`package` skip the frontend build entirely
+(useful for fast backend-only builds, but the resulting WAR has no frontend).
 
 ## Testing
 

--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -90,8 +90,7 @@ mvn clean package -DgenerateReactDist -DskipTests=true \
 The `-DgenerateReactDist` flag activates the `generateReactDistFiles` Maven profile,
 which installs Node/npm locally, runs `npm ci`, and runs the Vite production build,
 bundling the resulting `dist/` files into the WAR. Without this flag the frontend is
-not built, so any command that produces a deployable WAR must pass it (the Jenkins
-packaging stages do).
+not built.
 
 You can also check top-level Jenkinsfile file to see how internal tests builds are created by
 ResearchSpace dev team (check 'Build prodRelease-like package' stage script).  
@@ -266,14 +265,6 @@ to cache.
 
 Run the usual `mvn jetty:run` command, just change the active spring profile to `prod`
 i.e. pass a `-Dspring.profiles.active=prod` parameter.
-
-**NOTE:** when you want Jetty to serve a freshly built production frontend bundle
-(i.e. running without `-DreactDevMode=true`), add `-DgenerateReactDist` to the
-command, e.g. `mvn jetty:run -DgenerateReactDist -Dspring.profiles.active=prod`.
-The frontend build lives in the opt-in `generateReactDistFiles` profile and is not
-run by default, so without the flag Jetty would serve a stale or missing bundle. The
-everyday dev loop that passes `-DreactDevMode=true` does not need this, because that
-flag makes Jetty proxy frontend requests to the local Vite dev server instead.
 
 Note that when running through jetty, the `defaultDeployment.properties` file is not used for some reason.
 That means deployment properties that are not explicitly set in your `deployment.properties` file may have unexpected values. 

--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -82,10 +82,16 @@ all code dependencies and compile the code.
 The application .war file can be built with the following maven command:  
 
 ```
-mvn clean package -DskipTests=true \
+mvn clean package -DgenerateReactDist -DskipTests=true \
   -Denvironment=prodRelease -Dspring.profiles.active=prod -DRS.logLevel=WARN -Ddeployment=production \
   -Djava-version=17 -Djava-vendor=openjdk
 ```
+
+The `-DgenerateReactDist` flag activates the `generateReactDistFiles` Maven profile,
+which installs Node/npm locally, runs `npm ci`, and runs the Vite production build,
+bundling the resulting `dist/` files into the WAR. Without this flag the frontend is
+not built, so any command that produces a deployable WAR must pass it (the Jenkins
+packaging stages do).
 
 You can also check top-level Jenkinsfile file to see how internal tests builds are created by
 ResearchSpace dev team (check 'Build prodRelease-like package' stage script).  
@@ -262,13 +268,12 @@ Run the usual `mvn jetty:run` command, just change the active spring profile to 
 i.e. pass a `-Dspring.profiles.active=prod` parameter.
 
 **NOTE:** when you want Jetty to serve a freshly built production frontend bundle
-(i.e. running without `-DreactDevMode=true`), build the bundle first with
-`mvn prepare-package jetty:run`. The `frontend-maven-plugin` executions that run
-`npm ci` and the Vite build are bound to the `prepare-package` phase, which the
-`jetty:run` goal does not reach on its own (it forks the build only up to
-`test-compile`). The everyday dev loop that passes `-DreactDevMode=true` is
-unaffected, because that flag skips the frontend build entirely and Jetty proxies
-to the Vite dev server instead.
+(i.e. running without `-DreactDevMode=true`), add `-DgenerateReactDist` to the
+command, e.g. `mvn jetty:run -DgenerateReactDist -Dspring.profiles.active=prod`.
+The frontend build lives in the opt-in `generateReactDistFiles` profile and is not
+run by default, so without the flag Jetty would serve a stale or missing bundle. The
+everyday dev loop that passes `-DreactDevMode=true` does not need this, because that
+flag makes Jetty proxy frontend requests to the local Vite dev server instead.
 
 Note that when running through jetty, the `defaultDeployment.properties` file is not used for some reason.
 That means deployment properties that are not explicitly set in your `deployment.properties` file may have unexpected values. 

--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -261,6 +261,15 @@ to cache.
 Run the usual `mvn jetty:run` command, just change the active spring profile to `prod`
 i.e. pass a `-Dspring.profiles.active=prod` parameter.
 
+**NOTE:** when you want Jetty to serve a freshly built production frontend bundle
+(i.e. running without `-DreactDevMode=true`), build the bundle first with
+`mvn prepare-package jetty:run`. The `frontend-maven-plugin` executions that run
+`npm ci` and the Vite build are bound to the `prepare-package` phase, which the
+`jetty:run` goal does not reach on its own (it forks the build only up to
+`test-compile`). The everyday dev loop that passes `-DreactDevMode=true` is
+unaffected, because that flag skips the frontend build entirely and Jetty proxies
+to the Vite dev server instead.
+
 Note that when running through jetty, the `defaultDeployment.properties` file is not used for some reason.
 That means deployment properties that are not explicitly set in your `deployment.properties` file may have unexpected values. 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -285,7 +285,7 @@ pipeline {
             steps {
                 echo 'Building feature branch'
                 sh '''
-                ./mvnw clean package -DskipTests=true \
+                ./mvnw clean package -DgenerateReactDist -DskipTests=true \
                 -Denvironment=keepdbintact -Dspring.profiles.active=prod -DRS.logLevel=INFO \
                 -Djava-version=${MAVEN_TOOLCHAIN_JAVA_VERSION} -Djava-vendor=${MAVEN_TOOLCHAIN_JAVA_VENDOR} \
                 -Dliquibase.context=run,dev-test -DpropertyFileDirPlaceholder=\\$\\{propertyFileDir\\}
@@ -312,7 +312,7 @@ pipeline {
             steps {
                 echo "Building prodRelease .war package"
                  sh '''
-                 ./mvnw clean package -DskipTests=true \
+                 ./mvnw clean package -DgenerateReactDist -DskipTests=true \
                 -Denvironment=prodRelease -Dspring.profiles.active=prod -DRS.logLevel=WARN -Ddeployment=production \
                 -Djava-version=${MAVEN_TOOLCHAIN_JAVA_VERSION} \
                 -Djava-vendor=${MAVEN_TOOLCHAIN_JAVA_VENDOR} \
@@ -413,7 +413,7 @@ pipeline {
                 // this is to create a valid datbase name from the branch name
 
                 echo "sanitised DB Name is $SANITIZED_DBNAME"
-                sh "./mvnw clean verify -Djava-version=${params.MAVEN_TOOLCHAIN_JAVA_VERSION} \
+                sh "./mvnw clean verify -DgenerateReactDist -Djava-version=${params.MAVEN_TOOLCHAIN_JAVA_VERSION} \
                   -Djava-vendor=${params.MAVEN_TOOLCHAIN_JAVA_VENDOR} \
                   -Djavax.xml.accessExternalDTD=all\
                   -Dlog4j2.configurationFile=log4j2-dev.xml -Dsurefire.rerunFailingTestsCount=2\

--- a/pom.xml
+++ b/pom.xml
@@ -2570,8 +2570,6 @@
     <deployment>dev</deployment>
     <!-- default location of external properties file is actually the classpath one! -->
     <propertyFileDirPlaceholder>classpath:deployments/${deployment}</propertyFileDirPlaceholder>
-    <!-- set to true when using a local Vite dev server, skipping the production Vite build -->
-    <reactDevMode>false</reactDevMode>
     <!-- opt-in cache busting for legacy /scripts/** and /styles/** assets in dev mode; production always cache-busts -->
     <legacyAssetCacheBustingInDevMode>false</legacyAssetCacheBustingInDevMode>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <executions>
           <execution>
             <id>Install node and npm locally to the project</id>
+            <phase>prepare-package</phase>
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
@@ -104,6 +105,7 @@
           </execution>
           <execution>
             <id>Collect npm dependencies</id>
+            <phase>prepare-package</phase>
             <goals>
               <goal>npm</goal>
             </goals>
@@ -114,6 +116,7 @@
           </execution>
           <execution>
             <id>Build react dist files</id>
+            <phase>prepare-package</phase>
             <goals>
               <goal>npm</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -84,50 +84,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <version>2.0.0</version>
-        <configuration>
-          <nodeVersion>v24.15.0</nodeVersion>
-          <npmVersion>11.14.1</npmVersion>
-          <workingDirectory>src/main/webapp/ui</workingDirectory>
-        </configuration>
-        <executions>
-          <execution>
-            <id>Install node and npm locally to the project</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>install-node-and-npm</goal>
-            </goals>
-            <configuration>
-              <skip>${reactDevMode}</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>Collect npm dependencies</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <configuration>
-              <arguments>${npm.dependencies.collection.arg}</arguments>
-              <skip>${reactDevMode}</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>Build react dist files</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <configuration>
-              <arguments>run build</arguments>
-              <skip>${reactDevMode}</skip>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <executions>
@@ -1955,6 +1911,63 @@
   </dependencies>
 
   <profiles>
+    <!-- Generates the React/Vite frontend dist files and bundles them into the WAR.
+      Opt-in: activated only when -DgenerateReactDist is passed. This keeps the npm
+      install and Vite build out of everyday `mvn compile`/`test` runs, while CI
+      packaging and release stages pass the flag explicitly (see Jenkinsfile). The
+      executions use the implicit generate-resources phase so that
+      `mvn jetty:run -DgenerateReactDist` also rebuilds the bundle. The normal dev
+      loop uses -DreactDevMode=true and does not set this flag, so the build is
+      skipped and Jetty proxies frontend requests to the local Vite dev server. -->
+    <profile>
+      <id>generateReactDistFiles</id>
+      <activation>
+        <property>
+          <name>generateReactDist</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <version>2.0.0</version>
+            <configuration>
+              <nodeVersion>v24.15.0</nodeVersion>
+              <npmVersion>11.14.1</npmVersion>
+              <workingDirectory>src/main/webapp/ui</workingDirectory>
+            </configuration>
+            <executions>
+              <execution>
+                <id>Install node and npm locally to the project</id>
+                <goals>
+                  <goal>install-node-and-npm</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>Collect npm dependencies</id>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>${npm.dependencies.collection.arg}</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>Build react dist files</id>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>run build</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- builds application but makes no changes to the database at all, for
       testing update scripts -->
     <profile>


### PR DESCRIPTION
RSDEV-1158

## Description ##

After the Webpack-to-Vite migration (#771), the `frontend-maven-plugin` (Node install + `npm ci` + Vite build) became always-on, so even `mvn compile` / `mvn test` triggered a full Node install and Vite production build.

This PR restores the opt-in model: the plugin now lives in a `generateReactDistFiles` Maven profile, activated only by `-DgenerateReactDist`, as was the case before the vite migration

## Which flag, when ##

| You want | Command | Frontend built? |
|---|---|---|
| Backend-only compile/test | `mvn clean compile` / `mvn clean test` | No |
| Fast backend WAR | `mvn clean package` | No |
| **Deployable WAR (with UI)** | `mvn clean package -DgenerateReactDist` | **Yes** |
| Jetty serving a local prod bundle | `mvn jetty:run -DgenerateReactDist` | Yes |
| Everyday dev loop | `mvn jetty:run -DreactDevMode=true` (+ `npm run serve`) | No (Jetty proxies to the Vite dev server) |

**Rule:** pass `-DgenerateReactDist` whenever the artifact needs a working UI; omit it for backend-only builds. `-DreactDevMode=true` is a separate flag for the dev-server proxy, not a build toggle. The profile's executions stay on the implicit `generate-resources` phase, so `jetty:run -DgenerateReactDist` rebuilds the bundle too.

## Notes ##

- Removed reactDevMode as a maven property, as it's no longer used in `pom.xml`, although it's still passed as a system property used to proxy to the vite dev server, when set to true.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
