### PR TITLE
PRT-1086: fix a11n issue with 'Move to S3/iRODS' dialogs

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.tsx
@@ -16,6 +16,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Menu from "@mui/material/Menu";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemButton from "@mui/material/ListItemButton";
+import ListItem from "@mui/material/ListItem";
 import List from "@mui/material/List";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import ChoiceField from "../../../components/Inputs/ChoiceField";
@@ -278,21 +279,23 @@ function MoveCopyDialog({
                         renderInput={() => (
                           <Box>
                             <List>
-                              <ListItemButton
-                                sx={{ maxWidth: "400px" }}
-                                onClick={(e) =>
-                                  setLocationsAnchorEl(e.currentTarget)
-                                }
-                              >
-                                <ListItemText
-                                  primary={
-                                    selectedDestination?.name ??
-                                    "Select a destination"
+                              <ListItem disablePadding>
+                                <ListItemButton
+                                  sx={{ maxWidth: "400px" }}
+                                  onClick={(e) =>
+                                    setLocationsAnchorEl(e.currentTarget)
                                   }
-                                  secondary={selectedDestination?.path ?? ""}
-                                />
-                                <KeyboardArrowDownIcon />
-                              </ListItemButton>
+                                >
+                                  <ListItemText
+                                    primary={
+                                      selectedDestination?.name ??
+                                      "Select a destination"
+                                    }
+                                    secondary={selectedDestination?.path ?? ""}
+                                  />
+                                  <KeyboardArrowDownIcon />
+                                </ListItemButton>
+                              </ListItem>
                             </List>
                             <Menu
                               open={Boolean(locationsAnchorEl)}

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.spec.tsx
@@ -216,8 +216,7 @@ const feature = test.extend<{
             (v) =>
               v.id !== "landmark-one-main" &&
               v.id !== "page-has-heading-one" &&
-              v.id !== "region" &&
-              v.id !== "color-contrast",
+              v.id !== "region",
           ),
         ).toEqual([]);
       },

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.spec.tsx
@@ -217,8 +217,7 @@ const feature = test.extend<{
               v.id !== "landmark-one-main" &&
               v.id !== "page-has-heading-one" &&
               v.id !== "region" &&
-              v.id !== "color-contrast" &&
-              v.id !== "list",
+              v.id !== "color-contrast",
           ),
         ).toEqual([]);
       },

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.tsx
@@ -15,6 +15,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Menu from "@mui/material/Menu";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemButton from "@mui/material/ListItemButton";
+import ListItem from "@mui/material/ListItem";
 import List from "@mui/material/List";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import ChoiceField from "../../../components/Inputs/ChoiceField";
@@ -234,20 +235,22 @@ function MoveCopyDialog({
                           renderInput={() => (
                             <Box>
                               <List>
-                                <ListItemButton
-                                  sx={{ maxWidth: "400px" }}
-                                  onClick={(e) =>
-                                    setDestinationAnchorEl(e.currentTarget)
-                                  }
-                                >
-                                  <ListItemText
-                                    primary={
-                                      selectedFilestore?.name ??
-                                      "Select a filestore"
+                                <ListItem disablePadding>
+                                  <ListItemButton
+                                    sx={{ maxWidth: "400px" }}
+                                    onClick={(e) =>
+                                      setDestinationAnchorEl(e.currentTarget)
                                     }
-                                  />
-                                  <KeyboardArrowDownIcon />
-                                </ListItemButton>
+                                  >
+                                    <ListItemText
+                                      primary={
+                                        selectedFilestore?.name ??
+                                        "Select a filestore"
+                                      }
+                                    />
+                                    <KeyboardArrowDownIcon />
+                                  </ListItemButton>
+                                </ListItem>
                               </List>
                               <Menu
                                 open={Boolean(destinationAnchorEl)}


### PR DESCRIPTION
## Summary

Fixes [PRT-1086](https://researchspace.atlassian.net/browse/PRT-1086): the destination picker in the **Move/Transfer to S3** and **Move to iRODS** dialogs rendered a `<List>` (`<ul>`) with a direct  `<ListItemButton>` child, which MUI renders as a `<div>`. The resulting `<ul> > <div>` is invalid list markup and is flagged by axe-core's `list` rule (serious, WCAG A).

## Changes

- Wrapped the trigger `<ListItemButton>` in `<ListItem disablePadding>` so the structure is valid `<ul> > <li> > <div role="button">`, matching the convention already used in `DrawerTab`, `SkipToContentMenu`, and `CallableSnapGenePreview`. Visuals are unchanged.
    - `MoveToS3.tsx`
    - `MoveToIrods.tsx` (same bug, found while verifying)
- Removed the `list`-rule suppression from `MoveToS3.spec.tsx`'s axe scan (it was muting this issue) so the existing accessibility test now enforces it.

## Testing

- `npm run tsc` and `npm run lint` pass.
- `MoveToS3` axe component tests pass with the `list` rule enforced.

## Notes

- `MoveToIrods.tsx` has no spec/story, so it has no automated coverage yet (a follow-up could add a Playwright harness like the S3 one).