### PR TITLE
PRT-1085: error handling in s3 allowlists

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/NfsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/NfsController.java
@@ -271,6 +271,9 @@ public class NfsController extends BaseController {
       throw new IllegalArgumentException("could not find file store with id: " + fileStoreId);
     }
     aclChecker.assertCanRead(user, fileStore.getFileSystem());
+    if (fileStore.getFileSystem().isDisabled()) {
+      return getText("net.filestores.error.disabled");
+    }
 
     Long fileSystemId = fileStore.getFileSystem().getId();
     if (!nfsManager.checkIfUserLoggedIn(fileSystemId, nfsClients, user)) {

--- a/src/main/resources/bundles/gallery/netfiles.properties
+++ b/src/main/resources/bundles/gallery/netfiles.properties
@@ -10,6 +10,7 @@ net.filestores.error.auth.password=Authentication problem, check your username a
 net.filestores.error.auth.publicKey=Authentication problem, verify that your public key is properly registered or contact your System Admin
 net.filestores.error.connection=Connection problem, please try again or contact your System Admin
 net.filestores.error.download=Couldn't retrieve the file, please try again or contact your System Admin
+net.filestores.error.disabled=This file system has been disabled, please contact your System Admin
 
 net.filestores.validation.no.username=Please provide the username
 net.filestores.validation.no.password=Please provide the password

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -305,6 +305,7 @@ system.netfilesystem.details.allowlists.read.question=Who can read from this fil
 system.netfilesystem.details.allowlists.anyone=Anyone with an RSpace account
 system.netfilesystem.details.allowlists.only.these=Only the following users:
 system.netfilesystem.details.allowlists.nobody=Nobody (read access only)
+system.netfilesystem.details.allowlists.read.nobody=Nobody (write access only)
 
 # LDAP settings page
 system.ldap.button.run.sid.retrieval=Retrieve SID values for LDAP users

--- a/src/main/webapp/WEB-INF/pages/system/netfilesystem_ajax.jsp
+++ b/src/main/webapp/WEB-INF/pages/system/netfilesystem_ajax.jsp
@@ -247,7 +247,9 @@
                         <spring:message code="system.netfilesystem.details.allowlists.anyone" /></label><br/>
                     <label><input type="radio" id="fileSystemLimitReadYes" name="fileSystemLimitRead" value="yes">
                         <spring:message code="system.netfilesystem.details.allowlists.only.these" /></label>
-                    <input id="fileSystemReadAllowlist" type="text" style="width: 15em" placeholder="carol" />
+                    <input id="fileSystemReadAllowlist" type="text" style="width: 15em" placeholder="carol" /><br/>
+                    <label><input type="radio" id="fileSystemLimitReadNobody" name="fileSystemLimitRead" value="nobody">
+                        <spring:message code="system.netfilesystem.details.allowlists.read.nobody" /></label>
                 </td>
             </tr>
 

--- a/src/main/webapp/scripts/global.js
+++ b/src/main/webapp/scripts/global.js
@@ -1912,7 +1912,7 @@ RS.downloadNetFile = function (relPath, nfsId, fileSystemId) {
       }
     });
     jqxhr.fail(function (result) {
-      apprise('An error occured on file download: ' + RS.escapeHtml(RS.extractAjaxErrorMessage(result)));
+      apprise('An error occurred on file download: ' + RS.escapeHtml(RS.extractAjaxErrorMessage(result)));
     });
     jqxhr.always(function () {
       RS.unblockPage();
@@ -1942,7 +1942,7 @@ RS.updateNfsPath = function(relPath, nfsId, fileSystemId, $infoPanel) {
       }
     });
     jqxhr.fail(function (result) {
-      apprise('An error occured retrieving current path: ' + RS.escapeHtml(RS.extractAjaxErrorMessage(result)));
+      apprise('An error occurred retrieving current path: ' + RS.escapeHtml(RS.extractAjaxErrorMessage(result)));
     });
     jqxhr.always(function () {
       RS.unblockPage();
@@ -2247,6 +2247,21 @@ RS.showNetFileLoginDialog = function (fileSystemId, fileStoreId, afterLoginCallb
     return;
   }
 
+  // Resolve the file system up front (synchronous, from the client's list). A
+  // disabled/removed file system isn't in the list, so show a message rather than
+  // fetching and appending the login dialog and then crashing on fileSystem.authType.
+  var fileSystem;
+  if (fileSystemId != null) {
+    fileSystem = getFileSystemById(fileSystemId);
+  } else if (fileStoreId != null) {
+    var fileStore = getFileStoreById(fileStoreId);
+    fileSystem = fileStore && fileStore.fileSystem;
+  }
+  if (!fileSystem) {
+    apprise('This file system is no longer available; it may have been disabled or removed. Please contact your System Admin.');
+    return;
+  }
+
   var jqxhrPage = $.get('/netFiles/ajax/netFilesLoginView');
 
   jqxhrPage.done(function (page) {
@@ -2254,21 +2269,6 @@ RS.showNetFileLoginDialog = function (fileSystemId, fileStoreId, afterLoginCallb
     $(document.body).append(page);
 
     initNetFilesLoginDialog();
-
-    var fileSystem;
-    if (fileSystemId != null) {
-      fileSystem = getFileSystemById(fileSystemId);
-    } else if (fileStoreId != null) {
-      var fileStore = getFileStoreById(fileStoreId);
-      fileSystem = fileStore && fileStore.fileSystem;
-    }
-
-    // A disabled/removed file system isn't in the client's list, so the lookup
-    // returns nothing; show a message rather than crashing on fileSystem.authType.
-    if (!fileSystem) {
-      apprise('This file system is no longer available; it may have been disabled or removed. Please contact your System Admin.');
-      return;
-    }
 
     if (fileSystem.authType === "PASSWORD") {
       showUsernamePasswordDialog(fileSystem, afterLoginCallback);
@@ -2279,7 +2279,7 @@ RS.showNetFileLoginDialog = function (fileSystemId, fileStoreId, afterLoginCallb
 
   });
   jqxhrPage.fail(function (jqxhr, settings, exception) {
-    apprise('An error occured on loading net files gallery');
+    apprise('An error occurred on loading net files gallery');
   });
 
 };

--- a/src/main/webapp/scripts/global.js
+++ b/src/main/webapp/scripts/global.js
@@ -2259,7 +2259,15 @@ RS.showNetFileLoginDialog = function (fileSystemId, fileStoreId, afterLoginCallb
     if (fileSystemId != null) {
       fileSystem = getFileSystemById(fileSystemId);
     } else if (fileStoreId != null) {
-      fileSystem = getFileStoreById(fileStoreId).fileSystem;
+      var fileStore = getFileStoreById(fileStoreId);
+      fileSystem = fileStore && fileStore.fileSystem;
+    }
+
+    // A disabled/removed file system isn't in the client's list, so the lookup
+    // returns nothing; show a message rather than crashing on fileSystem.authType.
+    if (!fileSystem) {
+      apprise('This file system is no longer available; it may have been disabled or removed. Please contact your System Admin.');
+      return;
     }
 
     if (fileSystem.authType === "PASSWORD") {

--- a/src/main/webapp/scripts/global.js
+++ b/src/main/webapp/scripts/global.js
@@ -1872,6 +1872,25 @@ RS.initAndOpenNetFileInfoDialog = function ($link) {
   }
 };
 
+// Readable message from a failed ajax response: the JSON error model, else the
+// ajaxError.jsp fragment's message, else raw responseText. Escape before rendering.
+RS.extractAjaxErrorMessage = function (jqxhr) {
+  if (jqxhr.responseJSON && jqxhr.responseJSON.exceptionMessage) {
+    return jqxhr.responseJSON.exceptionMessage;
+  }
+  var responseText = jqxhr.responseText || '';
+  if (responseText.indexOf('ajaxErrorMsg') !== -1) {
+    // Parse in an inert document (no script exec / resource loads / event handlers)
+    // rather than via jQuery, which is unsafe for untrusted HTML on this version.
+    var doc = new DOMParser().parseFromString(responseText, 'text/html');
+    var el = doc.getElementById('ajaxErrorMsg');
+    if (el && el.textContent.trim()) {
+      return el.textContent.trim();
+    }
+  }
+  return responseText;
+};
+
 RS.downloadNetFile = function (relPath, nfsId, fileSystemId) {
   if (!RS.isNullOrUndefined(relPath)) {
     var nfsparams = {
@@ -1893,7 +1912,7 @@ RS.downloadNetFile = function (relPath, nfsId, fileSystemId) {
       }
     });
     jqxhr.fail(function (result) {
-      apprise('An error occured on file download: ' + result.responseText);
+      apprise('An error occured on file download: ' + RS.escapeHtml(RS.extractAjaxErrorMessage(result)));
     });
     jqxhr.always(function () {
       RS.unblockPage();
@@ -1923,7 +1942,7 @@ RS.updateNfsPath = function(relPath, nfsId, fileSystemId, $infoPanel) {
       }
     });
     jqxhr.fail(function (result) {
-      apprise('An error occured retrieving current path: ' + result.responseText);
+      apprise('An error occured retrieving current path: ' + RS.escapeHtml(RS.extractAjaxErrorMessage(result)));
     });
     jqxhr.always(function () {
       RS.unblockPage();

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -303,7 +303,14 @@ function saveFileSystem() {
         loadNetFileSystemsList();
     });
     jqxhr.fail(function () {
-         RS.ajaxFailed("Couldn't save File System", false, jqxhr);
+        // Show the server's error message rather than letting RS.ajaxFailed dump the
+        // raw JSON body (toastmessage renders HTML, so escape it).
+        var errorMsg = RS.extractAjaxErrorMessage(jqxhr);
+        if (errorMsg) {
+            showStickyError(RS.escapeHtml(errorMsg.trim()).replace(/\n/g, '<br/>'));
+        } else {
+            RS.ajaxFailed("Couldn't save File System", false, jqxhr);
+        }
     });
     jqxhr.always(function () {
          RS.unblockPage();
@@ -472,6 +479,10 @@ function showAllowlistWarnings(result) {
 
 function showStickyWarning(text) {
     $().toastmessage('showToast', { text: text, type: 'warning', sticky: true });
+}
+
+function showStickyError(text) {
+    $().toastmessage('showToast', { text: text, type: 'error', sticky: true });
 }
 
 $(document).ready(function() {	

--- a/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
+++ b/src/main/webapp/scripts/pages/system/netfilesystem_mod.js
@@ -435,12 +435,10 @@ function refreshAllowlistRows() {
 function setAllowlistFields(suffix, value) {
     var isEveryone = value === '*';
     var hasNames = typeof value === 'string' && value !== '' && !isEveryone;
+    var isNobody = value === '' || value === null;
     $('#fileSystemLimit' + suffix + 'No').prop('checked', isEveryone);
     $('#fileSystemLimit' + suffix + 'Yes').prop('checked', hasNames);
-    if (suffix === 'Write') {
-        var isNobody = value === '' || value === null;
-        $('#fileSystemLimitWriteNobody').prop('checked', isNobody);
-    }
+    $('#fileSystemLimit' + suffix + 'Nobody').prop('checked', isNobody);
     $('#fileSystem' + suffix + 'Allowlist').val(hasNames ? value : '');
 }
 

--- a/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsControllerTest.java
@@ -243,6 +243,17 @@ public class NfsControllerTest extends SpringTransactionalTest {
     assertEquals(TEST_FILE_SYSTEM_URL, fileStoreInfo.getFileSystem().getUrl());
   }
 
+  @Test
+  public void prepareNfsFileForDownload_fileSystemDisabled_returnsDisabledMessage() {
+    // a disabled file system must surface a clear message rather than need.log.in
+    testNfsFileSystem.setDisabled(true);
+    String filePath = TEST_FILE_STORE_ID + ":someFile";
+
+    String result = controller.prepareNfsFileForDownload(filePath, null, request, principalStub);
+
+    assertEquals(getMsgFromResourceBundler("net.filestores.error.disabled"), result);
+  }
+
   private void loginTestUserToTestFileSystem() {
     // mock session and manager as if user logged in
     Map<Long, NfsClient> nfsClients = new HashMap<>();


### PR DESCRIPTION
## Summary

  Fixes [PRT-1085](https://researchspace.atlassian.net/browse/PRT-1085) plus two related issues found while testing the S3 allowlist feature. All in the sysadmin/external-filestore area.

  ### 1. Filestore error popups showed raw JSON instead of the message
  Saving a file system with the same username on both the read and write allowlists failed, and the popup rendered the raw JSON error body. Root cause: the save posts with `dataType: json`, so the server's
  error model is content-negotiated to JSON, which `RS.ajaxFailed` could not unpack. Added `RS.extractAjaxErrorMessage(jqxhr)` (JSON error model, else the `ajaxError` fragment's message, else raw body; parsed
  in an inert `DOMParser` document and HTML-escaped before rendering) and wired it into the save handler and the legacy document-link browse/download handlers.

  ### 2. No error when downloading from a disabled file system
  Clicking a filestore link for a file system the sysadmin had disabled gave no feedback: the server returned `need.log.in`, the client opened the login dialog, and it crashed on `fileSystem.authType` because
  a disabled file system is not in the client's (enabled-only) list. Now `prepareNfsFileForDownload` returns a clear "file system has been disabled" message, and `showNetFileLoginDialog` guards against an
  unknown (disabled or removed) file system instead of throwing.

  ### 3. "Nobody" option on the read allowlist radio
  The write radio offered Anyone / Only these users / Nobody, but the read radio only had Anyone / Only these users. Added "Nobody" so a sysadmin can grant specific users read+write while denying read-only
  access to everyone else (write implies read, so the listed users still read).

  ## Testing
  - `NfsControllerTest` covers the disabled-file-system download path (passing).
  - Frontend scripts pass `node --check`; sysadmin dialog read/write radios verified manually.

  ## Notes
  - Security: error text is HTML-escaped before rendering, and HTML fragments are parsed in an inert `DOMParser` document (no script execution or resource loads), which matters given this repo's jQuery 2.1.3.
  - Per ResearchSpace policy, follow the AI and Third Party code policy in Drata for AI-assisted code in this PR.