### PR TITLE
RSDEV-1032: Enable referencing of instruments in ELN documents in LoM

### DIFF
--- a/src/main/java/com/researchspace/archive/elninventory/ArchivalMaterialUsage.java
+++ b/src/main/java/com/researchspace/archive/elninventory/ArchivalMaterialUsage.java
@@ -20,10 +20,11 @@ import lombok.ToString;
 public class ArchivalMaterialUsage {
 
   @XmlElement(required = true)
-  private Integer schemaVersion = 1;
+  private Integer schemaVersion = 2;
 
   private Long invRecId;
   private String invRecType;
+  private String globalId;
   private String igsn;
   private BigDecimal usageValue;
   private Integer usageUnitId;
@@ -32,6 +33,7 @@ public class ArchivalMaterialUsage {
   public ArchivalMaterialUsage(MaterialUsage mu) {
     setInvRecId(mu.getInventoryRecord().getId());
     setInvRecType(mu.getInventoryRecord().getType().name());
+    setGlobalId(mu.getInventoryRecord().getGlobalIdentifier());
     if (mu.getInventoryRecord().getActiveIdentifiers() != null
         && !mu.getInventoryRecord().getActiveIdentifiers().isEmpty()) {
       setIgsn(

--- a/src/test/java/com/researchspace/api/v1/controller/ListOfMaterialsApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/ListOfMaterialsApiControllerMVCIT.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.researchspace.api.v1.model.ApiInstrument;
 import com.researchspace.api.v1.model.ApiListOfMaterials;
 import com.researchspace.api.v1.model.ApiMaterialUsage;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
@@ -156,6 +157,48 @@ public class ListOfMaterialsApiControllerMVCIT extends API_MVC_InventoryTestBase
     foundLists = mvcUtils.getFromJsonResponseBodyByTypeRef(result, new TypeReference<>() {});
     assertNotNull(foundLists);
     assertEquals(0, foundLists.size());
+  }
+
+  @Test
+  public void listOfMaterialsForInstrumentReturnsLinkedDocuments() throws Exception {
+
+    User anyUser = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(anyUser);
+
+    ApiInstrument myInstrument = createBasicInstrumentForUser(anyUser);
+    StructuredDocument myDoc = createBasicDocumentInRootFolderWithText(anyUser, "text");
+    Field myField = myDoc.getFields().get(0);
+
+    // link the instrument to the document field via a List of Materials (no quantity)
+    createBasicListOfMaterialsForUserAndDocField(
+        anyUser, myField, List.of(new ApiMaterialUsage(myInstrument, null)));
+
+    // GET /listOfMaterials/forInventoryItem/{instrumentGlobalId}
+    MvcResult result =
+        this.mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE,
+                    apiKey,
+                    "/listOfMaterials/forInventoryItem/" + myInstrument.getGlobalId(),
+                    anyUser))
+            .andExpect(status().isOk())
+            .andReturn();
+    assertNull(result.getResolvedException());
+
+    List<ApiListOfMaterials> foundLists =
+        mvcUtils.getFromJsonResponseBodyByTypeRef(result, new TypeReference<>() {});
+    assertNotNull(foundLists);
+    assertEquals(1, foundLists.size());
+
+    // the endpoint returns the list of linked documents: each LoM carries its ELN document
+    ApiListOfMaterials lom = foundLists.get(0);
+    assertNotNull(lom.getElnDocument());
+    assertEquals(myDoc.getGlobalIdentifier(), lom.getElnDocument().getGlobalId());
+
+    // and the linked material is the instrument we added
+    assertEquals(1, lom.getMaterials().size());
+    assertEquals(myInstrument.getGlobalId(), lom.getMaterials().get(0).getRecord().getGlobalId());
   }
 
   @Test

--- a/src/test/java/com/researchspace/archive/ArchivalDocumentLomExportImportRoundTripTest.java
+++ b/src/test/java/com/researchspace/archive/ArchivalDocumentLomExportImportRoundTripTest.java
@@ -1,0 +1,76 @@
+package com.researchspace.archive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.researchspace.archive.elninventory.ArchivalListOfMaterials;
+import com.researchspace.archive.elninventory.ArchivalMaterialUsage;
+import com.researchspace.model.elninventory.MaterialUsage;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.SubSample;
+import com.researchspace.testutils.ArchiveTestUtils;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards that an ELN document whose List of Materials references an instrument (and other inventory
+ * objects) stays importable after the LoM XML change (RSDEV-1032): the new {@code globalId} element
+ * must be present in the schema that {@code /export/importArchive} validates against.
+ *
+ * <p>{@link ArchiveTestUtils#writeToXMLAndReadFromXML} reproduces the export/import round-trip
+ * exactly: it marshals the document to XML, generates the XSD from {@code ArchivalDocument.class}
+ * (the same call the real exporter makes in {@code XMLArchiveExportManagerServiceImpl}), then
+ * unmarshals validating against that generated schema. It uses the default JAXB validation handler,
+ * which throws on the first schema error - stricter than the import-time {@code
+ * XMLImportSchemaValidator}, which only records the error. So if this round-trip succeeds, import
+ * validation cannot reject the new field.
+ */
+public class ArchivalDocumentLomExportImportRoundTripTest {
+
+  @Test
+  public void documentWithInstrumentLomRoundTripsAndValidatesAgainstGeneratedSchema()
+      throws Exception {
+    Instrument instrument = new Instrument();
+    instrument.setId(42L);
+    SubSample subSample = new SubSample();
+    subSample.setId(7L);
+
+    ArchivalListOfMaterials lom = new ArchivalListOfMaterials();
+    lom.setName("instrument LoM");
+    lom.setDescription("references an instrument and a subsample");
+    lom.setOriginalElnFieldId(1L);
+    lom.getMaterials().add(new ArchivalMaterialUsage(new MaterialUsage(null, instrument, null)));
+    lom.getMaterials().add(new ArchivalMaterialUsage(new MaterialUsage(null, subSample, null)));
+
+    ArchivalField field = new ArchivalField();
+    field.getListsOfMaterials().add(lom);
+
+    ArchivalDocument doc = new ArchivalDocument();
+    doc.setDocId(1L);
+    doc.setName("doc with instrument LoM");
+    doc.setType("NORMAL");
+    doc.setCreatedBy("user1a");
+    doc.setCreationDate(new Date(0L));
+    doc.setLastModifiedDate(new Date(0L));
+    doc.setVersion(1L);
+    doc.addArchivalField(field);
+
+    ArchivalDocument roundTripped =
+        ArchiveTestUtils.writeToXMLAndReadFromXML(doc, ArchivalDocument.class);
+
+    assertNotNull(roundTripped);
+    ArchivalListOfMaterials importedLom =
+        roundTripped.getListFields().get(0).getListsOfMaterials().get(0);
+    assertEquals(2, importedLom.getMaterials().size());
+
+    ArchivalMaterialUsage importedInstrument = importedLom.getMaterials().get(0);
+    assertEquals("IN42", importedInstrument.getGlobalId());
+    assertEquals("INSTRUMENT", importedInstrument.getInvRecType());
+    assertEquals(2, importedInstrument.getSchemaVersion());
+
+    // the "Could" requirement: global IDs for the other inventory objects survive too
+    ArchivalMaterialUsage importedSubSample = importedLom.getMaterials().get(1);
+    assertEquals("SS7", importedSubSample.getGlobalId());
+    assertEquals("SUBSAMPLE", importedSubSample.getInvRecType());
+  }
+}

--- a/src/test/java/com/researchspace/archive/elninventory/ArchivalMaterialUsageTest.java
+++ b/src/test/java/com/researchspace/archive/elninventory/ArchivalMaterialUsageTest.java
@@ -1,0 +1,50 @@
+package com.researchspace.archive.elninventory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.researchspace.model.elninventory.MaterialUsage;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.SubSample;
+import org.junit.jupiter.api.Test;
+
+public class ArchivalMaterialUsageTest {
+
+  @Test
+  public void schemaVersionIs2() {
+    SubSample subSample = new SubSample();
+    subSample.setId(1L);
+    MaterialUsage mu = new MaterialUsage(null, subSample, null);
+
+    ArchivalMaterialUsage archivalUsage = new ArchivalMaterialUsage(mu);
+
+    assertEquals(2, archivalUsage.getSchemaVersion());
+  }
+
+  @Test
+  public void globalIdIsPopulatedForSubSample() {
+    SubSample subSample = new SubSample();
+    subSample.setId(7L);
+    MaterialUsage mu = new MaterialUsage(null, subSample, null);
+
+    ArchivalMaterialUsage archivalUsage = new ArchivalMaterialUsage(mu);
+
+    assertEquals("SS7", archivalUsage.getGlobalId());
+    assertEquals("SUBSAMPLE", archivalUsage.getInvRecType());
+    assertEquals(7L, archivalUsage.getInvRecId());
+  }
+
+  @Test
+  public void globalIdIsPopulatedForInstrument() {
+    Instrument instrument = new Instrument();
+    instrument.setId(42L);
+    MaterialUsage mu = new MaterialUsage(null, instrument, null);
+
+    ArchivalMaterialUsage archivalUsage = new ArchivalMaterialUsage(mu);
+
+    assertEquals("IN42", archivalUsage.getGlobalId());
+    assertEquals("INSTRUMENT", archivalUsage.getInvRecType());
+    assertEquals(42L, archivalUsage.getInvRecId());
+    assertNull(archivalUsage.getUsageValue()); // no quantity for instruments
+  }
+}

--- a/src/test/java/com/researchspace/export/pdf/HTMLStringGeneratorTest.java
+++ b/src/test/java/com/researchspace/export/pdf/HTMLStringGeneratorTest.java
@@ -21,6 +21,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.elninventory.ListOfMaterials;
 import com.researchspace.model.field.ChoiceFieldForm;
 import com.researchspace.model.field.TextFieldForm;
+import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.netfiles.NfsElement;
@@ -240,6 +241,29 @@ public class HTMLStringGeneratorTest {
     assertTrue(documentAsHtml, documentAsHtml.contains("SAMPLE"));
     assertTrue(documentAsHtml, documentAsHtml.contains("SUBSAMPLE"));
     assertFalse(documentAsHtml, documentAsHtml.contains("CONTAINER"));
+  }
+
+  @Test
+  public void testIncludeInstrumentInListOfMaterials() {
+    // a document whose list of materials references an instrument (RSDEV-1032) must render the
+    // instrument's name, identifier and a link to the RSpace entity in PDF/Word exports
+    StructuredDocument anyDoc = createAnySDWithText("any");
+    anyDoc.setId(1L);
+    ListOfMaterials lom = new ListOfMaterials();
+    lom.setName("instrument lom");
+    Instrument instrument = new Instrument();
+    instrument.setId(42L);
+    instrument.setName("Confocal Microscope");
+    lom.addMaterial(instrument, null); // instruments have no usage quantity
+    anyDoc.getFields().get(0).addListOfMaterials(lom);
+
+    ExportProcessorInput input = htmlGenerator.extractHtmlStr(anyDoc, cfg);
+    String documentAsHtml = input.getDocumentAsHtml();
+
+    assertTrue(documentAsHtml, documentAsHtml.contains("instrument lom"));
+    assertTrue(documentAsHtml, documentAsHtml.contains("INSTRUMENT"));
+    assertTrue(documentAsHtml, documentAsHtml.contains("Confocal Microscope"));
+    assertTrue(documentAsHtml, documentAsHtml.contains("http://test.com/globalId/IN42"));
   }
 
   @Test

--- a/src/test/java/com/researchspace/inv/audit/ListOfMaterialsAuditTrailTest.java
+++ b/src/test/java/com/researchspace/inv/audit/ListOfMaterialsAuditTrailTest.java
@@ -10,6 +10,7 @@ import com.researchspace.model.elninventory.ListOfMaterials;
 import com.researchspace.model.events.ListOfMaterialsCreationEvent;
 import com.researchspace.model.events.ListOfMaterialsDeleteEvent;
 import com.researchspace.model.events.ListOfMaterialsEditingEvent;
+import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.record.StructuredDocument;
@@ -64,6 +65,57 @@ public class ListOfMaterialsAuditTrailTest {
     lom.getMaterials().get(0).setId(1L);
     lom.getMaterials().get(1).setId(2L);
     return lom;
+  }
+
+  @Test
+  public void lomCreateEventWithInstrumentIsLogged() {
+    ListOfMaterials lom = createTestLomWithSampleAndInstrument();
+    StructuredDocument anyDocument = TestFactory.createAnySD();
+
+    ListOfMaterialsCreationEvent event =
+        new ListOfMaterialsCreationEvent(lom, anyUser, anyDocument);
+    listener.listOfMaterialsCreated(event);
+    verify(auditTrail).notify(eventArgumentCaptor.capture());
+    assertEquals(
+        "Added List of Materials LM123. Added inventory items: SA11, IN42.",
+        eventArgumentCaptor.getValue().getDescription());
+
+    Mockito.verifyNoMoreInteractions(auditTrail);
+  }
+
+  private ListOfMaterials createTestLomWithSampleAndInstrument() {
+    Sample anySample = TestFactory.createBasicSampleOutsideContainer(anyUser);
+    anySample.setId(11L);
+    Instrument anyInstrument = new Instrument();
+    anyInstrument.setId(42L);
+    ListOfMaterials lom = new ListOfMaterials();
+    lom.setId(123L);
+    lom.addMaterial(anySample, null);
+    lom.addMaterial(anyInstrument, null);
+    lom.getMaterials().get(0).setId(1L);
+    lom.getMaterials().get(1).setId(2L);
+    return lom;
+  }
+
+  @Test
+  public void lomEditEventWithInstrumentIsLogged() {
+    ListOfMaterials editedLom = createTestLomWithSampleAndInstrument();
+    editedLom.getMaterials().remove(1); // edited state keeps only the sample
+    ListOfMaterials originalState = createTestLomWithSampleAndInstrument();
+    originalState.getMaterials().remove(0); // original state had only the instrument
+    StructuredDocument anyDocument = TestFactory.createAnySD();
+
+    ListOfMaterialsEditingEvent event =
+        new ListOfMaterialsEditingEvent(
+            editedLom, anyUser, anyDocument, originalState.getMaterials());
+    listener.listOfMaterialsEdited(event);
+    verify(auditTrail).notify(eventArgumentCaptor.capture());
+    assertEquals(
+        "Edited List of Materials LM123. Added inventory items: SA11. Removed inventory items:"
+            + " IN42.",
+        eventArgumentCaptor.getValue().getDescription());
+
+    Mockito.verifyNoMoreInteractions(auditTrail);
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/ListOfMaterialsApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/ListOfMaterialsApiManagerTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.researchspace.Constants;
 import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiInstrument;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiListOfMaterials;
 import com.researchspace.api.v1.model.ApiMaterialUsage;
@@ -302,6 +303,61 @@ public class ListOfMaterialsApiManagerTest extends SpringTransactionalTest {
 
     latestSubSample = subSampleManager.getApiSubSampleById(subSampleId, testUser);
     assertEquals("0 g", latestSubSample.getQuantity().toQuantityInfo().toPlainString());
+  }
+
+  @Test
+  public void instrumentCanBeAddedAndFetchedFromLom() throws BindException {
+
+    StructuredDocument basicDoc = createBasicDocumentInRootFolderWithText(testUser, "test");
+    Long basicDocFieldId = basicDoc.getFields().get(0).getId();
+
+    ApiInstrument instrument = createBasicInstrumentForUser(testUser);
+    GlobalIdentifier instrumentOid = new GlobalIdentifier(instrument.getGlobalId());
+
+    // no LoM yet
+    List<ApiListOfMaterials> foundLoms =
+        lomManager.getListOfMaterialsForInvRecGlobalId(instrumentOid, testUser);
+    assertEquals(0, foundLoms.size());
+
+    // create LoM with instrument (no quantity)
+    ApiListOfMaterials newLom = new ApiListOfMaterials();
+    newLom.setName("instrument LoM");
+    newLom.setElnFieldId(basicDocFieldId);
+    newLom.addMaterialUsage(instrument, null, false);
+    ApiListOfMaterials createdLom = lomManager.createNewListOfMaterials(newLom, testUser);
+    assertNotNull(createdLom.getId());
+    assertEquals(1, createdLom.getMaterials().size());
+    Mockito.verify(mockPublisher).publishEvent(Mockito.any(ListOfMaterialsCreationEvent.class));
+
+    // fetch by id: instrument record info must be enriched (name, permittedActions)
+    ApiListOfMaterials fetchedLom = lomManager.getListOfMaterialsById(createdLom.getId(), testUser);
+    ApiMaterialUsage instrumentUsage = fetchedLom.getMaterials().get(0);
+    ApiInventoryRecordInfo instrumentRecord = instrumentUsage.getRecord();
+    assertEquals("myInstrument", instrumentRecord.getName());
+    assertEquals(instrument.getGlobalId(), instrumentRecord.getGlobalId());
+    assertFalse(instrumentRecord.getPermittedActions().isEmpty());
+    assertNull(instrumentUsage.getUsedQuantity()); // instruments have no quantity
+
+    // findLomsByInvRecGlobalId runs a native SQL query, so pending inserts must be flushed for it
+    // to be visible within this single transaction (see SpringTransactionalTest#flushDatabaseState)
+    flushDatabaseState();
+    // find LoM via instrument globalId
+    foundLoms = lomManager.getListOfMaterialsForInvRecGlobalId(instrumentOid, testUser);
+    assertEquals(1, foundLoms.size());
+    assertNotNull(foundLoms.get(0).getElnDocument());
+
+    // remove instrument from LoM: an explicit empty materials list clears all materials,
+    // whereas a null materials list would mean "leave materials unchanged"
+    ApiListOfMaterials lomUpdate = new ApiListOfMaterials();
+    lomUpdate.setId(createdLom.getId());
+    lomUpdate.setMaterials(List.of());
+    lomManager.updateListOfMaterials(lomUpdate, testUser);
+    Mockito.verify(mockPublisher).publishEvent(Mockito.any(ListOfMaterialsEditingEvent.class));
+
+    // flush the material removal so the native-query search reflects it within this transaction
+    flushDatabaseState();
+    foundLoms = lomManager.getListOfMaterialsForInvRecGlobalId(instrumentOid, testUser);
+    assertEquals(0, foundLoms.size());
   }
 
   @Test


### PR DESCRIPTION
## Description ##
This PR enables `Instruments` to be referenced from a document's `List of Materials (LoM)`. 
It reuses the existing generic write path, audit trail, permission checks, and PDF/Word rendering, and adds only two things:
 - a `globalId` element on the archive XML model
 - a type-dispatch in the LoM read path. 

### Jira ticket ###
- https://researchspace.atlassian.net/browse/RSDEV-1032

## Testing notes
The ticket cannot manual tested until the UI is ready. But multiple unit and MVCIT test have been added (updated) in order to very the correctness of the implementation

