### PR TITLE
RSDEV-1065: Refactoring `SampleTemplate` to become a new entity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1489,7 +1489,7 @@
            Pinned to the jitpack commit build of the RSDEV-1065-model tip, which integrates the
            RSDEV-1131 link fields. A branch -SNAPSHOT alias here served a stale pre-1131 build
            (jitpack caches the branch HEAD), so use the immutable commit hash. -->
-      <version>e25bb4393e</version>
+      <version>RSDEV-1065-model-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1484,9 +1484,12 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <!-- TODO(RSDEV-1065): replace with the released core-model version that contains the
-           SampleEntity/SampleTemplate hierarchy (the published 2.28.0 predates it) -->
-      <version>RSDEV-1065-model-SNAPSHOT</version>
+      <!-- TODO(RSDEV-1065): replace with the released core-model version once RSDEV-1065 +
+           RSDEV-1131 ship (the published 2.28.0 lacks the SampleEntity/SampleTemplate hierarchy).
+           Pinned to the jitpack commit build of the RSDEV-1065-model tip, which integrates the
+           RSDEV-1131 link fields. A branch -SNAPSHOT alias here served a stale pre-1131 build
+           (jitpack caches the branch HEAD), so use the immutable commit hash. -->
+      <version>e25bb4393e</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1484,7 +1484,9 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>2.28.0</version>
+      <!-- TODO(RSDEV-1065): replace with the released core-model version that contains the
+           SampleEntity/SampleTemplate hierarchy (the published 2.28.0 predates it) -->
+      <version>RSDEV-1065-model-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1484,12 +1484,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <!-- TODO(RSDEV-1065): replace with the released core-model version once RSDEV-1065 +
-           RSDEV-1131 ship (the published 2.28.0 lacks the SampleEntity/SampleTemplate hierarchy).
-           Pinned to the jitpack commit build of the RSDEV-1065-model tip, which integrates the
-           RSDEV-1131 link fields. A branch -SNAPSHOT alias here served a stale pre-1131 build
-           (jitpack caches the branch HEAD), so use the immutable commit hash. -->
-      <version>RSDEV-1065-model-SNAPSHOT</version>
+      <version>2.29.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/src/main/java/com/axiope/model/record/init/AntibodySampleTemplate.java
+++ b/src/main/java/com/axiope/model/record/init/AntibodySampleTemplate.java
@@ -4,7 +4,7 @@ import static com.researchspace.core.util.TransformerUtils.toList;
 
 import com.researchspace.core.util.TransformerUtils;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
@@ -32,15 +32,15 @@ public class AntibodySampleTemplate extends BuiltinContent implements SampleTemp
     return "Antibody";
   }
 
