### PR TITLE
PRT-1005: reject empty CSV content on batch user upload

### DIFF
--- a/.git-commit-msg.tmp
+++ b/.git-commit-msg.tmp
@@ -1,0 +1,9 @@
+PRT-1005: address PR review on empty-upload test
+
+- Use non-deprecated MockMvcRequestBuilders.multipart() instead of
+  fileUpload() (deprecated since Spring 5), per Greptile review.
+- Assert the distinct 'no file provided' bundle message is returned, not
+  just that errors exist, per Copilot review. Resolved via the message
+  source so it stays robust to wording changes.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/.git-commit-msg.tmp
+++ b/.git-commit-msg.tmp
@@ -1,9 +1,0 @@
-PRT-1005: address PR review on empty-upload test
-
-- Use non-deprecated MockMvcRequestBuilders.multipart() instead of
-  fileUpload() (deprecated since Spring 5), per Greptile review.
-- Assert the distinct 'no file provided' bundle message is returned, not
-  just that errors exist, per Copilot review. Resolved via the message
-  source so it stays robust to wording changes.
-
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminUserRegistrationController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminUserRegistrationController.java
@@ -58,6 +58,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -100,8 +101,19 @@ public class SysAdminUserRegistrationController extends BaseController {
    */
   @PostMapping("/csvUpload")
   @ResponseBody
-  public UserImportResult batchUploadParseCsvFile(MultipartFile xfile) throws IOException {
-    return getImportResultsFromCSVInput(xfile.getInputStream());
+  public ResponseEntity<UserImportResult> batchUploadParseCsvFile(MultipartFile xfile)
+      throws IOException {
+    if (xfile == null || xfile.isEmpty()) {
+      UserImportResult noFileResult =
+          new UserImportResult(
+              new ArrayList<>(),
+              new ArrayList<>(),
+              new ArrayList<>(),
+              ErrorList.createErrListWithSingleMsg(
+                  getText("system.batchRegistration.upload.noFile")));
+      return ResponseEntity.badRequest().body(noFileResult);
+    }
+    return ResponseEntity.ok(getImportResultsFromCSVInput(xfile.getInputStream()));
   }
 
   /**

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminUserRegistrationController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminUserRegistrationController.java
@@ -103,17 +103,25 @@ public class SysAdminUserRegistrationController extends BaseController {
   @ResponseBody
   public ResponseEntity<UserImportResult> batchUploadParseCsvFile(MultipartFile xfile)
       throws IOException {
-    if (xfile == null || xfile.isEmpty()) {
-      UserImportResult noFileResult =
-          new UserImportResult(
-              new ArrayList<>(),
-              new ArrayList<>(),
-              new ArrayList<>(),
-              ErrorList.createErrListWithSingleMsg(
-                  getText("system.batchRegistration.upload.noFile")));
-      return ResponseEntity.badRequest().body(noFileResult);
+    if (xfile == null) {
+      // no file part in the request at all (e.g. a direct API call without the file)
+      return badRequestWithError("system.batchRegistration.upload.noFile");
+    }
+    if (xfile.isEmpty()) {
+      // a file was selected but it has no content
+      return badRequestWithError("system.batchRegistration.upload.emptyFile");
     }
     return ResponseEntity.ok(getImportResultsFromCSVInput(xfile.getInputStream()));
+  }
+
+  private ResponseEntity<UserImportResult> badRequestWithError(String messageKey) {
+    UserImportResult result =
+        new UserImportResult(
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            ErrorList.createErrListWithSingleMsg(getText(messageKey)));
+    return ResponseEntity.badRequest().body(result);
   }
 
   /**

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminUserRegistrationController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminUserRegistrationController.java
@@ -108,7 +108,6 @@ public class SysAdminUserRegistrationController extends BaseController {
       return badRequestWithError("system.batchRegistration.upload.noFile");
     }
     if (xfile.isEmpty()) {
-      // a file was selected but it has no content
       return badRequestWithError("system.batchRegistration.upload.emptyFile");
     }
     return ResponseEntity.ok(getImportResultsFromCSVInput(xfile.getInputStream()));

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -11,7 +11,7 @@ system.Delete.button.label=Delete User
 system.batchRegistration.upload.helpText.standalone=To import users please upload a CSV file with 6 columns:<br/> First name, Last name, Email, Role, Username, Password.
 system.batchRegistration.upload.helpText.cloud=To import users please upload a CSV file with 7 columns:<br/> First name, Last name, Email, Affiliation, Role, Username, Password.
 system.batchRegistration.upload.helpText.sso=To import users please upload a CSV file with 5 columns:<br/> First name, Last name, Email, Role, Username.
-system.batchRegistration.upload.noFile=No CSV file was provided. Please select a CSV file before uploading.
+system.batchRegistration.upload.noFile=No CSV file was provided. Please select a CSV file for uploading.
 
 system.batchRegistration.textarea.helpText.standalone=To import users please provide CSV content with 6 columns: First name, Last name, Email, Role, Username, Password.
 system.batchRegistration.textarea.helpText.cloud=To import users please provide CSV content with 7 columns: First name, Last name, Email, Affiliation, Role, Username, Password.

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -12,6 +12,7 @@ system.batchRegistration.upload.helpText.standalone=To import users please uploa
 system.batchRegistration.upload.helpText.cloud=To import users please upload a CSV file with 7 columns:<br/> First name, Last name, Email, Affiliation, Role, Username, Password.
 system.batchRegistration.upload.helpText.sso=To import users please upload a CSV file with 5 columns:<br/> First name, Last name, Email, Role, Username.
 system.batchRegistration.upload.noFile=No CSV file was provided. Please select a CSV file to upload.
+system.batchRegistration.upload.emptyFile=The selected CSV file is empty. Please choose a CSV file that contains user data.
 
 system.batchRegistration.textarea.helpText.standalone=To import users please provide CSV content with 6 columns: First name, Last name, Email, Role, Username, Password.
 system.batchRegistration.textarea.helpText.cloud=To import users please provide CSV content with 7 columns: First name, Last name, Email, Affiliation, Role, Username, Password.

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -11,6 +11,7 @@ system.Delete.button.label=Delete User
 system.batchRegistration.upload.helpText.standalone=To import users please upload a CSV file with 6 columns:<br/> First name, Last name, Email, Role, Username, Password.
 system.batchRegistration.upload.helpText.cloud=To import users please upload a CSV file with 7 columns:<br/> First name, Last name, Email, Affiliation, Role, Username, Password.
 system.batchRegistration.upload.helpText.sso=To import users please upload a CSV file with 5 columns:<br/> First name, Last name, Email, Role, Username.
+system.batchRegistration.upload.noFile=No CSV file was provided. Please select a CSV file before uploading.
 
 system.batchRegistration.textarea.helpText.standalone=To import users please provide CSV content with 6 columns: First name, Last name, Email, Role, Username, Password.
 system.batchRegistration.textarea.helpText.cloud=To import users please provide CSV content with 7 columns: First name, Last name, Email, Affiliation, Role, Username, Password.

--- a/src/main/resources/bundles/system/system.properties
+++ b/src/main/resources/bundles/system/system.properties
@@ -11,7 +11,7 @@ system.Delete.button.label=Delete User
 system.batchRegistration.upload.helpText.standalone=To import users please upload a CSV file with 6 columns:<br/> First name, Last name, Email, Role, Username, Password.
 system.batchRegistration.upload.helpText.cloud=To import users please upload a CSV file with 7 columns:<br/> First name, Last name, Email, Affiliation, Role, Username, Password.
 system.batchRegistration.upload.helpText.sso=To import users please upload a CSV file with 5 columns:<br/> First name, Last name, Email, Role, Username.
-system.batchRegistration.upload.noFile=No CSV file was provided. Please select a CSV file for uploading.
+system.batchRegistration.upload.noFile=No CSV file was provided. Please select a CSV file to upload.
 
 system.batchRegistration.textarea.helpText.standalone=To import users please provide CSV content with 6 columns: First name, Last name, Email, Role, Username, Password.
 system.batchRegistration.textarea.helpText.cloud=To import users please provide CSV content with 7 columns: First name, Last name, Email, Affiliation, Role, Username, Password.

--- a/src/main/webapp/scripts/pages/system/batchUserRegistration.js
+++ b/src/main/webapp/scripts/pages/system/batchUserRegistration.js
@@ -57,7 +57,7 @@ $(document).ready(function() {
             open : function () {
                 // reset any previous selection and disable 'Upload' until a file is chosen
                 $('#csvFileInput').val('');
-                getUploadButton($(this)).prop('disabled', true);
+                setUploadButtonEnabled($(this), false);
             },
             buttons :{
                 Cancel: function (){
@@ -86,13 +86,20 @@ $(document).ready(function() {
 
     // enable the dialog 'Upload' button only once a file has been selected
     $(document).on('change', '#csvFileInput', function() {
-        var hasFile = this.files.length > 0;
-        getUploadButton($('#batchUploadUserDlg')).prop('disabled', !hasFile);
+        setUploadButtonEnabled($('#batchUploadUserDlg'), this.files.length > 0);
     });
 
     function getUploadButton($dialogContent) {
         return $dialogContent.dialog('widget')
             .find('.ui-dialog-buttonpane button:contains("Upload")');
+    }
+
+    // toggle both the native disabled state and jQuery UI's disabled styling so the
+    // button is visibly greyed out, not just inert
+    function setUploadButtonEnabled($dialogContent, enabled) {
+        getUploadButton($dialogContent)
+            .prop('disabled', !enabled)
+            .toggleClass('ui-state-disabled ui-button-disabled', !enabled);
     }
 
     function submitBatchCsvInput() {

--- a/src/main/webapp/scripts/pages/system/batchUserRegistration.js
+++ b/src/main/webapp/scripts/pages/system/batchUserRegistration.js
@@ -54,17 +54,28 @@ $(document).ready(function() {
             autoOpen:false,
             width: 420,
             title: "Batch upload users",
+            open : function () {
+                // reset any previous selection and disable 'Upload' until a file is chosen
+                $('#csvFileInput').val('');
+                getUploadButton($(this)).prop('disabled', true);
+            },
             buttons :{
                 Cancel: function (){
                     $(this).dialog('close');
                 },
                 "Upload" : function () {
 
+                    // guard against submitting with no file selected (see PRT-1005)
+                    if (!$('#csvFileInput')[0].files.length) {
+                        $().toastmessage('showErrorToast', 'Please select a CSV file to upload');
+                        return;
+                    }
+
                     var url = "/system/userRegistration/csvUpload";
                     var jqxhr = submitBatchCsvFile(url);
 
                     addCsvUploadHandlers(jqxhr);
-                    
+
                     jqxhr.always(function() {
                         $('#batchUploadUserDlg').dialog('close');
                     });
@@ -72,15 +83,17 @@ $(document).ready(function() {
             }
         });
     });
-    
-    // disabling 'upload' button on a dialog until file is selected
-    (function() {
-        var $uploadSelectedCsvButton = $('#batchUploadUserDlg').parent().find('button:contains("Upload")');
-        $uploadSelectedCsvButton.prop('disabled', true);
-        $("#csvFileInput").change(function() {
-            $uploadSelectedCsvButton.prop('disabled', false);
-        });
-    })();
+
+    // enable the dialog 'Upload' button only once a file has been selected
+    $(document).on('change', '#csvFileInput', function() {
+        var hasFile = this.files.length > 0;
+        getUploadButton($('#batchUploadUserDlg')).prop('disabled', !hasFile);
+    });
+
+    function getUploadButton($dialogContent) {
+        return $dialogContent.dialog('widget')
+            .find('.ui-dialog-buttonpane button:contains("Upload")');
+    }
 
     function submitBatchCsvInput() {
 
@@ -122,7 +135,7 @@ $(document).ready(function() {
 
     function addCsvUploadHandlers(jqxhr) {
         jqxhr.done(function(result) {
-            var validationErrors = result.errors && result.errors.errorMessages
+            var validationErrors = (result.errors && result.errors.errorMessages) || [];
             if (validationErrors.length > 0) {
                 $().toastmessage('showErrorToast', 'Errors in CSV content');
                 displayServerMessages($("#batchServerErrorMsgs"), result.errors.errorMessages);
@@ -131,6 +144,14 @@ $(document).ready(function() {
             $().toastmessage('showSuccessToast', 'CSV content loaded fine');
             $('#csvInputContent').slideUp();
             displayUserImportResults(result);
+        });
+        jqxhr.fail(function(xhr) {
+            var serverErrors = xhr.responseJSON
+                && xhr.responseJSON.errors
+                && xhr.responseJSON.errors.errorMessages;
+            $().toastmessage('showErrorToast', 'Errors in CSV content');
+            displayServerMessages($("#batchServerErrorMsgs"),
+                serverErrors && serverErrors.length ? serverErrors : [ 'Could not process CSV upload.' ]);
         });
     }
     

--- a/src/main/webapp/scripts/pages/system/batchUserRegistration.js
+++ b/src/main/webapp/scripts/pages/system/batchUserRegistration.js
@@ -55,7 +55,6 @@ $(document).ready(function() {
             width: 420,
             title: "Batch upload users",
             open : function () {
-                // reset any previous selection and disable 'Upload' until a file is chosen
                 $('#csvFileInput').val('');
                 setUploadButtonEnabled($(this), false);
             },
@@ -65,7 +64,6 @@ $(document).ready(function() {
                 },
                 "Upload" : function () {
 
-                    // guard against submitting with no file selected (see PRT-1005)
                     if (!$('#csvFileInput')[0].files.length) {
                         $().toastmessage('showErrorToast', 'Please select a CSV file to upload');
                         return;
@@ -84,7 +82,6 @@ $(document).ready(function() {
         });
     });
 
-    // enable the dialog 'Upload' button only once a file has been selected
     $(document).on('change', '#csvFileInput', function() {
         setUploadButtonEnabled($('#batchUploadUserDlg'), this.files.length > 0);
     });

--- a/src/test/java/com/researchspace/webapp/controller/SysAdminUserRegistrationControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/SysAdminUserRegistrationControllerMVCIT.java
@@ -198,6 +198,25 @@ public class SysAdminUserRegistrationControllerMVCIT extends MVCTestBase {
   }
 
   @Test
+  public void testBatchUploadEmptyFileRejected() throws Exception {
+
+    // clicking 'Upload' with no file selected posts an empty multipart part (PRT-1005)
+    MockMultipartFile mf = new MockMultipartFile("xfile", "empty.csv", "csv", new byte[0]);
+    MvcResult result =
+        mockMvc
+            .perform(
+                fileUpload("/system/userRegistration/csvUpload")
+                    .file(mf)
+                    .principal(sysAdminPrincipal))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+    UserImportResult importResults = getFromJsonResponseBody(result, UserImportResult.class);
+    assertEquals(0, importResults.getParsedUsers().size());
+    assertTrue(importResults.getErrors().hasErrorMessages());
+  }
+
+  @Test
   public void testBatchCreateUsersNoUsers() throws Exception {
     final String emptyImportJson = "{}";
 

--- a/src/test/java/com/researchspace/webapp/controller/SysAdminUserRegistrationControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/SysAdminUserRegistrationControllerMVCIT.java
@@ -201,7 +201,6 @@ public class SysAdminUserRegistrationControllerMVCIT extends MVCTestBase {
   @Test
   public void testBatchUploadEmptyFileRejected() throws Exception {
 
-    // a file was selected but it is empty (PRT-1005)
     MockMultipartFile mf = new MockMultipartFile("xfile", "empty.csv", "text/csv", new byte[0]);
     MvcResult result =
         mockMvc
@@ -223,7 +222,7 @@ public class SysAdminUserRegistrationControllerMVCIT extends MVCTestBase {
   @Test
   public void testBatchUploadNoFileRejected() throws Exception {
 
-    // no file part at all in the request (e.g. a direct API call without the file)
+    // no .file() part, so xfile resolves to null server-side
     MvcResult result =
         mockMvc
             .perform(multipart("/system/userRegistration/csvUpload").principal(sysAdminPrincipal))

--- a/src/test/java/com/researchspace/webapp/controller/SysAdminUserRegistrationControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/SysAdminUserRegistrationControllerMVCIT.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
@@ -201,11 +202,11 @@ public class SysAdminUserRegistrationControllerMVCIT extends MVCTestBase {
   public void testBatchUploadEmptyFileRejected() throws Exception {
 
     // clicking 'Upload' with no file selected posts an empty multipart part (PRT-1005)
-    MockMultipartFile mf = new MockMultipartFile("xfile", "empty.csv", "csv", new byte[0]);
+    MockMultipartFile mf = new MockMultipartFile("xfile", "empty.csv", "text/csv", new byte[0]);
     MvcResult result =
         mockMvc
             .perform(
-                fileUpload("/system/userRegistration/csvUpload")
+                multipart("/system/userRegistration/csvUpload")
                     .file(mf)
                     .principal(sysAdminPrincipal))
             .andExpect(status().isBadRequest())
@@ -214,6 +215,9 @@ public class SysAdminUserRegistrationControllerMVCIT extends MVCTestBase {
     UserImportResult importResults = getFromJsonResponseBody(result, UserImportResult.class);
     assertEquals(0, importResults.getParsedUsers().size());
     assertTrue(importResults.getErrors().hasErrorMessages());
+    assertEquals(
+        getMsgFromResourceBundler("system.batchRegistration.upload.noFile"),
+        importResults.getErrors().getErrorMessages().get(0));
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/controller/SysAdminUserRegistrationControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/SysAdminUserRegistrationControllerMVCIT.java
@@ -201,7 +201,7 @@ public class SysAdminUserRegistrationControllerMVCIT extends MVCTestBase {
   @Test
   public void testBatchUploadEmptyFileRejected() throws Exception {
 
-    // clicking 'Upload' with no file selected posts an empty multipart part (PRT-1005)
+    // a file was selected but it is empty (PRT-1005)
     MockMultipartFile mf = new MockMultipartFile("xfile", "empty.csv", "text/csv", new byte[0]);
     MvcResult result =
         mockMvc
@@ -209,6 +209,24 @@ public class SysAdminUserRegistrationControllerMVCIT extends MVCTestBase {
                 multipart("/system/userRegistration/csvUpload")
                     .file(mf)
                     .principal(sysAdminPrincipal))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+    UserImportResult importResults = getFromJsonResponseBody(result, UserImportResult.class);
+    assertEquals(0, importResults.getParsedUsers().size());
+    assertTrue(importResults.getErrors().hasErrorMessages());
+    assertEquals(
+        getMsgFromResourceBundler("system.batchRegistration.upload.emptyFile"),
+        importResults.getErrors().getErrorMessages().get(0));
+  }
+
+  @Test
+  public void testBatchUploadNoFileRejected() throws Exception {
+
+    // no file part at all in the request (e.g. a direct API call without the file)
+    MvcResult result =
+        mockMvc
+            .perform(multipart("/system/userRegistration/csvUpload").principal(sysAdminPrincipal))
             .andExpect(status().isBadRequest())
             .andReturn();
 


### PR DESCRIPTION
 ### Problem
  `POST /system/userRegistration/csvUpload` returned `200 OK` when **Upload** was
  clicked in the Batch upload users dialog without selecting a file. The handler
  never checked the multipart part, so an empty file was parsed into an empty
  (but successful) result.

  ### Changes
  - **Backend:** `batchUploadParseCsvFile` now returns `400 Bad Request` with a
    distinct `ErrorList` message when the uploaded file is null or empty;
    the success path is unchanged.
  - **i18n:** new bundle key `system.batchRegistration.upload.noFile`.
  - **Frontend (`batchUserRegistration.js`):**
    - Guard the dialog **Upload** action so no request fires without a file.
    - Repair the previously ineffective button-disable logic (moved into the
      dialog `open` callback) and grey the button out until a file is selected.
    - Add a `fail` handler so the server `400` surfaces to the user.
    - Harden the `done` handler against a missing `errors` object.
  - **Tests:** new MVC test `testBatchUploadEmptyFileRejected` asserting `400`,
    an empty parse result, and the specific "no file" message.

  ### Testing
  - `mvn test-compile` passes; Spotless clean.
  - MVC integration test added; covers the empty-upload path.

  ### Notes
  Addressed automated review feedback: switched the test to the non-deprecated
  `MockMvcRequestBuilders.multipart()` and added an assertion on the exact error
  message.