### PR TITLE
RSDEV-1105: fix oversized RSpace logo on public pages

### DIFF
--- a/src/main/webapp/WEB-INF/tags/biggerLogo.tag
+++ b/src/main/webapp/WEB-INF/tags/biggerLogo.tag
@@ -1,4 +1,4 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <div class="biggerLogoDiv" style="text-align: center">
-    <img src="<c:url value='/images/mainLogo3.svg'/>" alt="RSpace">
+    <img src="<c:url value='/images/mainLogo3.svg'/>" alt="RSpace" style="width: 400px; max-width: 100%;">
 </div>

--- a/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.tsx
+++ b/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.tsx
@@ -105,6 +105,10 @@ const useStyles = makeStyles()((theme) => ({
     padding: theme.spacing(0, 0.5),
     width: "70px",
   },
+  institutionLogo: {
+    maxHeight: "78px",
+    maxWidth: "255px",
+  },
   primary: { color: theme.palette.primary.main },
   grey: { color: theme.palette.lightestGrey },
   ac: { alignItems: "center" },
@@ -243,6 +247,7 @@ export const IdentifierDataGrid = ({
             src={INSTITUTION_LOGO_ADDRESS}
             alt="Institution Logo"
             title="Institution Logo"
+            className={classes.institutionLogo}
           />
         </Grid>
         <Grid>


### PR DESCRIPTION
PR #753 swapped in the new `mainLogo3` assets, which rendered oversized wherever the logo `<img>` had no size constraint.

### Changes
- **`IdentifierPublicPage.tsx`** (IGSN landing page): capped the institution banner at `max 78x255`, matching the old logo footprint.
- **`biggerLogo.tag`** (login/public pages, e.g. `/public/requestUsernameReminder`): capped the SVG at `width: 400px; max-width: 100%` (the viewBox-only SVG was stretching to container width).

CSS/markup only. Other `mainLogo3.svg` usages were already constrained.