### PR TITLE
PRT-1083-remove-jove:just alter Jove card

### DIFF
--- a/src/main/webapp/ui/src/assets/DocLinks.ts
+++ b/src/main/webapp/ui/src/assets/DocLinks.ts
@@ -55,7 +55,7 @@ const docLinks: Record<string, URL> = {
   github: mkDocLink("y2080yw30x"),
   galaxy: mkDocLink("zzsl46jo5y"),
   cloudstorage: mkDocLink("j2z5f5r90q"),
-  jove: mkDocLink("mopbqzzdf5"),
+  videoIntegration: mkDocLink("cdzdub1ykw"),
   jupyter: mkDocLink("gg0ao0rqpt"),
   chemistry: mkDocLink("wfxm4xwtio"),
   pubchem: mkDocLink(

--- a/src/main/webapp/ui/src/eln/apps/integrations/Jove.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Jove.tsx
@@ -15,7 +15,7 @@ function Jove(): React.ReactNode {
           mode: "EXTERNAL",
           credentials: null,
         }}
-        explanatoryText="Embed JoVE and other video players (eg YouTube, TIB AV-Portal)"
+        explanatoryText="Embed JoVE and other video players (e.g., YouTube, TIB AV-Portal)."
         image={JoveIcon}
         color={LOGO_COLOR}
         update={() => {}}

--- a/src/main/webapp/ui/src/eln/apps/integrations/Jove.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Jove.tsx
@@ -10,26 +10,26 @@ function Jove(): React.ReactNode {
   return (
     <Grid item sm={6} xs={12} sx={{ display: "flex" }}>
       <IntegrationCard
-        name="JoVE"
+        name="Jove"
         integrationState={{
           mode: "EXTERNAL",
           credentials: null,
         }}
-        explanatoryText="Watch, reference, and teach research methods and technologies through detailed process videos."
+        explanatoryText="and other video players eg YouTube, TIB AV-Portal"
         image={JoveIcon}
         color={LOGO_COLOR}
         update={() => {}}
         usageText="Embed JoVE videos in RSpace documents by opening the Video tool from the Documents Editor, pasting a JoVE URL, and inserting the generated embed at the cursor position."
-        helpLinkText="JoVE integration docs"
+        helpLinkText="video integration docs"
         website="jove.com"
-        docLink="jove"
+        docLink="videoIntegration"
         setupSection={
           <Stack direction="column" gap={2}>
             <ol>
               <li>
-                Open a document in the Documents Editor and click the <strong>Video</strong>
-                button in the editor toolbar, the insert menu, or the slash
-                menu.
+                Open a document in the Documents Editor and click the{" "}
+                <strong>Video</strong> button in the editor toolbar, the insert
+                menu, or the slash menu.
               </li>
               <li>
                 Paste a full JoVE URL from a supported <code>jove.com</code>{" "}

--- a/src/main/webapp/ui/src/eln/apps/integrations/Jove.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Jove.tsx
@@ -15,12 +15,12 @@ function Jove(): React.ReactNode {
           mode: "EXTERNAL",
           credentials: null,
         }}
-        explanatoryText="Embed JoVE other video players (eg YouTube, TIB AV-Portal)"
+        explanatoryText="Embed JoVE and other video players (eg YouTube, TIB AV-Portal)"
         image={JoveIcon}
         color={LOGO_COLOR}
         update={() => {}}
         usageText="Embed JoVE videos in RSpace documents by opening the Video tool from the Documents Editor, pasting a JoVE URL, and inserting the generated embed at the cursor position."
-        helpLinkText="video integration docs"
+        helpLinkText="Video integration docs"
         website="jove.com"
         docLink="videoIntegration"
         setupSection={

--- a/src/main/webapp/ui/src/eln/apps/integrations/Jove.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Jove.tsx
@@ -10,12 +10,12 @@ function Jove(): React.ReactNode {
   return (
     <Grid item sm={6} xs={12} sx={{ display: "flex" }}>
       <IntegrationCard
-        name="Jove"
+        name="JoVE"
         integrationState={{
           mode: "EXTERNAL",
           credentials: null,
         }}
-        explanatoryText="and other video players eg YouTube, TIB AV-Portal"
+        explanatoryText="Embed JoVE other video players (eg YouTube, TIB AV-Portal)"
         image={JoveIcon}
         color={LOGO_COLOR}
         update={() => {}}


### PR DESCRIPTION
## Description ##
We decided to alter the JoVE apps card to mention other video players can be embedded and to link to our generic Embed a Video Player documentation. The rest of the JoVE apps card is to continue to refer to JoVE.