-  public Optional<Sample> createSampleTemplate(User createdBy) {
-    Sample sample = createTemplate(createdBy);
+  public Optional<SampleTemplate> createSampleTemplate(User createdBy) {
+    SampleTemplate sample = createTemplate(createdBy);
     m_initializer.saveSampleTemplate(sample);
     m_sampleTemplate = sample;
     return Optional.of(sample);
   }
 
-  private Sample createTemplate(User createdBy) {
-    Sample sample = recordFactory.createSample("Antibody", createdBy);
+  private SampleTemplate createTemplate(User createdBy) {
+    SampleTemplate sample = recordFactory.createSampleTemplate("Antibody", createdBy);
     sample.setStorageTempMax(QuantityInfo.of(5, RSUnitDef.CELSIUS));
     sample.setStorageTempMin(QuantityInfo.of(3, RSUnitDef.CELSIUS));
 
@@ -105,7 +105,6 @@ public class AntibodySampleTemplate extends BuiltinContent implements SampleTemp
     sample.addSampleField(ref);
 
     sample.setSubSampleAliases(SubSampleName.ALIQUOT);
-    sample.setTemplate(true);
     return sample;
   }
 

--- a/src/main/java/com/axiope/model/record/init/BacterialSampleTemplate.java
+++ b/src/main/java/com/axiope/model/record/init/BacterialSampleTemplate.java
@@ -1,7 +1,7 @@
 package com.axiope.model.record.init;
 
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryStringField;
@@ -24,14 +24,14 @@ public class BacterialSampleTemplate extends BuiltinContent implements SampleTem
     return "Bacteria";
   }
 
-  public Optional<Sample> createSampleTemplate(User createdBy) {
-    Sample sample = createTemplate(createdBy);
+  public Optional<SampleTemplate> createSampleTemplate(User createdBy) {
+    SampleTemplate sample = createTemplate(createdBy);
     m_initializer.saveSampleTemplate(sample);
     m_sampleTemplate = sample;
     return Optional.of(sample);
   }
 
-  private Sample createTemplate(User createdBy) {
+  private SampleTemplate createTemplate(User createdBy) {
     String[] stringFieldKeys1 =
         new String[] {
           "Organism",
@@ -43,11 +43,10 @@ public class BacterialSampleTemplate extends BuiltinContent implements SampleTem
           "Selectable marker"
         };
 
-    Sample sample = recordFactory.createSample("Bacteria", createdBy);
+    SampleTemplate sample = recordFactory.createSampleTemplate("Bacteria", createdBy);
     sample.setStorageTempMax(QuantityInfo.of(-18, RSUnitDef.CELSIUS));
     sample.setStorageTempMin(QuantityInfo.of(-30, RSUnitDef.CELSIUS));
     sample.setDescription("Description of a bacterial culture");
-    sample.setTemplate(true);
     InventoryEntityField id = new InventoryTextField("Identifier");
     sample.addSampleField(id);
 

--- a/src/main/java/com/axiope/model/record/init/BuiltinContent.java
+++ b/src/main/java/com/axiope/model/record/init/BuiltinContent.java
@@ -3,7 +3,7 @@ package com.axiope.model.record.init;
 import com.researchspace.Constants;
 import com.researchspace.model.User;
 import com.researchspace.model.core.RecordType;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.IRecordFactory;
 import com.researchspace.model.record.RSForm;
@@ -31,7 +31,7 @@ public abstract class BuiltinContent implements IBuiltinContent {
   RSForm m_form;
 
   /* the SampleTemplate associated with this content */
-  Sample m_sampleTemplate;
+  SampleTemplate m_sampleTemplate;
 
   Logger log = LoggerFactory.getLogger(BuiltinContent.class);
 

--- a/src/main/java/com/axiope/model/record/init/FFPESampleTemplate.java
+++ b/src/main/java/com/axiope/model/record/init/FFPESampleTemplate.java
@@ -2,8 +2,8 @@ package com.axiope.model.record.init;
 
 import com.researchspace.core.util.TransformerUtils;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
@@ -30,15 +30,15 @@ public class FFPESampleTemplate extends BuiltinContent implements SampleTemplate
     return "FFPE ";
   }
 
-  public Optional<Sample> createSampleTemplate(User createdBy) {
-    Sample sample = createTemplate(createdBy);
+  public Optional<SampleTemplate> createSampleTemplate(User createdBy) {
+    SampleTemplate sample = createTemplate(createdBy);
     m_initializer.saveSampleTemplate(sample);
     m_sampleTemplate = sample;
     return Optional.of(sample);
   }
 
-  private Sample createTemplate(User createdBy) {
-    Sample sample = recordFactory.createSample("FFPE tissue", createdBy);
+  private SampleTemplate createTemplate(User createdBy) {
+    SampleTemplate sample = recordFactory.createSampleTemplate("FFPE tissue", createdBy);
     sample.setSampleSource(SampleSource.LAB_CREATED);
     sample.setSubSampleAliases(SubSampleName.PORTION);
     sample.setDefaultUnitId(RSUnitDef.DIMENSIONLESS.getId());
@@ -84,7 +84,6 @@ public class FFPESampleTemplate extends BuiltinContent implements SampleTemplate
 
     sample.setStorageTempMax(QuantityInfo.of(5, RSUnitDef.CELSIUS));
     sample.setStorageTempMin(QuantityInfo.of(3, RSUnitDef.CELSIUS));
-    sample.setTemplate(true);
     return sample;
   }
 

--- a/src/main/java/com/axiope/model/record/init/IBuiltInPersistor.java
+++ b/src/main/java/com/axiope/model/record/init/IBuiltInPersistor.java
@@ -1,7 +1,7 @@
 package com.axiope.model.record.init;
 
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.UserFolderSetup;
@@ -27,5 +27,5 @@ public interface IBuiltInPersistor {
 
   void saveForm(RSForm form);
 
-  void saveSampleTemplate(Sample template);
+  void saveSampleTemplate(SampleTemplate template);
 }

--- a/src/main/java/com/axiope/model/record/init/IBuiltinContent.java
+++ b/src/main/java/com/axiope/model/record/init/IBuiltinContent.java
@@ -1,7 +1,7 @@
 package com.axiope.model.record.init;
 
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.UserFolderSetup;
@@ -28,7 +28,7 @@ public interface IBuiltinContent {
    * @param createdBy
    * @return
    */
-  default Optional<Sample> createSampleTemplate(User createdBy) {
+  default Optional<SampleTemplate> createSampleTemplate(User createdBy) {
     return Optional.empty();
   }
 

--- a/src/main/java/com/axiope/model/record/init/SyntheticWaxSampleTemplate.java
+++ b/src/main/java/com/axiope/model/record/init/SyntheticWaxSampleTemplate.java
@@ -2,8 +2,8 @@ package com.axiope.model.record.init;
 
 import com.researchspace.core.util.TransformerUtils;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
@@ -31,15 +31,15 @@ public class SyntheticWaxSampleTemplate extends BuiltinContent implements Sample
     return "Synthetic Wax";
   }
 
-  public Optional<Sample> createSampleTemplate(User createdBy) {
-    Sample sample = createTemplate(createdBy);
+  public Optional<SampleTemplate> createSampleTemplate(User createdBy) {
+    SampleTemplate sample = createTemplate(createdBy);
     m_initializer.saveSampleTemplate(sample);
     m_sampleTemplate = sample;
     return Optional.of(sample);
   }
 
-  private Sample createTemplate(User createdBy) {
-    Sample sample = recordFactory.createSample("Synthetic Wax", createdBy);
+  private SampleTemplate createTemplate(User createdBy) {
+    SampleTemplate sample = recordFactory.createSampleTemplate("Synthetic Wax", createdBy);
     sample.setSampleSource(SampleSource.LAB_CREATED);
     sample.setSubSampleAliases(SubSampleName.PORTION);
     sample.setDefaultUnitId(RSUnitDef.GRAM.getId());
@@ -67,7 +67,6 @@ public class SyntheticWaxSampleTemplate extends BuiltinContent implements Sample
 
     sample.setStorageTempMax(QuantityInfo.of(5, RSUnitDef.CELSIUS));
     sample.setStorageTempMin(QuantityInfo.of(3, RSUnitDef.CELSIUS));
-    sample.setTemplate(true);
     return sample;
   }
 

--- a/src/main/java/com/researchspace/api/v1/controller/BaseApiInventoryController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/BaseApiInventoryController.java
@@ -158,8 +158,9 @@ public class BaseApiInventoryController extends BaseApiController {
       GlobalIdentifier recordOid, User user) {
     switch (recordOid.getPrefix()) {
       case SA:
-      case IT:
         return sampleApiMgr.assertUserCanEditSample(recordOid.getDbId(), user);
+      case IT:
+        return sampleApiMgr.assertUserCanEditSampleTemplate(recordOid.getDbId(), user);
       case SS:
         return subSampleApiMgr.assertUserCanEditSubSample(recordOid.getDbId(), user);
       case IC:
@@ -180,8 +181,9 @@ public class BaseApiInventoryController extends BaseApiController {
       GlobalIdentifier recordOid, User user) {
     switch (recordOid.getPrefix()) {
       case SA:
-      case IT:
         return sampleApiMgr.assertUserCanReadSample(recordOid.getDbId(), user);
+      case IT:
+        return sampleApiMgr.assertUserCanReadSampleTemplate(recordOid.getDbId(), user);
       case SS:
         return subSampleApiMgr.assertUserCanReadSubSample(recordOid.getDbId(), user);
       case IC:

--- a/src/main/java/com/researchspace/api/v1/controller/SampleApiPostFullValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleApiPostFullValidator.java
@@ -4,7 +4,7 @@ import com.researchspace.api.v1.controller.SamplesApiController.ApiSampleFullPos
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.api.v1.service.ApiFieldsHelper;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.units.RSUnitDef;
 import java.util.List;
@@ -92,7 +92,7 @@ public class SampleApiPostFullValidator implements Validator {
 
   private void validateQuantityUnit(Errors errors, ApiSampleFullPost apiSamplePost) {
     ApiSampleWithFullSubSamples postedApiSample = apiSamplePost.getApiSample();
-    Sample template = apiSamplePost.getTemplate();
+    SampleTemplate template = apiSamplePost.getTemplate();
     if (template != null && postedApiSample.getQuantity() != null) {
       RSUnitDef templateUnit = RSUnitDef.getUnitById(template.getDefaultUnitId());
       RSUnitDef sampleUnit = RSUnitDef.getUnitById(postedApiSample.getQuantity().getUnitId());

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplatesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplatesApiController.java
@@ -18,7 +18,8 @@ import com.researchspace.api.v1.model.ApiSampleTemplateSearchResult;
 import com.researchspace.api.v1.service.impl.SpringMultipartFileAdapter;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.IconEntity;
 import com.researchspace.service.IconImageManager;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
@@ -65,7 +66,8 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
     if (apiPgCrit == null) {
       apiPgCrit = new InventoryApiPaginationCriteria();
     }
-    PaginationCriteria<Sample> pgCrit = getPaginationCriteriaForApiSearch(apiPgCrit, Sample.class);
+    PaginationCriteria<SampleTemplate> pgCrit =
+        getPaginationCriteriaForApiSearch(apiPgCrit, SampleTemplate.class);
 
     String ownedBy = null;
     InventorySearchDeletedOption deletedItemsOption = null;
@@ -105,7 +107,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
   @Override
   public ApiInventoryRecordRevisionList getSampleTemplateAllRevisions(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
-    Sample dbTemplate = sampleApiMgr.assertUserCanReadSample(id, user);
+    SampleEntity dbTemplate = sampleApiMgr.assertUserCanReadSample(id, user);
     if (!dbTemplate.isTemplate()) {
       // a plain sample id is not addressable through the template endpoint
       throw new NotFoundException(createNotFoundMessage("Sample template", id));
@@ -154,7 +156,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
 
     // update incoming object's id which could be omitted
     incomingTemplate.setIdIfNotSet(id);
-    Sample dbSample = sampleApiMgr.assertUserCanEditSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanEditSample(id, user);
     assertIsSampleTemplate(dbSample);
 
     // update the template
@@ -173,7 +175,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
     }
   }
 
-  private void assertIsSampleTemplate(Sample sampleToCheck) {
+  private void assertIsSampleTemplate(SampleEntity sampleToCheck) {
     Validate.isTrue(
         sampleToCheck.isTemplate(),
         "Seems like the sample is not a template, please use /samples endpoint for sample actions");
@@ -183,7 +185,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
   public ApiSampleTemplate deleteSampleTemplate(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
 
-    Sample dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
     assertIsSampleTemplate(dbSample);
     return (ApiSampleTemplate) sampleApiMgr.markSampleAsDeleted(id, false, user);
   }
@@ -192,7 +194,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
   public ApiSampleTemplate restoreDeletedSampleTemplate(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
 
-    Sample dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
     assertIsSampleTemplate(dbSample);
     return (ApiSampleTemplate) sampleApiMgr.restoreDeletedSample(id, user, true);
   }
@@ -216,7 +218,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
       @PathVariable Long templateId, MultipartFile file, @RequestAttribute(name = "user") User user)
       throws BindException, IOException {
 
-    Sample template = sampleApiMgr.assertUserCanReadSample(templateId, user);
+    SampleEntity template = sampleApiMgr.assertUserCanReadSample(templateId, user);
     Optional<BufferedImage> img =
         getBufferedImageFromUploadedFile(new SpringMultipartFileAdapter(file));
     if (!img.isPresent()) {
@@ -233,7 +235,9 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
     return result;
   }
 
-  private ApiSampleInfo convertToApiSampleTemplateInfo(User user, Sample newTemplate) {
+  // Intentionally returns the ApiSampleInfo shape (not ApiSampleTemplateInfo): this endpoint's
+  // JSON payload has always been the info shape, and changing the class changes the payload.
+  private ApiSampleInfo convertToApiSampleTemplateInfo(User user, SampleEntity newTemplate) {
     ApiSampleInfo rc = new ApiSampleInfo(newTemplate);
     return rc;
   }
@@ -278,7 +282,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
 
     // find the template
-    Sample template = sampleApiMgr.assertUserCanReadSample(id, user);
+    SampleEntity template = sampleApiMgr.assertUserCanReadSample(id, user);
     assertIsSampleTemplate(template);
 
     // find connected user's samples taken from non-latest template
@@ -308,7 +312,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
   public ApiInventoryRecordInfo duplicate(Long id, User user) {
     /* there are default templates for which user only has read permissions,
      * but should still be be able to copy and reuse */
-    Sample dbSample = sampleApiMgr.assertUserCanReadSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanReadSample(id, user);
     assertIsSampleTemplate(dbSample);
 
     ApiSampleTemplate copy = sampleApiMgr.duplicateTemplate(id, user);

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplatesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplatesApiController.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.ws.rs.NotFoundException;
-import org.apache.commons.lang3.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -107,11 +106,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
   @Override
   public ApiInventoryRecordRevisionList getSampleTemplateAllRevisions(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
-    SampleEntity dbTemplate = sampleApiMgr.assertUserCanReadSample(id, user);
-    if (!dbTemplate.isTemplate()) {
-      // a plain sample id is not addressable through the template endpoint
-      throw new NotFoundException(createNotFoundMessage("Sample template", id));
-    }
+    SampleEntity dbTemplate = sampleApiMgr.assertUserCanReadSampleTemplate(id, user);
     ApiInventoryRecordRevisionList revisions =
         inventoryAuditMgr.getInventoryRecordRevisions(dbTemplate);
     for (ApiInventoryRecordRevisionList.ApiInventoryRecordRevision templateRev :
@@ -156,8 +151,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
 
     // update incoming object's id which could be omitted
     incomingTemplate.setIdIfNotSet(id);
-    SampleEntity dbSample = sampleApiMgr.assertUserCanEditSample(id, user);
-    assertIsSampleTemplate(dbSample);
+    sampleApiMgr.assertUserCanEditSampleTemplate(id, user);
 
     // update the template
     ApiSampleTemplate updatedTemplate =
@@ -175,18 +169,11 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
     }
   }
 
-  private void assertIsSampleTemplate(SampleEntity sampleToCheck) {
-    Validate.isTrue(
-        sampleToCheck.isTemplate(),
-        "Seems like the sample is not a template, please use /samples endpoint for sample actions");
-  }
-
   @Override
   public ApiSampleTemplate deleteSampleTemplate(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
 
-    SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
-    assertIsSampleTemplate(dbSample);
+    sampleApiMgr.assertUserCanDeleteSampleTemplate(id, user);
     return (ApiSampleTemplate) sampleApiMgr.markSampleAsDeleted(id, false, user);
   }
 
@@ -194,8 +181,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
   public ApiSampleTemplate restoreDeletedSampleTemplate(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
 
-    SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
-    assertIsSampleTemplate(dbSample);
+    sampleApiMgr.assertUserCanDeleteSampleTemplate(id, user);
     return (ApiSampleTemplate) sampleApiMgr.restoreDeletedSample(id, user, true);
   }
 
@@ -203,14 +189,15 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
   public ResponseEntity<byte[]> getSampleTemplateImage(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) throws IOException {
     return doImageResponse(
-        user, () -> sampleApiMgr.assertUserCanReadSample(id, user).getImageFileProperty());
+        user, () -> sampleApiMgr.assertUserCanReadSampleTemplate(id, user).getImageFileProperty());
   }
 
   @Override
   public ResponseEntity<byte[]> getSampleTemplateThumbnail(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) throws IOException {
     return doImageResponse(
-        user, () -> sampleApiMgr.assertUserCanReadSample(id, user).getThumbnailFileProperty());
+        user,
+        () -> sampleApiMgr.assertUserCanReadSampleTemplate(id, user).getThumbnailFileProperty());
   }
 
   @Override
@@ -218,7 +205,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
       @PathVariable Long templateId, MultipartFile file, @RequestAttribute(name = "user") User user)
       throws BindException, IOException {
 
-    SampleEntity template = sampleApiMgr.assertUserCanReadSample(templateId, user);
+    SampleEntity template = sampleApiMgr.assertUserCanReadSampleTemplate(templateId, user);
     Optional<BufferedImage> img =
         getBufferedImageFromUploadedFile(new SpringMultipartFileAdapter(file));
     if (!img.isPresent()) {
@@ -267,7 +254,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
 
     // update incoming object's id which could be omitted
     incomingTemplate.setIdIfNotSet(id);
-    sampleApiMgr.assertUserCanEditSample(id, user);
+    sampleApiMgr.assertUserCanEditSampleTemplate(id, user);
 
     // updated sample
     ApiSampleTemplate updatedTemplate =
@@ -282,8 +269,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
 
     // find the template
-    SampleEntity template = sampleApiMgr.assertUserCanReadSample(id, user);
-    assertIsSampleTemplate(template);
+    SampleEntity template = sampleApiMgr.assertUserCanReadSampleTemplate(id, user);
 
     // find connected user's samples taken from non-latest template
     List<ApiInventoryRecordInfo> samplesFromNonLatestTemplate =
@@ -312,8 +298,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
   public ApiInventoryRecordInfo duplicate(Long id, User user) {
     /* there are default templates for which user only has read permissions,
      * but should still be be able to copy and reuse */
-    SampleEntity dbSample = sampleApiMgr.assertUserCanReadSample(id, user);
-    assertIsSampleTemplate(dbSample);
+    sampleApiMgr.assertUserCanReadSampleTemplate(id, user);
 
     ApiSampleTemplate copy = sampleApiMgr.duplicateTemplate(id, user);
     buildAndAddInventoryRecordLinks(copy);

--- a/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
@@ -15,6 +15,8 @@ import com.researchspace.api.v1.model.ApiTargetLocation;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import java.io.IOException;
@@ -54,7 +56,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     ApiSampleWithFullSubSamples apiSample;
     User user;
     // may be null
-    Sample template;
+    SampleTemplate template;
   }
 
   // this class doesn't seem to be used at all, nor its validator
@@ -66,9 +68,9 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     User user;
     Long templateId;
     // may be null
-    Sample template;
+    SampleTemplate template;
     // the db sample matching the api sample
-    Sample dbSample;
+    SampleEntity dbSample;
   }
 
   @Override
@@ -85,6 +87,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     if (apiPgCrit == null) {
       apiPgCrit = new InventoryApiPaginationCriteria();
     }
+    // samples-only listing: Sample.class (not SampleEntity.class) is correct here
     PaginationCriteria<Sample> pgCrit = getPaginationCriteriaForApiSearch(apiPgCrit, Sample.class);
 
     String ownedBy = null;
@@ -141,7 +144,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     return result;
   }
 
-  private void assertNotSampleTemplate(Sample dbSample) {
+  private void assertNotSampleTemplate(SampleEntity dbSample) {
     assertNotSampleTemplate(dbSample.isTemplate());
   }
 
@@ -157,7 +160,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   public void validateCreateSampleInput(
       ApiSampleWithFullSubSamples apiSample, BindingResult errors, User user) throws BindException {
 
-    Sample template = verifyTemplate(apiSample, errors, user);
+    SampleTemplate template = verifyTemplate(apiSample, errors, user);
     // we validate the posted object. We can set errors on individual fields in this validator (
     // doesn't need template)
     inputValidator.validate(apiSample, sampleApiPostValidator, errors);
@@ -194,7 +197,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   }
 
   // ok for template id to be null
-  private Sample verifyTemplate(ApiSampleInfo apiSample, BindingResult errors, User user)
+  private SampleTemplate verifyTemplate(ApiSampleInfo apiSample, BindingResult errors, User user)
       throws BindException {
     if (apiSample.getTemplateId() == null) {
       return null;
@@ -259,7 +262,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     validateUpdateSampleInput(incomingSample, errors);
     // update incoming object's id which could be omitted
     incomingSample.setIdIfNotSet(id);
-    Sample dbSample = sampleApiMgr.assertUserCanEditSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanEditSample(id, user);
     assertNotSampleTemplate(dbSample);
 
     // update the sample
@@ -275,7 +278,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
       @RequestParam(name = "forceDelete", required = false) boolean forceDelete,
       @RequestAttribute(name = "user") User user) {
 
-    Sample dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
     assertNotSampleTemplate(dbSample);
 
     ApiSample result;
@@ -290,7 +293,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   @Override
   public ApiSample restoreDeletedSample(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
-    Sample dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
     assertNotSampleTemplate(dbSample);
     return sampleApiMgr.restoreDeletedSample(id, user, true);
   }
@@ -331,7 +334,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   @Override
   public ApiSampleWithFullSubSamples duplicate(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
-    Sample dbSample = sampleApiMgr.assertUserCanReadSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanReadSample(id, user);
     assertNotSampleTemplate(dbSample);
 
     ApiSampleWithFullSubSamples copy = sampleApiMgr.duplicate(id, user);
@@ -351,7 +354,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   public ApiInventoryRecordRevisionList getSampleAllRevisions(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
 
-    Sample dbSample = sampleApiMgr.assertUserCanReadSample(id, user);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanReadSample(id, user);
     ApiInventoryRecordRevisionList revisions =
         inventoryAuditMgr.getInventoryRecordRevisions(dbSample);
     for (ApiInventoryRecordRevision sampleRev : revisions.getRevisions()) {

--- a/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.validation.Valid;
@@ -151,6 +152,23 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     }
   }
 
+  /**
+   * If {@code id} belongs to a SampleTemplate the caller is permitted to access, reject the request
+   * with the documented endpoint-mismatch error. The permission-aware template assert runs first so
+   * template existence is never revealed to callers without access: a non-template id (or one the
+   * caller cannot see) throws NotFoundException and falls through to normal sample handling. {@code
+   * templatePermissionCheck} is the read/edit/delete SampleTemplate assert for the operation.
+   */
+  private void rejectIfSampleTemplate(
+      Long id, User user, BiConsumer<Long, User> templatePermissionCheck) {
+    try {
+      templatePermissionCheck.accept(id, user);
+    } catch (NotFoundException notATemplateOrNoReadAccess) {
+      return;
+    }
+    throw new IllegalArgumentException("Please use /sampleTemplates endpoint for template actions");
+  }
+
   /* errors might already be populated with simple validation errors using javax.validation annotations
    * by Spring's automatic validation */
   public void validateCreateSampleInput(
@@ -258,9 +276,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     validateUpdateSampleInput(incomingSample, errors);
     // update incoming object's id which could be omitted
     incomingSample.setIdIfNotSet(id);
-    // reject a template id with the documented error: assertUserCanEditSample resolves only
-    // Sample rows (DTYPE='Sample') and would otherwise surface a 404 for a template id
-    assertNotSampleTemplate(sampleApiMgr.getSampleById(id, user).isSampleTemplate());
+    rejectIfSampleTemplate(id, user, sampleApiMgr::assertUserCanEditSampleTemplate);
     sampleApiMgr.assertUserCanEditSample(id, user);
 
     // update the sample
@@ -276,7 +292,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
       @RequestParam(name = "forceDelete", required = false) boolean forceDelete,
       @RequestAttribute(name = "user") User user) {
 
-    assertNotSampleTemplate(sampleApiMgr.getSampleById(id, user).isSampleTemplate());
+    rejectIfSampleTemplate(id, user, sampleApiMgr::assertUserCanDeleteSampleTemplate);
     SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
 
     ApiSample result;
@@ -291,7 +307,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   @Override
   public ApiSample restoreDeletedSample(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
-    assertNotSampleTemplate(sampleApiMgr.getSampleById(id, user).isSampleTemplate());
+    rejectIfSampleTemplate(id, user, sampleApiMgr::assertUserCanDeleteSampleTemplate);
     sampleApiMgr.assertUserCanDeleteSample(id, user);
     return sampleApiMgr.restoreDeletedSample(id, user, true);
   }
@@ -332,7 +348,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   @Override
   public ApiSampleWithFullSubSamples duplicate(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
-    assertNotSampleTemplate(sampleApiMgr.getSampleById(id, user).isSampleTemplate());
+    rejectIfSampleTemplate(id, user, sampleApiMgr::assertUserCanReadSampleTemplate);
     sampleApiMgr.assertUserCanReadSample(id, user);
 
     ApiSampleWithFullSubSamples copy = sampleApiMgr.duplicate(id, user);

--- a/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
@@ -144,10 +144,6 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     return result;
   }
 
-  private void assertNotSampleTemplate(SampleEntity dbSample) {
-    assertNotSampleTemplate(dbSample.isTemplate());
-  }
-
   private void assertNotSampleTemplate(boolean sampleTemplateFlag) {
     if (sampleTemplateFlag) {
       throw new IllegalArgumentException(
@@ -262,8 +258,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     validateUpdateSampleInput(incomingSample, errors);
     // update incoming object's id which could be omitted
     incomingSample.setIdIfNotSet(id);
-    SampleEntity dbSample = sampleApiMgr.assertUserCanEditSample(id, user);
-    assertNotSampleTemplate(dbSample);
+    sampleApiMgr.assertUserCanEditSample(id, user);
 
     // update the sample
     ApiSample updatedSample = sampleApiMgr.updateApiSample(incomingSample, user);
@@ -279,7 +274,6 @@ public class SamplesApiController extends BaseApiInventoryController implements 
       @RequestAttribute(name = "user") User user) {
 
     SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
-    assertNotSampleTemplate(dbSample);
 
     ApiSample result;
     String sampleLock = dbSample.getGlobalIdentifier().intern();
@@ -293,8 +287,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   @Override
   public ApiSample restoreDeletedSample(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
-    SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
-    assertNotSampleTemplate(dbSample);
+    sampleApiMgr.assertUserCanDeleteSample(id, user);
     return sampleApiMgr.restoreDeletedSample(id, user, true);
   }
 
@@ -334,8 +327,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   @Override
   public ApiSampleWithFullSubSamples duplicate(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
-    SampleEntity dbSample = sampleApiMgr.assertUserCanReadSample(id, user);
-    assertNotSampleTemplate(dbSample);
+    sampleApiMgr.assertUserCanReadSample(id, user);
 
     ApiSampleWithFullSubSamples copy = sampleApiMgr.duplicate(id, user);
     buildAndAddInventoryRecordLinks(copy);

--- a/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
@@ -276,6 +276,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
       @RequestParam(name = "forceDelete", required = false) boolean forceDelete,
       @RequestAttribute(name = "user") User user) {
 
+    assertNotSampleTemplate(sampleApiMgr.getSampleById(id, user).isSampleTemplate());
     SampleEntity dbSample = sampleApiMgr.assertUserCanDeleteSample(id, user);
 
     ApiSample result;
@@ -290,6 +291,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   @Override
   public ApiSample restoreDeletedSample(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
+    assertNotSampleTemplate(sampleApiMgr.getSampleById(id, user).isSampleTemplate());
     sampleApiMgr.assertUserCanDeleteSample(id, user);
     return sampleApiMgr.restoreDeletedSample(id, user, true);
   }
@@ -330,6 +332,7 @@ public class SamplesApiController extends BaseApiInventoryController implements 
   @Override
   public ApiSampleWithFullSubSamples duplicate(
       @PathVariable Long id, @RequestAttribute(name = "user") User user) {
+    assertNotSampleTemplate(sampleApiMgr.getSampleById(id, user).isSampleTemplate());
     sampleApiMgr.assertUserCanReadSample(id, user);
 
     ApiSampleWithFullSubSamples copy = sampleApiMgr.duplicate(id, user);

--- a/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
@@ -258,6 +258,9 @@ public class SamplesApiController extends BaseApiInventoryController implements 
     validateUpdateSampleInput(incomingSample, errors);
     // update incoming object's id which could be omitted
     incomingSample.setIdIfNotSet(id);
+    // reject a template id with the documented error: assertUserCanEditSample resolves only
+    // Sample rows (DTYPE='Sample') and would otherwise surface a 404 for a template id
+    assertNotSampleTemplate(sampleApiMgr.getSampleById(id, user).isSampleTemplate());
     sampleApiMgr.assertUserCanEditSample(id, user);
 
     // update the sample

--- a/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SamplesApiController.java
@@ -154,18 +154,27 @@ public class SamplesApiController extends BaseApiInventoryController implements 
 
   /**
    * If {@code id} belongs to a SampleTemplate the caller is permitted to access, reject the request
-   * with the documented endpoint-mismatch error. The permission-aware template assert runs first so
-   * template existence is never revealed to callers without access: a non-template id (or one the
-   * caller cannot see) throws NotFoundException and falls through to normal sample handling. {@code
-   * templatePermissionCheck} is the read/edit/delete SampleTemplate assert for the operation.
+   * with the documented endpoint-mismatch error.
+   *
+   * <p>Template-ness is resolved with the non-throwing {@code getIfExists} rather than by catching
+   * the kind-typed template assert. That assert participates in any enclosing transaction (e.g. the
+   * single transaction wrapping a bulk operation), so throwing-and-swallowing it for the common
+   * plain-sample id would mark that transaction rollback-only and surface as an {@link
+   * org.springframework.transaction.UnexpectedRollbackException} at commit, even though the request
+   * is valid.
+   *
+   * <p>Only once the id is known to be a template is the permission-aware {@code
+   * templatePermissionCheck} (the read/edit/delete SampleTemplate assert for the operation) run, so
+   * a caller without access still falls through to normal not-found sample handling and template
+   * existence is never revealed. Throwing on that branch is harmless: it is a reject/error path
+   * that rolls the transaction back anyway.
    */
   private void rejectIfSampleTemplate(
       Long id, User user, BiConsumer<Long, User> templatePermissionCheck) {
-    try {
-      templatePermissionCheck.accept(id, user);
-    } catch (NotFoundException notATemplateOrNoReadAccess) {
-      return;
+    if (!sampleApiMgr.getIfExists(id).isSampleTemplate()) {
+      return; // a plain sample (non-template) id: let normal sample handling proceed
     }
+    templatePermissionCheck.accept(id, user);
     throw new IllegalArgumentException("Please use /sampleTemplates endpoint for template actions");
   }
 

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
@@ -20,6 +20,7 @@ import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.ExtraField;
 import com.researchspace.service.impl.DocumentTagManagerImpl;
@@ -33,6 +34,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.apache.commons.collections.CollectionUtils;
+import org.hibernate.Hibernate;
 import org.springframework.beans.BeanUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -159,10 +161,22 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
   @JsonProperty(value = "newBase64Image", access = Access.WRITE_ONLY)
   private String newBase64Image;
 
+  /*
+   * Lazily-loaded references (Envers revision reads in particular) arrive as proxies typed to
+   * the abstract hierarchy root (e.g. SampleEntity), which never satisfy instanceof checks
+   * against the concrete subclasses; unwrap before any class-based dispatch.
+   */
+  @SuppressWarnings("unchecked")
+  static <T> T unproxy(T entity) {
+    return (T) Hibernate.unproxy(entity);
+  }
+
   public static ApiInventoryRecordInfo fromInventoryRecord(InventoryRecord invRecord) {
-    if (invRecord.isSample()) {
-      Sample sample = (Sample) invRecord;
-      return sample.isTemplate() ? new ApiSampleTemplateInfo(sample) : new ApiSampleInfo(sample);
+    invRecord = unproxy(invRecord);
+    if (invRecord instanceof SampleTemplate) {
+      return new ApiSampleTemplateInfo((SampleTemplate) invRecord);
+    } else if (invRecord instanceof Sample) {
+      return new ApiSampleInfo((Sample) invRecord);
     } else if (invRecord.isSubSample()) {
       return new ApiSubSampleInfoWithSampleInfo((SubSample) invRecord);
     } else if (invRecord.isContainer()) {
@@ -178,9 +192,11 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
 
   public static ApiInventoryRecordInfo fromInventoryRecordToFullApiRecord(
       InventoryRecord invRecord) {
-    if (invRecord.isSample()) {
-      Sample sample = (Sample) invRecord;
-      return sample.isTemplate() ? new ApiSampleTemplate(sample) : new ApiSample(sample);
+    invRecord = unproxy(invRecord);
+    if (invRecord instanceof SampleTemplate) {
+      return new ApiSampleTemplate((SampleTemplate) invRecord);
+    } else if (invRecord instanceof Sample) {
+      return new ApiSample((Sample) invRecord);
     } else if (invRecord.isSubSample()) {
       return new ApiSubSample((SubSample) invRecord);
     } else if (invRecord.isContainer()) {

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
@@ -163,8 +163,8 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
 
   /*
    * Lazily-loaded references (Envers revision reads in particular) arrive as proxies typed to
-   * the abstract hierarchy root (e.g. SampleEntity), which never satisfy instanceof checks
-   * against the concrete subclasses; unwrap before any class-based dispatch.
+   * the abstract hierarchy root (e.g. SampleEntity). The is*() checks dispatch through proxies,
+   * but the casts to concrete subclasses still need the real instance, so unwrap first.
    */
   @SuppressWarnings("unchecked")
   static <T> T unproxy(T entity) {
@@ -173,9 +173,9 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
 
   public static ApiInventoryRecordInfo fromInventoryRecord(InventoryRecord invRecord) {
     invRecord = unproxy(invRecord);
-    if (invRecord instanceof SampleTemplate) {
+    if (invRecord.isSampleTemplate()) {
       return new ApiSampleTemplateInfo((SampleTemplate) invRecord);
-    } else if (invRecord instanceof Sample) {
+    } else if (invRecord.isSample()) {
       return new ApiSampleInfo((Sample) invRecord);
     } else if (invRecord.isSubSample()) {
       return new ApiSubSampleInfoWithSampleInfo((SubSample) invRecord);
@@ -193,9 +193,9 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
   public static ApiInventoryRecordInfo fromInventoryRecordToFullApiRecord(
       InventoryRecord invRecord) {
     invRecord = unproxy(invRecord);
-    if (invRecord instanceof SampleTemplate) {
+    if (invRecord.isSampleTemplate()) {
       return new ApiSampleTemplate((SampleTemplate) invRecord);
-    } else if (invRecord instanceof Sample) {
+    } else if (invRecord.isSample()) {
       return new ApiSample((Sample) invRecord);
     } else if (invRecord.isSubSample()) {
       return new ApiSubSample((SubSample) invRecord);

--- a/src/main/java/com/researchspace/api/v1/model/ApiSample.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSample.java
@@ -3,7 +3,7 @@ package com.researchspace.api.v1.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,7 +67,7 @@ public class ApiSample extends ApiSampleWithoutSubSamples {
   @JsonProperty(value = "canBeDeleted")
   private Boolean canBeDeleted;
 
-  public ApiSample(Sample sample) {
+  public ApiSample(SampleEntity sample) {
     super(sample);
 
     for (SubSample subSample : sample.getActiveSubSamples()) {

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleInfo.java
@@ -11,6 +11,7 @@ import com.researchspace.api.v1.controller.BaseApiInventoryController;
 import com.researchspace.core.util.jsonserialisers.LocalDateDeserialiser;
 import com.researchspace.core.util.jsonserialisers.LocalDateSerialiser;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SampleSource;
 import com.researchspace.model.units.ValidTemperature;
 import java.math.BigDecimal;
@@ -119,7 +120,7 @@ public class ApiSampleInfo extends ApiInventoryRecordInfo {
     setType(ApiInventoryRecordType.SAMPLE);
   }
 
-  public ApiSampleInfo(Sample sample) {
+  public ApiSampleInfo(SampleEntity sample) {
     super(sample);
 
     if (sample.getQuantityInfo() != null) {
@@ -134,11 +135,17 @@ public class ApiSampleInfo extends ApiInventoryRecordInfo {
         new ApiSubSampleAlias(sample.getSubSampleAlias(), sample.getSubSampleAliasPlural()));
     setSubSamplesCount(sample.getActiveSubSamplesCount());
     setTemplate(sample.isTemplate());
-    // may be null if the sample isn't created from a template.
-    if (sample.getSTemplate() != null) {
-      setTemplateId(sample.getSTemplate().getId());
-      setTemplateVersion(sample.getSTemplateLinkedVersion());
-      setTemplateImageAvailable(sample.getSTemplate().getImageFileProperty() != null);
+    // unwrap lazy proxies typed to the abstract SampleEntity root, which never satisfy
+    // instanceof checks against the concrete subclasses (e.g. Envers revision reads)
+    SampleEntity unproxiedSample = unproxy(sample);
+    if (unproxiedSample instanceof Sample) {
+      Sample nonTemplateSample = (Sample) unproxiedSample;
+      // may be null if the sample isn't created from a template.
+      if (nonTemplateSample.getSTemplate() != null) {
+        setTemplateId(nonTemplateSample.getSTemplate().getId());
+        setTemplateVersion(nonTemplateSample.getSTemplateLinkedVersion());
+        setTemplateImageAvailable(nonTemplateSample.getSTemplate().getImageFileProperty() != null);
+      }
     }
     if (sample.getStorageTempMin() != null) {
       setStorageTempMin(new ApiQuantityInfo(sample.getStorageTempMin()));
@@ -151,7 +158,7 @@ public class ApiSampleInfo extends ApiInventoryRecordInfo {
     setVersion(sample.getVersion());
   }
 
-  protected boolean applyChangesToDatabaseSample(Sample sample) {
+  protected boolean applyChangesToDatabaseSample(SampleEntity sample) {
     boolean contentChanged = super.applyChangesToDatabaseInventoryRecord(sample);
 
     if (storageTempMin != null

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleInfo.java
@@ -135,11 +135,10 @@ public class ApiSampleInfo extends ApiInventoryRecordInfo {
         new ApiSubSampleAlias(sample.getSubSampleAlias(), sample.getSubSampleAliasPlural()));
     setSubSamplesCount(sample.getActiveSubSamplesCount());
     setTemplate(sample.isTemplate());
-    // unwrap lazy proxies typed to the abstract SampleEntity root, which never satisfy
-    // instanceof checks against the concrete subclasses (e.g. Envers revision reads)
-    SampleEntity unproxiedSample = unproxy(sample);
-    if (unproxiedSample instanceof Sample) {
-      Sample nonTemplateSample = (Sample) unproxiedSample;
+    if (sample.isSample()) {
+      // the cast still needs the real instance: lazy references (e.g. Envers revision reads)
+      // are proxies typed to the abstract SampleEntity root
+      Sample nonTemplateSample = (Sample) unproxy(sample);
       // may be null if the sample isn't created from a template.
       if (nonTemplateSample.getSTemplate() != null) {
         setTemplateId(nonTemplateSample.getSTemplate().getId());

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplate.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplate.java
@@ -4,11 +4,10 @@ package com.researchspace.api.v1.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.apache.commons.lang3.Validate;
 
 /** API representation of an Inventory Sample, with information about SubSamples. */
 @Data
@@ -75,15 +74,13 @@ public class ApiSampleTemplate extends ApiSample {
     setType(ApiInventoryRecordType.SAMPLE_TEMPLATE);
   }
 
-  public ApiSampleTemplate(Sample template) {
+  public ApiSampleTemplate(SampleTemplate template) {
     super(template);
     setType(ApiInventoryRecordType.SAMPLE_TEMPLATE);
-    Validate.isTrue(
-        template.isTemplate(), String.format("Sample '%d' is not a template", template.getId()));
     setDefaultUnitId(template.getDefaultUnitId());
   }
 
-  public boolean applyChangesToDatabaseTemplate(Sample dbSample, User user) {
+  public boolean applyChangesToDatabaseTemplate(SampleTemplate dbSample, User user) {
     boolean contentChanged = false;
 
     if (defaultUnitId != null && !defaultUnitId.equals(dbSample.getDefaultUnitId())) {

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplateInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplateInfo.java
@@ -3,10 +3,9 @@ package com.researchspace.api.v1.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.Validate;
 
 /** The SampleTemplate on which a Sample is based. Does not include fields. */
 @Data
@@ -58,11 +57,9 @@ public class ApiSampleTemplateInfo extends ApiSampleInfo {
     setType(ApiInventoryRecordType.SAMPLE_TEMPLATE);
   }
 
-  public ApiSampleTemplateInfo(Sample template) {
+  public ApiSampleTemplateInfo(SampleTemplate template) {
     super(template);
     setType(ApiInventoryRecordType.SAMPLE_TEMPLATE);
-    Validate.isTrue(
-        template.isTemplate(), String.format("Sample '%d' is not a template", template.getId()));
     setDefaultUnitId(template.getDefaultUnitId());
   }
 }

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplatePost.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleTemplatePost.java
@@ -1,7 +1,7 @@
 package com.researchspace.api.v1.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.units.RSUnitDef;
@@ -34,7 +34,7 @@ public class ApiSampleTemplatePost extends ApiSampleTemplateInfo {
   @JsonProperty(value = "sharedWith")
   private List<ApiGroupInfoWithSharedFlag> sharedWith;
 
-  public ApiSampleTemplatePost(Sample template) {
+  public ApiSampleTemplatePost(SampleTemplate template) {
     super(template);
     for (InventoryEntityField f : template.getActiveFields()) {
       fields.add(new ApiInventoryEntityField(f));

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleWithoutSubSamples.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleWithoutSubSamples.java
@@ -4,7 +4,7 @@ package com.researchspace.api.v1.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.field.ExtraField;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import java.util.ArrayList;
@@ -72,7 +72,7 @@ public class ApiSampleWithoutSubSamples extends ApiSampleInfo {
   @JsonProperty(value = "sharedWith")
   private List<ApiGroupInfoWithSharedFlag> sharedWith;
 
-  protected ApiSampleWithoutSubSamples(Sample sample) {
+  protected ApiSampleWithoutSubSamples(SampleEntity sample) {
     super(sample);
 
     for (InventoryEntityField field : sample.getActiveFields()) {
@@ -103,7 +103,7 @@ public class ApiSampleWithoutSubSamples extends ApiSampleInfo {
    * @param dbSample db entity to which incoming changes should be applied
    * @return if any change was applied
    */
-  public boolean applyChangesToDatabaseSample(Sample dbSample, User user) {
+  public boolean applyChangesToDatabaseSample(SampleEntity dbSample, User user) {
     boolean contentChanged = super.applyChangesToDatabaseSample(dbSample);
 
     if (fields != null) {

--- a/src/main/java/com/researchspace/dao/SampleDao.java
+++ b/src/main/java/com/researchspace/dao/SampleDao.java
@@ -9,8 +9,8 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Sample;
 import java.util.List;
 
-/** For DAO operations on Inventory Sample. */
-public interface SampleDao extends GenericDao<Sample, Long> {
+/** For DAO operations specific to Inventory {@link Sample} (not templates). */
+public interface SampleDao extends SampleEntityDao<Sample> {
 
   /**
    * @return Samples with a given name belonging to the user, or empty Array
@@ -57,50 +57,20 @@ public interface SampleDao extends GenericDao<Sample, Long> {
   Sample persistNewSample(Sample sample);
 
   /**
-   * Use this method over standard 'save' if subsamples of the sample were not modified but still
-   * should be re-indexed, e.g. after owner change.
-   *
-   * @return saved sample
+   * Returns all (non-template) samples that reference the given {@link FileProperty} as their image
+   * or thumbnail.
    */
-  Sample saveAndReindexSubSamples(Sample sample);
-
-  /**
-   * Get non-deleted sample templates ({@code template == true}) visible to the current user.
-   * Optionally, limit to templates belonging to particular owner
-   *
-   * @param pgCrit
-   * @param ownedBy (optional) limits results to samples belonging to particular owner
-   * @param deletedItemsOption
-   * @param user
-   * @return
-   */
-  ISearchResults<Sample> getTemplatesForUser(
-      PaginationCriteria<Sample> pgCrit,
-      String ownedBy,
-      InventorySearchDeletedOption deletedItemsOption,
-      User user);
-
-  /**
-   * @return username of the user who owns the default sample templates.
-   */
-  String getDefaultTemplatesOwner();
-
-  /**
-   * For use with new Templates RSINV-41 based on Samples. <br>
-   * Saves the sample, fields plus radio/choice definitions
-   *
-   * @return saved sample
-   */
-  Sample persistSampleTemplate(Sample sample);
-
-  Long getTemplateCount();
-
-  int saveIconId(Sample sample, Long iconId);
-
-  /** Should be only called in unit tests (I think). Sets stored default template owner to null. */
-  void resetDefaultTemplateOwner();
-
   List<Sample> getAllUsingImage(FileProperty fileProperty);
 
-  List<Sample> getAllTemplatesUsingImage(FileProperty fileProperty);
+  /**
+   * Returns {@code true} if an entity (sample <em>or</em> template) with the given name already
+   * exists for the given owner. This method deliberately counts across both discriminator values to
+   * preserve the legacy name-uniqueness behaviour that prevented a user from creating a sample and
+   * a template with the same name.
+   *
+   * @param name the name to check
+   * @param owner the owning user
+   * @return {@code true} if at least one sample or template with that name is owned by the user
+   */
+  boolean entityNameExistsForUser(String name, User owner);
 }

--- a/src/main/java/com/researchspace/dao/SampleEntityDao.java
+++ b/src/main/java/com/researchspace/dao/SampleEntityDao.java
@@ -1,0 +1,30 @@
+package com.researchspace.dao;
+
+import com.researchspace.model.inventory.SampleEntity;
+
+/** For DAO operations common to all Inventory {@link SampleEntity} subtypes. */
+public interface SampleEntityDao<T extends SampleEntity> extends GenericDao<T, Long> {
+
+  /**
+   * Updates the icon stored for the given entity.
+   *
+   * <p>The DML targets {@code SampleEntity} (the mapped superclass table) rather than a concrete
+   * subclass, so it applies correctly to both samples and templates. A subclass-scoped bulk update
+   * would silently skip rows belonging to the other discriminator value.
+   *
+   * @param sample the entity whose icon to update (only its id is used)
+   * @param iconId the new icon id to set
+   * @return the number of rows updated (0 or 1)
+   */
+  int saveIconId(SampleEntity sample, Long iconId);
+
+  /**
+   * Use instead of plain {@code save} when subsample rows have not been directly modified (so
+   * Hibernate will not cascade index updates to them) but they still need re-indexing, e.g. after
+   * an owner transfer on the parent.
+   *
+   * @param sample the entity to save
+   * @return the saved entity
+   */
+  T saveAndReindexSubSamples(T sample);
+}

--- a/src/main/java/com/researchspace/dao/SampleTemplateDao.java
+++ b/src/main/java/com/researchspace/dao/SampleTemplateDao.java
@@ -1,0 +1,49 @@
+package com.researchspace.dao;
+
+import com.axiope.search.InventorySearchConfig.InventorySearchDeletedOption;
+import com.researchspace.core.util.ISearchResults;
+import com.researchspace.model.FileProperty;
+import com.researchspace.model.PaginationCriteria;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.SampleTemplate;
+import java.util.List;
+
+/** For DAO operations specific to Inventory {@link SampleTemplate}. */
+public interface SampleTemplateDao extends SampleEntityDao<SampleTemplate> {
+
+  /**
+   * Get non-deleted sample templates visible to the current user. Optionally, limit to templates
+   * belonging to particular owner.
+   *
+   * @param pgCrit
+   * @param ownedBy (optional) limits results to samples belonging to particular owner
+   * @param deletedItemsOption
+   * @param user
+   * @return
+   */
+  ISearchResults<SampleTemplate> getTemplatesForUser(
+      PaginationCriteria<SampleTemplate> pgCrit,
+      String ownedBy,
+      InventorySearchDeletedOption deletedItemsOption,
+      User user);
+
+  /**
+   * @return username of the user who owns the default sample templates.
+   */
+  String getDefaultTemplatesOwner();
+
+  /**
+   * For use with new Templates RSINV-41 based on Samples. <br>
+   * Saves the template, fields plus radio/choice definitions.
+   *
+   * @return saved template
+   */
+  SampleTemplate persistSampleTemplate(SampleTemplate template);
+
+  Long getTemplateCount();
+
+  List<SampleTemplate> getAllTemplatesUsingImage(FileProperty fileProperty);
+
+  /** Sets stored default template owner cache to null. Should only be called in tests. */
+  void resetDefaultTemplateOwner();
+}

--- a/src/main/java/com/researchspace/dao/customliquibaseupdates/CreateWorkbenchAndMoveSubSamples_1_70.java
+++ b/src/main/java/com/researchspace/dao/customliquibaseupdates/CreateWorkbenchAndMoveSubSamples_1_70.java
@@ -102,7 +102,12 @@ public class CreateWorkbenchAndMoveSubSamples_1_70 extends AbstractCustomLiquiba
         sessionFactory
             .getCurrentSession()
             .createQuery(
-                "from SubSample where sample.owner=:owner and sample.template = false and"
+                // 'sample.class = Sample' replaces the legacy 'sample.template = false': it
+                // excludes subsamples of sample templates via the discriminator, since the
+                // 'template' boolean no longer exists as an entity property
+                // (the type(sample) = Sample form fails under Hibernate 5's HQL translator on
+                // implicit joins)
+                "from SubSample where sample.owner=:owner and sample.class = Sample and"
                     + " parentLocation is null",
                 SubSample.class)
             .setParameter("owner", user)

--- a/src/main/java/com/researchspace/dao/customliquibaseupdates/hashfilecontents/StoreFileContentsHashForInventoryFileProperties_rsdev292.java
+++ b/src/main/java/com/researchspace/dao/customliquibaseupdates/hashfilecontents/StoreFileContentsHashForInventoryFileProperties_rsdev292.java
@@ -94,9 +94,11 @@ public class StoreFileContentsHashForInventoryFileProperties_rsdev292
         sessionFactory
             .getCurrentSession()
             .createQuery(
+                // SampleEntity spans samples and sample templates so the backfill processes
+                // template rows too, as it did when Sample was a single entity
                 "select new com.researchspace.dao.customliquibaseupdates"
                     + ".hashfilecontents.ImageThumbnailDTO(s.imageFileProperty,"
-                    + " s.thumbnailFileProperty) from Sample s",
+                    + " s.thumbnailFileProperty) from SampleEntity s",
                 ImageThumbnailDTO.class)
             .list();
 

--- a/src/main/java/com/researchspace/dao/hibernate/FileMetadataHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FileMetadataHibernate.java
@@ -24,7 +24,13 @@ import com.researchspace.model.record.ObjectToIdPropertyTransformer;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
@@ -350,11 +356,12 @@ public class FileMetadataHibernate extends GenericDaoHibernate<FileProperty, Lon
 
   @Override
   public boolean doesUserOwnDocWithHash(User user, String contentsHash) {
+    // SampleEntity spans samples and sample templates, both of which can use the image
     long sampleHits =
         (long)
             getSession()
                 .createQuery(
-                    "select count(*) from Sample where owner = :user and"
+                    "select count(*) from SampleEntity where owner = :user and"
                         + " (imageFileProperty.contentsHash = :contentsHash or"
                         + " thumbnailFileProperty.contentsHash = :contentsHash) ")
                 .setParameter("user", user)

--- a/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
@@ -25,7 +25,6 @@ import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleEntity;
-import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
@@ -424,13 +423,13 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
   }
 
   private boolean isMatchingSearchType(InventoryRecord foundRec, InventorySearchType searchType) {
-    // note: a SampleTemplate's type is SAMPLE, so the type-name arm matches templates for SAMPLE
-    // searches, exactly as before the Sample/SampleTemplate split; templates are then dropped from
-    // SAMPLE results by isMatchingTemplateOption
+    // a template's type is SAMPLE_TEMPLATE, so the type-name arm no longer matches templates for
+    // SAMPLE searches (isMatchingTemplateOption used to drop them later; same outcome), and the
+    // explicit last arm matches them for TEMPLATE searches
     return searchType == null
         || searchType.equals(InventorySearchType.ALL)
         || searchType.toString().equals(foundRec.getType().toString())
-        || (searchType.equals(InventorySearchType.TEMPLATE) && foundRec instanceof SampleTemplate);
+        || (searchType.equals(InventorySearchType.TEMPLATE) && foundRec.isSampleTemplate());
   }
 
   private boolean isMatchingDeletedItemsOption(
@@ -457,9 +456,9 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
         return foundRecParent != null && foundRecParent.getOid().equals(parentOid);
       }
     } else if (GlobalIdPrefix.IT.equals(parentOid.getPrefix())) {
-      // only concrete samples have a parent template; a template hit fails the instanceof check,
+      // only concrete samples have a parent template; a template hit fails the isSample() check,
       // matching the old behavior where a template's parentTemplateId was always null
-      return foundRec instanceof Sample
+      return foundRec.isSample()
           && parentOid.getDbId().equals(((Sample) foundRec).getParentTemplateId());
     } else if (GlobalIdPrefix.SA.equals(parentOid.getPrefix())) {
       return foundRec.isSubSample()
@@ -477,7 +476,7 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
   }
 
   private boolean isMatchingTemplateOption(InventoryRecord record, InventorySearchType searchType) {
-    boolean isTemplate = record instanceof SampleTemplate;
+    boolean isTemplate = record.isSampleTemplate();
     if (isTemplate
         && !(searchType == InventorySearchType.ALL || searchType == InventorySearchType.TEMPLATE)) {
       return false;
@@ -492,8 +491,7 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
     }
     boolean notOwnedByDefaultTemplateOwner =
         !defaultTemplatesOwner.equals(rec.getOwner().getUsername());
-    boolean isSampleTemplate = rec instanceof SampleTemplate;
-    return notOwnedByDefaultTemplateOwner || isSampleTemplate;
+    return notOwnedByDefaultTemplateOwner || rec.isSampleTemplate();
   }
 
   private boolean canCurrentUserReadInvRec(InventoryRecord rec, User authenticatedUser) {

--- a/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
@@ -24,6 +24,8 @@ import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
@@ -320,7 +322,9 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
     switch (searchType) {
       case SAMPLE:
       case TEMPLATE:
-        resultClasses = new Class[] {Sample.class};
+        // Sample and SampleTemplate have separate Lucene indexes; targeting the abstract
+        // SampleEntity searches both, and search-type post-filtering picks the right kind
+        resultClasses = new Class[] {SampleEntity.class};
         break;
       case SUBSAMPLE:
         resultClasses = new Class[] {SubSample.class};
@@ -329,7 +333,7 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
         resultClasses = new Class[] {Container.class};
         break;
       case ALL:
-        resultClasses = new Class[] {Sample.class, SubSample.class, Container.class};
+        resultClasses = new Class[] {SampleEntity.class, SubSample.class, Container.class};
         break;
       default:
         throw new IllegalArgumentException("unknown requested search type: " + searchType);
@@ -420,12 +424,13 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
   }
 
   private boolean isMatchingSearchType(InventoryRecord foundRec, InventorySearchType searchType) {
+    // note: a SampleTemplate's type is SAMPLE, so the type-name arm matches templates for SAMPLE
+    // searches, exactly as before the Sample/SampleTemplate split; templates are then dropped from
+    // SAMPLE results by isMatchingTemplateOption
     return searchType == null
         || searchType.equals(InventorySearchType.ALL)
         || searchType.toString().equals(foundRec.getType().toString())
-        || (searchType.equals(InventorySearchType.TEMPLATE)
-            && foundRec.isSample()
-            && ((Sample) foundRec).isTemplate());
+        || (searchType.equals(InventorySearchType.TEMPLATE) && foundRec instanceof SampleTemplate);
   }
 
   private boolean isMatchingDeletedItemsOption(
@@ -452,7 +457,9 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
         return foundRecParent != null && foundRecParent.getOid().equals(parentOid);
       }
     } else if (GlobalIdPrefix.IT.equals(parentOid.getPrefix())) {
-      return foundRec.isSample()
+      // only concrete samples have a parent template; a template hit fails the instanceof check,
+      // matching the old behavior where a template's parentTemplateId was always null
+      return foundRec instanceof Sample
           && parentOid.getDbId().equals(((Sample) foundRec).getParentTemplateId());
     } else if (GlobalIdPrefix.SA.equals(parentOid.getPrefix())) {
       return foundRec.isSubSample()
@@ -470,7 +477,7 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
   }
 
   private boolean isMatchingTemplateOption(InventoryRecord record, InventorySearchType searchType) {
-    boolean isTemplate = record.isSample() && ((Sample) record).isTemplate();
+    boolean isTemplate = record instanceof SampleTemplate;
     if (isTemplate
         && !(searchType == InventorySearchType.ALL || searchType == InventorySearchType.TEMPLATE)) {
       return false;
@@ -485,7 +492,7 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
     }
     boolean notOwnedByDefaultTemplateOwner =
         !defaultTemplatesOwner.equals(rec.getOwner().getUsername());
-    boolean isSampleTemplate = rec.isSample() && ((Sample) rec).isTemplate();
+    boolean isSampleTemplate = rec instanceof SampleTemplate;
     return notOwnedByDefaultTemplateOwner || isSampleTemplate;
   }
 

--- a/src/main/java/com/researchspace/dao/hibernate/InventoryTagDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/InventoryTagDaoHibernateImpl.java
@@ -32,7 +32,9 @@ public class InventoryTagDaoHibernateImpl extends InventoryDaoHibernate<Inventor
             null, user, userGroupMembers, userGroupsUniqueNames, visibleOwners);
 
     Set<String> allTags = new HashSet<>();
-    for (String targetClass : List.of("Sample", "SubSample", "Container")) {
+    // SampleEntity spans both samples and sample templates: template tags are part of the result,
+    // matching the behavior of the old single-class Sample entity
+    for (String targetClass : List.of("SampleEntity", "SubSample", "Container")) {
       allTags.addAll(
           getTagsForTargetClass(
               targetClass,

--- a/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
@@ -81,7 +81,7 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
         limitByParentTemplate ? "and STemplate.id=:parentTemplateId " : "";
 
     // get total count
-    // raw discriminator-column anchor (like DTYPE in the instrument DAOs): keeps the WHERE clause
+    // raw DTYPE discriminator anchor (matching the instrument DAOs): keeps the WHERE clause
     // non-empty when deletedOption=INCLUDE makes the deleted fragment blank; redundant with the
     // discriminator Hibernate adds for the concrete entity
     Query<Long> countQueryBase =
@@ -89,7 +89,7 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
             .getCurrentSession()
             .createQuery(
                 "select count(s) from Sample s where "
-                    + connectSqlConditionsWithAnd(deletedFragment, " template=0 ")
+                    + connectSqlConditionsWithAnd(deletedFragment, " DTYPE='Sample' ")
                     + parentTemplateQueryFragment
                     + ownedByAndPermittedItemsQueryFragment,
                 Long.class);
@@ -110,7 +110,7 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
             .getCurrentSession()
             .createQuery(
                 FROM_SAMPLE_WHERE
-                    + connectSqlConditionsWithAnd(deletedFragment, " template=0 ")
+                    + connectSqlConditionsWithAnd(deletedFragment, " DTYPE='Sample' ")
                     + parentTemplateQueryFragment
                     + ownedByAndPermittedItemsQueryFragment
                     + orderByFragment,

--- a/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SampleDaoHibernateImpl.java
@@ -9,22 +9,19 @@ import com.researchspace.model.Group;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
-import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Sample;
-import com.researchspace.model.inventory.field.InventoryChoiceField;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.field.InventoryEntityField;
-import com.researchspace.model.inventory.field.InventoryRadioField;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.Validate;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.springframework.stereotype.Repository;
 
-@Repository
+@Repository("sampleDao")
 public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
     implements SampleDao {
 
@@ -78,16 +75,21 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
     int maxResult = pgCrit.getResultsPerPage();
 
     boolean limitByParentTemplate = parentTemplateId != null;
+    // property name is STemplate: JavaBeans decapitalize keeps the leading double-uppercase of
+    // getSTemplate()
     String parentTemplateQueryFragment =
-        limitByParentTemplate ? "and STemplate_id=:parentTemplateId " : "";
+        limitByParentTemplate ? "and STemplate.id=:parentTemplateId " : "";
 
     // get total count
+    // raw discriminator-column anchor (like DTYPE in the instrument DAOs): keeps the WHERE clause
+    // non-empty when deletedOption=INCLUDE makes the deleted fragment blank; redundant with the
+    // discriminator Hibernate adds for the concrete entity
     Query<Long> countQueryBase =
         sessionFactory
             .getCurrentSession()
             .createQuery(
                 "select count(s) from Sample s where "
-                    + connectSqlConditionsWithAnd(deletedFragment, " template=false ")
+                    + connectSqlConditionsWithAnd(deletedFragment, " template=0 ")
                     + parentTemplateQueryFragment
                     + ownedByAndPermittedItemsQueryFragment,
                 Long.class);
@@ -108,7 +110,7 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
             .getCurrentSession()
             .createQuery(
                 FROM_SAMPLE_WHERE
-                    + connectSqlConditionsWithAnd(deletedFragment, " template=false ")
+                    + connectSqlConditionsWithAnd(deletedFragment, " template=0 ")
                     + parentTemplateQueryFragment
                     + ownedByAndPermittedItemsQueryFragment
                     + orderByFragment,
@@ -147,12 +149,15 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
   @Override
   public List<Sample> getSamplesLinkingOlderTemplateVersionForUser(
       Long templateId, Long version, User user) {
+    // property names are STemplate/STemplateLinkedVersion: JavaBeans keeps the leading
+    // double-uppercase of the getter
     return sessionFactory
         .getCurrentSession()
         .createQuery(
             FROM_SAMPLE_WHERE
-                + " owner=:owner and template=false and deleted=false "
-                + " and STemplate_id=:parentTemplateId "
+                // "from Sample" already excludes templates; no template=false needed
+                + " owner=:owner and deleted=false "
+                + " and STemplate.id=:parentTemplateId "
                 + " and STemplateLinkedVersion < :parentTemplateMaxVersion",
             Sample.class)
         .setParameter("owner", user)
@@ -173,119 +178,11 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
     return get(sample.getId());
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public ISearchResults<Sample> getTemplatesForUser(
-      PaginationCriteria<Sample> pgCrit,
-      String ownedBy,
-      InventorySearchDeletedOption deletedItemsOption,
-      User user) {
-
-    // prepare permission limiting query fragment
-    List<String> userGroupMembers =
-        invPermissionUtils.getUsernameOfUserAndAllMembersOfTheirGroups(user);
-    List<String> userGroupsUniqueNames =
-        user.getGroups().stream().map(Group::getUniqueName).collect(Collectors.toList());
-    List<String> visibleOwners = invPermissionUtils.getOwnersVisibleWithUserRole(user);
-    visibleOwners.add(getDefaultTemplatesOwner()); // can also see templates of a default user
-    String ownedByAndPermittedItemsQueryFragment =
-        getOwnedByAndPermittedItemsSqlQueryFragment(
-            ownedBy, user, userGroupMembers, userGroupsUniqueNames, visibleOwners);
-
-    // get the page of results
-    if (pgCrit == null) {
-      pgCrit = PaginationCriteria.createDefaultForClass(Sample.class);
-    }
-    String orderByFragment = getOrderBySqlFragmentForInventoryRecord(pgCrit);
-    String deletedFragment = getDeletedSqlFragmentForInventoryRecord(deletedItemsOption);
-    int startPosition = pgCrit.getFirstResultIndex();
-    int maxResult = pgCrit.getResultsPerPage();
-
-    // find the total count
-    Query<Long> countQueryBase =
-        sessionFactory
-            .getCurrentSession()
-            .createQuery(
-                "select count(s) from Sample s where "
-                    + connectSqlConditionsWithAnd(deletedFragment, " template=true ")
-                    + ownedByAndPermittedItemsQueryFragment);
-    Query<Long> countQueryWithParams =
-        addQueryParams(
-            ownedBy, user, countQueryBase, visibleOwners, userGroupMembers, userGroupsUniqueNames);
-    long allTemplatesCount = countQueryWithParams.getSingleResult();
-    if (allTemplatesCount == 0) {
-      return new SearchResultsImpl<>(new ArrayList<>(), pgCrit, 0);
-    }
-
-    Query<Sample> sampleQueryBase =
-        sessionFactory
-            .getCurrentSession()
-            .createQuery(
-                FROM_SAMPLE_WHERE
-                    + connectSqlConditionsWithAnd(deletedFragment, " template=true ")
-                    + ownedByAndPermittedItemsQueryFragment
-                    + orderByFragment)
-            .setFirstResult(startPosition)
-            .setMaxResults(maxResult);
-    Query<Sample> sampleQueryWithParams =
-        addQueryParams(
-            ownedBy, user, sampleQueryBase, visibleOwners, userGroupMembers, userGroupsUniqueNames);
-    List<Sample> pagedTemplates = sampleQueryWithParams.list();
-    return new SearchResultsImpl<>(pagedTemplates, pgCrit, allTemplatesCount);
-  }
-
-  private String defaultTemplateOwner;
-
-  @Override
-  public String getDefaultTemplatesOwner() {
-    if (defaultTemplateOwner == null) {
-      defaultTemplateOwner =
-          (String)
-              sessionFactory
-                  .getCurrentSession()
-                  .createQuery(
-                      "select owner.username from Sample s where template=true order by id asc")
-                  .setMaxResults(1)
-                  .getSingleResult();
-    }
-    return defaultTemplateOwner;
-  }
-
-  private long countTemplates() {
-    return (long)
-        sessionFactory
-            .getCurrentSession()
-            .createQuery("select count(s) from Sample s where deleted=false and template=true")
-            .getSingleResult();
-  }
-
-  @Override
-  public Sample persistSampleTemplate(Sample template) {
-    assertIsSampleTemplate(template);
-    Session currentSession = sessionFactory.getCurrentSession();
-    template.getActiveFields().stream()
-        .filter(f -> FieldType.CHOICE.equals(f.getType()))
-        .map(InventoryChoiceField.class::cast)
-        .forEach(cf -> currentSession.save(cf.getChoiceDef()));
-    template.getActiveFields().stream()
-        .filter(f -> FieldType.RADIO.equals(f.getType()))
-        .map(InventoryRadioField.class::cast)
-        .forEach(cf -> currentSession.save(cf.getRadioDef()));
-    return persistNewSample(template);
-  }
-
-  private void assertIsSampleTemplate(Sample sampleToCheck) {
-    Validate.isTrue(sampleToCheck.isTemplate(), "Was expecting a template, but found a sample");
-  }
-
-  @Override
-  public Long getTemplateCount() {
-    return countTemplates();
-  }
-
-  @Override
-  public int saveIconId(Sample sample, Long iconId) {
-    Query<?> q = getSession().createQuery("update Sample set iconId=:iconId where id = :id");
+  public int saveIconId(SampleEntity sample, Long iconId) {
+    // DML targets SampleEntity (the mapped superclass) so it applies to both samples and
+    // templates. Using "update Sample ..." would silently skip template rows.
+    Query<?> q = getSession().createQuery("update SampleEntity set iconId=:iconId where id = :id");
     q.setParameter("iconId", iconId);
     q.setParameter("id", sample.getId());
     return q.executeUpdate();
@@ -301,6 +198,8 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
 
   @Override
   public List<Sample> getAllUsingImage(FileProperty fileProperty) {
+    // Intentionally restricted to Sample rows (template=false). The template DAO's
+    // getAllTemplatesUsingImage handles the template side; callers that need both invoke both DAOs.
     return sessionFactory
         .getCurrentSession()
         .createQuery(
@@ -312,25 +211,21 @@ public class SampleDaoHibernateImpl extends InventoryDaoHibernate<Sample, Long>
   }
 
   @Override
-  public List<Sample> getAllTemplatesUsingImage(FileProperty fileProperty) {
-    return sessionFactory
-        .getCurrentSession()
-        .createQuery(
-            "from Sample where template = true and (imageFileProperty=:fileProperty OR "
-                + "thumbnailFileProperty=:fileProperty)",
-            Sample.class)
-        .setParameter("fileProperty", fileProperty)
-        .list();
-  }
-
-  /*
-   * ============
-   *  for tests
-   * ============
-   */
-
-  @Override
-  public void resetDefaultTemplateOwner() {
-    defaultTemplateOwner = null;
+  public boolean entityNameExistsForUser(String name, User owner) {
+    // Query SampleEntity to count across BOTH discriminator values (samples and templates),
+    // preserving the legacy behaviour that treated them as a single name-uniqueness namespace.
+    // The explicit editInfo.name path is required: unqualified embedded sub-properties (like
+    // "name") resolve only on concrete-leaf persisters, not on the abstract hierarchy root.
+    long count =
+        sessionFactory
+            .getCurrentSession()
+            .createQuery(
+                "select count(se) from SampleEntity se where se.editInfo.name=:name and"
+                    + " se.owner=:owner",
+                Long.class)
+            .setParameter("name", name)
+            .setParameter("owner", owner)
+            .getSingleResult();
+    return count > 0;
   }
 }

--- a/src/main/java/com/researchspace/dao/hibernate/SampleTemplateDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SampleTemplateDaoHibernateImpl.java
@@ -133,11 +133,10 @@ public class SampleTemplateDaoHibernateImpl extends InventoryDaoHibernate<Sample
 
   @Override
   public Long getTemplateCount() {
-    return (long)
-        sessionFactory
-            .getCurrentSession()
-            .createQuery("select count(s) from SampleTemplate s where s.deleted=false")
-            .getSingleResult();
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery("select count(s) from SampleTemplate s where s.deleted=false", Long.class)
+        .getSingleResult();
   }
 
   @Override

--- a/src/main/java/com/researchspace/dao/hibernate/SampleTemplateDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SampleTemplateDaoHibernateImpl.java
@@ -1,0 +1,184 @@
+package com.researchspace.dao.hibernate;
+
+import com.axiope.search.InventorySearchConfig.InventorySearchDeletedOption;
+import com.researchspace.core.util.ISearchResults;
+import com.researchspace.core.util.SearchResultsImpl;
+import com.researchspace.dao.SampleTemplateDao;
+import com.researchspace.model.FileProperty;
+import com.researchspace.model.Group;
+import com.researchspace.model.PaginationCriteria;
+import com.researchspace.model.User;
+import com.researchspace.model.field.FieldType;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
+import com.researchspace.model.inventory.field.InventoryChoiceField;
+import com.researchspace.model.inventory.field.InventoryRadioField;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.springframework.stereotype.Repository;
+
+@Repository("sampleTemplateDao")
+public class SampleTemplateDaoHibernateImpl extends InventoryDaoHibernate<SampleTemplate, Long>
+    implements SampleTemplateDao {
+
+  private String defaultTemplateOwner;
+
+  public SampleTemplateDaoHibernateImpl(Class<SampleTemplate> persistentClass) {
+    super(persistentClass);
+  }
+
+  public SampleTemplateDaoHibernateImpl() {
+    super(SampleTemplate.class);
+  }
+
+  @Override
+  public ISearchResults<SampleTemplate> getTemplatesForUser(
+      PaginationCriteria<SampleTemplate> pgCrit,
+      String ownedBy,
+      InventorySearchDeletedOption deletedItemsOption,
+      User user) {
+
+    // prepare permission limiting query fragment
+    List<String> userGroupMembers =
+        invPermissionUtils.getUsernameOfUserAndAllMembersOfTheirGroups(user);
+    List<String> userGroupsUniqueNames =
+        user.getGroups().stream().map(Group::getUniqueName).collect(Collectors.toList());
+    List<String> visibleOwners = invPermissionUtils.getOwnersVisibleWithUserRole(user);
+    visibleOwners.add(getDefaultTemplatesOwner()); // can also see templates of a default user
+    String ownedByAndPermittedItemsQueryFragment =
+        getOwnedByAndPermittedItemsSqlQueryFragment(
+            ownedBy, user, userGroupMembers, userGroupsUniqueNames, visibleOwners);
+
+    // get the page of results
+    if (pgCrit == null) {
+      pgCrit = PaginationCriteria.createDefaultForClass(SampleTemplate.class);
+    }
+    String orderByFragment = getOrderBySqlFragmentForInventoryRecord(pgCrit);
+    String deletedFragment = getDeletedSqlFragmentForInventoryRecord(deletedItemsOption);
+    int startPosition = pgCrit.getFirstResultIndex();
+    int maxResult = pgCrit.getResultsPerPage();
+
+    // raw discriminator-column anchor (like DTYPE in the instrument DAOs): keeps the WHERE clause
+    // non-empty when deletedOption=INCLUDE makes the deleted fragment blank; redundant with the
+    // discriminator Hibernate adds for the concrete entity
+    Query<Long> countQueryBase =
+        sessionFactory
+            .getCurrentSession()
+            .createQuery(
+                "select count(s) from SampleTemplate s where "
+                    + connectSqlConditionsWithAnd(deletedFragment, " template=1 ")
+                    + ownedByAndPermittedItemsQueryFragment,
+                Long.class);
+    Query<Long> countQueryWithParams =
+        addQueryParams(
+            ownedBy, user, countQueryBase, visibleOwners, userGroupMembers, userGroupsUniqueNames);
+    long allTemplatesCount = countQueryWithParams.getSingleResult();
+    if (allTemplatesCount == 0) {
+      return new SearchResultsImpl<>(new ArrayList<>(), pgCrit, 0);
+    }
+
+    Query<SampleTemplate> sampleQueryBase =
+        sessionFactory
+            .getCurrentSession()
+            .createQuery(
+                "from SampleTemplate where "
+                    + connectSqlConditionsWithAnd(deletedFragment, " template=1 ")
+                    + ownedByAndPermittedItemsQueryFragment
+                    + orderByFragment,
+                SampleTemplate.class)
+            .setFirstResult(startPosition)
+            .setMaxResults(maxResult);
+    Query<SampleTemplate> sampleQueryWithParams =
+        addQueryParams(
+            ownedBy, user, sampleQueryBase, visibleOwners, userGroupMembers, userGroupsUniqueNames);
+    List<SampleTemplate> pagedTemplates = sampleQueryWithParams.list();
+    return new SearchResultsImpl<>(pagedTemplates, pgCrit, allTemplatesCount);
+  }
+
+  @Override
+  public String getDefaultTemplatesOwner() {
+    if (defaultTemplateOwner == null) {
+      defaultTemplateOwner =
+          (String)
+              sessionFactory
+                  .getCurrentSession()
+                  .createQuery(
+                      // "from SampleTemplate" selects only template rows; no template=true needed
+                      "select s.owner.username from SampleTemplate s order by s.id asc")
+                  .setMaxResults(1)
+                  .getSingleResult();
+    }
+    return defaultTemplateOwner;
+  }
+
+  @Override
+  public SampleTemplate persistSampleTemplate(SampleTemplate template) {
+    Session currentSession = sessionFactory.getCurrentSession();
+    template.getActiveFields().stream()
+        .filter(f -> FieldType.CHOICE.equals(f.getType()))
+        .map(InventoryChoiceField.class::cast)
+        .forEach(cf -> currentSession.save(cf.getChoiceDef()));
+    template.getActiveFields().stream()
+        .filter(f -> FieldType.RADIO.equals(f.getType()))
+        .map(InventoryRadioField.class::cast)
+        .forEach(cf -> currentSession.save(cf.getRadioDef()));
+    currentSession.persist(template);
+    return get(template.getId());
+  }
+
+  @Override
+  public Long getTemplateCount() {
+    return (long)
+        sessionFactory
+            .getCurrentSession()
+            .createQuery("select count(s) from SampleTemplate s where s.deleted=false")
+            .getSingleResult();
+  }
+
+  @Override
+  public List<SampleTemplate> getAllTemplatesUsingImage(FileProperty fileProperty) {
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery(
+            "from SampleTemplate where imageFileProperty=:fileProperty OR"
+                + " thumbnailFileProperty=:fileProperty",
+            SampleTemplate.class)
+        .setParameter("fileProperty", fileProperty)
+        .list();
+  }
+
+  @Override
+  public int saveIconId(SampleEntity sample, Long iconId) {
+    // DML targets SampleEntity (the mapped superclass) so iconId can be set by whichever DAO is
+    // invoked; a subclass-scoped update would silently miss rows of the other discriminator
+    // value.
+    Query<?> q = getSession().createQuery("update SampleEntity set iconId=:iconId where id = :id");
+    q.setParameter("iconId", iconId);
+    q.setParameter("id", sample.getId());
+    return q.executeUpdate();
+  }
+
+  @Override
+  public SampleTemplate saveAndReindexSubSamples(SampleTemplate sample) {
+    Session ssnx = sessionFactory.getCurrentSession();
+    FullTextSession fssn = Search.getFullTextSession(ssnx);
+    sample.getSubSamples().forEach(fssn::index);
+    return save(sample);
+  }
+
+  /*
+   * ============
+   *  for tests
+   * ============
+   */
+
+  @Override
+  public void resetDefaultTemplateOwner() {
+    defaultTemplateOwner = null;
+  }
+}

--- a/src/main/java/com/researchspace/dao/hibernate/SampleTemplateDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SampleTemplateDaoHibernateImpl.java
@@ -63,7 +63,7 @@ public class SampleTemplateDaoHibernateImpl extends InventoryDaoHibernate<Sample
     int startPosition = pgCrit.getFirstResultIndex();
     int maxResult = pgCrit.getResultsPerPage();
 
-    // raw discriminator-column anchor (like DTYPE in the instrument DAOs): keeps the WHERE clause
+    // raw DTYPE discriminator anchor (matching the instrument DAOs): keeps the WHERE clause
     // non-empty when deletedOption=INCLUDE makes the deleted fragment blank; redundant with the
     // discriminator Hibernate adds for the concrete entity
     Query<Long> countQueryBase =
@@ -71,7 +71,7 @@ public class SampleTemplateDaoHibernateImpl extends InventoryDaoHibernate<Sample
             .getCurrentSession()
             .createQuery(
                 "select count(s) from SampleTemplate s where "
-                    + connectSqlConditionsWithAnd(deletedFragment, " template=1 ")
+                    + connectSqlConditionsWithAnd(deletedFragment, " DTYPE='SampleTemplate' ")
                     + ownedByAndPermittedItemsQueryFragment,
                 Long.class);
     Query<Long> countQueryWithParams =
@@ -87,7 +87,7 @@ public class SampleTemplateDaoHibernateImpl extends InventoryDaoHibernate<Sample
             .getCurrentSession()
             .createQuery(
                 "from SampleTemplate where "
-                    + connectSqlConditionsWithAnd(deletedFragment, " template=1 ")
+                    + connectSqlConditionsWithAnd(deletedFragment, " DTYPE='SampleTemplate' ")
                     + ownedByAndPermittedItemsQueryFragment
                     + orderByFragment,
                 SampleTemplate.class)

--- a/src/main/java/com/researchspace/dao/hibernate/SubSampleDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/SubSampleDaoHibernateImpl.java
@@ -44,8 +44,14 @@ public class SubSampleDaoHibernateImpl extends InventoryDaoHibernate<SubSample, 
         getOwnedByAndPermittedItemsSqlQueryFragment(
             ownedBy, user, userGroupMembers, userGroupsUniqueNames, visibleOwners, "ss.sample.");
 
-    // prepare fragment limiting to non-template subsamples
-    String nonTemplateFragment = "ss.sample.template = false ";
+    /*
+     * Fragment limiting to non-template subsamples. With the Sample/SampleTemplate single-table
+     * hierarchy the legacy 'template' boolean property no longer exists; the discriminator-based
+     * '.class' comparison expresses the same restriction. The 'type(ss.sample) = Sample' form is
+     * NOT used because Hibernate 5's classic HQL translator cannot apply type() to an
+     * implicit-join path ("could not resolve property: class").
+     */
+    String nonTemplateFragment = "ss.sample.class = Sample ";
 
     if (pgCrit == null) {
       pgCrit = PaginationCriteria.createDefaultForClass(SubSample.class);

--- a/src/main/java/com/researchspace/service/IContentInitializer.java
+++ b/src/main/java/com/researchspace/service/IContentInitializer.java
@@ -1,6 +1,6 @@
 package com.researchspace.service;
 
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.IllegalAddChildOperation;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.StructuredDocument;
@@ -29,7 +29,7 @@ public interface IContentInitializer {
 
   void saveForm(RSForm form);
 
-  void saveSampleTemplate(Sample sampleTemplate);
+  void saveSampleTemplate(SampleTemplate sampleTemplate);
 
   /**
    * Optional configuration to disable the custom initialization of forms and records for testing.

--- a/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
+++ b/src/main/java/com/researchspace/service/fieldmark/impl/FieldmarkServiceManagerImpl.java
@@ -33,7 +33,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.dtos.IControllerInputValidator;
 import com.researchspace.model.dtos.fieldmark.FieldmarkNotebookDTO;
 import com.researchspace.model.dtos.fieldmark.FieldmarkRecordDTO;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.service.ApiAvailabilityHandler;
 import com.researchspace.service.fieldmark.FieldmarkServiceClientAdapter;
 import com.researchspace.service.fieldmark.FieldmarkServiceManager;
@@ -255,14 +255,14 @@ public class FieldmarkServiceManagerImpl implements FieldmarkServiceManager {
   public void validateCreateSampleInput(
       ApiSampleWithFullSubSamples apiSample, BindingResult errors, User user) throws BindException {
 
-    Sample template = verifyTemplateIsCompatible(apiSample, errors, user);
+    SampleTemplate template = verifyTemplateIsCompatible(apiSample, errors, user);
     inputValidator.validate(apiSample, sampleApiPostValidator, errors);
     ApiSampleFullPost allData = new ApiSampleFullPost(apiSample, user, template);
     inputValidator.validate(allData, sampleApiPostFullValidator, errors);
     throwBindExceptionIfErrors(errors);
   }
 
-  private Sample verifyTemplateIsCompatible(
+  private SampleTemplate verifyTemplateIsCompatible(
       ApiSampleInfo apiSample, BindingResult errors, User user) throws BindException {
     if (apiSample.getTemplateId() != null) {
       try {

--- a/src/main/java/com/researchspace/service/impl/AbstractContentInitializer.java
+++ b/src/main/java/com/researchspace/service/impl/AbstractContentInitializer.java
@@ -3,13 +3,13 @@ package com.researchspace.service.impl;
 import com.researchspace.dao.FolderDao;
 import com.researchspace.dao.FormDao;
 import com.researchspace.dao.RecordDao;
-import com.researchspace.dao.SampleDao;
+import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.dao.UserDao;
 import com.researchspace.linkedelements.RichTextUpdater;
 import com.researchspace.model.EcatImage;
 import com.researchspace.model.User;
 import com.researchspace.model.core.UniquelyIdentifiable;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.record.BaseRecord;
@@ -62,7 +62,7 @@ public abstract class AbstractContentInitializer
   protected @Autowired FormDao formDao;
 
   protected @Autowired SampleApiManager sampleApiMgr;
-  protected @Autowired SampleDao sampleDao;
+  protected @Autowired SampleTemplateDao sampleTemplateDao;
   protected @Autowired ContainerApiManager containerApiMgr;
   protected @Autowired IRecordFactory recordFactory;
   protected @Autowired MediaManager mediaMgr;
@@ -144,7 +144,7 @@ public abstract class AbstractContentInitializer
   @Override
   public int createSampleTemplates(User user) {
 
-    Long sampleTemplatesCount = sampleDao.getTemplateCount();
+    Long sampleTemplatesCount = sampleTemplateDao.getTemplateCount();
     if (sampleTemplatesCount > 0) {
       log.info(
           "There are already {} templates - skipping creation of system sample templates",
@@ -154,7 +154,7 @@ public abstract class AbstractContentInitializer
     log.info("There are no sample templates - creating them.");
     addStandardSampleTemplates(user);
     addCustomSampleTemplates(user);
-    int created = sampleDao.getTemplateCount().intValue();
+    int created = sampleTemplateDao.getTemplateCount().intValue();
     log.info("{} templates created", created);
     return created;
   }
@@ -181,10 +181,10 @@ public abstract class AbstractContentInitializer
   }
 
   private void addStandardSampleTemplates(User u) {
-    // create new empty Sample with no fields.
-    Sample basicSample = recordFactory.createSample(DEFAULT_SAMPLE_TEMPLATE_NAME, u);
-    basicSample.setTemplate(true);
-    sampleDao.persistSampleTemplate(basicSample);
+    // create new empty SampleTemplate with no fields.
+    SampleTemplate basicSample =
+        recordFactory.createSampleTemplate(DEFAULT_SAMPLE_TEMPLATE_NAME, u);
+    sampleTemplateDao.persistSampleTemplate(basicSample);
   }
 
   /**
@@ -268,12 +268,12 @@ public abstract class AbstractContentInitializer
     return ice;
   }
 
-  protected IconEntity createAndSaveIconEntity(String fileName, Sample template)
+  protected IconEntity createAndSaveIconEntity(String fileName, SampleTemplate template)
       throws IOException {
     IconEntity ice = saveIconEntity(fileName, template);
     log.info("saved icon " + ice.getId() + " for template " + template.getName());
     template.setIconId(ice.getId());
-    sampleDao.save(template);
+    sampleTemplateDao.save(template);
     return ice;
   }
 
@@ -293,7 +293,7 @@ public abstract class AbstractContentInitializer
     return ice;
   }
 
-  protected void createAndSavePreviewImage(String fileName, User user, Sample template)
+  protected void createAndSavePreviewImage(String fileName, User user, SampleTemplate template)
       throws IOException {
     Resource resource = appContext.getResource("classpath:formIcons/" + fileName);
     InputStream is = resource.getInputStream();
@@ -302,7 +302,7 @@ public abstract class AbstractContentInitializer
         "data:image/png;base64," + new String(Base64.encodeBase64(bytes), StandardCharsets.UTF_8);
 
     sampleApiMgr.createImagesForRecord(template, base64image, user);
-    sampleDao.save(template);
+    sampleTemplateDao.save(template);
   }
 
   /**
@@ -328,8 +328,8 @@ public abstract class AbstractContentInitializer
   }
 
   @Override
-  public void saveSampleTemplate(Sample template) {
-    sampleDao.persistSampleTemplate(template);
+  public void saveSampleTemplate(SampleTemplate template) {
+    sampleTemplateDao.persistSampleTemplate(template);
   }
 
   @Override
@@ -399,8 +399,8 @@ public abstract class AbstractContentInitializer
     this.userContentCreator = userContentCreator;
   }
 
-  void setSampleDao(SampleDao sampleDao) {
-    this.sampleDao = sampleDao;
+  void setSampleTemplateDao(SampleTemplateDao sampleTemplateDao) {
+    this.sampleTemplateDao = sampleTemplateDao;
   }
 
   void setSampleApiMgr(SampleApiManager sampleApiMgr) {

--- a/src/main/java/com/researchspace/service/impl/BuiltInPersistorFacade.java
+++ b/src/main/java/com/researchspace/service/impl/BuiltInPersistorFacade.java
@@ -2,7 +2,7 @@ package com.researchspace.service.impl;
 
 import com.axiope.model.record.init.IBuiltInPersistor;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.UserFolderSetup;
@@ -43,7 +43,7 @@ class BuiltInPersistorFacade implements IBuiltInPersistor {
   }
 
   @Override
-  public void saveSampleTemplate(Sample template) {
+  public void saveSampleTemplate(SampleTemplate template) {
     delegate.saveSampleTemplate(template);
   }
 }

--- a/src/main/java/com/researchspace/service/impl/ContentInitializerForDevRunManager.java
+++ b/src/main/java/com/researchspace/service/impl/ContentInitializerForDevRunManager.java
@@ -15,7 +15,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.field.Field;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Container.ContainerType;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.permissions.PermissionFactory;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.record.ACLPropagationPolicy;
@@ -99,9 +99,11 @@ public class ContentInitializerForDevRunManager extends AbstractContentInitializ
 
   @Override
   protected void addCustomSampleTemplates(User u) {
-    PaginationCriteria<Sample> pg = PaginationCriteria.createDefaultForClass(Sample.class);
+    PaginationCriteria<SampleTemplate> pg =
+        PaginationCriteria.createDefaultForClass(SampleTemplate.class);
     pg.setGetAllResults();
-    List<Sample> sampleTemplates = sampleDao.getTemplatesForUser(pg, null, null, u).getResults();
+    List<SampleTemplate> sampleTemplates =
+        sampleTemplateDao.getTemplatesForUser(pg, null, null, u).getResults();
     boolean t1Created =
         sampleTemplates.stream()
             .filter(t -> t.getName().equals(COMPLEX_SAMPLE_TEMPLATE_NAME))
@@ -121,8 +123,9 @@ public class ContentInitializerForDevRunManager extends AbstractContentInitializ
   }
 
   private void createComplexSampleTemplate(User u, String name) {
-    Sample complexTemplate = recordFactory.createComplexSampleTemplate(name, "for testing", u);
-    complexTemplate = sampleDao.persistSampleTemplate(complexTemplate);
+    SampleTemplate complexTemplate =
+        recordFactory.createComplexSampleTemplate(name, "for testing", u);
+    complexTemplate = sampleTemplateDao.persistSampleTemplate(complexTemplate);
     try {
       createAndSaveIconEntity("Experiment32.png", complexTemplate);
       createAndSavePreviewImage("Experiment 88.png", u, complexTemplate);
@@ -238,18 +241,21 @@ public class ContentInitializerForDevRunManager extends AbstractContentInitializ
   private void initialiseInventoryWithExampleRecords(User u) {
 
     // create standalone complex sample
-    PaginationCriteria<Sample> allTemplatesPagCrit =
-        PaginationCriteria.createDefaultForClass(Sample.class);
+    PaginationCriteria<SampleTemplate> allTemplatesPagCrit =
+        PaginationCriteria.createDefaultForClass(SampleTemplate.class);
     allTemplatesPagCrit.setResultsPerPage(Integer.MAX_VALUE);
-    Optional<Sample> complexTemplateOpt =
-        sampleDao.getTemplatesForUser(allTemplatesPagCrit, null, null, u).getResults().stream()
+    Optional<SampleTemplate> complexTemplateOpt =
+        sampleTemplateDao
+            .getTemplatesForUser(allTemplatesPagCrit, null, null, u)
+            .getResults()
+            .stream()
             .filter(st -> st.getName().contentEquals(COMPLEX_SAMPLE_TEMPLATE_NAME))
             .findFirst();
 
     if (complexTemplateOpt.isEmpty()) {
       throw new IllegalStateException("complex sample template not found for user " + u.getId());
     }
-    Sample complexSampleTemplate = complexTemplateOpt.get();
+    SampleTemplate complexSampleTemplate = complexTemplateOpt.get();
     ApiSampleWithFullSubSamples complexSample = new ApiSampleWithFullSubSamples();
     complexSample.setName(EXAMPLE_COMPLEX_SAMPLE_NAME);
     complexSample.setTemplateId(complexSampleTemplate.getId());

--- a/src/main/java/com/researchspace/service/impl/ProdContentInitializerManager.java
+++ b/src/main/java/com/researchspace/service/impl/ProdContentInitializerManager.java
@@ -15,7 +15,7 @@ import com.researchspace.archive.ArchivalImportConfig;
 import com.researchspace.core.util.progress.ProgressMonitor;
 import com.researchspace.model.EcatMediaFile;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.Notebook;
@@ -89,16 +89,16 @@ public class ProdContentInitializerManager extends AbstractContentInitializer
 
   @Override
   protected void addCustomSampleTemplates(User u) {
-    List<Sample> templates = new ArrayList<>();
+    List<SampleTemplate> templates = new ArrayList<>();
     createBuiltIns();
     log.info("No sample templates in system; adding builtin sample templates");
     for (SampleTemplateBuiltIn builtin : sampleBuiltins) {
-      Optional<Sample> sampleTemplateOpt = builtin.createSampleTemplate(u);
+      Optional<SampleTemplate> sampleTemplateOpt = builtin.createSampleTemplate(u);
       if (!sampleTemplateOpt.isPresent()) {
         log.warn("Couldn't create template with name : {}", builtin.getClass().getName());
         continue;
       }
-      Sample template = sampleTemplateOpt.get();
+      SampleTemplate template = sampleTemplateOpt.get();
 
       log.info("Created sample template {}", template.getName());
       try {

--- a/src/main/java/com/researchspace/service/impl/SearchManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SearchManagerImpl.java
@@ -21,7 +21,7 @@ import com.axiope.search.WorkspaceSearchInputValidator;
 import com.researchspace.Constants;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
 import com.researchspace.core.util.ISearchResults;
-import com.researchspace.dao.SampleDao;
+import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.dao.TextSearchDao;
 import com.researchspace.model.Group;
 import com.researchspace.model.PaginationCriteria;
@@ -64,7 +64,7 @@ public class SearchManagerImpl implements SearchManager {
   private @Autowired RecordManager recordManager;
   private @Autowired FolderManager folderMgr;
   private @Autowired SampleApiManager sampleApiManager;
-  private @Autowired SampleDao sampleDao;
+  private @Autowired SampleTemplateDao sampleTemplateDao;
   private @Autowired BasketApiManager basketApiManager;
   private @Autowired InventoryPermissionUtils invPermissionUtils;
   private @Autowired MessageSourceUtils messages;
@@ -298,7 +298,7 @@ public class SearchManagerImpl implements SearchManager {
      * so default templates are included in search.
      */
     if (searchConfig.isRestrictByUser()) {
-      String defaultTemplatesOwner = sampleDao.getDefaultTemplatesOwner();
+      String defaultTemplatesOwner = sampleTemplateDao.getDefaultTemplatesOwner();
       if (defaultTemplatesOwner != null
           && !invPermissionUtils.isInventoryOwnerReadableByUser(defaultTemplatesOwner, user)) {
         // let's also search templates of default templates owner

--- a/src/main/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImpl.java
@@ -6,7 +6,7 @@ import com.researchspace.dao.StoichiometryInventoryLinkDao;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
@@ -67,14 +67,11 @@ public class StoichiometryInventoryLinkManagerImpl implements StoichiometryInven
         invPermissionUtils.assertUserCanEditInventoryRecord(
             new GlobalIdentifier(req.getInventoryItemGlobalId()), user);
 
-    if (inventoryRecord instanceof Sample) {
-      Sample sample = (Sample) inventoryRecord;
-      if (sample.isTemplate()) {
-        throw new IllegalArgumentException(
-            inventoryRecord.getGlobalIdentifier()
-                + " is a sample template. Only Containers, Samples and Subsamples are valid for"
-                + " linking.");
-      }
+    if (inventoryRecord instanceof SampleTemplate) {
+      throw new IllegalArgumentException(
+          inventoryRecord.getGlobalIdentifier()
+              + " is a sample template. Only Containers, Samples and Subsamples are valid for"
+              + " linking.");
     }
 
     StoichiometryInventoryLink link = new StoichiometryInventoryLink();

--- a/src/main/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImpl.java
@@ -6,7 +6,6 @@ import com.researchspace.dao.StoichiometryInventoryLinkDao;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
@@ -67,7 +66,7 @@ public class StoichiometryInventoryLinkManagerImpl implements StoichiometryInven
         invPermissionUtils.assertUserCanEditInventoryRecord(
             new GlobalIdentifier(req.getInventoryItemGlobalId()), user);
 
-    if (inventoryRecord instanceof SampleTemplate) {
+    if (inventoryRecord.isSampleTemplate()) {
       throw new IllegalArgumentException(
           inventoryRecord.getGlobalIdentifier()
               + " is a sample template. Only Containers, Samples and Subsamples are valid for"

--- a/src/main/java/com/researchspace/service/inventory/ApiExtraFieldsHelper.java
+++ b/src/main/java/com/researchspace/service/inventory/ApiExtraFieldsHelper.java
@@ -13,7 +13,7 @@ import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.ExtraField;
 import com.researchspace.model.inventory.field.ExtraLinkField;
@@ -89,7 +89,7 @@ public class ApiExtraFieldsHelper implements Validator {
   }
 
   public boolean createDeleteRequestedExtraFieldsInDatabaseSample(
-      ApiSampleWithoutSubSamples apiSample, Sample sample, User user) {
+      ApiSampleWithoutSubSamples apiSample, SampleEntity sample, User user) {
     return createDeleteRequestedExtraFields(
         apiSample.getExtraFields(), sample.getActiveExtraFields(), sample, user);
   }

--- a/src/main/java/com/researchspace/service/inventory/InventoryAuditApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryAuditApiManager.java
@@ -11,7 +11,8 @@ import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 
 /** For handling revision history requests around RS Inventory items */
@@ -23,7 +24,7 @@ public interface InventoryAuditApiManager {
 
   ApiSubSample getApiSubSampleRevision(Long subSampleId, Long revisionId);
 
-  ApiSampleTemplate getApiTemplateVersion(Sample latestTemplate, Long version);
+  ApiSampleTemplate getApiTemplateVersion(SampleTemplate latestTemplate, Long version);
 
   ApiInstrument getApiInstrumentRevision(Long instrumentId, Long revisionId);
 
@@ -33,26 +34,27 @@ public interface InventoryAuditApiManager {
       InstrumentTemplate latestTemplate, Long version);
 
   /**
-   * Returns the sample as it was at the given user-facing version. The current version is served
-   * from the live entity; older versions resolve to the newest audit revision carrying that
-   * version, flagged as historical. Returns null if the version does not exist.
+   * Returns the sample (or sample template) as it was at the given user-facing version. The current
+   * version is served from the live entity; older versions resolve to the newest audit revision
+   * carrying that version, flagged as historical. Returns null if the version does not exist.
    *
    * <p>Must be called with an entity attached to the current transaction (i.e. from within another
-   * manager's transaction, as {@link #getApiTemplateVersion(Sample, Long)} is). The caller is
-   * responsible for populating outgoing fields, such as permitted actions, on the result.
+   * manager's transaction, as {@link #getApiTemplateVersion(SampleTemplate, Long)} is). The caller
+   * is responsible for populating outgoing fields, such as permitted actions, on the result.
    */
-  ApiSample getApiSampleVersion(Sample currentSample, Long version);
+  ApiSample getApiSampleVersion(SampleEntity currentSample, Long version);
 
-  /** As {@link #getApiSampleVersion(Sample, Long)}, for a subsample. */
+  /** As {@link #getApiSampleVersion(SampleEntity, Long)}, for a subsample. */
   ApiSubSample getApiSubSampleVersion(SubSample currentSubSample, Long version);
 
   /**
-   * As {@link #getApiSampleVersion(Sample, Long)}, for a container. Historical container snapshots
-   * exclude content: locations are not audited, so a snapshot could only show present-day contents.
+   * As {@link #getApiSampleVersion(SampleEntity, Long)}, for a container. Historical container
+   * snapshots exclude content: locations are not audited, so a snapshot could only show present-day
+   * contents.
    */
   ApiContainer getApiContainerVersion(Container currentContainer, Long version);
 
-  /** As {@link #getApiSampleVersion(Sample, Long)}, for an instrument. */
+  /** As {@link #getApiSampleVersion(SampleEntity, Long)}, for an instrument. */
   ApiInstrument getApiInstrumentVersion(Instrument currentInstrument, Long version);
 
   /**

--- a/src/main/java/com/researchspace/service/inventory/InventoryFieldNameUniquenessValidator.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryFieldNameUniquenessValidator.java
@@ -5,7 +5,7 @@ import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.field.ExtraField;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import java.util.HashSet;
@@ -56,8 +56,8 @@ public final class InventoryFieldNameUniquenessValidator {
    */
   public static void assertNoDuplicateFieldNames(InventoryRecord record) {
     Set<String> seen = new HashSet<>();
-    if (record instanceof Sample) {
-      for (InventoryEntityField field : ((Sample) record).getActiveFields()) {
+    if (record instanceof SampleEntity) {
+      for (InventoryEntityField field : ((SampleEntity) record).getActiveFields()) {
         rejectIfDuplicate(seen, field.getName());
       }
     } else if (record instanceof InstrumentEntity) {

--- a/src/main/java/com/researchspace/service/inventory/InventoryPermissionUtils.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryPermissionUtils.java
@@ -4,6 +4,7 @@ import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
 import com.researchspace.dao.ListOfMaterialsDao;
 import com.researchspace.dao.SampleDao;
+import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.model.Group;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.Role;
@@ -17,6 +18,8 @@ import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.InventoryRecord.InventorySharingMode;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
@@ -33,6 +36,7 @@ import org.springframework.stereotype.Component;
 public class InventoryPermissionUtils {
 
   private @Autowired SampleDao sampleDao;
+  private @Autowired SampleTemplateDao sampleTemplateDao;
   private @Autowired ListOfMaterialsDao lomDao;
 
   private @Autowired UserManager userMgr;
@@ -180,10 +184,9 @@ public class InventoryPermissionUtils {
   }
 
   private boolean isDefaultSampleTemplate(InventoryRecord record) {
-    if (record.isSample()) {
-      Sample sample = (Sample) record;
-      return sample.isTemplate()
-          && sample.getOwner().getUsername().equals(sampleDao.getDefaultTemplatesOwner());
+    if (record instanceof SampleTemplate) {
+      SampleTemplate template = (SampleTemplate) record;
+      return template.getOwner().getUsername().equals(sampleTemplateDao.getDefaultTemplatesOwner());
     }
     return false;
   }
@@ -345,7 +348,7 @@ public class InventoryPermissionUtils {
   private boolean isSampleLimitedReadAllowedThroughSubsampleLimitedRead(
       InventoryRecord invRec, User user) {
     if (invRec.isSample()) {
-      Sample sample = (Sample) invRec;
+      SampleEntity sample = (SampleEntity) invRec;
       for (SubSample ss : sample.getSubSamples()) {
         if (canUserLimitedReadInventoryRecord(ss, user)) {
           return true;
@@ -369,20 +372,18 @@ public class InventoryPermissionUtils {
   }
 
   private boolean isTemplateLimitedReadAllowedThroughSample(InventoryRecord invRec, User user) {
-    if (invRec.isSample()) {
-      Sample recordAsSample = (Sample) invRec;
-      if (recordAsSample.isTemplate()) {
-        PaginationCriteria<Sample> allSamplesPgCrit =
-            PaginationCriteria.createDefaultForClass(Sample.class);
-        allSamplesPgCrit.setResultsPerPage(Integer.MAX_VALUE);
-        List<Sample> dbSamplesFromTemplate =
-            sampleDao
-                .getSamplesForUser(allSamplesPgCrit, recordAsSample.getId(), null, null, user)
-                .getResults();
-        for (Sample sa : dbSamplesFromTemplate) {
-          if (canUserReadInventoryRecord(sa, user)) {
-            return true;
-          }
+    if (invRec instanceof SampleTemplate) {
+      SampleTemplate recordAsTemplate = (SampleTemplate) invRec;
+      PaginationCriteria<Sample> allSamplesPgCrit =
+          PaginationCriteria.createDefaultForClass(Sample.class);
+      allSamplesPgCrit.setResultsPerPage(Integer.MAX_VALUE);
+      List<Sample> dbSamplesFromTemplate =
+          sampleDao
+              .getSamplesForUser(allSamplesPgCrit, recordAsTemplate.getId(), null, null, user)
+              .getResults();
+      for (Sample sa : dbSamplesFromTemplate) {
+        if (canUserReadInventoryRecord(sa, user)) {
+          return true;
         }
       }
     }

--- a/src/main/java/com/researchspace/service/inventory/InventoryPermissionUtils.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryPermissionUtils.java
@@ -19,7 +19,6 @@ import com.researchspace.model.inventory.InventoryRecord.InventorySharingMode;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleEntity;
-import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
@@ -184,9 +183,8 @@ public class InventoryPermissionUtils {
   }
 
   private boolean isDefaultSampleTemplate(InventoryRecord record) {
-    if (record instanceof SampleTemplate) {
-      SampleTemplate template = (SampleTemplate) record;
-      return template.getOwner().getUsername().equals(sampleTemplateDao.getDefaultTemplatesOwner());
+    if (record.isSampleTemplate()) {
+      return record.getOwner().getUsername().equals(sampleTemplateDao.getDefaultTemplatesOwner());
     }
     return false;
   }
@@ -347,7 +345,9 @@ public class InventoryPermissionUtils {
 
   private boolean isSampleLimitedReadAllowedThroughSubsampleLimitedRead(
       InventoryRecord invRec, User user) {
-    if (invRec.isSample()) {
+    // templates included: with getType() now SAMPLE_TEMPLATE for templates, a bare isSample()
+    // would drop them from this limited-read path, which covered them before the type split
+    if (invRec.isSample() || invRec.isSampleTemplate()) {
       SampleEntity sample = (SampleEntity) invRec;
       for (SubSample ss : sample.getSubSamples()) {
         if (canUserLimitedReadInventoryRecord(ss, user)) {
@@ -372,14 +372,13 @@ public class InventoryPermissionUtils {
   }
 
   private boolean isTemplateLimitedReadAllowedThroughSample(InventoryRecord invRec, User user) {
-    if (invRec instanceof SampleTemplate) {
-      SampleTemplate recordAsTemplate = (SampleTemplate) invRec;
+    if (invRec.isSampleTemplate()) {
       PaginationCriteria<Sample> allSamplesPgCrit =
           PaginationCriteria.createDefaultForClass(Sample.class);
       allSamplesPgCrit.setResultsPerPage(Integer.MAX_VALUE);
       List<Sample> dbSamplesFromTemplate =
           sampleDao
-              .getSamplesForUser(allSamplesPgCrit, recordAsTemplate.getId(), null, null, user)
+              .getSamplesForUser(allSamplesPgCrit, invRec.getId(), null, null, user)
               .getResults();
       for (Sample sa : dbSamplesFromTemplate) {
         if (canUserReadInventoryRecord(sa, user)) {

--- a/src/main/java/com/researchspace/service/inventory/InventoryRecordRetriever.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryRecordRetriever.java
@@ -5,6 +5,7 @@ import com.researchspace.dao.ContainerDao;
 import com.researchspace.dao.InstrumentDao;
 import com.researchspace.dao.InstrumentTemplateDao;
 import com.researchspace.dao.SampleDao;
+import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.dao.SubSampleDao;
 import com.researchspace.model.FileProperty;
 import com.researchspace.model.User;
@@ -14,6 +15,8 @@ import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import java.util.List;
 import javax.ws.rs.NotFoundException;
@@ -33,6 +36,7 @@ public class InventoryRecordRetriever {
   // lazy-loaded as a quick fix for non-obvious cycle problem with spring context loading
   private @Autowired @Lazy ContainerDao containerDao;
   private @Autowired SampleDao sampleDao;
+  private @Autowired SampleTemplateDao sampleTemplateDao;
   private @Autowired SubSampleDao subSampleDao;
   private @Autowired InstrumentDao instrumentDao;
   private @Autowired InstrumentTemplateDao instrumentTemplateDao;
@@ -152,10 +156,10 @@ public class InventoryRecordRetriever {
   /**
    * Looks for a sample (or sample template) with given id.
    *
-   * @return a Sample with given id, or null if doesn't exist
+   * @return the Sample or SampleTemplate with the given id, or null if it doesn't exist
    */
-  public Sample getSampleById(Long id) {
-    Sample result = null;
+  public SampleEntity getSampleById(Long id) {
+    SampleEntity result = null;
     try {
       result = getSampleIfExists(id);
     } catch (NotFoundException nfe) {
@@ -189,16 +193,18 @@ public class InventoryRecordRetriever {
   }
 
   /**
-   * Tries retrieving sample with given id.
+   * Tries retrieving sample (or sample template) with given id.
    *
-   * @throws NotFoundException if there is no sample with given id
+   * @throws NotFoundException if there is no sample (or sample template) with given id
    */
-  public Sample getSampleIfExists(Long id) {
-    boolean exists = sampleDao.exists(id);
-    if (!exists) {
-      throw new NotFoundException("No sample with id: " + id);
+  public SampleEntity getSampleIfExists(Long id) {
+    if (sampleDao.exists(id)) {
+      return sampleDao.get(id);
     }
-    return sampleDao.get(id);
+    if (sampleTemplateDao.exists(id)) {
+      return sampleTemplateDao.get(id);
+    }
+    throw new NotFoundException("No sample with id: " + id);
   }
 
   /**
@@ -225,7 +231,8 @@ public class InventoryRecordRetriever {
   }
 
   public boolean userHasCanViewFileProperty(User user, FileProperty fileProperty) {
-    List<Sample> templatesUsingImageFile = sampleDao.getAllTemplatesUsingImage(fileProperty);
+    List<SampleTemplate> templatesUsingImageFile =
+        sampleTemplateDao.getAllTemplatesUsingImage(fileProperty);
     if (userHasReadPermissionsForRecord(user, templatesUsingImageFile)) {
       return true;
     }

--- a/src/main/java/com/researchspace/service/inventory/SampleApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/SampleApiManager.java
@@ -54,40 +54,84 @@ public interface SampleApiManager extends InventoryApiManager<SampleEntity> {
   boolean exists(long id);
 
   /**
-   * Returns the sample (or sample template), if it exists and user has read permission
+   * Returns the {@link Sample} (not a template) if it exists and user has read permission.
    *
    * @param id
    * @param user
-   * @return the loaded sample (or sample template).
+   * @return the loaded sample
+   * @throws javax.ws.rs.NotFoundException if no sample (as opposed to a template) has that id
    */
-  SampleEntity assertUserCanReadSample(Long id, User user);
+  Sample assertUserCanReadSample(Long id, User user);
 
   /**
-   * Returns sample (or sample template) entity if it exists and user has edit permission
+   * Returns the {@link Sample} (not a template) if it exists and user has edit permission.
    *
    * @param id
    * @param user
-   * @return
+   * @return the loaded sample
+   * @throws javax.ws.rs.NotFoundException if no sample (as opposed to a template) has that id
    */
-  SampleEntity assertUserCanEditSample(Long id, User user);
+  Sample assertUserCanEditSample(Long id, User user);
 
   /**
-   * Returns sample (or sample template) entity if it exists and user can delete/restore it
+   * Returns the {@link Sample} (not a template) if it exists and user can delete/restore it.
    *
    * @param id
    * @param user
-   * @return
+   * @return the loaded sample
+   * @throws javax.ws.rs.NotFoundException if no sample (as opposed to a template) has that id
    */
-  SampleEntity assertUserCanDeleteSample(Long id, User user);
+  Sample assertUserCanDeleteSample(Long id, User user);
 
   /**
-   * Returns sample (or sample template) entity if it exists and user has transfer permission
+   * Returns the {@link Sample} (not a template) if it exists and user has transfer permission.
    *
    * @param id
    * @param user
-   * @return
+   * @return the loaded sample
+   * @throws javax.ws.rs.NotFoundException if no sample (as opposed to a template) has that id
    */
-  SampleEntity assertUserCanTransferSample(Long id, User user);
+  Sample assertUserCanTransferSample(Long id, User user);
+
+  /**
+   * Returns the {@link SampleTemplate} if it exists and user has read permission.
+   *
+   * @param id
+   * @param user
+   * @return the loaded sample template
+   * @throws javax.ws.rs.NotFoundException if no template (as opposed to a sample) has that id
+   */
+  SampleTemplate assertUserCanReadSampleTemplate(Long id, User user);
+
+  /**
+   * Returns the {@link SampleTemplate} if it exists and user has edit permission.
+   *
+   * @param id
+   * @param user
+   * @return the loaded sample template
+   * @throws javax.ws.rs.NotFoundException if no template (as opposed to a sample) has that id
+   */
+  SampleTemplate assertUserCanEditSampleTemplate(Long id, User user);
+
+  /**
+   * Returns the {@link SampleTemplate} if it exists and user can delete/restore it.
+   *
+   * @param id
+   * @param user
+   * @return the loaded sample template
+   * @throws javax.ws.rs.NotFoundException if no template (as opposed to a sample) has that id
+   */
+  SampleTemplate assertUserCanDeleteSampleTemplate(Long id, User user);
+
+  /**
+   * Returns the {@link SampleTemplate} if it exists and user has transfer permission.
+   *
+   * @param id
+   * @param user
+   * @return the loaded sample template
+   * @throws javax.ws.rs.NotFoundException if no template (as opposed to a sample) has that id
+   */
+  SampleTemplate assertUserCanTransferSampleTemplate(Long id, User user);
 
   /** Checks if sample with given name exists for the user */
   boolean nameExistsForUser(String sampleName, User user);

--- a/src/main/java/com/researchspace/service/inventory/SampleApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/SampleApiManager.java
@@ -15,11 +15,13 @@ import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import java.util.List;
 import javax.ws.rs.NotFoundException;
 
 /** Handles API actions around Inventory Sample. */
-public interface SampleApiManager extends InventoryApiManager<Sample> {
+public interface SampleApiManager extends InventoryApiManager<SampleEntity> {
 
   /**
    * Get All not-deleted samples that user can see. Optionally limit to samples belonging to
@@ -52,40 +54,40 @@ public interface SampleApiManager extends InventoryApiManager<Sample> {
   boolean exists(long id);
 
   /**
-   * Returns the sample, if it exists and user has read permission
+   * Returns the sample (or sample template), if it exists and user has read permission
    *
    * @param id
    * @param user
-   * @return the loaded sample.
+   * @return the loaded sample (or sample template).
    */
-  Sample assertUserCanReadSample(Long id, User user);
+  SampleEntity assertUserCanReadSample(Long id, User user);
 
   /**
-   * Returns Sample entity if it exists and user has edit permission
+   * Returns sample (or sample template) entity if it exists and user has edit permission
    *
    * @param id
    * @param user
    * @return
    */
-  Sample assertUserCanEditSample(Long id, User user);
+  SampleEntity assertUserCanEditSample(Long id, User user);
 
   /**
-   * Retuns Sample entity if it exists and user can delete/restore it
+   * Returns sample (or sample template) entity if it exists and user can delete/restore it
    *
    * @param id
    * @param user
    * @return
    */
-  Sample assertUserCanDeleteSample(Long id, User user);
+  SampleEntity assertUserCanDeleteSample(Long id, User user);
 
   /**
-   * Returns Sample entity if it exists and user has transfer permission
+   * Returns sample (or sample template) entity if it exists and user has transfer permission
    *
    * @param id
    * @param user
    * @return
    */
-  Sample assertUserCanTransferSample(Long id, User user);
+  SampleEntity assertUserCanTransferSample(Long id, User user);
 
   /** Checks if sample with given name exists for the user */
   boolean nameExistsForUser(String sampleName, User user);
@@ -125,10 +127,10 @@ public interface SampleApiManager extends InventoryApiManager<Sample> {
       User user);
 
   /**
-   * @return Sample with a given id with uninitialized subsample list
+   * @return sample (or sample template) with a given id with uninitialized subsample list
    * @throws NotFoundException if Sample with a given id doesn't exist
    */
-  Sample getSampleById(Long id, User user);
+  SampleEntity getSampleById(Long id, User user);
 
   /**
    * @return updated sample
@@ -140,7 +142,7 @@ public interface SampleApiManager extends InventoryApiManager<Sample> {
    */
   ApiSample changeApiSampleOwner(ApiSampleInfo apiSample, User user);
 
-  void saveDbSampleUpdate(Sample dbSample, User user);
+  void saveDbSampleUpdate(SampleEntity dbSample, User user);
 
   /**
    * Marks sample as deleted - it will no longer be included in standard listings. Also marks all
@@ -191,7 +193,7 @@ public interface SampleApiManager extends InventoryApiManager<Sample> {
    * particular owner.
    */
   ApiSampleTemplateSearchResult getTemplatesForUser(
-      PaginationCriteria<Sample> pgCrit,
+      PaginationCriteria<SampleTemplate> pgCrit,
       String ownedBy,
       InventorySearchDeletedOption deletedOption,
       User user);
@@ -202,9 +204,9 @@ public interface SampleApiManager extends InventoryApiManager<Sample> {
    * @param user
    * @return
    */
-  List<Sample> getAllTemplates(User user);
+  List<SampleTemplate> getAllTemplates(User user);
 
-  Sample getSampleTemplateByIdWithPopulatedFields(Long id, User user);
+  SampleTemplate getSampleTemplateByIdWithPopulatedFields(Long id, User user);
 
   ApiSampleTemplate getApiSampleTemplateById(Long id, User user);
 
@@ -229,5 +231,5 @@ public interface SampleApiManager extends InventoryApiManager<Sample> {
    */
   ApiSample updateSampleToLatestTemplateVersion(Long sampleId, User user);
 
-  Sample saveIconId(Sample sample, Long iconId);
+  SampleEntity saveIconId(SampleEntity sample, Long iconId);
 }

--- a/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleExporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleExporter.java
@@ -118,8 +118,7 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
 
   private void addSampleSpecificPropertiesForExport(
       SampleEntity sample, List<String> itemProperties) {
-    SampleTemplate parentTemplate =
-        sample instanceof Sample ? ((Sample) sample).getSTemplate() : null;
+    SampleTemplate parentTemplate = sample.isSample() ? ((Sample) sample).getSTemplate() : null;
     for (ExportableInvRecProperty prop : getExportableProps()) {
       String valueForProp = null;
       switch (prop) {

--- a/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleExporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleExporter.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.researchspace.archive.ExportScope;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +31,10 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
   };
 
   public List<String> writeSampleCsvHeaderIntoOutput(
-      List<Sample> samples, CsvExportMode exportMode, CsvMapper mapper, OutputStream outputStream)
+      List<? extends SampleEntity> samples,
+      CsvExportMode exportMode,
+      CsvMapper mapper,
+      OutputStream outputStream)
       throws IOException {
     if (mapper == null) {
       mapper = getCsvMapper();
@@ -46,7 +51,8 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
     return SAMPLE_EXPORTABLE_PROPS;
   }
 
-  private List<String> getSampleColumnNamesForCsv(List<Sample> samples, CsvExportMode exportMode) {
+  private List<String> getSampleColumnNamesForCsv(
+      List<? extends SampleEntity> samples, CsvExportMode exportMode) {
     List<String> columnNames = super.getBasicColumnNamesForCsv(exportMode);
     for (ExportableInvRecProperty prop : getExportableProps()) {
       columnNames.add(prop.getCsvColumnHeader());
@@ -58,7 +64,8 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
     return columnNames;
   }
 
-  private List<InventoryEntityField> getSampleFieldsFromAllSamples(List<Sample> samples) {
+  private List<InventoryEntityField> getSampleFieldsFromAllSamples(
+      List<? extends SampleEntity> samples) {
     return samples.stream().flatMap(s -> s.getActiveFields().stream()).collect(Collectors.toList());
   }
 
@@ -82,7 +89,7 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
   }
 
   protected List<String> writeSampleCsvDetailsIntoOutput(
-      Sample sample,
+      SampleEntity sample,
       List<String> csvColumnNames,
       CsvExportMode exportMode,
       CsvMapper mapper,
@@ -101,7 +108,7 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
   }
 
   private List<String> getSamplePropertiesForCsv(
-      Sample sample, List<String> csvColumnNames, CsvExportMode exportMode) {
+      SampleEntity sample, List<String> csvColumnNames, CsvExportMode exportMode) {
     List<String> itemProperties = getBasicItemPropertiesForExport(sample, exportMode);
     addSampleSpecificPropertiesForExport(sample, itemProperties);
     addVariableSamplePropertiesForExport(sample, exportMode, csvColumnNames, itemProperties);
@@ -109,7 +116,10 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
     return itemProperties;
   }
 
-  private void addSampleSpecificPropertiesForExport(Sample sample, List<String> itemProperties) {
+  private void addSampleSpecificPropertiesForExport(
+      SampleEntity sample, List<String> itemProperties) {
+    SampleTemplate parentTemplate =
+        sample instanceof Sample ? ((Sample) sample).getSTemplate() : null;
     for (ExportableInvRecProperty prop : getExportableProps()) {
       String valueForProp = null;
       switch (prop) {
@@ -136,11 +146,15 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
                   : null;
           break;
         case TEMPLATE_GLOBAL_ID:
-          valueForProp =
-              sample.getSTemplate() != null ? sample.getSTemplate().getGlobalIdentifier() : null;
+          // templates have no parent template: empty cell, as when sTemplate was a null field
+          if (parentTemplate != null) {
+            valueForProp = parentTemplate.getGlobalIdentifier();
+          }
           break;
         case TEMPLATE_NAME:
-          valueForProp = sample.getSTemplate() != null ? sample.getSTemplate().getName() : null;
+          if (parentTemplate != null) {
+            valueForProp = parentTemplate.getName();
+          }
           break;
         default:
           throw new IllegalStateException("unhandled property: " + prop);
@@ -150,7 +164,7 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
   }
 
   private void addVariableSamplePropertiesForExport(
-      Sample sample,
+      SampleEntity sample,
       CsvExportMode exportMode,
       List<String> csvColumnNames,
       List<String> itemProperties) {
@@ -168,14 +182,14 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
     }
   }
 
-  public OutputStream getCsvFragmentForSamples(List<Sample> samples, CsvExportMode exportMode)
-      throws IOException {
+  public OutputStream getCsvFragmentForSamples(
+      List<? extends SampleEntity> samples, CsvExportMode exportMode) throws IOException {
     CsvMapper mapper = getCsvMapper();
     OutputStream outputStream = new ByteArrayOutputStream();
     if (!samples.isEmpty()) {
       List<String> columnNames =
           writeSampleCsvHeaderIntoOutput(samples, exportMode, mapper, outputStream);
-      for (Sample s : samples) {
+      for (SampleEntity s : samples) {
         writeSampleCsvDetailsIntoOutput(s, columnNames, exportMode, mapper, outputStream);
       }
     }

--- a/src/main/java/com/researchspace/service/inventory/csvimport/CsvSampleImporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/CsvSampleImporter.java
@@ -14,8 +14,8 @@ import com.researchspace.apiutils.ApiError;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.field.FieldType;
-import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.record.IRecordFactory;
 import com.researchspace.model.units.RSUnitDef;
@@ -63,8 +63,7 @@ public class CsvSampleImporter extends InventoryItemCsvImporter {
         filename.toLowerCase().endsWith(".csv")
             ? filename.substring(0, filename.length() - 4)
             : filename;
-    Sample template = recordFactory.createSample(templateName, createdBy);
-    template.setTemplate(true);
+    SampleTemplate template = recordFactory.createSampleTemplate(templateName, createdBy);
     setDefaultsInSuggestedParsedTemplate(template);
 
     // for each column decide field type and add to result template
@@ -84,7 +83,7 @@ public class CsvSampleImporter extends InventoryItemCsvImporter {
     return sampleParseResult;
   }
 
-  private void setDefaultsInSuggestedParsedTemplate(Sample template) {
+  private void setDefaultsInSuggestedParsedTemplate(SampleTemplate template) {
     template.setSampleSource(SampleSource.OTHER);
   }
 

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -784,6 +784,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     switch (parentEntity.getType()) {
       case SAMPLE:
         return sampleApiManager.assertUserCanReadSample(entityGlobalId.getDbId(), user);
+      case SAMPLE_TEMPLATE:
+        return sampleApiManager.assertUserCanReadSampleTemplate(entityGlobalId.getDbId(), user);
       case INSTRUMENT:
         return this.assertUserCanReadInstrument(entityGlobalId.getDbId(), user);
       case INSTRUMENT_TEMPLATE:
@@ -801,6 +803,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     switch (parentEntity.getType()) {
       case SAMPLE:
         return sampleApiManager.assertUserCanEditSample(entityGlobalId.getDbId(), user);
+      case SAMPLE_TEMPLATE:
+        return sampleApiManager.assertUserCanEditSampleTemplate(entityGlobalId.getDbId(), user);
       case INSTRUMENT:
         return this.assertUserCanEditInstrument(entityGlobalId.getDbId(), user);
       case INSTRUMENT_TEMPLATE:

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryAuditApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryAuditApiManagerImpl.java
@@ -16,7 +16,8 @@ import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.service.AuditManager;
 import com.researchspace.service.UserManager;
@@ -73,7 +74,8 @@ public class InventoryAuditApiManagerImpl implements InventoryAuditApiManager {
   @Override
   public ApiSample getApiSampleRevision(Long sampleId, Long revisionId) {
     ApiSample result = null;
-    Sample sample = getInventoryRecordRevision(Sample.class, sampleId, revisionId);
+    // must target SampleEntity so the Envers read resolves either discriminator value
+    SampleEntity sample = getInventoryRecordRevision(SampleEntity.class, sampleId, revisionId);
     if (sample != null) {
       initialiseInventoryRecordRelationships(sample);
       result = (ApiSample) ApiInventoryRecordInfo.fromInventoryRecordToFullApiRecord(sample);
@@ -115,7 +117,7 @@ public class InventoryAuditApiManagerImpl implements InventoryAuditApiManager {
   }
 
   @Override
-  public ApiSampleTemplate getApiTemplateVersion(Sample currTemplate, Long version) {
+  public ApiSampleTemplate getApiTemplateVersion(SampleTemplate currTemplate, Long version) {
     if (version.equals(currTemplate.getVersion())) {
       return new ApiSampleTemplate(currTemplate);
     }
@@ -131,7 +133,7 @@ public class InventoryAuditApiManagerImpl implements InventoryAuditApiManager {
   }
 
   @Override
-  public ApiSample getApiSampleVersion(Sample currentSample, Long version) {
+  public ApiSample getApiSampleVersion(SampleEntity currentSample, Long version) {
     if (version.equals(currentSample.getVersion())) {
       return (ApiSample) ApiInventoryRecordInfo.fromInventoryRecordToFullApiRecord(currentSample);
     }
@@ -293,7 +295,7 @@ public class InventoryAuditApiManagerImpl implements InventoryAuditApiManager {
       Hibernate.initialize(((Container) record).getLocationsImageFileProperty());
     }
     if (record.isSubSample()) {
-      Sample connectedSample = ((SubSample) record).getSample();
+      SampleEntity connectedSample = ((SubSample) record).getSample();
       if (connectedSample != null) {
         initialiseInventoryRecordRelationships(connectedSample);
       }

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryExportManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryExportManagerImpl.java
@@ -7,6 +7,7 @@ import com.researchspace.dao.ContainerDao;
 import com.researchspace.dao.InstrumentDao;
 import com.researchspace.dao.InstrumentTemplateDao;
 import com.researchspace.dao.SampleDao;
+import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
@@ -17,6 +18,8 @@ import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.service.inventory.ContainerApiManager;
@@ -68,6 +71,8 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
 
   @Autowired private SampleDao sampleDao;
 
+  @Autowired private SampleTemplateDao sampleTemplateDao;
+
   @Autowired private InstrumentEntityApiManager instrumentManager;
 
   @Autowired private InstrumentDao instrumentDao;
@@ -95,8 +100,8 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
   @Data
   private static class ItemsToExport {
     private final Set<Container> containersToExport;
-    private final Set<Sample> samplesToExport;
-    private final Set<Sample> templatesToExport;
+    private final Set<SampleEntity> samplesToExport;
+    private final Set<SampleEntity> templatesToExport;
     private final Set<SubSample> subSamplesToExport;
     private final Set<ListOfMaterials> lomsToExport;
     private final Set<Instrument> instrumentsToExport;
@@ -113,8 +118,8 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
       throws IOException {
 
     Set<Container> containersToExport = new LinkedHashSet<>();
-    Set<Sample> samplesToExport = new LinkedHashSet<>();
-    Set<Sample> templatesToExport = new LinkedHashSet<>();
+    Set<SampleEntity> samplesToExport = new LinkedHashSet<>();
+    Set<SampleEntity> templatesToExport = new LinkedHashSet<>();
     Set<SubSample> subSamplesToExport = new LinkedHashSet<>();
     Set<ListOfMaterials> lomsToExport = new LinkedHashSet<>();
     Set<Instrument> instrumentsToExport = new LinkedHashSet<>();
@@ -178,8 +183,8 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
   private void findItemByGlobalIdAndPutIntoSetToExport(
       GlobalIdentifier globalId,
       Set<Container> containersToExport,
-      Set<Sample> samplesToExport,
-      Set<Sample> templatesToExport,
+      Set<SampleEntity> samplesToExport,
+      Set<SampleEntity> templatesToExport,
       Set<SubSample> subSamplesToExport,
       Set<Instrument> instrumentsToExport,
       Set<InstrumentTemplate> instrumentTemplatesToExport,
@@ -189,13 +194,13 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
     if (globalId.getPrefix().equals(GlobalIdPrefix.SS)) {
       subSamplesToExport.add(subSampleManager.assertUserCanReadSubSample(globalId.getDbId(), user));
     } else if (globalId.getPrefix().equals(GlobalIdPrefix.SA)) {
-      Sample sample = sampleManager.assertUserCanReadSample(globalId.getDbId(), user);
+      SampleEntity sample = sampleManager.assertUserCanReadSample(globalId.getDbId(), user);
       samplesToExport.add(sample);
       if (includeSampleContent) {
         subSamplesToExport.addAll(sample.getActiveSubSamples());
       }
     } else if (globalId.getPrefix().equals(GlobalIdPrefix.IT)) {
-      Sample template = sampleManager.assertUserCanReadSample(globalId.getDbId(), user);
+      SampleEntity template = sampleManager.assertUserCanReadSample(globalId.getDbId(), user);
       templatesToExport.add(template);
     } else if (globalId.getPrefix().equals(GlobalIdPrefix.IC)) {
       Container container = containerManager.assertUserCanReadContainer(globalId.getDbId(), user);
@@ -281,9 +286,9 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
       User user)
       throws IOException {
     Set<Container> containersToExport = new LinkedHashSet<>();
-    Set<Sample> samplesToExport = new LinkedHashSet<>();
+    Set<SampleEntity> samplesToExport = new LinkedHashSet<>();
     Set<SubSample> subSamplesToExport = new LinkedHashSet<>();
-    Set<Sample> templatesToExport = new LinkedHashSet<>();
+    Set<SampleEntity> templatesToExport = new LinkedHashSet<>();
     Set<Instrument> instrumentsToExport = new LinkedHashSet<>();
     Set<InstrumentTemplate> instrumentTemplatesToExport = new LinkedHashSet<>();
 
@@ -297,6 +302,9 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
       PaginationCriteria<Sample> samplePgCrit =
           PaginationCriteria.createDefaultForClass(Sample.class);
       samplePgCrit.setResultsPerPage(Integer.MAX_VALUE);
+      PaginationCriteria<SampleTemplate> templatePgCrit =
+          PaginationCriteria.createDefaultForClass(SampleTemplate.class);
+      templatePgCrit.setResultsPerPage(Integer.MAX_VALUE);
       PaginationCriteria<Instrument> instrumentPgCrit =
           PaginationCriteria.createDefaultForClass(Instrument.class);
       instrumentPgCrit.setResultsPerPage(Integer.MAX_VALUE);
@@ -307,10 +315,10 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
         ISearchResults<Container> dbContainers =
             containerDao.getAllContainersForUser(containerPgCrit, username, null, user);
         containersToExport.addAll(dbContainers.getResults());
-        ISearchResults<Sample> dbSamples =
+        ISearchResults<? extends SampleEntity> dbSamples =
             sampleDao.getSamplesForUser(samplePgCrit, null, username, null, user);
         samplesToExport.addAll(dbSamples.getResults());
-        for (Sample sample : samplesToExport) {
+        for (SampleEntity sample : samplesToExport) {
           subSamplesToExport.addAll(sample.getActiveSubSamples());
         }
         ISearchResults<Instrument> dbInstruments =
@@ -321,8 +329,8 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
           addAllContainerContentToExportSets(
               containersToExport, subSamplesToExport, instrumentsToExport, user);
         }
-        ISearchResults<Sample> dbTemplates =
-            sampleDao.getTemplatesForUser(samplePgCrit, username, null, user);
+        ISearchResults<SampleTemplate> dbTemplates =
+            sampleTemplateDao.getTemplatesForUser(templatePgCrit, username, null, user);
         templatesToExport.addAll(dbTemplates.getResults());
         ISearchResults<InstrumentTemplate> dbInstrumentTemplates =
             instrumentTemplateDao.getTemplatesForUser(

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryExportManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryExportManagerImpl.java
@@ -200,7 +200,8 @@ public class InventoryExportManagerImpl implements InventoryExportManager {
         subSamplesToExport.addAll(sample.getActiveSubSamples());
       }
     } else if (globalId.getPrefix().equals(GlobalIdPrefix.IT)) {
-      SampleEntity template = sampleManager.assertUserCanReadSample(globalId.getDbId(), user);
+      SampleEntity template =
+          sampleManager.assertUserCanReadSampleTemplate(globalId.getDbId(), user);
       templatesToExport.add(template);
     } else if (globalId.getPrefix().equals(GlobalIdPrefix.IC)) {
       Container container = containerManager.assertUserCanReadContainer(globalId.getDbId(), user);

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImpl.java
@@ -14,7 +14,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.record.IRecordFactory;
 import com.researchspace.service.BaseRecordManager;
@@ -132,7 +132,8 @@ public class InventoryFileApiManagerImpl implements InventoryFileApiManager {
       InventoryRecord invRec, InventoryFile invFile, GlobalIdentifier globalIdToAttachTo) {
 
     if (GlobalIdPrefix.SF.equals(globalIdToAttachTo.getPrefix())) {
-      Sample sample = (Sample) invRec;
+      // sample fields can belong to a sample or a template, so cast to the common supertype
+      SampleEntity sample = (SampleEntity) invRec;
       InventoryEntityField field = sample.getFieldById(globalIdToAttachTo.getDbId()).orElse(null);
       if (field == null) {
         throwNotFoundException(globalIdToAttachTo.getDbId(), "Sample field");

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryImportManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryImportManagerImpl.java
@@ -36,7 +36,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Container.ContainerType;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.service.inventory.ContainerApiManager;
 import com.researchspace.service.inventory.InstrumentEntityApiManager;
@@ -548,7 +548,7 @@ public class InventoryImportManagerImpl implements InventoryImportManager {
     }
     if (sampleGlobalId != null) {
       try {
-        Sample sample = sampleManager.getSampleById(sampleGlobalId.getDbId(), user);
+        SampleEntity sample = sampleManager.getSampleById(sampleGlobalId.getDbId(), user);
         invPermissions.assertUserCanEditInventoryRecord(sample, user);
 
         if (sample.getQuantityInfo() != null) {

--- a/src/main/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImpl.java
@@ -9,7 +9,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.Folder;
@@ -126,7 +126,7 @@ public class LinkTargetSnapshotResolverImpl implements LinkTargetSnapshotResolve
   private Class<?> entityClassFor(GlobalIdPrefix prefix) {
     switch (prefix) {
       case SA:
-        return Sample.class;
+        return SampleEntity.class;
       case SS:
         return SubSample.class;
       case IC:
@@ -134,8 +134,10 @@ public class LinkTargetSnapshotResolverImpl implements LinkTargetSnapshotResolve
       case IN:
         return Instrument.class;
       case IT:
-        // Sample templates are persisted as Sample rows (treated as SA elsewhere).
-        return Sample.class;
+        // Sample templates are now a SampleEntity subtype (DTYPE discriminator) on the shared
+        // Sample table; resolve via SampleEntity so Envers returns the concrete SampleTemplate
+        // revision (querying Sample.class would filter to DTYPE='Sample' and miss templates).
+        return SampleEntity.class;
       case SD:
         return StructuredDocument.class;
       case NB:

--- a/src/main/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImpl.java
@@ -9,7 +9,8 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.Folder;
@@ -126,7 +127,7 @@ public class LinkTargetSnapshotResolverImpl implements LinkTargetSnapshotResolve
   private Class<?> entityClassFor(GlobalIdPrefix prefix) {
     switch (prefix) {
       case SA:
-        return SampleEntity.class;
+        return Sample.class;
       case SS:
         return SubSample.class;
       case IC:
@@ -134,10 +135,10 @@ public class LinkTargetSnapshotResolverImpl implements LinkTargetSnapshotResolve
       case IN:
         return Instrument.class;
       case IT:
-        // Sample templates are now a SampleEntity subtype (DTYPE discriminator) on the shared
-        // Sample table; resolve via SampleEntity so Envers returns the concrete SampleTemplate
-        // revision (querying Sample.class would filter to DTYPE='Sample' and miss templates).
-        return SampleEntity.class;
+        // a template is a distinct SampleTemplate entity (DTYPE='SampleTemplate'); query that
+        // concrete class so Envers resolves the template revision (Sample.class would filter to
+        // DTYPE='Sample' and miss it).
+        return SampleTemplate.class;
       case SD:
         return StructuredDocument.class;
       case NB:

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -229,21 +229,21 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   public ApiSampleWithFullSubSamples createNewApiSample(
       ApiSampleWithFullSubSamples apiSample, User user) {
 
-    SampleTemplate template = getSampleTemplateIfExists(apiSample);
+    SampleTemplate template = getSampleTemplateIfExists(apiSample, user);
 
     String sampleName = getNameForIncomingApiSample(apiSample);
     return createSample(sampleName, apiSample, template, user);
   }
 
-  private SampleTemplate getSampleTemplateIfExists(ApiSampleWithFullSubSamples apiSample) {
-    SampleTemplate template = null;
+  private SampleTemplate getSampleTemplateIfExists(
+      ApiSampleWithFullSubSamples apiSample, User user) {
     Long templateId = apiSample.getTemplateId();
-    // if templateId is null(we're creating a new sample), that's ok, but if not null, we expect it
-    // to exist
-    if (templateId != null) {
-      template = sampleTemplateDao.get(templateId);
+    // templateId is null when creating a sample with no template; when provided, the caller must
+    // have read access to it (enforced, not just existence-checked)
+    if (templateId == null) {
+      return null;
     }
-    return template;
+    return assertUserCanReadSampleTemplate(templateId, user);
   }
 
   private String getNameForIncomingApiSample(ApiSampleInfo prototypeSample) {
@@ -985,8 +985,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   @Override
   public SampleTemplate getSampleTemplateByIdWithPopulatedFields(Long id, User user) {
-    // cast is safe: getIfExists(id, true) throws NotFoundException unless the entity is a template
-    SampleTemplate template = (SampleTemplate) getIfExists(id, true);
+    // enforce read/limited-read permission (not just existence) before returning the template
+    SampleTemplate template = assertUserCanReadSampleTemplate(id, user);
     template.getActiveFields().size(); // initialize lazy-loaded collection
     return template;
   }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -137,31 +137,87 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   }
 
   @Override
-  public SampleEntity assertUserCanReadSample(Long id, User user) {
-    SampleEntity sample = getIfExists(id);
+  public Sample assertUserCanReadSample(Long id, User user) {
+    Sample sample = getSampleOrThrowNotFound(id);
     invPermissions.assertUserCanReadOrLimitedReadInventoryRecord(sample, user);
     return sample;
   }
 
   @Override
-  public SampleEntity assertUserCanEditSample(Long id, User user) {
-    SampleEntity sample = getIfExists(id);
+  public Sample assertUserCanEditSample(Long id, User user) {
+    Sample sample = getSampleOrThrowNotFound(id);
     invPermissions.assertUserCanEditInventoryRecord(sample, user);
     return sample;
   }
 
   @Override
-  public SampleEntity assertUserCanDeleteSample(Long id, User user) {
-    SampleEntity sample = getIfExists(id);
+  public Sample assertUserCanDeleteSample(Long id, User user) {
+    Sample sample = getSampleOrThrowNotFound(id);
     invPermissions.assertUserCanDeleteInventoryRecord(sample, user);
     return sample;
   }
 
   @Override
-  public SampleEntity assertUserCanTransferSample(Long id, User user) {
-    SampleEntity sample = getIfExists(id);
+  public Sample assertUserCanTransferSample(Long id, User user) {
+    Sample sample = getSampleOrThrowNotFound(id);
     invPermissions.assertUserCanTransferInventoryRecord(sample, user);
     return sample;
+  }
+
+  @Override
+  public SampleTemplate assertUserCanReadSampleTemplate(Long id, User user) {
+    SampleTemplate template = getSampleTemplateOrThrowNotFound(id);
+    invPermissions.assertUserCanReadOrLimitedReadInventoryRecord(template, user);
+    return template;
+  }
+
+  @Override
+  public SampleTemplate assertUserCanEditSampleTemplate(Long id, User user) {
+    SampleTemplate template = getSampleTemplateOrThrowNotFound(id);
+    invPermissions.assertUserCanEditInventoryRecord(template, user);
+    return template;
+  }
+
+  @Override
+  public SampleTemplate assertUserCanDeleteSampleTemplate(Long id, User user) {
+    SampleTemplate template = getSampleTemplateOrThrowNotFound(id);
+    invPermissions.assertUserCanDeleteInventoryRecord(template, user);
+    return template;
+  }
+
+  @Override
+  public SampleTemplate assertUserCanTransferSampleTemplate(Long id, User user) {
+    SampleTemplate template = getSampleTemplateOrThrowNotFound(id);
+    invPermissions.assertUserCanTransferInventoryRecord(template, user);
+    return template;
+  }
+
+  /**
+   * Returns the {@link Sample} (not a template) with the given id, or throws {@link
+   * NotFoundException} if no sample exists with that id. A {@link SampleTemplate} that shares the
+   * id space is treated as absent: {@code sampleDao} is anchored on {@code DTYPE='Sample'}.
+   */
+  private Sample getSampleOrThrowNotFound(Long id) {
+    if (!sampleDao.exists(id)) {
+      throw new NotFoundException("No sample with id: " + id);
+    }
+    Sample sample = sampleDao.get(id);
+    for (SubSample ss : sample.getSubSamples()) {
+      populateSubSampleParentContainerChain(ss);
+    }
+    return sample;
+  }
+
+  /**
+   * Returns the {@link SampleTemplate} with the given id, or throws {@link NotFoundException} if no
+   * template exists with that id. A plain {@link Sample} that shares the id space is treated as
+   * absent: {@code sampleTemplateDao} is anchored on {@code DTYPE='SampleTemplate'}.
+   */
+  private SampleTemplate getSampleTemplateOrThrowNotFound(Long id) {
+    if (!sampleTemplateDao.exists(id)) {
+      throw new NotFoundException("No sample template with id: " + id);
+    }
+    return sampleTemplateDao.get(id);
   }
 
   @Override
@@ -676,12 +732,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   @Override
   public ApiSample updateApiSample(ApiSampleWithoutSubSamples apiSample, User user) {
+    // assertUserCanEditSample returns a Sample (a template id 404s), so ApiSample is safe
     SampleEntity dbSample = assertUserCanEditSample(apiSample.getId(), user);
-    if (dbSample.isSampleTemplate()) {
-      throw new IllegalArgumentException(
-          "trying to update sample template through sample update method");
-    }
-    // safe for ApiSample: the SampleTemplate case was rejected above
     ApiSample original = new ApiSample(dbSample);
 
     boolean temporaryLock = lockItemForEdit(dbSample, user);
@@ -704,7 +756,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     Validate.notNull(apiSample.getOwner(), "'owner' field not present");
     Validate.notNull(apiSample.getOwner().getUsername(), "'owner.username' field not present");
 
-    assertUserCanTransferSample(apiSample.getId(), user);
+    invPermissions.assertUserCanTransferInventoryRecord(getIfExists(apiSample.getId()), user);
 
     SampleEntity dbSample = getIfExists(apiSample.getId());
     boolean temporaryLock = lockItemForEdit(dbSample, user);
@@ -790,7 +842,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   @Override
   public ApiSample markSampleAsDeleted(Long sampleId, boolean forceDelete, User user) {
-    SampleEntity dbSample = assertUserCanDeleteSample(sampleId, user);
+    SampleEntity dbSample = getIfExists(sampleId);
+    invPermissions.assertUserCanDeleteInventoryRecord(dbSample, user);
     boolean temporaryLock = lockItemForEdit(dbSample, user);
 
     try {
@@ -826,7 +879,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   @Override
   public ApiSample restoreDeletedSample(
       Long sampleId, User user, boolean includeSubSamplesDeletedOnSampleDeletion) {
-    SampleEntity dbSample = assertUserCanDeleteSample(sampleId, user);
+    SampleEntity dbSample = getIfExists(sampleId);
+    invPermissions.assertUserCanDeleteInventoryRecord(dbSample, user);
     boolean temporaryLock = lockItemForEdit(dbSample, user);
     try {
       dbSample = getIfExists(dbSample.getId());
@@ -898,7 +952,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   }
 
   private SampleEntity copyDbSample(Long sampleId, User user) {
-    SampleEntity dbSample = assertUserCanReadSample(sampleId, user);
+    SampleEntity dbSample = getIfExists(sampleId);
+    invPermissions.assertUserCanReadOrLimitedReadInventoryRecord(dbSample, user);
     SampleEntity copy;
     if (dbSample.isSample()) {
       Sample sampleCopy = ((Sample) dbSample).copy(user);
@@ -1024,17 +1079,12 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   @Override
   public ApiSampleTemplate updateApiSampleTemplate(ApiSampleTemplate apiSample, User user) {
-    SampleEntity dbSample = assertUserCanEditSample(apiSample.getId(), user);
-    if (!dbSample.isSampleTemplate()) {
-      throw new IllegalArgumentException(
-          "trying to update sample through sample template update method");
-    }
-    SampleTemplate dbTemplate = (SampleTemplate) dbSample;
+    SampleTemplate dbTemplate = assertUserCanEditSampleTemplate(apiSample.getId(), user);
 
     boolean temporaryLock = lockItemForEdit(dbTemplate, user);
     try {
-      // cast is safe: re-fetch by id returns the same template row
-      dbTemplate = (SampleTemplate) getIfExists(dbTemplate.getId());
+      // re-fetch by id returns the same template row
+      dbTemplate = getSampleTemplateOrThrowNotFound(dbTemplate.getId());
       boolean contentChanged =
           createDeleteRequestedFieldsInDbSampleTemplate(apiSample, dbTemplate, user);
       contentChanged |= apiSample.applyChangesToDatabaseTemplate(dbTemplate, user);
@@ -1086,7 +1136,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     // templates have no parent template; a null id keeps the legacy not-found behaviour of the
     // assert call below
     Long parentTemplateId = dbSample.isSample() ? ((Sample) dbSample).getParentTemplateId() : null;
-    SampleEntity dbTemplate = assertUserCanReadSample(parentTemplateId, user);
+    SampleEntity dbTemplate = assertUserCanReadSampleTemplate(parentTemplateId, user);
     if (dbTemplate == null) {
       throw new IllegalArgumentException("Sample is not based on any template");
     }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -518,7 +518,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   private ApiSample doGetSample(Long id, User user, boolean asTemplate) {
     SampleEntity sample = getIfExists(id);
-    if (asTemplate != (sample instanceof SampleTemplate)) {
+    if (asTemplate != sample.isSampleTemplate()) {
       throw new IllegalArgumentException(
           String.format("Sample template flag doesn't match the request (id %d)", id));
     }
@@ -528,7 +528,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   private ApiSample getOutgoingApiSample(SampleEntity sample, User user) {
     ApiSample result =
-        sample instanceof SampleTemplate
+        sample.isSampleTemplate()
             ? new ApiSampleTemplate((SampleTemplate) sample)
             : new ApiSample((Sample) sample);
     populateOutgoingApiSample(result, sample, user);
@@ -677,7 +677,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   @Override
   public ApiSample updateApiSample(ApiSampleWithoutSubSamples apiSample, User user) {
     SampleEntity dbSample = assertUserCanEditSample(apiSample.getId(), user);
-    if (dbSample instanceof SampleTemplate) {
+    if (dbSample.isSampleTemplate()) {
       throw new IllegalArgumentException(
           "trying to update sample template through sample update method");
     }
@@ -723,7 +723,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
         dbSample
             .getActiveSubSamples()
             .forEach(ss -> moveItemBetweenWorkbenches(ss, originalOwner, newOwner));
-        if (dbSample instanceof SampleTemplate) {
+        if (dbSample.isSampleTemplate()) {
           dbSample = sampleTemplateDao.saveAndReindexSubSamples((SampleTemplate) dbSample);
         } else {
           dbSample = sampleDao.saveAndReindexSubSamples((Sample) dbSample);
@@ -782,7 +782,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   /** Routes a plain save to the DAO matching the entity's concrete kind. */
   private SampleEntity saveSampleEntity(SampleEntity dbSample) {
-    if (dbSample instanceof SampleTemplate) {
+    if (dbSample.isSampleTemplate()) {
       return sampleTemplateDao.save((SampleTemplate) dbSample);
     }
     return sampleDao.save((Sample) dbSample);
@@ -900,7 +900,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   private SampleEntity copyDbSample(Long sampleId, User user) {
     SampleEntity dbSample = assertUserCanReadSample(sampleId, user);
     SampleEntity copy;
-    if (dbSample instanceof Sample) {
+    if (dbSample.isSample()) {
       Sample sampleCopy = ((Sample) dbSample).copy(user);
       setWorkbenchAsParentForNewSubSamples(sampleCopy, user);
       copy = sampleDao.persistNewSample(sampleCopy);
@@ -939,7 +939,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   @Override
   public ApiSampleTemplate getApiSampleTemplateVersion(Long templateId, Long version, User user) {
     SampleEntity currentVersion = getIfExists(templateId);
-    if (!(currentVersion instanceof SampleTemplate)) {
+    if (!currentVersion.isSampleTemplate()) {
       throw new IllegalArgumentException(
           String.format("Requested id (%d) points to the sample, not template", templateId));
     }
@@ -1025,7 +1025,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   @Override
   public ApiSampleTemplate updateApiSampleTemplate(ApiSampleTemplate apiSample, User user) {
     SampleEntity dbSample = assertUserCanEditSample(apiSample.getId(), user);
-    if (!(dbSample instanceof SampleTemplate)) {
+    if (!dbSample.isSampleTemplate()) {
       throw new IllegalArgumentException(
           "trying to update sample through sample template update method");
     }
@@ -1085,8 +1085,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     SampleEntity dbSample = assertUserCanEditSample(sampleId, user);
     // templates have no parent template; a null id keeps the legacy not-found behaviour of the
     // assert call below
-    Long parentTemplateId =
-        dbSample instanceof Sample ? ((Sample) dbSample).getParentTemplateId() : null;
+    Long parentTemplateId = dbSample.isSample() ? ((Sample) dbSample).getParentTemplateId() : null;
     SampleEntity dbTemplate = assertUserCanReadSample(parentTemplateId, user);
     if (dbTemplate == null) {
       throw new IllegalArgumentException("Sample is not based on any template");

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -550,7 +550,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
         }
       }
     } else if (apiSample instanceof ApiSampleTemplate) {
-      setSamplesToUpdateCount((ApiSampleTemplate) apiSample, sample, user);
+      setSamplesToUpdateCount((ApiSampleTemplate) apiSample, (SampleTemplate) sample, user);
     }
   }
 
@@ -561,7 +561,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
    * nothing to update - notably for a template that is merely the target of a link from some sample
    * (that sample is not created from the template, so it is not counted).
    */
-  void setSamplesToUpdateCount(ApiSampleTemplate apiTemplate, Sample template, User user) {
+  void setSamplesToUpdateCount(ApiSampleTemplate apiTemplate, SampleTemplate template, User user) {
     apiTemplate.setSamplesToUpdateCount(
         sampleDao
             .getSamplesLinkingOlderTemplateVersionForUser(
@@ -760,7 +760,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
             apiSample.getIdentifiers(), dbSample, user);
     contentChanged |= apiSample.applyChangesToDatabaseSample(dbSample, user);
     if (!dbSample.isTemplate()) {
-      contentChanged |= applyLinkFieldValuesOnUpdate(apiSample, dbSample, user);
+      contentChanged |= applyLinkFieldValuesOnUpdate(apiSample, (Sample) dbSample, user);
     }
     contentChanged |= saveSharingACLForIncomingApiInvRec(dbSample, apiSample);
     contentChanged |= saveIncomingSampleImage(dbSample, apiSample, user);

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -22,6 +22,7 @@ import com.researchspace.api.v1.model.ApiSubSampleNote;
 import com.researchspace.core.util.ISearchResults;
 import com.researchspace.core.util.jsonserialisers.LocalDateDeserialiser;
 import com.researchspace.dao.SampleDao;
+import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
@@ -38,6 +39,8 @@ import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.InventorySeriesNamingHelper;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryLink;
@@ -67,13 +70,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service("sampleApiManager")
-public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
+public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     implements SampleApiManager {
 
   public static final String SAMPLE_DEFAULT_NAME = "Generic Sample";
 
   private @Autowired SubSampleApiManager subSampleMgr;
   private @Autowired SampleDao sampleDao;
+  private @Autowired SampleTemplateDao sampleTemplateDao;
   private @Autowired InventoryMoveHelper inventoryMoveHelper;
   private @Autowired InventoryAuditApiManager inventoryAuditMgr;
   private @Autowired ApiFieldToModelFieldFactory apiFieldToModelFieldFactory;
@@ -105,15 +109,15 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
   @Override
   public ApiSampleTemplateSearchResult getTemplatesForUser(
-      PaginationCriteria<Sample> pgCrit,
+      PaginationCriteria<SampleTemplate> pgCrit,
       String ownedBy,
       InventorySearchDeletedOption deletedOption,
       User user) {
 
-    ISearchResults<Sample> dbTemplates =
-        sampleDao.getTemplatesForUser(pgCrit, ownedBy, deletedOption, user);
+    ISearchResults<SampleTemplate> dbTemplates =
+        sampleTemplateDao.getTemplatesForUser(pgCrit, ownedBy, deletedOption, user);
     List<ApiSampleTemplateInfo> templateInfos = new ArrayList<>();
-    for (Sample st : dbTemplates.getResults()) {
+    for (SampleTemplate st : dbTemplates.getResults()) {
       ApiSampleTemplateInfo apiInvRec = new ApiSampleTemplateInfo(st);
       setOtherFieldsForOutgoingApiInventoryRecord(apiInvRec, st, user);
       templateInfos.add(apiInvRec);
@@ -129,59 +133,59 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
   @Override
   public boolean exists(long id) {
-    return sampleDao.exists(id);
+    return sampleDao.exists(id) || sampleTemplateDao.exists(id);
   }
 
   @Override
-  public Sample assertUserCanReadSample(Long id, User user) {
-    Sample sample = getIfExists(id);
+  public SampleEntity assertUserCanReadSample(Long id, User user) {
+    SampleEntity sample = getIfExists(id);
     invPermissions.assertUserCanReadOrLimitedReadInventoryRecord(sample, user);
     return sample;
   }
 
   @Override
-  public Sample assertUserCanEditSample(Long id, User user) {
-    Sample sample = getIfExists(id);
+  public SampleEntity assertUserCanEditSample(Long id, User user) {
+    SampleEntity sample = getIfExists(id);
     invPermissions.assertUserCanEditInventoryRecord(sample, user);
     return sample;
   }
 
   @Override
-  public Sample assertUserCanDeleteSample(Long id, User user) {
-    Sample sample = getIfExists(id);
+  public SampleEntity assertUserCanDeleteSample(Long id, User user) {
+    SampleEntity sample = getIfExists(id);
     invPermissions.assertUserCanDeleteInventoryRecord(sample, user);
     return sample;
   }
 
   @Override
-  public Sample assertUserCanTransferSample(Long id, User user) {
-    Sample sample = getIfExists(id);
+  public SampleEntity assertUserCanTransferSample(Long id, User user) {
+    SampleEntity sample = getIfExists(id);
     invPermissions.assertUserCanTransferInventoryRecord(sample, user);
     return sample;
   }
 
   @Override
   public boolean nameExistsForUser(String sampleName, User user) {
-    return sampleDao.findSamplesByName(sampleName, user).size() > 0;
+    return sampleDao.entityNameExistsForUser(sampleName, user);
   }
 
   @Override
   public ApiSampleWithFullSubSamples createNewApiSample(
       ApiSampleWithFullSubSamples apiSample, User user) {
 
-    Sample template = getSampleTemplateIfExists(apiSample);
+    SampleTemplate template = getSampleTemplateIfExists(apiSample);
 
     String sampleName = getNameForIncomingApiSample(apiSample);
     return createSample(sampleName, apiSample, template, user);
   }
 
-  private Sample getSampleTemplateIfExists(ApiSampleWithFullSubSamples apiSample) {
-    Sample template = null;
+  private SampleTemplate getSampleTemplateIfExists(ApiSampleWithFullSubSamples apiSample) {
+    SampleTemplate template = null;
     Long templateId = apiSample.getTemplateId();
     // if templateId is null(we're creating a new sample), that's ok, but if not null, we expect it
     // to exist
     if (templateId != null) {
-      template = sampleDao.get(templateId);
+      template = sampleTemplateDao.get(templateId);
     }
     return template;
   }
@@ -193,7 +197,10 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   }
 
   private ApiSampleWithFullSubSamples createSample(
-      String sampleName, ApiSampleWithFullSubSamples apiSample, Sample sampleTemplate, User user) {
+      String sampleName,
+      ApiSampleWithFullSubSamples apiSample,
+      SampleTemplate sampleTemplate,
+      User user) {
     Sample sample =
         sampleTemplate != null
             ? recordFactory.createSample(sampleName, user, sampleTemplate)
@@ -285,7 +292,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
     }
   }
 
-  private void setSampleCoreProperties(ApiSampleInfo apiSample, Sample sample) {
+  private void setSampleCoreProperties(ApiSampleInfo apiSample, SampleEntity sample) {
 
     if (apiSample.getStorageTempMin() != null) {
       sample.setStorageTempMin(apiSample.getStorageTempMin().toQuantityInfo());
@@ -510,8 +517,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   }
 
   private ApiSample doGetSample(Long id, User user, boolean asTemplate) {
-    Sample sample = getIfExists(id);
-    if (asTemplate != sample.isTemplate()) {
+    SampleEntity sample = getIfExists(id);
+    if (asTemplate != (sample instanceof SampleTemplate)) {
       throw new IllegalArgumentException(
           String.format("Sample template flag doesn't match the request (id %d)", id));
     }
@@ -519,13 +526,16 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
     return getOutgoingApiSample(sample, user);
   }
 
-  private ApiSample getOutgoingApiSample(Sample sample, User user) {
-    ApiSample result = sample.isTemplate() ? new ApiSampleTemplate(sample) : new ApiSample(sample);
+  private ApiSample getOutgoingApiSample(SampleEntity sample, User user) {
+    ApiSample result =
+        sample instanceof SampleTemplate
+            ? new ApiSampleTemplate((SampleTemplate) sample)
+            : new ApiSample((Sample) sample);
     populateOutgoingApiSample(result, sample, user);
     return result;
   }
 
-  private void populateOutgoingApiSample(ApiSample apiSample, Sample sample, User user) {
+  private void populateOutgoingApiSample(ApiSample apiSample, SampleEntity sample, User user) {
     if (apiSample == null) {
       return;
     }
@@ -578,7 +588,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
       PaginationCriteria<InventoryRecord> pgCrit,
       User user) {
 
-    Sample sample = getIfExists(sampleId);
+    SampleEntity sample = getIfExists(sampleId);
     boolean canRead = invPermissions.canUserReadInventoryRecord(sample, user);
 
     if (!canRead
@@ -610,7 +620,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
       PaginationCriteria<Sample> pgCrit,
       User user) {
 
-    Sample template = getIfExists(templateId);
+    SampleEntity template = getIfExists(templateId);
     boolean canRead = invPermissions.canUserReadInventoryRecord(template, user);
     if (!canRead) {
       return ApiInventorySearchResult
@@ -630,7 +640,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   @Override
   public List<ApiInventoryRecordInfo> getSamplesLinkingOldTemplateVersion(
       Long templateId, User user) {
-    Sample template = getIfExists(templateId, true);
+    SampleEntity template = getIfExists(templateId, true);
     List<Sample> samples =
         sampleDao.getSamplesLinkingOlderTemplateVersionForUser(
             templateId, template.getVersion(), user);
@@ -641,17 +651,20 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   }
 
   @Override
-  public Sample getIfExists(Long id) {
+  public SampleEntity getIfExists(Long id) {
     return getIfExists(id, false);
   }
 
-  private Sample getIfExists(Long id, boolean onlyIfTemplate) {
-    boolean exists = sampleDao.exists(id);
-    if (!exists) {
+  private SampleEntity getIfExists(Long id, boolean onlyIfTemplate) {
+    SampleEntity s;
+    if (sampleDao.exists(id)) {
+      s = sampleDao.get(id);
+    } else if (sampleTemplateDao.exists(id)) {
+      s = sampleTemplateDao.get(id);
+    } else {
       throw new NotFoundException(
           "No sample " + (onlyIfTemplate ? "template " : "") + "with id: " + id);
     }
-    Sample s = sampleDao.get(id);
     if (onlyIfTemplate && !s.isTemplate()) {
       throw new NotFoundException("No sample template with id: " + id);
     }
@@ -663,12 +676,13 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
   @Override
   public ApiSample updateApiSample(ApiSampleWithoutSubSamples apiSample, User user) {
-    Sample dbSample = assertUserCanEditSample(apiSample.getId(), user);
-    ApiSample original = new ApiSample(dbSample);
-    if (dbSample.isTemplate()) {
+    SampleEntity dbSample = assertUserCanEditSample(apiSample.getId(), user);
+    if (dbSample instanceof SampleTemplate) {
       throw new IllegalArgumentException(
           "trying to update sample template through sample update method");
     }
+    // safe for ApiSample: the SampleTemplate case was rejected above
+    ApiSample original = new ApiSample(dbSample);
 
     boolean temporaryLock = lockItemForEdit(dbSample, user);
     try {
@@ -692,7 +706,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
     assertUserCanTransferSample(apiSample.getId(), user);
 
-    Sample dbSample = getIfExists(apiSample.getId());
+    SampleEntity dbSample = getIfExists(apiSample.getId());
     boolean temporaryLock = lockItemForEdit(dbSample, user);
 
     try {
@@ -709,7 +723,11 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
         dbSample
             .getActiveSubSamples()
             .forEach(ss -> moveItemBetweenWorkbenches(ss, originalOwner, newOwner));
-        dbSample = sampleDao.saveAndReindexSubSamples(dbSample);
+        if (dbSample instanceof SampleTemplate) {
+          dbSample = sampleTemplateDao.saveAndReindexSubSamples((SampleTemplate) dbSample);
+        } else {
+          dbSample = sampleDao.saveAndReindexSubSamples((Sample) dbSample);
+        }
         publisher.publishEvent(new InventoryTransferEvent(dbSample, user, originalOwner, newOwner));
       }
     } finally {
@@ -724,7 +742,10 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   }
 
   private void updateDbSample(
-      ApiSampleWithoutSubSamples apiSample, Sample dbSample, boolean alreadyChanged, User user) {
+      ApiSampleWithoutSubSamples apiSample,
+      SampleEntity dbSample,
+      boolean alreadyChanged,
+      User user) {
     boolean contentChanged = alreadyChanged;
     contentChanged |=
         extraFieldHelper.createDeleteRequestedExtraFieldsInDatabaseSample(
@@ -751,17 +772,25 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   }
 
   @Override
-  public void saveDbSampleUpdate(Sample dbSample, User user) {
+  public void saveDbSampleUpdate(SampleEntity dbSample, User user) {
     dbSample.setModificationDate(new Date());
     dbSample.setModifiedBy(user.getUsername(), IActiveUserStrategy.CHECK_OPERATE_AS);
     dbSample.increaseVersion();
-    dbSample = sampleDao.save(dbSample);
+    dbSample = saveSampleEntity(dbSample);
     publisher.publishEvent(new InventoryEditingEvent(dbSample, user));
+  }
+
+  /** Routes a plain save to the DAO matching the entity's concrete kind. */
+  private SampleEntity saveSampleEntity(SampleEntity dbSample) {
+    if (dbSample instanceof SampleTemplate) {
+      return sampleTemplateDao.save((SampleTemplate) dbSample);
+    }
+    return sampleDao.save((Sample) dbSample);
   }
 
   @Override
   public ApiSample markSampleAsDeleted(Long sampleId, boolean forceDelete, User user) {
-    Sample dbSample = assertUserCanDeleteSample(sampleId, user);
+    SampleEntity dbSample = assertUserCanDeleteSample(sampleId, user);
     boolean temporaryLock = lockItemForEdit(dbSample, user);
 
     try {
@@ -780,7 +809,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
           /* then delete the sample */
           dbSample.setRecordDeleted(true);
-          dbSample = sampleDao.save(dbSample);
+          dbSample = saveSampleEntity(dbSample);
           publisher.publishEvent(new InventoryDeleteEvent(dbSample, user));
         }
       }
@@ -797,7 +826,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   @Override
   public ApiSample restoreDeletedSample(
       Long sampleId, User user, boolean includeSubSamplesDeletedOnSampleDeletion) {
-    Sample dbSample = assertUserCanDeleteSample(sampleId, user);
+    SampleEntity dbSample = assertUserCanDeleteSample(sampleId, user);
     boolean temporaryLock = lockItemForEdit(dbSample, user);
     try {
       dbSample = getIfExists(dbSample.getId());
@@ -813,7 +842,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
         dbSample.setRecordDeleted(false);
         dbSample.refreshActiveSubSamples();
         dbSample.recalculateTotalQuantity();
-        dbSample = sampleDao.save(dbSample);
+        dbSample = saveSampleEntity(dbSample);
         publisher.publishEvent(new InventoryRestoreEvent(dbSample, user));
       }
     } finally {
@@ -833,44 +862,65 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
    * @throws IOException
    * @returns true if any images were saved
    */
-  private boolean saveIncomingSampleImage(Sample dbSample, ApiSampleInfo apiSample, User user) {
+  private boolean saveIncomingSampleImage(
+      SampleEntity dbSample, ApiSampleInfo apiSample, User user) {
+    if (dbSample.isTemplate()) {
+      return saveIncomingImage(
+          dbSample,
+          apiSample,
+          user,
+          SampleTemplate.class,
+          template -> sampleTemplateDao.save(template));
+    }
     return saveIncomingImage(
         dbSample, apiSample, user, Sample.class, sample -> sampleDao.save(sample));
   }
 
   @Override
-  public Sample getSampleById(Long id, User user) {
+  public SampleEntity getSampleById(Long id, User user) {
     return getIfExists(id);
   }
 
   @Override
   public ApiSampleWithFullSubSamples duplicate(Long sampleId, User user) {
-    Sample copy = copyDbSample(sampleId, user);
-    return new ApiSampleWithFullSubSamples(copy);
+    SampleEntity copy = copyDbSample(sampleId, user);
+    // cast is safe: copyDbSample persists and returns a Sample for non-template ids (controller
+    // guards the endpoint)
+    return new ApiSampleWithFullSubSamples((Sample) copy);
   }
 
   @Override
   public ApiSampleTemplate duplicateTemplate(Long sampleId, User user) {
-    Sample copy = copyDbSample(sampleId, user);
-    return new ApiSampleTemplate(copy);
+    SampleEntity copy = copyDbSample(sampleId, user);
+    // cast is safe: copyDbSample persists and returns a SampleTemplate for template ids (controller
+    // guards the endpoint)
+    return new ApiSampleTemplate((SampleTemplate) copy);
   }
 
-  private Sample copyDbSample(Long sampleId, User user) {
-    Sample dbSample = assertUserCanReadSample(sampleId, user);
-    Sample copy = dbSample.copy(user);
-    if (!dbSample.isTemplate()) {
-      setWorkbenchAsParentForNewSubSamples(copy, user);
+  private SampleEntity copyDbSample(Long sampleId, User user) {
+    SampleEntity dbSample = assertUserCanReadSample(sampleId, user);
+    SampleEntity copy;
+    if (dbSample instanceof Sample) {
+      Sample sampleCopy = ((Sample) dbSample).copy(user);
+      setWorkbenchAsParentForNewSubSamples(sampleCopy, user);
+      copy = sampleDao.persistNewSample(sampleCopy);
+    } else {
+      SampleTemplate templateCopy = ((SampleTemplate) dbSample).copy(user);
+      /* persistSampleTemplate's choice/radio-definition pre-save is a no-op here: the copied
+       * fields share the original template's already-persistent definitions, so this matches
+       * the plain persist the legacy persistNewSample call performed for template copies. */
+      copy = sampleTemplateDao.persistSampleTemplate(templateCopy);
     }
-    copy = sampleDao.persistNewSample(copy);
     publisher.publishEvent(new InventoryCreationEvent(copy, user));
     return copy;
   }
 
   @Override
-  public List<Sample> getAllTemplates(User user) {
-    PaginationCriteria<Sample> pg = PaginationCriteria.createDefaultForClass(Sample.class);
+  public List<SampleTemplate> getAllTemplates(User user) {
+    PaginationCriteria<SampleTemplate> pg =
+        PaginationCriteria.createDefaultForClass(SampleTemplate.class);
     pg.setGetAllResults();
-    return sampleDao.getTemplatesForUser(pg, null, null, user).getResults();
+    return sampleTemplateDao.getTemplatesForUser(pg, null, null, user).getResults();
   }
 
   @Override
@@ -879,16 +929,17 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   }
 
   @Override
-  public Sample getSampleTemplateByIdWithPopulatedFields(Long id, User user) {
-    Sample template = getIfExists(id, true);
+  public SampleTemplate getSampleTemplateByIdWithPopulatedFields(Long id, User user) {
+    // cast is safe: getIfExists(id, true) throws NotFoundException unless the entity is a template
+    SampleTemplate template = (SampleTemplate) getIfExists(id, true);
     template.getActiveFields().size(); // initialize lazy-loaded collection
     return template;
   }
 
   @Override
   public ApiSampleTemplate getApiSampleTemplateVersion(Long templateId, Long version, User user) {
-    Sample currentVersion = getIfExists(templateId);
-    if (!currentVersion.isTemplate()) {
+    SampleEntity currentVersion = getIfExists(templateId);
+    if (!(currentVersion instanceof SampleTemplate)) {
       throw new IllegalArgumentException(
           String.format("Requested id (%d) points to the sample, not template", templateId));
     }
@@ -897,7 +948,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
     }
 
     ApiSampleTemplate apiTemplateVersion =
-        inventoryAuditMgr.getApiTemplateVersion(currentVersion, version);
+        inventoryAuditMgr.getApiTemplateVersion((SampleTemplate) currentVersion, version);
     populateOutgoingApiSample(apiTemplateVersion, currentVersion, user);
     return apiTemplateVersion;
   }
@@ -910,7 +961,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
     // drop that reduction in a refactor or this would leak full historical data. (The sibling
     // /revisions endpoint asserts at the controller instead and hard-errors; the same data is
     // exposed either way, only the HTTP status differs.)
-    Sample currentSample = getIfExists(sampleId);
+    SampleEntity currentSample = getIfExists(sampleId);
     if (version.equals(currentSample.getVersion())) {
       return getApiSampleById(sampleId, user);
     }
@@ -928,7 +979,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
    * inherits the sample's permissions.
    */
   private void populateOutgoingHistoricalApiSample(
-      ApiSample apiSample, Sample currentSample, User user) {
+      ApiSample apiSample, SampleEntity currentSample, User user) {
     if (apiSample == null) {
       return;
     }
@@ -943,8 +994,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
   @Override
   public ApiSampleTemplate createSampleTemplate(ApiSampleTemplatePost apiSample, User user) {
-    Sample sampleTemplate = recordFactory.createSample(apiSample.getName(), user);
-    sampleTemplate.setTemplate(true);
+    SampleTemplate sampleTemplate = recordFactory.createSampleTemplate(apiSample.getName(), user);
     sampleTemplate.setIconId(DEFAULT_ICON_ID);
     sampleTemplate.setSubSampleAliases(
         apiSample.getSubSampleAlias().getAlias(), apiSample.getSubSampleAlias().getPlural());
@@ -954,7 +1004,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
     createFields(apiSample, sampleTemplate);
 
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNames(sampleTemplate);
-    Sample savedSampleTemplate = sampleDao.persistSampleTemplate(sampleTemplate);
+    SampleTemplate savedSampleTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
     saveIncomingSampleImage(savedSampleTemplate, apiSample, user);
     publisher.publishEvent(new InventoryCreationEvent(savedSampleTemplate, user));
     ApiSampleTemplate rc = new ApiSampleTemplate(savedSampleTemplate);
@@ -963,7 +1013,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
     return rc;
   }
 
-  private void createFields(ApiSampleTemplatePost apiSample, Sample sample) {
+  private void createFields(ApiSampleTemplatePost apiSample, SampleTemplate sample) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiSample.getFields(), null);
     for (ApiInventoryEntityField field : apiSample.getFields()) {
@@ -974,30 +1024,32 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
   @Override
   public ApiSampleTemplate updateApiSampleTemplate(ApiSampleTemplate apiSample, User user) {
-    Sample dbSample = assertUserCanEditSample(apiSample.getId(), user);
-    if (!dbSample.isTemplate()) {
+    SampleEntity dbSample = assertUserCanEditSample(apiSample.getId(), user);
+    if (!(dbSample instanceof SampleTemplate)) {
       throw new IllegalArgumentException(
           "trying to update sample through sample template update method");
     }
+    SampleTemplate dbTemplate = (SampleTemplate) dbSample;
 
-    boolean temporaryLock = lockItemForEdit(dbSample, user);
+    boolean temporaryLock = lockItemForEdit(dbTemplate, user);
     try {
-      dbSample = getIfExists(dbSample.getId());
+      // cast is safe: re-fetch by id returns the same template row
+      dbTemplate = (SampleTemplate) getIfExists(dbTemplate.getId());
       boolean contentChanged =
-          createDeleteRequestedFieldsInDbSampleTemplate(apiSample, dbSample, user);
-      contentChanged |= apiSample.applyChangesToDatabaseTemplate(dbSample, user);
-      updateDbSample(apiSample, dbSample, contentChanged, user);
+          createDeleteRequestedFieldsInDbSampleTemplate(apiSample, dbTemplate, user);
+      contentChanged |= apiSample.applyChangesToDatabaseTemplate(dbTemplate, user);
+      updateDbSample(apiSample, dbTemplate, contentChanged, user);
     } finally {
       if (temporaryLock) {
-        unlockItemAfterEdit(dbSample, user);
+        unlockItemAfterEdit(dbTemplate, user);
       }
     }
 
-    return (ApiSampleTemplate) getOutgoingApiSample(dbSample, user);
+    return (ApiSampleTemplate) getOutgoingApiSample(dbTemplate, user);
   }
 
   private boolean createDeleteRequestedFieldsInDbSampleTemplate(
-      ApiSampleWithoutSubSamples apiSample, Sample dbTemplate, User user) {
+      ApiSampleWithoutSubSamples apiSample, SampleTemplate dbTemplate, User user) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiSample.getFields(), null);
     boolean changed = false;
@@ -1030,16 +1082,23 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
 
   @Override
   public ApiSample updateSampleToLatestTemplateVersion(Long sampleId, User user) {
-    Sample dbSample = assertUserCanEditSample(sampleId, user);
-    Sample dbTemplate = assertUserCanReadSample(dbSample.getParentTemplateId(), user);
+    SampleEntity dbSample = assertUserCanEditSample(sampleId, user);
+    // templates have no parent template; a null id keeps the legacy not-found behaviour of the
+    // assert call below
+    Long parentTemplateId =
+        dbSample instanceof Sample ? ((Sample) dbSample).getParentTemplateId() : null;
+    SampleEntity dbTemplate = assertUserCanReadSample(parentTemplateId, user);
     if (dbTemplate == null) {
       throw new IllegalArgumentException("Sample is not based on any template");
     }
 
     boolean temporaryLock = lockItemForEdit(dbSample, user);
     try {
+      // casts below are safe: templates throw earlier on the null parent-template id, and a
+      // re-fetch by the same id cannot change the entity kind (discriminator is written only on
+      // insert)
       dbSample = getIfExists(dbSample.getId());
-      if (!dbTemplate.getVersion().equals(dbSample.getSTemplateLinkedVersion())) {
+      if (!dbTemplate.getVersion().equals(((Sample) dbSample).getSTemplateLinkedVersion())) {
         // Snapshot the link fields before the sync: propagating a deleted template link-field
         // marks the matching sample field deleted in the model layer, which cannot soft-delete the
         // field's InventoryLink. Reconcile those orphaned links here once the sync has run.
@@ -1048,7 +1107,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
                 .filter(InventoryLinkField.class::isInstance)
                 .map(InventoryLinkField.class::cast)
                 .collect(Collectors.toList());
-        dbSample.updateToLatestTemplateVersion();
+        ((Sample) dbSample).updateToLatestTemplateVersion();
         syncLinkFieldWhitelistsFromTemplate(dbSample.getActiveFields());
         linkFieldsBeforeUpdate.forEach(field -> softDeleteLinkOfDeletedLinkField(field, user));
         saveDbSampleUpdate(dbSample, user);
@@ -1063,7 +1122,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
   }
 
   @Override
-  public Sample saveIconId(Sample sample, Long iconId) {
+  public SampleEntity saveIconId(SampleEntity sample, Long iconId) {
+    // either DAO works here: saveIconId's DML targets SampleEntity, covering both kinds
     sampleDao.saveIconId(sample, iconId);
     return sample;
   }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -1133,13 +1133,12 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   @Override
   public ApiSample updateSampleToLatestTemplateVersion(Long sampleId, User user) {
     SampleEntity dbSample = assertUserCanEditSample(sampleId, user);
-    // templates have no parent template; a null id keeps the legacy not-found behaviour of the
-    // assert call below
-    Long parentTemplateId = dbSample.isSample() ? ((Sample) dbSample).getParentTemplateId() : null;
-    SampleEntity dbTemplate = assertUserCanReadSampleTemplate(parentTemplateId, user);
-    if (dbTemplate == null) {
+    // assertUserCanEditSample resolves a Sample (a template id 404s), so the cast is safe
+    Long parentTemplateId = ((Sample) dbSample).getParentTemplateId();
+    if (parentTemplateId == null) {
       throw new IllegalArgumentException("Sample is not based on any template");
     }
+    SampleTemplate dbTemplate = assertUserCanReadSampleTemplate(parentTemplateId, user);
 
     boolean temporaryLock = lockItemForEdit(dbSample, user);
     try {

--- a/src/main/java/com/researchspace/service/inventory/impl/SubSampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SubSampleApiManagerImpl.java
@@ -18,7 +18,7 @@ import com.researchspace.model.events.InventoryMoveEvent;
 import com.researchspace.model.events.InventoryRestoreEvent;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.InventorySeriesNamingHelper;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.record.IActiveUserStrategy;
 import com.researchspace.model.units.QuantityInfo;
@@ -205,7 +205,7 @@ public class SubSampleApiManagerImpl extends InventoryApiManagerImpl<SubSample>
       Long sampleId, Integer newSubSamplesCount, ApiQuantityInfo subSampleQuantity, User user) {
 
     List<ApiSubSample> result = new ArrayList<>();
-    Sample dbSample = sampleApiMgr.getSampleById(sampleId, user);
+    SampleEntity dbSample = sampleApiMgr.getSampleById(sampleId, user);
     invPermissions.assertUserCanEditInventoryRecord(dbSample, user);
 
     int initSubSampleCount = dbSample.getSubSamples().size();
@@ -225,7 +225,7 @@ public class SubSampleApiManagerImpl extends InventoryApiManagerImpl<SubSample>
   public ApiSubSample addNewApiSubSampleToSample(
       ApiSubSample incomingSubSample, Long sampleId, User user) {
 
-    Sample dbSample = sampleApiMgr.getSampleById(sampleId, user);
+    SampleEntity dbSample = sampleApiMgr.getSampleById(sampleId, user);
     invPermissions.assertUserCanEditInventoryRecord(dbSample, user);
 
     SubSample newSubSample;
@@ -403,7 +403,7 @@ public class SubSampleApiManagerImpl extends InventoryApiManagerImpl<SubSample>
     boolean temporaryLock = lockItemForEdit(dbSubSample, user);
     try {
       dbSubSample = getIfExists(dbSubSample.getId());
-      Sample parentSample = dbSubSample.getSample();
+      SampleEntity parentSample = dbSubSample.getSample();
       if (dbSubSample.isDeleted()) {
         if (!parentSample.isTemplate()) {
           Container workbench = containerDao.getWorkbenchForUser(user);

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -129,6 +129,7 @@
         <mapping class="com.researchspace.model.events.GroupMembershipEvent"/>
 
         <mapping class="com.researchspace.model.inventory.Sample"/>
+        <mapping class="com.researchspace.model.inventory.SampleTemplate"/>
         <mapping class="com.researchspace.model.inventory.SubSample"/>
         <mapping class="com.researchspace.model.inventory.SubSampleNote"/>
 

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1065.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1065.xml
@@ -1,64 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog
-	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-	<!--
-	  RSDEV-1065: SampleTemplate becomes a real entity. Single-table inheritance over the
-	  existing Sample table now uses Hibernate's default DTYPE discriminator (values
-	  "Sample"/"SampleTemplate"), mirroring InstrumentEntity. The legacy boolean "template"
-	  column is intentionally retained but no longer maintained by Hibernate; DTYPE is
-	  backfilled from it here for both the live and audit tables.
-	-->
+  <!--
+    RSDEV-1065: SampleTemplate becomes a real entity. Single-table inheritance over the
+    existing Sample table now uses Hibernate's default DTYPE discriminator (values
+    "Sample"/"SampleTemplate"), mirroring InstrumentEntity. The legacy boolean "template"
+    column is intentionally retained but no longer maintained by Hibernate; DTYPE is
+    backfilled from it here for both the live and audit tables.
+  -->
 
-	<changeSet id="2026-06-11a-a" context="run" author="nico">
-		<comment>RSDEV-1065 add DTYPE discriminator column to the Sample table</comment>
-		<addColumn tableName="Sample">
-			<column name="DTYPE" type="varchar(20)">
-				<constraints nullable="true"/>
-			</column>
-		</addColumn>
-	</changeSet>
+  <changeSet id="2026-06-11a-a" context="run" author="nico">
+    <comment>RSDEV-1065 add DTYPE discriminator column to the Sample table</comment>
+    <addColumn tableName="Sample">
+      <column name="DTYPE" type="varchar(20)">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+  </changeSet>
 
-	<changeSet id="2026-06-11a-b" context="run" author="nico">
-		<comment>RSDEV-1065 add DTYPE discriminator column to the Sample_AUD table</comment>
-		<addColumn tableName="Sample_AUD">
-			<column name="DTYPE" type="varchar(20)">
-				<constraints nullable="true"/>
-			</column>
-		</addColumn>
-	</changeSet>
+  <changeSet id="2026-06-11a-b" context="run" author="nico">
+    <comment>RSDEV-1065 add DTYPE discriminator column to the Sample_AUD table</comment>
+    <addColumn tableName="Sample_AUD">
+      <column name="DTYPE" type="varchar(20)">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+  </changeSet>
 
-	<changeSet id="2026-06-11b-a" context="run" author="nico">
-		<comment>RSDEV-1065 backfill Sample.DTYPE from the legacy template flag</comment>
-		<update tableName="Sample">
-			<column name="DTYPE" value="SampleTemplate"/>
-			<where>template = 1</where>
-		</update>
-		<update tableName="Sample">
-			<column name="DTYPE" value="Sample"/>
-			<where>DTYPE IS NULL</where>
-		</update>
-	</changeSet>
+  <changeSet id="2026-06-11b-a" context="run" author="nico">
+    <comment>RSDEV-1065 backfill Sample.DTYPE from the legacy template flag</comment>
+    <update tableName="Sample">
+      <column name="DTYPE" value="SampleTemplate"/>
+      <where>template = 1</where>
+    </update>
+    <update tableName="Sample">
+      <column name="DTYPE" value="Sample"/>
+      <where>DTYPE IS NULL</where>
+    </update>
+  </changeSet>
 
-	<changeSet id="2026-06-11b-b" context="run" author="nico">
-		<comment>RSDEV-1065 backfill Sample_AUD.DTYPE from the legacy template flag so Envers can
-			resolve historical Sample/SampleTemplate revisions</comment>
-		<update tableName="Sample_AUD">
-			<column name="DTYPE" value="SampleTemplate"/>
-			<where>template = 1</where>
-		</update>
-		<update tableName="Sample_AUD">
-			<column name="DTYPE" value="Sample"/>
-			<where>DTYPE IS NULL</where>
-		</update>
-	</changeSet>
+  <changeSet id="2026-06-11b-b" context="run" author="nico">
+    <comment>RSDEV-1065 backfill Sample_AUD.DTYPE from the legacy template flag so Envers can
+      resolve historical Sample/SampleTemplate revisions</comment>
+    <update tableName="Sample_AUD">
+      <column name="DTYPE" value="SampleTemplate"/>
+      <where>template = 1</where>
+    </update>
+    <update tableName="Sample_AUD">
+      <column name="DTYPE" value="Sample"/>
+      <where>DTYPE IS NULL</where>
+    </update>
+  </changeSet>
 
-	<changeSet id="2026-06-11c-a" context="run" author="nico">
-		<comment>RSDEV-1065 make Sample.DTYPE NOT NULL once backfilled (audit table stays nullable,
-			matching Envers conventions)</comment>
-		<addNotNullConstraint tableName="Sample" columnName="DTYPE" columnDataType="varchar(20)"/>
-	</changeSet>
+  <changeSet id="2026-06-11c-a" context="run" author="nico">
+    <comment>RSDEV-1065 make Sample.DTYPE NOT NULL once backfilled (audit table stays nullable,
+      matching Envers conventions)</comment>
+    <addNotNullConstraint tableName="Sample" columnName="DTYPE" columnDataType="varchar(20)"/>
+  </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1065.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1065.xml
@@ -1,0 +1,64 @@
+<databaseChangeLog
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+	<!--
+	  RSDEV-1065: SampleTemplate becomes a real entity. Single-table inheritance over the
+	  existing Sample table now uses Hibernate's default DTYPE discriminator (values
+	  "Sample"/"SampleTemplate"), mirroring InstrumentEntity. The legacy boolean "template"
+	  column is intentionally retained but no longer maintained by Hibernate; DTYPE is
+	  backfilled from it here for both the live and audit tables.
+	-->
+
+	<changeSet id="2026-06-11a-a" context="run" author="nico">
+		<comment>RSDEV-1065 add DTYPE discriminator column to the Sample table</comment>
+		<addColumn tableName="Sample">
+			<column name="DTYPE" type="varchar(20)">
+				<constraints nullable="true"/>
+			</column>
+		</addColumn>
+	</changeSet>
+
+	<changeSet id="2026-06-11a-b" context="run" author="nico">
+		<comment>RSDEV-1065 add DTYPE discriminator column to the Sample_AUD table</comment>
+		<addColumn tableName="Sample_AUD">
+			<column name="DTYPE" type="varchar(20)">
+				<constraints nullable="true"/>
+			</column>
+		</addColumn>
+	</changeSet>
+
+	<changeSet id="2026-06-11b-a" context="run" author="nico">
+		<comment>RSDEV-1065 backfill Sample.DTYPE from the legacy template flag</comment>
+		<update tableName="Sample">
+			<column name="DTYPE" value="SampleTemplate"/>
+			<where>template = 1</where>
+		</update>
+		<update tableName="Sample">
+			<column name="DTYPE" value="Sample"/>
+			<where>DTYPE IS NULL</where>
+		</update>
+	</changeSet>
+
+	<changeSet id="2026-06-11b-b" context="run" author="nico">
+		<comment>RSDEV-1065 backfill Sample_AUD.DTYPE from the legacy template flag so Envers can
+			resolve historical Sample/SampleTemplate revisions</comment>
+		<update tableName="Sample_AUD">
+			<column name="DTYPE" value="SampleTemplate"/>
+			<where>template = 1</where>
+		</update>
+		<update tableName="Sample_AUD">
+			<column name="DTYPE" value="Sample"/>
+			<where>DTYPE IS NULL</where>
+		</update>
+	</changeSet>
+
+	<changeSet id="2026-06-11c-a" context="run" author="nico">
+		<comment>RSDEV-1065 make Sample.DTYPE NOT NULL once backfilled (audit table stays nullable,
+			matching Envers conventions)</comment>
+		<addNotNullConstraint tableName="Sample" columnName="DTYPE" columnDataType="varchar(20)"/>
+	</changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1065.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1065.xml
@@ -5,13 +5,6 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-  <!--
-    RSDEV-1065: SampleTemplate becomes a real entity. Single-table inheritance over the
-    existing Sample table now uses Hibernate's default DTYPE discriminator (values
-    "Sample"/"SampleTemplate"), mirroring InstrumentEntity. The legacy boolean "template"
-    column is intentionally retained but no longer maintained by Hibernate; DTYPE is
-    backfilled from it here for both the live and audit tables.
-  -->
 
   <changeSet id="2026-06-11a-a" context="run" author="nico">
     <comment>RSDEV-1065 add DTYPE discriminator column to the Sample table</comment>
@@ -60,6 +53,14 @@
     <comment>RSDEV-1065 make Sample.DTYPE NOT NULL once backfilled (audit table stays nullable,
       matching Envers conventions)</comment>
     <addNotNullConstraint tableName="Sample" columnName="DTYPE" columnDataType="varchar(20)"/>
+  </changeSet>
+
+  <changeSet id="2026-06-11d-a" context="run" author="nico">
+    <comment>RSDEV-1065 drop the legacy boolean template column now that DTYPE has fully replaced it.
+      It was retained only as a vestigial backfill source for DTYPE and is no longer mapped by
+      Hibernate or read anywhere, so it is now removed from the live and audit tables.</comment>
+    <dropColumn tableName="Sample" columnName="template"/>
+    <dropColumn tableName="Sample_AUD" columnName="template"/>
   </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -60,6 +60,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1154.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1131.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1175.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-1065.xml"/>
 
   <!-- These two run last: recurring-changeLog.xml (runAlways diagnostics / batch re-init) then
        customUpdates-changeLog.xml. customUpdates-changeLog.xml must ALWAYS be the final include

--- a/src/test/java/com/axiope/model/record/init/SampleTemplateBuiltInTest.java
+++ b/src/test/java/com/axiope/model/record/init/SampleTemplateBuiltInTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.testutils.TestFactory;
 import java.util.Optional;
 import org.junit.Rule;
@@ -26,7 +26,7 @@ public class SampleTemplateBuiltInTest {
   public void test() {
 
     User anyUser = TestFactory.createAnyUser("any");
-    Optional<Sample> opt = antibody.createSampleTemplate(anyUser);
+    Optional<SampleTemplate> opt = antibody.createSampleTemplate(anyUser);
     assertTrue(opt.isPresent());
     assertEquals(10, opt.get().getActiveFields().size());
   }

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryBulkOperationsApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryBulkOperationsApiControllerMVCIT.java
@@ -267,6 +267,40 @@ public class InventoryBulkOperationsApiControllerMVCIT extends API_MVC_Inventory
   }
 
   @Test
+  public void bulkCreateWithInvalidTemplateIdReportsPerRecordErrorWithoutRollback()
+      throws Exception {
+    User anyUser = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(anyUser);
+
+    // a plain sample's id is a valid id that is NOT a SampleTemplate, so using it as a templateId
+    // drives the create-time template lookup down its "not a readable template" branch
+    Long nonTemplateId = createBasicSampleForUser(anyUser).getId();
+
+    // With rollbackOnError=false each record is processed in its own transaction, so a record with
+    // an invalid templateId must surface as a per-record error while the other records are still
+    // created, rather than aborting the whole request with an UnexpectedRollbackException.
+    String createWithBadTemplateJSON =
+        String.format(
+            "{ \"operationType\": \"CREATE\", \"rollbackOnError\": false, \"records\": [ "
+                + "{ \"type\": \"SAMPLE\", \"name\": \"okSampleA\" }, "
+                + "{ \"type\": \"SAMPLE\", \"name\": \"badTemplate\", \"templateId\": %d }, "
+                + "{ \"type\": \"SAMPLE\", \"name\": \"okSampleB\" } ] }",
+            nonTemplateId);
+    MvcResult result = postBulkOperation(anyUser, apiKey, createWithBadTemplateJSON);
+
+    assertNull(result.getResolvedException());
+    ApiInventoryBulkOperationResult bulkOpResult =
+        getFromJsonResponseBody(result, ApiInventoryBulkOperationResult.class);
+    assertNotNull(bulkOpResult);
+    assertEquals(2, bulkOpResult.getSuccessCount());
+    assertEquals(1, bulkOpResult.getErrorCount());
+    assertEquals(InventoryBulkOperationStatus.COMPLETED, bulkOpResult.getStatus());
+    assertNotNull(bulkOpResult.getResults().get(1).getError());
+    String templateError = bulkOpResult.getResults().get(1).getError().getErrors().get(0);
+    assertTrue(templateError.contains("templateId"), templateError);
+  }
+
+  @Test
   public void bulkMoveAndSwap() throws Exception {
     Mockito.reset(auditer);
 

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryBulkOperationsApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryBulkOperationsApiControllerMVCIT.java
@@ -46,7 +46,10 @@ public class InventoryBulkOperationsApiControllerMVCIT extends API_MVC_Inventory
 
     ApiSampleWithFullSubSamples sample = createComplexSampleForUser(anyUser);
     ApiSampleTemplate template = createBasicSampleTemplate(anyUser);
+    // Sample and SampleTemplate are separate entities sharing the legacy "Sample" table; count
+    // each so the duplicate of the sample and of the template are both asserted to persist
     final long initialSampleCont = getCountOfEntityTable("Sample");
+    final long initialTemplateCount = getCountOfEntityTable("SampleTemplate");
 
     String duplicateSampleAndTemplateJSON =
         String.format(
@@ -67,7 +70,8 @@ public class InventoryBulkOperationsApiControllerMVCIT extends API_MVC_Inventory
     assertEquals(
         ApiInventoryRecordType.SAMPLE_TEMPLATE,
         bulkOpResult.getResults().get(1).getRecord().getType());
-    assertEquals(initialSampleCont + 2, getCountOfEntityTable("Sample"));
+    assertEquals(initialSampleCont + 1, getCountOfEntityTable("Sample"));
+    assertEquals(initialTemplateCount + 1, getCountOfEntityTable("SampleTemplate"));
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryImportApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryImportApiControllerMVCIT.java
@@ -29,8 +29,8 @@ import com.researchspace.dao.DigitalObjectIdentifierDao;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Container.ContainerType;
 import com.researchspace.model.inventory.DigitalObjectIdentifier;
-import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.service.ApiAvailabilityHandler;
 import com.researchspace.service.inventory.ContainerApiManager;
@@ -351,7 +351,7 @@ public class InventoryImportApiControllerMVCIT extends API_MVC_InventoryTestBase
   @Test
   public void importComplexTemplateCsvWithoutTemplateCreation() throws Exception {
 
-    Sample complexTemplate = findComplexSampleTemplate(anyUser);
+    SampleTemplate complexTemplate = findComplexSampleTemplate(anyUser);
 
     /* let's import with name column being 'Name' */
     String settingsJson =
@@ -685,7 +685,7 @@ public class InventoryImportApiControllerMVCIT extends API_MVC_InventoryTestBase
   @Test
   public void importSamplesIntoContainersCsvFiles() throws Exception {
 
-    Sample sampleTemplate = findBasicSampleTemplate(anyUser);
+    SampleTemplate sampleTemplate = findBasicSampleTemplate(anyUser);
     String samplesSettingsJson =
         "{ \"fieldMappings\": { \"Name\": \"name\", \"Description\": \"description\", \"Import"
             + " identifier\": \"import identifier\", \"Parent container\":\"parent container import"
@@ -864,7 +864,7 @@ public class InventoryImportApiControllerMVCIT extends API_MVC_InventoryTestBase
   @Test
   public void importMultipleCsvFiles() throws Exception {
 
-    Sample basicTemplate = findBasicSampleTemplate(anyUser);
+    SampleTemplate basicTemplate = findBasicSampleTemplate(anyUser);
     String containersSettingsJson =
         "{ \"fieldMappings\": { \"Name\": \"name\", \"Import identifier\": \"import identifier\","
             + " \"Parent container\": \"parent container import id\" } }";

--- a/src/test/java/com/researchspace/api/v1/controller/InventorySearchApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventorySearchApiControllerTest.java
@@ -36,7 +36,7 @@ public class InventorySearchApiControllerTest extends SpringTransactionalTest {
 
   @Before
   public void setUp() {
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
 
     testUser = createInitAndLoginAnyUser();
     assertTrue(testUser.isContentInitialized());

--- a/src/test/java/com/researchspace/api/v1/controller/SampleApiPostFullValidatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleApiPostFullValidatorTest.java
@@ -7,7 +7,7 @@ import com.researchspace.api.v1.model.ApiQuantityInfo;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.units.RSUnitDef;
 import java.math.BigDecimal;
 import java.util.List;
@@ -40,8 +40,7 @@ public class SampleApiPostFullValidatorTest extends InventoryRecordValidationTes
   public void validateQuantityUnit() {
 
     // template defining grams as a default unit
-    Sample baseTemplate = new Sample();
-    baseTemplate.setTemplate(true);
+    SampleTemplate baseTemplate = new SampleTemplate();
     baseTemplate.setDefaultUnitId(RSUnitDef.GRAM.getId());
 
     // incoming sample with millilitre quantity

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
@@ -12,7 +12,6 @@ import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleTemplate;
-import com.researchspace.model.record.RecordFactory;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.SampleApiManager;
@@ -49,7 +48,7 @@ public class SampleTemplatesRevisionsEndpointTest {
 
   @Test
   public void templateRevisionsEndpointReturnsRevisionListForTemplate() {
-    SampleTemplate template = new RecordFactory().createSampleTemplate("template", user);
+    SampleTemplate template = new SampleTemplate();
     when(sampleMgr.assertUserCanReadSample(1L, user)).thenReturn(template);
     ApiInventoryRecordRevisionList revisions = new ApiInventoryRecordRevisionList();
     when(auditMgr.getInventoryRecordRevisions(template)).thenReturn(revisions);

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
@@ -49,7 +48,7 @@ public class SampleTemplatesRevisionsEndpointTest {
   @Test
   public void templateRevisionsEndpointReturnsRevisionListForTemplate() {
     SampleTemplate template = new SampleTemplate();
-    when(sampleMgr.assertUserCanReadSample(1L, user)).thenReturn(template);
+    when(sampleMgr.assertUserCanReadSampleTemplate(1L, user)).thenReturn(template);
     ApiInventoryRecordRevisionList revisions = new ApiInventoryRecordRevisionList();
     when(auditMgr.getInventoryRecordRevisions(template)).thenReturn(revisions);
 
@@ -58,9 +57,9 @@ public class SampleTemplatesRevisionsEndpointTest {
 
   @Test
   public void templateRevisionsEndpointThrows404ForNonTemplateId() {
-    // a plain sample id must not be readable through the template endpoint
-    Sample sample = TestFactory.createBasicSampleOutsideContainer(user);
-    when(sampleMgr.assertUserCanReadSample(1L, user)).thenReturn(sample);
+    // a plain sample id is not addressable through the template endpoint: the manager 404s
+    when(sampleMgr.assertUserCanReadSampleTemplate(1L, user))
+        .thenThrow(new NotFoundException("No sample template with id: 1"));
 
     assertThrows(NotFoundException.class, () -> controller.getSampleTemplateAllRevisions(1L, user));
   }

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.when;
 import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
+import com.researchspace.model.record.RecordFactory;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.SampleApiManager;
@@ -47,8 +49,7 @@ public class SampleTemplatesRevisionsEndpointTest {
 
   @Test
   public void templateRevisionsEndpointReturnsRevisionListForTemplate() {
-    Sample template = TestFactory.createBasicSampleOutsideContainer(user);
-    template.setTemplate(true);
+    SampleTemplate template = new RecordFactory().createSampleTemplate("template", user);
     when(sampleMgr.assertUserCanReadSample(1L, user)).thenReturn(template);
     ApiInventoryRecordRevisionList revisions = new ApiInventoryRecordRevisionList();
     when(auditMgr.getInventoryRecordRevisions(template)).thenReturn(revisions);

--- a/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerMVCIT.java
@@ -27,8 +27,9 @@ import com.researchspace.model.EcatDocumentFile;
 import com.researchspace.model.User;
 import com.researchspace.model.audittrail.AuditAction;
 import com.researchspace.model.inventory.Container.ContainerType;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.service.impl.ContentInitializerForDevRunManager;
 import java.time.LocalDate;
@@ -449,7 +450,7 @@ public class SamplesApiControllerMVCIT extends API_MVC_InventoryTestBase {
     assertEquals(1, sampleRev3Full.getExtraFields().size());
   }
 
-  private Optional<Sample> getComplexSampleTemplate(User user) {
+  private Optional<SampleTemplate> getComplexSampleTemplate(User user) {
     return sampleApiMgr.getAllTemplates(user).stream()
         .filter(
             t ->
@@ -521,7 +522,7 @@ public class SamplesApiControllerMVCIT extends API_MVC_InventoryTestBase {
     String apiKey = createNewApiKeyForUser(anyUser);
 
     ApiSampleWithFullSubSamples complexSample = createComplexSampleForUser(anyUser);
-    Sample complexTemplateInfo =
+    SampleTemplate complexTemplateInfo =
         sampleApiMgr.getSampleTemplateByIdWithPopulatedFields(
             complexSample.getTemplateId(), anyUser);
 
@@ -961,7 +962,7 @@ public class SamplesApiControllerMVCIT extends API_MVC_InventoryTestBase {
             .andReturn();
     ApiSampleWithFullSubSamples sample =
         mvcUtils.getFromJsonResponseBody(result, ApiSampleWithFullSubSamples.class);
-    Sample dbSample = sampleApiMgr.assertUserCanReadSample(sample.getId(), anyUser);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanReadSample(sample.getId(), anyUser);
     assertNotNull(dbSample.getImageFileProperty());
     assertNotNull(dbSample.getThumbnailFileProperty());
     // 2 x image, self and icon

--- a/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
@@ -663,6 +663,34 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
   }
 
   @Test
+  public void sampleDeleteRestoreDuplicateRejectTemplateIds() {
+    SampleTemplate sampleTemplate =
+        recordFactory.createComplexSampleTemplate("API sample template", "API test", testUser);
+    SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
+    Long templateId = savedTemplate.getId();
+
+    IllegalArgumentException deleteError =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> samplesApi.deleteSample(templateId, false, testUser));
+    assertEquals(
+        "Please use /sampleTemplates endpoint for template actions", deleteError.getMessage());
+
+    IllegalArgumentException restoreError =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> samplesApi.restoreDeletedSample(templateId, testUser));
+    assertEquals(
+        "Please use /sampleTemplates endpoint for template actions", restoreError.getMessage());
+
+    IllegalArgumentException duplicateError =
+        assertThrows(
+            IllegalArgumentException.class, () -> samplesApi.duplicate(templateId, testUser));
+    assertEquals(
+        "Please use /sampleTemplates endpoint for template actions", duplicateError.getMessage());
+  }
+
+  @Test
   public void checkRevisionHistoryMethods() throws Exception {
     // revisions are only created in real database transaction, this test just runs the code
 

--- a/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
@@ -692,8 +692,12 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
 
   @Test
   public void duplicateDoesNotLeakTemplateExistenceToUnauthorizedUser() {
+    // The template must be genuinely private. testUser (created first in setUp) owns the lowest-id
+    // sample templates and is therefore the default-templates-owner, whose templates are
+    // world-readable; own this one with a later-created user so it is not a "default" template.
+    User templateOwner = createInitAndLoginAnyUser();
     SampleTemplate sampleTemplate =
-        recordFactory.createComplexSampleTemplate("API sample template", "API test", testUser);
+        recordFactory.createComplexSampleTemplate("API sample template", "API test", templateOwner);
     SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
     User otherUser = createInitAndLoginAnyUser();
 
@@ -705,8 +709,11 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
 
   @Test
   public void createSampleFromInaccessibleTemplateIsRejected() {
+    // owner must not be the default-templates-owner (testUser, created first in setUp), otherwise
+    // the template is a world-readable "default" template and is not actually inaccessible
+    User templateOwner = createInitAndLoginAnyUser();
     SampleTemplate sampleTemplate =
-        recordFactory.createComplexSampleTemplate("API sample template", "API test", testUser);
+        recordFactory.createComplexSampleTemplate("API sample template", "API test", templateOwner);
     SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
     User otherUser = createInitAndLoginAnyUser();
     ApiSampleWithFullSubSamples newSample =

--- a/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
@@ -691,6 +691,19 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
   }
 
   @Test
+  public void duplicateDoesNotLeakTemplateExistenceToUnauthorizedUser() {
+    SampleTemplate sampleTemplate =
+        recordFactory.createComplexSampleTemplate("API sample template", "API test", testUser);
+    SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
+    User otherUser = createInitAndLoginAnyUser();
+
+    // the template-id guard must enforce permissions before revealing it is a template: a user
+    // without access gets the read-path not-found rather than the 400 endpoint-mismatch leak
+    assertThrows(
+        NotFoundException.class, () -> samplesApi.duplicate(savedTemplate.getId(), otherUser));
+  }
+
+  @Test
   public void checkRevisionHistoryMethods() throws Exception {
     // revisions are only created in real database transaction, this test just runs the code
 

--- a/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
@@ -39,7 +39,7 @@ import com.researchspace.api.v1.model.ApiSubSampleNote;
 import com.researchspace.api.v1.model.ApiTargetLocation;
 import com.researchspace.model.Group;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.service.impl.ContentInitializerForDevRunManager;
@@ -77,7 +77,7 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
   @Before
   public void setUp() {
     openMocks(this);
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
     ReflectionTestUtils.setField(sampleApiMgr, "documentTagManager", documentTagManagerMock);
     testUser = createInitAndLoginAnyUser();
     assertTrue(testUser.isContentInitialized());
@@ -280,13 +280,13 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
     extraApiNumberField.setType(ExtraFieldTypeEnum.NUMBER);
     newSample.setExtraFields(List.of(extraApiNumberField));
 
-    Sample sampleTemplate =
+    SampleTemplate sampleTemplate =
         recordFactory.createComplexSampleTemplate("API sample template", "API test", testUser);
     // add default value to various fields
     sampleTemplate.getActiveFields().get(4).setData("text"); // text
     sampleTemplate.getActiveFields().get(8).setData("option1"); // radio
     sampleTemplate.getActiveFields().get(9).setSelectedOptions(List.of("optionA")); // choice
-    Sample savedTemplate = sampleDao.persistSampleTemplate(sampleTemplate);
+    SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
     newSample.setTemplateId(savedTemplate.getId());
 
     ApiSampleWithFullSubSamples createdSample =
@@ -344,9 +344,9 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
     ApiSampleWithFullSubSamples newSample = new ApiSampleWithFullSubSamples();
     newSample.setName("complex sample with field content");
 
-    Sample sampleTemplate =
+    SampleTemplate sampleTemplate =
         recordFactory.createComplexSampleTemplate("API sample template", "API test", testUser);
-    Sample savedTemplate = sampleDao.persistSampleTemplate(sampleTemplate);
+    SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
     newSample.setTemplateId(savedTemplate.getId());
 
     List<ApiInventoryEntityField> fields = new ArrayList<>();
@@ -645,9 +645,9 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
             () -> samplesApi.createNewSample(newSample, mockBindingResult, testUser));
     assertEquals("Please use /sampleTemplates endpoint for template actions", iae.getMessage());
 
-    Sample sampleTemplate =
+    SampleTemplate sampleTemplate =
         recordFactory.createComplexSampleTemplate("API sample template", "API test", testUser);
-    Sample savedTemplate = sampleDao.persistSampleTemplate(sampleTemplate);
+    SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
     newSample.setTemplateId(savedTemplate.getId());
 
     // try changing template name through samples controller

--- a/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SamplesApiControllerTest.java
@@ -704,6 +704,23 @@ public class SamplesApiControllerTest extends SpringTransactionalTest {
   }
 
   @Test
+  public void createSampleFromInaccessibleTemplateIsRejected() {
+    SampleTemplate sampleTemplate =
+        recordFactory.createComplexSampleTemplate("API sample template", "API test", testUser);
+    SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
+    User otherUser = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples newSample =
+        new ApiSampleWithFullSubSamples("from inaccessible template");
+    newSample.setTemplateId(savedTemplate.getId());
+
+    // a user without read access to the template must not be able to create a sample from it
+    // (would otherwise be a permission bypass and a template-existence oracle)
+    assertThrows(
+        NotFoundException.class,
+        () -> samplesApi.createNewSample(newSample, mockBindingResult, otherUser));
+  }
+
+  @Test
   public void checkRevisionHistoryMethods() throws Exception {
     // revisions are only created in real database transaction, this test just runs the code
 

--- a/src/test/java/com/researchspace/api/v1/controller/SubSamplesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SubSamplesApiControllerTest.java
@@ -70,7 +70,7 @@ public class SubSamplesApiControllerTest extends SpringTransactionalTest {
   @Before
   public void setUp() {
     openMocks(this);
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
     ReflectionTestUtils.setField(sampleApiMgr, "documentTagManager", documentTagManagerMock);
     ReflectionTestUtils.setField(subSampleApiMgr, "documentTagManager", documentTagManagerMock);
     testUser = createInitAndLoginAnyUser();

--- a/src/test/java/com/researchspace/api/v1/model/ApiSubSampleTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiSubSampleTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.testutils.SpringTransactionalTest;
@@ -166,7 +167,8 @@ public class ApiSubSampleTest extends SpringTransactionalTest {
     subSampleWithJustGlobalViewProperties.setPermittedActions(apiSubSample.getPermittedActions());
     subSampleWithJustGlobalViewProperties.setLinks(apiSubSample.getLinks());
     // also has a reference to public info of parent sample
-    Sample parentSample = sampleApiMgr.getSampleById(apiSubSample.getSampleInfo().getId(), user);
+    SampleEntity parentSample =
+        sampleApiMgr.getSampleById(apiSubSample.getSampleInfo().getId(), user);
     ApiSampleWithoutSubSamples apiParentSamplePublicView =
         new ApiSampleWithoutSubSamples(parentSample);
     apiParentSamplePublicView.clearPropertiesForPublicView();

--- a/src/test/java/com/researchspace/dao/SampleTemplateDaoTest.java
+++ b/src/test/java/com/researchspace/dao/SampleTemplateDaoTest.java
@@ -1,0 +1,174 @@
+package com.researchspace.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.core.util.ISearchResults;
+import com.researchspace.model.PaginationCriteria;
+import com.researchspace.model.User;
+import com.researchspace.model.field.FieldType;
+import com.researchspace.model.inventory.SampleTemplate;
+import com.researchspace.model.inventory.field.InventoryChoiceField;
+import com.researchspace.model.inventory.field.InventoryRadioField;
+import com.researchspace.testutils.SpringTransactionalTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SampleTemplateDaoTest extends SpringTransactionalTest {
+
+  @Before
+  public void setUp() {
+    sampleTemplateDao.resetDefaultTemplateOwner();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+    // don't leak an owner cached during this (rolled-back) transaction into later tests
+    sampleTemplateDao.resetDefaultTemplateOwner();
+  }
+
+  @Test
+  public void persistSampleTemplateSavesRadioAndChoiceDefinitions() {
+    User user = createInitAndLoginAnyUser();
+    long initialCount = sampleTemplateDao.getTemplateCount();
+
+    // complex template contains radio & choice fields with transient definitions,
+    // so the definition pre-save path of persistSampleTemplate is exercised
+    SampleTemplate template =
+        recordFactory.createComplexSampleTemplate("dao test template", "dao test desc", user);
+    SampleTemplate savedTemplate = sampleTemplateDao.persistSampleTemplate(template);
+    assertNotNull(savedTemplate.getId());
+    assertTrue(savedTemplate.isTemplate());
+    assertEquals(initialCount + 1, sampleTemplateDao.getTemplateCount().longValue());
+
+    SampleTemplate retrievedTemplate = sampleTemplateDao.get(savedTemplate.getId());
+    assertEquals(savedTemplate, retrievedTemplate);
+    InventoryRadioField radioField =
+        retrievedTemplate.getActiveFields().stream()
+            .filter(f -> FieldType.RADIO.equals(f.getType()))
+            .map(InventoryRadioField.class::cast)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no radio field on complex template"));
+    assertNotNull(radioField.getRadioDef().getId());
+    InventoryChoiceField choiceField =
+        retrievedTemplate.getActiveFields().stream()
+            .filter(f -> FieldType.CHOICE.equals(f.getType()))
+            .map(InventoryChoiceField.class::cast)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no choice field on complex template"));
+    assertNotNull(choiceField.getChoiceDef().getId());
+  }
+
+  @Test
+  public void getTemplatesForUserSeesOwnAndDefaultOwnerTemplates() {
+    User user = createInitAndLoginAnyUser();
+
+    // On a fresh DB the test user may itself be the default-templates owner (it was the first user
+    // initialised and createSampleTemplates() assigned the built-ins to it). On an aged DB an
+    // older user owns them. Either case must pass.
+    // @Before already called resetDefaultTemplateOwner(), so the cache is clear.
+    String defaultOwner = sampleTemplateDao.getDefaultTemplatesOwner();
+    // defaultOwner may be null (no templates yet) or any username – do NOT assume it differs
+    // from user.getUsername().
+
+    PaginationCriteria<SampleTemplate> pgCrit =
+        PaginationCriteria.createDefaultForClass(SampleTemplate.class);
+    pgCrit.setResultsPerPage(100);
+    ISearchResults<SampleTemplate> initialTemplates =
+        sampleTemplateDao.getTemplatesForUser(pgCrit, null, null, user);
+    long initialCount = initialTemplates.getTotalHits();
+    // All initially visible templates must be owned by either the default owner or the test user.
+    if (defaultOwner != null) {
+      final String finalDefaultOwner = defaultOwner;
+      assertTrue(
+          initialTemplates.getResults().stream()
+              .allMatch(
+                  t ->
+                      t.getOwner().getUsername().equals(finalDefaultOwner)
+                          || t.getOwner().getUsername().equals(user.getUsername())));
+    }
+
+    // a new template of the user's own must become visible to them
+    SampleTemplate ownTemplate = recordFactory.createSampleTemplate("dao owned template", user);
+    sampleTemplateDao.persistSampleTemplate(ownTemplate);
+    ISearchResults<SampleTemplate> updatedTemplates =
+        sampleTemplateDao.getTemplatesForUser(pgCrit, null, null, user);
+    assertEquals(initialCount + 1, updatedTemplates.getTotalHits().longValue());
+    assertTrue(
+        updatedTemplates.getResults().stream()
+            .anyMatch(t -> t.getId().equals(ownTemplate.getId())));
+
+    // Compute the true default owner now that ownTemplate is persisted (cache may have been
+    // populated before ownTemplate existed; reset to get an accurate picture).
+    sampleTemplateDao.resetDefaultTemplateOwner();
+    String currentDefaultOwner = sampleTemplateDao.getDefaultTemplatesOwner();
+
+    User otherUser = createInitAndLoginAnyUser();
+    ISearchResults<SampleTemplate> otherUserTemplates =
+        sampleTemplateDao.getTemplatesForUser(pgCrit, null, null, otherUser);
+
+    if (currentDefaultOwner != null && !currentDefaultOwner.equals(user.getUsername())) {
+      // Aged-DB path: default templates pre-exist and are owned by a DIFFERENT user.
+      // ownTemplate is a private template of `user`, so `otherUser` must NOT see it,
+      // and the count for `otherUser` stays at `initialCount` (only default-owner templates).
+      assertTrue(
+          otherUserTemplates.getResults().stream()
+              .noneMatch(t -> t.getId().equals(ownTemplate.getId())),
+          "otherUser should not see user's private template");
+      assertEquals(
+          initialCount,
+          otherUserTemplates.getTotalHits().longValue(),
+          "otherUser count must equal the pre-existing default-owner template count");
+      final String finalCurrentDefaultOwner = currentDefaultOwner;
+      assertTrue(
+          otherUserTemplates.getResults().stream()
+              .anyMatch(t -> t.getOwner().getUsername().equals(finalCurrentDefaultOwner)),
+          "otherUser must see at least one default-owner template");
+    } else {
+      // Fresh-DB path: `user` IS the default owner.
+      // The visibility rule exposes ALL templates owned by the default user to every user,
+      // so `ownTemplate` (owned by `user`) IS visible to `otherUser`.
+      // What we can assert: `otherUser` sees at least the default templates (initialCount)
+      // plus ownTemplate (initialCount + 1), and ownTemplate appears in the result.
+      assertEquals(
+          initialCount + 1,
+          otherUserTemplates.getTotalHits().longValue(),
+          "otherUser must see all default-owner templates plus ownTemplate");
+      assertTrue(
+          otherUserTemplates.getResults().stream()
+              .anyMatch(t -> t.getId().equals(ownTemplate.getId())),
+          "ownTemplate must be visible to otherUser when user is the default owner");
+    }
+  }
+
+  @Test
+  public void getTemplateCountIncludesAllUsersTemplates() {
+    User user = createInitAndLoginAnyUser();
+    long initialCount = sampleTemplateDao.getTemplateCount();
+    assertTrue(initialCount > 0); // default templates at least
+
+    SampleTemplate template = recordFactory.createSampleTemplate("dao count template", user);
+    sampleTemplateDao.persistSampleTemplate(template);
+    assertEquals(initialCount + 1, sampleTemplateDao.getTemplateCount().longValue());
+  }
+
+  @Test
+  public void getDefaultTemplatesOwnerReturnsOwnerOfOldestTemplate() {
+    createInitAndLoginAnyUser(); // guarantees default templates exist
+
+    String defaultOwner = sampleTemplateDao.getDefaultTemplatesOwner();
+    assertNotNull(defaultOwner);
+    SampleTemplate oldestTemplate =
+        sessionFactory
+            .getCurrentSession()
+            .createQuery("from SampleTemplate order by id asc", SampleTemplate.class)
+            .setMaxResults(1)
+            .getSingleResult();
+    assertEquals(oldestTemplate.getOwner().getUsername(), defaultOwner);
+    // value is cached until reset
+    assertEquals(defaultOwner, sampleTemplateDao.getDefaultTemplatesOwner());
+  }
+}

--- a/src/test/java/com/researchspace/dao/customliquibaseupdates/SampleRadioChoiceFieldOptionsFormatChangeIT.java
+++ b/src/test/java/com/researchspace/dao/customliquibaseupdates/SampleRadioChoiceFieldOptionsFormatChangeIT.java
@@ -5,10 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.researchspace.dao.ContainerDao;
-import com.researchspace.dao.SampleDao;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Container;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.field.InventoryChoiceField;
 import com.researchspace.model.inventory.field.InventoryChoiceFieldDef;
 import com.researchspace.model.inventory.field.InventoryEntityField;
@@ -30,8 +29,6 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
 
   private @Autowired ContainerDao containerDao;
 
-  private @Autowired SampleDao sampleDao;
-
   @After
   public void tearDown() throws Exception {
     super.tearDown();
@@ -45,8 +42,8 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
 
     // save sample in old format
     openTransaction();
-    Sample newSample = createSampleWithOldFormatRadioChoiceFields(user);
-    Sample persistedSample = sampleDao.persistSampleTemplate(newSample);
+    SampleTemplate newSample = createSampleWithOldFormatRadioChoiceFields(user);
+    SampleTemplate persistedSample = sampleTemplateDao.persistSampleTemplate(newSample);
     assertNotNull(persistedSample);
     List<InventoryEntityField> persistedFields = persistedSample.getActiveFields();
     commitTransaction();
@@ -111,7 +108,7 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
 
     // retrieve the sample
     openTransaction();
-    Sample retrievedSample = sampleDao.get(persistedSample.getId());
+    SampleTemplate retrievedSample = sampleTemplateDao.get(persistedSample.getId());
     assertNotNull(retrievedSample);
     List<InventoryEntityField> updatedFields = retrievedSample.getActiveFields();
     commitTransaction();
@@ -137,12 +134,12 @@ public class SampleRadioChoiceFieldOptionsFormatChangeIT extends AbstractDBHelpe
    * Creates a simplified sample template with choice/radio fields that use old format
    * for storing defined options and selected options.
    */
-  private Sample createSampleWithOldFormatRadioChoiceFields(User user)
+  private SampleTemplate createSampleWithOldFormatRadioChoiceFields(User user)
       throws IllegalAccessException {
 
     // create sample template
-    Sample newSample = recordFactory.createSample("old-format options sample", user);
-    newSample.setTemplate(true);
+    SampleTemplate newSample =
+        recordFactory.createSampleTemplate("old-format options sample", user);
     // put subsample in workbench
     Container workbench = containerDao.getWorkbenchForUser(user);
     newSample.getSubSamples().get(0).moveToNewParent(workbench);

--- a/src/test/java/com/researchspace/dao/hibernate/StoichiometryInventoryLinkDaoHibernateTest.java
+++ b/src/test/java/com/researchspace/dao/hibernate/StoichiometryInventoryLinkDaoHibernateTest.java
@@ -10,7 +10,6 @@ import com.researchspace.model.ChemElementsFormat;
 import com.researchspace.model.RSChemElement;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.SampleTemplate;
-import com.researchspace.model.record.RecordFactory;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.model.stoichiometry.MoleculeRole;
 import com.researchspace.model.stoichiometry.Stoichiometry;
@@ -44,7 +43,7 @@ public class StoichiometryInventoryLinkDaoHibernateTest extends SpringTransactio
   }
 
   private StoichiometryInventoryLink setupSampleTemplateAndStoichiometry(User user) {
-    SampleTemplate sample = new RecordFactory().createSampleTemplate("test sample", user);
+    SampleTemplate sample = recordFactory.createSampleTemplate("test sample", user);
     sampleTemplateDao.save(sample);
 
     StructuredDocument doc = createBasicDocumentInRootFolderWithText(user, "test");

--- a/src/test/java/com/researchspace/dao/hibernate/StoichiometryInventoryLinkDaoHibernateTest.java
+++ b/src/test/java/com/researchspace/dao/hibernate/StoichiometryInventoryLinkDaoHibernateTest.java
@@ -4,20 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.researchspace.dao.RSChemElementDao;
-import com.researchspace.dao.SampleDao;
 import com.researchspace.dao.StoichiometryDao;
 import com.researchspace.dao.StoichiometryInventoryLinkDao;
 import com.researchspace.model.ChemElementsFormat;
 import com.researchspace.model.RSChemElement;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
+import com.researchspace.model.record.RecordFactory;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.model.stoichiometry.MoleculeRole;
 import com.researchspace.model.stoichiometry.Stoichiometry;
 import com.researchspace.model.stoichiometry.StoichiometryInventoryLink;
 import com.researchspace.model.stoichiometry.StoichiometryMolecule;
 import com.researchspace.testutils.SpringTransactionalTest;
-import com.researchspace.testutils.TestFactory;
 import java.util.List;
 import javax.validation.ConstraintViolationException;
 import org.junit.Test;
@@ -26,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class StoichiometryInventoryLinkDaoHibernateTest extends SpringTransactionalTest {
 
   @Autowired private StoichiometryInventoryLinkDao dao;
-  @Autowired private SampleDao sampleDao;
   @Autowired private StoichiometryDao stoichDao;
   @Autowired private RSChemElementDao chemDao;
 
@@ -46,9 +44,8 @@ public class StoichiometryInventoryLinkDaoHibernateTest extends SpringTransactio
   }
 
   private StoichiometryInventoryLink setupSampleTemplateAndStoichiometry(User user) {
-    Sample sample = TestFactory.createBasicSampleOutsideContainer(user);
-    sample.setTemplate(true);
-    sampleDao.save(sample);
+    SampleTemplate sample = new RecordFactory().createSampleTemplate("test sample", user);
+    sampleTemplateDao.save(sample);
 
     StructuredDocument doc = createBasicDocumentInRootFolderWithText(user, "test");
 

--- a/src/test/java/com/researchspace/service/SearchManagerTest.java
+++ b/src/test/java/com/researchspace/service/SearchManagerTest.java
@@ -108,7 +108,7 @@ public class SearchManagerTest extends SearchSpringTestBase {
     getTargetObject(fileIndexSearcher.getFileSearchStrategy(), LuceneSearchStrategy.class)
         .setIndexFolderDirectly(indexfolder.getRoot());
     perFactory = new DefaultPermissionFactory();
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
   }
 
   /** Check if we can search documents created from templates by the template name */

--- a/src/test/java/com/researchspace/service/impl/ProdContentInitializerTestIT.java
+++ b/src/test/java/com/researchspace/service/impl/ProdContentInitializerTestIT.java
@@ -8,7 +8,7 @@ import com.researchspace.core.util.MediaUtils;
 import com.researchspace.dao.FolderDao;
 import com.researchspace.dao.FormDao;
 import com.researchspace.dao.RecordDao;
-import com.researchspace.dao.SampleDao;
+import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.dao.UserDao;
 import com.researchspace.linkedelements.RichTextUpdater;
 import com.researchspace.model.User;
@@ -66,7 +66,7 @@ public class ProdContentInitializerTestIT extends RealTransactionSpringTestBase 
     initializer.setContentInitialiserUtils(getBeanOfClass(IContentInitialiserUtils.class));
     initializer.setImporter(getBeanOfClass(ExportImport.class));
     initializer.setFolderManager(getBeanOfClass(FolderManager.class));
-    initializer.setSampleDao(getBeanOfClass(SampleDao.class));
+    initializer.setSampleTemplateDao(getBeanOfClass(SampleTemplateDao.class));
     initializer.setSampleApiMgr(getBeanOfClass(SampleApiManager.class));
     initializer.setContainerApiMgr(getBeanOfClass(ContainerApiManager.class));
     initializer.setImportRecordsOnly(

--- a/src/test/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImplTest.java
@@ -20,6 +20,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.permissions.PermissionType;
@@ -110,11 +111,12 @@ public class StoichiometryInventoryLinkManagerImplTest {
     StoichiometryInventoryLinkRequest req = new StoichiometryInventoryLinkRequest();
     req.setInventoryItemGlobalId("IT200");
 
-    invSample.setTemplate(true);
+    SampleTemplate invSampleTemplate = new SampleTemplate();
+    invSampleTemplate.setId(200L);
 
     when(moleculeManager.getById(10L)).thenReturn(molecule);
     when(invPerms.assertUserCanEditInventoryRecord(any(GlobalIdentifier.class), eq(user)))
-        .thenReturn(invSample);
+        .thenReturn(invSampleTemplate);
 
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user));

--- a/src/test/java/com/researchspace/service/inventory/InventoryAuditApiManagerIT.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryAuditApiManagerIT.java
@@ -13,7 +13,7 @@ import com.researchspace.api.v1.model.ApiSubSample;
 import com.researchspace.api.v1.model.ApiSubSampleNote;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Instrument;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.testutils.RealTransactionSpringTestBase;
 import java.util.List;
@@ -57,7 +57,7 @@ public class InventoryAuditApiManagerIT extends RealTransactionSpringTestBase {
     subSample.setName("updated subSample");
     subSampleApiMgr.updateApiSubSample(subSample, anyUser);
 
-    Sample dbSample = sampleApiMgr.assertUserCanEditSample(sample.getId(), anyUser);
+    SampleEntity dbSample = sampleApiMgr.assertUserCanEditSample(sample.getId(), anyUser);
     SubSample dbSubSample = subSampleApiMgr.assertUserCanEditSubSample(subSample.getId(), anyUser);
 
     // get all subsample revisions

--- a/src/test/java/com/researchspace/service/inventory/InventoryAuditApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryAuditApiManagerTest.java
@@ -9,7 +9,7 @@ import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.api.v1.model.ApiSample;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.testutils.SpringTransactionalTest;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +27,7 @@ public class InventoryAuditApiManagerTest extends SpringTransactionalTest {
     User user = createAndSaveRandomUser();
     initialiseContentWithEmptyContent(user);
     ApiSampleWithFullSubSamples basicSample = createBasicSampleForUser(user);
-    Sample sample = sampleApiMgr.assertUserCanEditSample(basicSample.getId(), user);
+    SampleEntity sample = sampleApiMgr.assertUserCanEditSample(basicSample.getId(), user);
 
     ApiInventoryRecordRevisionList revisions =
         inventoryAuditMgr.getInventoryRecordRevisions(sample);

--- a/src/test/java/com/researchspace/service/inventory/InventoryExtraFieldUniquenessTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryExtraFieldUniquenessTest.java
@@ -38,7 +38,7 @@ public class InventoryExtraFieldUniquenessTest extends SpringTransactionalTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
     testUser = createAndSaveUserIfNotExists(getRandomAlphabeticString("uniqApi"));
     initialiseContentWithEmptyContent(testUser);
     assertTrue(testUser.isContentInitialized());

--- a/src/test/java/com/researchspace/service/inventory/InventoryFileApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryFileApiManagerTest.java
@@ -15,7 +15,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.InventoryFile;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.service.impl.ContentInitializerForDevRunManager;
 import com.researchspace.testutils.SpringTransactionalTest;
 import com.researchspace.testutils.TestGroup;
@@ -30,7 +30,7 @@ public class InventoryFileApiManagerTest extends SpringTransactionalTest {
   public void setUp() throws Exception {
     super.setUp();
 
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
   }
 
   @Test
@@ -68,7 +68,7 @@ public class InventoryFileApiManagerTest extends SpringTransactionalTest {
 
     User user = createInitAndLoginAnyUser();
     ApiSampleWithFullSubSamples apiSample = createBasicSampleForUser(user);
-    Sample dbSample = sampleApiMgr.getSampleById(apiSample.getId(), user);
+    SampleEntity dbSample = sampleApiMgr.getSampleById(apiSample.getId(), user);
     assertEquals(0, dbSample.getAttachedFiles().size());
 
     // add file attachment
@@ -89,7 +89,7 @@ public class InventoryFileApiManagerTest extends SpringTransactionalTest {
 
     // copy inventory item
     ApiSampleWithFullSubSamples copiedSample = sampleApiMgr.duplicate(apiSample.getId(), user);
-    Sample dbSampleCopy = sampleApiMgr.getSampleById(copiedSample.getId(), user);
+    SampleEntity dbSampleCopy = sampleApiMgr.getSampleById(copiedSample.getId(), user);
     assertEquals(2, dbSampleCopy.getAttachedFiles().size());
 
     // delete attachment from original sample

--- a/src/test/java/com/researchspace/service/inventory/InventoryPermissionUtilsTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryPermissionUtilsTest.java
@@ -18,7 +18,7 @@ import com.researchspace.model.RoleInGroup;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.InventoryRecord.InventorySharingMode;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.record.StructuredDocument;
@@ -96,7 +96,7 @@ public class InventoryPermissionUtilsTest extends SpringTransactionalTest {
     // standard group-sharing mode
     ApiSampleWithFullSubSamples createdSample = createBasicSampleForUser(testUser, "basicSample");
     assertEquals(ApiInventorySharingMode.OWNER_GROUPS, createdSample.getSharingMode());
-    Sample sample = sampleApiMgr.getSampleById(createdSample.getId(), testUser);
+    SampleEntity sample = sampleApiMgr.getSampleById(createdSample.getId(), testUser);
 
     // all within group have full permission, outside group none
     assertTrue(invPermissionUtils.canUserEditInventoryRecord(sample, testUser));
@@ -157,7 +157,7 @@ public class InventoryPermissionUtilsTest extends SpringTransactionalTest {
     // create a sample that is shared with group1 only
     ApiSampleWithFullSubSamples createdSample =
         createBasicSampleForUserAndGroups(testUser, "basicSample", List.of(group1));
-    Sample sample = sampleApiMgr.getSampleById(createdSample.getId(), testUser);
+    SampleEntity sample = sampleApiMgr.getSampleById(createdSample.getId(), testUser);
     assertEquals(InventorySharingMode.WHITELIST, sample.getSharingMode());
     assertEquals(List.of(group1.getUniqueName()), sample.getSharedWithUniqueNames());
 
@@ -246,7 +246,7 @@ public class InventoryPermissionUtilsTest extends SpringTransactionalTest {
 
     // create a sample that is group-shared
     ApiSampleWithFullSubSamples createdSample = createBasicSampleForUser(testUser);
-    Sample sample = sampleApiMgr.getSampleById(createdSample.getId(), testUser);
+    SampleEntity sample = sampleApiMgr.getSampleById(createdSample.getId(), testUser);
     assertEquals(InventorySharingMode.OWNER_GROUPS, sample.getSharingMode());
 
     // within group1 full permission, outside group1 none
@@ -399,7 +399,7 @@ public class InventoryPermissionUtilsTest extends SpringTransactionalTest {
     ApiSubSample newSubSample2 = new ApiSubSample("SS2");
     newSample.setSubSamples(List.of(newSubSample1, newSubSample2));
     ApiSampleWithFullSubSamples apiSampleSA1 = sampleApiMgr.createNewApiSample(newSample, userE);
-    Sample sampleSA1 = sampleApiMgr.getSampleById(apiSampleSA1.getId(), userE);
+    SampleEntity sampleSA1 = sampleApiMgr.getSampleById(apiSampleSA1.getId(), userE);
     assertEquals("SA1", sampleSA1.getName());
     assertEquals(InventorySharingMode.OWNER_GROUPS, sampleSA1.getSharingMode());
     assertEquals(2, sampleSA1.getSubSamples().size());
@@ -650,7 +650,7 @@ public class InventoryPermissionUtilsTest extends SpringTransactionalTest {
     ApiSampleWithFullSubSamples apiSampleSA1 = createBasicSampleForUser(userA, "SA1");
     moveSubSampleIntoListContainer(
         apiSampleSA1.getSubSamples().get(0).getId(), containerC1.getId(), userA);
-    Sample sampleSA1 = sampleApiMgr.getSampleById(apiSampleSA1.getId(), userA);
+    SampleEntity sampleSA1 = sampleApiMgr.getSampleById(apiSampleSA1.getId(), userA);
     assertEquals("SA1", sampleSA1.getName());
     assertEquals(InventorySharingMode.OWNER_GROUPS, sampleSA1.getSharingMode());
     assertEquals(1, sampleSA1.getSubSamples().size());

--- a/src/test/java/com/researchspace/service/inventory/ListOfMaterialsApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/ListOfMaterialsApiManagerTest.java
@@ -50,7 +50,7 @@ public class ListOfMaterialsApiManagerTest extends SpringTransactionalTest {
   public void setUp() throws Exception {
     super.setUp();
 
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
     testUser = createAndSaveUserIfNotExists(getRandomAlphabeticString("api"));
     initialiseContentWithExampleContent(testUser);
     assertTrue(testUser.isContentInitialized());

--- a/src/test/java/com/researchspace/service/inventory/SampleApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/SampleApiManagerTest.java
@@ -69,7 +69,7 @@ public class SampleApiManagerTest extends SpringTransactionalTest {
   public void setUp() throws Exception {
     super.setUp();
 
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
     testUser = createAndSaveUserIfNotExists(getRandomAlphabeticString("api"));
     initialiseContentWithEmptyContent(testUser);
     assertTrue(testUser.isContentInitialized());

--- a/src/test/java/com/researchspace/service/inventory/SampleTemplatesApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/SampleTemplatesApiManagerTest.java
@@ -29,8 +29,8 @@ import com.researchspace.core.util.SortOrder;
 import com.researchspace.model.Group;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.testutils.SpringTransactionalTest;
@@ -46,7 +46,7 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
 
   @Before
   public void setUp() {
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
 
     testUser = createAndSaveUserIfNotExists(getRandomAlphabeticString("api"));
     initialiseContentWithEmptyContent(testUser);
@@ -55,8 +55,8 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
 
   @Test
   public void checkTemplateFiltering_rsinv131() {
-    PaginationCriteria<Sample> defaultPgCrit =
-        PaginationCriteria.createDefaultForClass(Sample.class);
+    PaginationCriteria<SampleTemplate> defaultPgCrit =
+        PaginationCriteria.createDefaultForClass(SampleTemplate.class);
     defaultPgCrit.setSortOrder(SortOrder.ASC);
     User firstUser = createInitAndLoginAnyUser();
     ApiSampleTemplateSearchResult initialTemplates =
@@ -107,8 +107,8 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     Group groupB = createGroup("groupB", pi2);
     addUsersToGroup(pi2, groupB, user3, user4);
 
-    PaginationCriteria<Sample> defaultPgCrit =
-        PaginationCriteria.createDefaultForClass(Sample.class);
+    PaginationCriteria<SampleTemplate> defaultPgCrit =
+        PaginationCriteria.createDefaultForClass(SampleTemplate.class);
     defaultPgCrit.setSortOrder(SortOrder.ASC);
     ApiSampleTemplateSearchResult initialTemplates =
         sampleApiMgr.getTemplatesForUser(defaultPgCrit, null, null, user1);
@@ -128,7 +128,7 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     assertEquals(2, user1Template.getSharedWith().size());
 
     // verify permissions,
-    Sample createdTemplate =
+    SampleTemplate createdTemplate =
         sampleApiMgr.getSampleTemplateByIdWithPopulatedFields(user1Template.getId(), user1);
     assertTrue(
         invPermissionUtils.canUserEditInventoryRecord(
@@ -602,6 +602,27 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
     testTemplate.setName("updated name 2");
     updatedTemplate = sampleApiMgr.updateApiSampleTemplate(testTemplate, testUser);
     assertEquals("updated name 2", updatedTemplate.getName());
+  }
+
+  @Test
+  public void saveIconIdPersistsOnSampleTemplate() {
+    ApiSampleTemplatePost sampleTemplatePost = getTemplatePostForTestTemplateWithTextField();
+    ApiSampleTemplate createdTemplate =
+        sampleApiMgr.createSampleTemplate(sampleTemplatePost, testUser);
+    SampleTemplate template =
+        sampleApiMgr.getSampleTemplateByIdWithPopulatedFields(createdTemplate.getId(), testUser);
+    assertEquals(Long.valueOf(-1L), template.getIconId()); // default icon id
+
+    // RSDEV-1065 regression guard: saveIconId's DML must target SampleEntity; an update
+    // scoped to the Sample subclass would silently no-op for template rows
+    sampleApiMgr.saveIconId(template, 12345L);
+
+    // bulk DML bypasses the session cache, so clear it before re-reading persisted state
+    sessionFactory.getCurrentSession().flush();
+    sessionFactory.getCurrentSession().clear();
+    SampleTemplate reloadedTemplate =
+        sampleApiMgr.getSampleTemplateByIdWithPopulatedFields(createdTemplate.getId(), testUser);
+    assertEquals(Long.valueOf(12345L), reloadedTemplate.getIconId());
   }
 
   @NotNull

--- a/src/test/java/com/researchspace/service/inventory/SampleTemplatesApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/SampleTemplatesApiManagerTest.java
@@ -1032,4 +1032,21 @@ public class SampleTemplatesApiManagerTest extends SpringTransactionalTest {
         List.of("c2", "c3", "c4"),
         retrievedSample1.getFields().get(1).getDefinition().getOptions());
   }
+
+  @Test
+  public void updateToLatestTemplateVersionRejectsSampleWithNoTemplate() {
+    // a sample created without a template has a null parent template id; updating it to the latest
+    // template version must surface a clear error rather than a not-found for template id "null"
+    ApiSampleWithFullSubSamples apiSample =
+        new ApiSampleWithFullSubSamples("sample without a template");
+    ApiSampleWithFullSubSamples createdSample =
+        sampleApiMgr.createNewApiSample(apiSample, testUser);
+
+    IllegalArgumentException iae =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                sampleApiMgr.updateSampleToLatestTemplateVersion(createdSample.getId(), testUser));
+    assertEquals("Sample is not based on any template", iae.getMessage());
+  }
 }

--- a/src/test/java/com/researchspace/service/inventory/SamplesApiManagerIT.java
+++ b/src/test/java/com/researchspace/service/inventory/SamplesApiManagerIT.java
@@ -17,7 +17,7 @@ import com.researchspace.api.v1.model.ApiSubSampleInfo;
 import com.researchspace.core.testutil.CoreTestUtils;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Container.ContainerType;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.testutils.RealTransactionSpringTestBase;
 import java.util.List;
@@ -41,7 +41,7 @@ public class SamplesApiManagerIT extends RealTransactionSpringTestBase {
     moveSubSampleIntoListContainer(subSample.getId(), subContainer.getId(), testUser);
 
     // get sample details, verify subsample parent/grandparent are present
-    Sample dbSample = sampleApiMgr.getSampleById(sample.getId(), testUser);
+    SampleEntity dbSample = sampleApiMgr.getSampleById(sample.getId(), testUser);
     assertEquals(1, dbSample.getSubSamples().size());
     SubSample dbSubSample = dbSample.getSubSamples().get(0);
     assertEquals(subContainer.getId(), dbSubSample.getParentId());

--- a/src/test/java/com/researchspace/service/inventory/SubSampleApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/SubSampleApiManagerTest.java
@@ -43,7 +43,7 @@ import com.researchspace.model.events.InventoryCreationEvent;
 import com.researchspace.model.events.InventoryDeleteEvent;
 import com.researchspace.model.events.InventoryEditingEvent;
 import com.researchspace.model.events.InventoryMoveEvent;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.units.QuantityInfo;
 import com.researchspace.model.units.RSUnitDef;
@@ -72,7 +72,7 @@ public class SubSampleApiManagerTest extends SpringTransactionalTest {
   public void setUp() throws Exception {
     super.setUp();
 
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
     testUser = createAndSaveUserIfNotExists(getRandomAlphabeticString("api"));
     initialiseContentWithEmptyContent(testUser);
     assertTrue(testUser.isContentInitialized());
@@ -942,7 +942,7 @@ public class SubSampleApiManagerTest extends SpringTransactionalTest {
     assertEquals("5 g", retrievedSample.getQuantity().toQuantityInfo().toPlainString());
 
     // assert naming rsinv-148
-    Sample reloadedSample = sampleApiMgr.getSampleById(createdSample.getId(), testUser);
+    SampleEntity reloadedSample = sampleApiMgr.getSampleById(createdSample.getId(), testUser);
     IntStream.range(0, reloadedSample.getActiveSubSamplesCount())
         .forEach(
             i -> {

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryAuditApiManagerVersionTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryAuditApiManagerVersionTest.java
@@ -21,6 +21,7 @@ import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.service.AuditManager;
 import com.researchspace.service.UserManager;
@@ -110,7 +111,8 @@ public class InventoryAuditApiManagerVersionTest {
     // the audit layer resolves a user version to the newest revision carrying it
     when(auditManager.getRevisionNumberForInventoryRecordVersion(current.getClass(), 42L, 2L))
         .thenReturn(380L);
-    when(auditManager.getObjectForRevision(Sample.class, 42L, 380L))
+    // the revision read targets SampleEntity so either discriminator value resolves
+    when(auditManager.getObjectForRevision(SampleEntity.class, 42L, 380L))
         .thenReturn(new AuditedEntity<>(v2, 380L));
 
     ApiSample result = mgr.getApiSampleVersion(current, 2L);
@@ -130,7 +132,7 @@ public class InventoryAuditApiManagerVersionTest {
     Sample v1 = sampleWithVersion(42L, 1L);
     when(auditManager.getRevisionNumberForInventoryRecordVersion(current.getClass(), 42L, 1L))
         .thenReturn(100L);
-    when(auditManager.getObjectForRevision(Sample.class, 42L, 100L))
+    when(auditManager.getObjectForRevision(SampleEntity.class, 42L, 100L))
         .thenReturn(new AuditedEntity<>(v1, 100L));
 
     ApiSample result = mgr.getApiSampleVersion(current, 1L);

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryImportManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryImportManagerTest.java
@@ -33,8 +33,8 @@ import com.researchspace.dao.DigitalObjectIdentifierDao;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.DigitalObjectIdentifier;
-import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.service.ApiAvailabilityHandler;
 import com.researchspace.service.inventory.ContainerApiManager;
@@ -629,7 +629,7 @@ public class InventoryImportManagerTest extends SpringTransactionalTest {
     nameDescriptionMapping.put("MyQuantity", "quantity");
 
     // use complex template
-    Sample complexTemplate = findComplexSampleTemplate(testUser);
+    SampleTemplate complexTemplate = findComplexSampleTemplate(testUser);
     ApiInventoryImportSampleImportResult sampleResult = new ApiInventoryImportSampleImportResult();
     sampleResult.addExistingTemplateResult(new ApiSampleTemplate(complexTemplate));
     ApiInventoryImportResult processingResult = new ApiInventoryImportResult(testUser);
@@ -691,7 +691,7 @@ public class InventoryImportManagerTest extends SpringTransactionalTest {
     HashMap<String, String> nameMapping = new HashMap<>();
     nameMapping.put("Name", "name");
 
-    Sample complexTemplate = findComplexSampleTemplate(testUser);
+    SampleTemplate complexTemplate = findComplexSampleTemplate(testUser);
     ApiSampleTemplate complexApiTemplate = new ApiSampleTemplate(complexTemplate);
 
     // find complex template

--- a/src/test/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImplTest.java
@@ -16,6 +16,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.audit.AuditedEntity;
 import com.researchspace.model.core.GlobalIdPrefix;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.AuditManager;
@@ -88,8 +89,8 @@ class LinkTargetSnapshotResolverImplTest {
   }
 
   @Test
-  void resolvesRevisionForSampleTemplateViaSampleClass() {
-    when(auditManager.getRevisionNumberForInventoryRecordVersion(Sample.class, 20L, 2L))
+  void resolvesRevisionForSampleTemplateViaSampleTemplateClass() {
+    when(auditManager.getRevisionNumberForInventoryRecordVersion(SampleTemplate.class, 20L, 2L))
         .thenReturn(33);
 
     Long rev = resolver.resolveRevisionForVersion(GlobalIdPrefix.IT, 20L, 2L);

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplSamplesToUpdateCountTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplSamplesToUpdateCountTest.java
@@ -9,6 +9,7 @@ import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.dao.SampleDao;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.testutils.TestFactory;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,8 +41,8 @@ class SampleApiManagerImplSamplesToUpdateCountTest {
     user = TestFactory.createAnyUser("any");
   }
 
-  private Sample templateWith(Long id, Long version) {
-    Sample template = mock(Sample.class);
+  private SampleTemplate templateWith(Long id, Long version) {
+    SampleTemplate template = mock(SampleTemplate.class);
     lenient().when(template.getId()).thenReturn(id);
     lenient().when(template.getVersion()).thenReturn(version);
     return template;
@@ -49,7 +50,7 @@ class SampleApiManagerImplSamplesToUpdateCountTest {
 
   @Test
   void countReflectsSamplesCreatedFromAnOlderVersion() {
-    Sample template = templateWith(7L, 3L);
+    SampleTemplate template = templateWith(7L, 3L);
     when(sampleDao.getSamplesLinkingOlderTemplateVersionForUser(7L, 3L, user))
         .thenReturn(Arrays.asList(mock(Sample.class), mock(Sample.class)));
 
@@ -61,7 +62,7 @@ class SampleApiManagerImplSamplesToUpdateCountTest {
 
   @Test
   void countIsZeroWhenNoSampleIsBehind() {
-    Sample template = templateWith(7L, 3L);
+    SampleTemplate template = templateWith(7L, 3L);
     when(sampleDao.getSamplesLinkingOlderTemplateVersionForUser(7L, 3L, user))
         .thenReturn(Collections.emptyList());
 

--- a/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
+++ b/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
@@ -45,6 +45,7 @@ import com.researchspace.dao.FormDao;
 import com.researchspace.dao.ListOfMaterialsDao;
 import com.researchspace.dao.RecordDao;
 import com.researchspace.dao.SampleDao;
+import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.dao.UserDao;
 import com.researchspace.linkedelements.FieldLinksEntitiesSynchronizer;
 import com.researchspace.linkedelements.FieldParser;
@@ -80,7 +81,7 @@ import com.researchspace.model.field.Field;
 import com.researchspace.model.inventory.Container.ContainerType;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventorySeriesNamingHelper;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.netfiles.NfsElement;
 import com.researchspace.model.netfiles.NfsFileStore;
 import com.researchspace.model.permissions.ConstraintBasedPermission;
@@ -285,6 +286,7 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
   protected @Autowired SampleApiManager sampleApiMgr;
   protected @Autowired InstrumentEntityApiManager instrumentApiMgr;
   protected @Autowired SampleDao sampleDao;
+  protected @Autowired SampleTemplateDao sampleTemplateDao;
   protected @Autowired ContainerDao containerDao;
   protected @Autowired SubSampleApiManager subSampleApiMgr;
   protected @Autowired InventoryTagApiManager inventoryTagsApiManager;
@@ -1783,7 +1785,7 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     ApiSampleWithFullSubSamples newSample = new ApiSampleWithFullSubSamples();
     newSample.setName("myComplexSample");
 
-    Sample complexTemplate = findComplexSampleTemplate(user);
+    SampleTemplate complexTemplate = findComplexSampleTemplate(user);
     newSample.setTemplateId(complexTemplate.getId());
     newSample.setApiTagInfo("complexSampleTag");
     newSample.setDescription("complexSampleDescription");
@@ -1833,16 +1835,16 @@ public abstract class BaseManagerTestCaseBase extends AbstractJUnit4SpringContex
     return sampleApiMgr.createNewApiSample(newSample, user);
   }
 
-  protected Sample findComplexSampleTemplate(User user) {
+  protected SampleTemplate findComplexSampleTemplate(User user) {
     return findSampleTemplateByName(
         user, ContentInitializerForDevRunManager.COMPLEX_SAMPLE_TEMPLATE_NAME);
   }
 
-  protected Sample findBasicSampleTemplate(User user) {
+  protected SampleTemplate findBasicSampleTemplate(User user) {
     return findSampleTemplateByName(user, AbstractContentInitializer.DEFAULT_SAMPLE_TEMPLATE_NAME);
   }
 
-  private Sample findSampleTemplateByName(User user, String templateName) {
+  private SampleTemplate findSampleTemplateByName(User user, String templateName) {
     return sampleApiMgr.getAllTemplates(user).stream()
         .filter(t -> t.getName().equals(templateName))
         .findAny()

--- a/src/test/java/com/researchspace/testutils/RealTransactionSpringTestBase.java
+++ b/src/test/java/com/researchspace/testutils/RealTransactionSpringTestBase.java
@@ -149,7 +149,7 @@ public class RealTransactionSpringTestBase extends BaseManagerTestCaseBase {
 
   @Before
   public void beforeEach() {
-    sampleDao.resetDefaultTemplateOwner();
+    sampleTemplateDao.resetDefaultTemplateOwner();
   }
 
   @AfterClass

--- a/src/test/java/com/researchspace/testutils/TestFactory.java
+++ b/src/test/java/com/researchspace/testutils/TestFactory.java
@@ -48,6 +48,7 @@ import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.ExtraNumberField;
 import com.researchspace.model.inventory.field.ExtraTextField;
@@ -727,7 +728,8 @@ public class TestFactory {
 
   public static Sample createComplexSampleInContainer(User user) {
     Container cont = rf.createListContainer("test", user);
-    Sample sampleTemplate = rf.createComplexSampleTemplate("complex template", "for tests", user);
+    SampleTemplate sampleTemplate =
+        rf.createComplexSampleTemplate("complex template", "for tests", user);
     Sample sample = rf.createSample("test complex sample", user, sampleTemplate);
     sample.getSubSamples().get(0).moveToNewParent(cont);
     return sample;


### PR DESCRIPTION
## Description ##

The rspace-web side of RSDEV-1065. It turns `SampleTemplate` into a first-class
entity instead of a `Sample` row flagged with `template = 1`. Building on the
core-model change (see Related PRs), the combined Sample code is split so that
`Sample` and `SampleTemplate` are distinct concrete entities over a single
`Sample` table, with their own DAO, service, and API surfaces.

This is a structural / technical-debt refactor (the JIRA is a Technical debt
item); it preserves existing sample and template behaviour rather than adding
features.

This refactoring is transparent to the UI and the end-user experience. There are
no frontend changes (no React/TypeScript, JSP, or Velocity), and the public API
contract is unchanged: existing endpoints under `/api/v1/samples` and
`/api/v1/sampleTemplates` keep the same paths, request bodies, and response
types, and the existing DTOs keep the same JSON shape. The modified `Api*` models
only change internal parameter types (`Sample` to `SampleEntity`); the new
`ApiSampleTemplate` / `ApiSampleTemplateInfo` / `ApiSampleTemplatePost` DTOs are
additive. So existing API consumers and the UI continue to work as usual.

Main changes:
- Single-table inheritance over the existing `Sample` table via a `DTYPE`
  discriminator, plus a Liquibase migration that adds and backfills it.
- DAO split into `SampleDao`, `SampleTemplateDao`, and a shared `SampleEntityDao`.
- New template API surface: `SampleTemplatesApiController` and
  `ApiSampleTemplate` / `ApiSampleTemplateInfo` / `ApiSampleTemplatePost`.
- Built-in sample templates and inventory services updated to the new type.

> [!IMPORTANT]
> **Deployment step:** this release must be deployed with `rs.indexOnstartup=true`
> so the Lucene full-text search index is rebuilt for the re-mapped `Sample` /
> `SampleTemplate` entities.

## Related PRs ##

- rspace-os/rspace-core-model#75 (RSDEV-1065): introduces the `SampleEntity`
  base class with `Sample` and `SampleTemplate` as concrete subclasses. This PR
  depends on it. The dependency is currently pinned to
  `RSDEV-1065-model-SNAPSHOT` (see the TODO in `pom.xml`); that pin must be
  replaced with the released core-model version before merge.

## Design decisions ##

- Single-table inheritance over the existing `Sample` table, using Hibernate's
  default `DTYPE` discriminator column (values `Sample` / `SampleTemplate`),
  mirroring the existing `InstrumentEntity` / `InstrumentTemplate` hierarchy for
  consistency.
- The legacy boolean `template` column is intentionally retained but no longer
  mapped or maintained by Hibernate. `DTYPE` is backfilled from it for both the
  live `Sample` table and the `Sample_AUD` audit table, so Envers can still
  resolve historical Sample / SampleTemplate revisions.
- Code discriminates via `isSample()` / `isSampleTemplate()` (and a raw `DTYPE`
  anchor in the inventory listing queries, matching the instrument DAOs) rather
  than the legacy `template` flag.
- Superclass-level DML (for example the `iconId` update) targets the mapped
  `SampleEntity` so it applies regardless of which discriminator a row holds.
- Template duplication reuses the source template's already-persistent field
  definitions, so the existing persist path stays a no-op for those definitions.

## Testing notes ##

- Requires `rspace-core-model:RSDEV-1065-model-SNAPSHOT` on the classpath
  (JitPack builds the branch). Swap to the released core-model version before
  merge.
- Database migration (`changeLog-rsdev-1065.xml`): adds `DTYPE` to `Sample` and
  `Sample_AUD`, backfills it from the legacy `template` flag, then makes
  `Sample.DTYPE` NOT NULL (the audit column stays nullable). On an existing
  database, run with `-Denvironment=keepdbintact` and confirm existing samples
  get `DTYPE = 'Sample'` and existing templates get `DTYPE = 'SampleTemplate'`.
- Backend tests: `mvn test -Dfast=true` (pure unit), `mvn test` (Spring
  transactional, needs DB), and `mvn verify -Denvironment=drop-recreate-db`
  (full MVC/IT). The new template endpoints are exercised by the inventory
  MVC/ITs (for example `SamplesApiControllerMVCIT`,
  `InventoryImportApiControllerMVCIT`, `InventoryBulkOperationsApiControllerMVCIT`).
- Manual smoke test: create, list, fetch, duplicate, and update a sample
  template via `/api/v1/sampleTemplates`; create a sample from a template; and
  confirm existing samples and templates still load after the DTYPE backfill.


