### PR TITLE
Fix YouTube Privacy-Enhanced Mode video URL parsing

### DIFF
--- a/src/main/webapp/scripts/externalTinymcePlugins/video/plugin.js
+++ b/src/main/webapp/scripts/externalTinymcePlugins/video/plugin.js
@@ -12,6 +12,16 @@ tinymce.PluginManager.add("videoembed", function (editor) {
     return /^https?:$/i.test(parsedUrl.protocol);
   }
 
+  function getWatchOrEmbedVideoId(parsedUrl) {
+    const watchId = parsedUrl.searchParams.get("v");
+    if (watchId && /^[\w-]+$/.test(watchId)) {
+      return watchId;
+    }
+
+    const pathMatch = parsedUrl.pathname.match(/^\/(?:embed|shorts)\/([\w-]+)\/?$/);
+    return pathMatch ? pathMatch[1] : null;
+  }
+
   function getYouTubeVideoId(parsedUrl) {
     if (isHost(parsedUrl.hostname, "youtu.be")) {
       const pathMatch = parsedUrl.pathname.match(/^\/([\w-]+)\/?$/);
@@ -22,13 +32,7 @@ tinymce.PluginManager.add("videoembed", function (editor) {
       return null;
     }
 
-    const watchId = parsedUrl.searchParams.get("v");
-    if (watchId && /^[\w-]+$/.test(watchId)) {
-      return watchId;
-    }
-
-    const pathMatch = parsedUrl.pathname.match(/^\/(?:embed|shorts)\/([\w-]+)\/?$/);
-    return pathMatch ? pathMatch[1] : null;
+    return getWatchOrEmbedVideoId(parsedUrl);
   }
 
   function parseYouTube(parsedUrl) {
@@ -58,8 +62,8 @@ tinymce.PluginManager.add("videoembed", function (editor) {
       return null;
     }
 
-    const pathMatch = parsedUrl.pathname.match(/^\/embed\/([\w-]+)\/?$/);
-    if (!pathMatch) {
+    const videoId = getWatchOrEmbedVideoId(parsedUrl);
+    if (!videoId) {
       return null;
     }
 
@@ -67,7 +71,7 @@ tinymce.PluginManager.add("videoembed", function (editor) {
       valid: true,
       provider: "YouTube Privacy-Enhanced Mode",
       iframe: {
-        src: "https://www.youtube-nocookie.com/embed/" + pathMatch[1],
+        src: "https://www.youtube-nocookie.com/embed/" + videoId,
         width: "560",
         height: "315",
         title: "YouTube video player",

--- a/src/main/webapp/ui/src/tinyMCE/video/__tests__/plugin.test.ts
+++ b/src/main/webapp/ui/src/tinyMCE/video/__tests__/plugin.test.ts
@@ -270,6 +270,12 @@ describe("TinyMCE video embed plugin", () => {
         '<div class="embedIframeDiv mceNonEditable"><iframe src="https://www.youtube-nocookie.com/embed/bhRExXIGxek" width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" referrerpolicy="strict-origin-when-cross-origin"></iframe></div><p>&nbsp;</p>',
     },
     {
+      url: "https://www.youtube-nocookie.com/watch?v=bhRExXIGxek&t=5s",
+      feedback: "YouTube Privacy-Enhanced Mode video detected.",
+      expected:
+        '<div class="embedIframeDiv mceNonEditable"><iframe src="https://www.youtube-nocookie.com/embed/bhRExXIGxek" width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" referrerpolicy="strict-origin-when-cross-origin"></iframe></div><p>&nbsp;</p>',
+    },
+    {
       url: "https://app.jove.com/v/60908/using-an-automated-hirschberg-test-app",
       feedback: "JoVE video detected.",
       expected:


### PR DESCRIPTION
## Description ##
Silently parses `youtube-nocookie.com/watch?v=videoId` to the correct embed.

Fixes PRT-1084