### PR TITLE
Remove frontend test stages from Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,6 @@ pipeline {
         booleanParam(name: 'ONLY_BUILD_WAR', defaultValue: false, description: 'It only build the WAR file without deploying in AWS')
         booleanParam(name: 'AWS_DEPLOY', defaultValue: false, description: 'Deploy branch build to AWS')
         booleanParam(name: 'AWS_DEPLOY_PROD_RELEASE', defaultValue: false, description: 'Deploy main branch build created in prodRelease mode to AWS')
-        booleanParam(name: 'FRONTEND_TESTS', defaultValue: false, description: 'Run TypeScript/Vitest tests (runs after changes to frontend files by default)')
-        booleanParam(name: 'FRONTEND_TESTS_TYPESCRIPT_CHECK', defaultValue: false, description: 'Run TypeScript check as a part of front-end tests')
         booleanParam(name: 'FULL_JAVA_TESTS', defaultValue: false, description: 'Run all Java tests')
         booleanParam(name: 'LIQUIBASE', defaultValue: false, description: 'Run tests on persistent liquibaseTest database')
     }
@@ -46,15 +44,6 @@ pipeline {
         SANITIZED_DBNAME = branchToDbName("${BRANCH_NAME}")
         AWS_TOMCAT_AMI = 'ami-0ccb4189a68a02c7d'
         APP_VERSION = readMavenPom().getVersion()
-
-        // Give corepack a writable, persistent home for its download cache. The
-        // default (~/.cache/node/corepack) is not always writable on Jenkins agents.
-        COREPACK_HOME = "${JENKINS_HOME}"
-        // `corepack enable` installs the pnpm/yarn shims next to the node binary
-        // (e.g. /usr/local/bin), which the Jenkins user cannot write to (EACCES).
-        // Install them into a writable dir under JENKINS_HOME and put it on PATH
-        // so every `sh` step resolves `pnpm` from there.
-        PATH = "${JENKINS_HOME}/corepack-bin:${PATH}"
 
         NODE_OPTIONS="--max-old-space-size=5120 --conditions=require"
     }
@@ -107,147 +96,11 @@ pipeline {
                 }
             }
         }
-        stage('PNPM Install') {
-            when {
-                anyOf {
-                    expression { return params.FRONTEND_TESTS }
-                    changeset '**/*.js'
-                    changeset '**/*.ts'
-                    changeset '**/*.tsx'
-                    changeset '**/*.jsp'
-                    changeset '**/*.css'
-                    changeset '**/*.json'
-                }
-            }
-            steps {
-                echo 'Installing pnpm packages'
-                sh 'node -v'
-                sh 'mkdir -p "$JENKINS_HOME/corepack-bin"'
-                sh 'corepack enable --install-directory "$JENKINS_HOME/corepack-bin"'
-                sh 'corepack prepare pnpm@11.3.0 --activate'
-                sh 'pnpm -v'
-                sh 'pnpm install --frozen-lockfile'
-            }
-        }
-        stage('TypeScript Check') {
-            when {
-                expression { return params.FRONTEND_TESTS }
-                expression { return params.FRONTEND_TESTS_TYPESCRIPT_CHECK }
-            }
-            steps {
-                echo 'Running TypeScript check'
-                sh 'pnpm exec tsc --version'
-                sh 'pnpm run tsc'
-            }
-        }
-        stage('Vitest Tests (feature branch)') {
-            when {
-                not {
-                    branch 'main'
-                }
-                anyOf {
-                    expression { return params.FRONTEND_TESTS }
-                    changeset '**/*.js'
-                    changeset '**/*.ts'
-                    changeset '**/*.tsx'
-                    changeset '**/*.jsp'
-                    changeset '**/*.css'
-                    changeset '**/*.json'
-                }
-            }
-            steps {
-                echo 'Running Vitest tests'
-                sh 'git fetch origin main:main || true'
-                // In Jenkins we limit this to 2 to not overwhelm the CI machine
-                sh 'env COLORS=false FORCE_COLOR=false pnpm run test --maxWorkers 2 --changed main'
-            }
-            post {
-                failure {
-                    notify currentBuild.result
-                    notifySlack('FAILURE', "Vitest tests failed: ${currentBuild.result}")
-                }
-                fixed {
-                    notify currentBuild.result
-                }
-                success {
-                    junit checksName: 'Vitest Tests', testResults: '**/ui/junit.xml', allowEmptyResults: true
-                }
-            }
-        }
-        stage('Vitest Tests (main branch)') {
-            when {
-                branch 'main'
-                anyOf {
-                    expression { return params.FRONTEND_TESTS }
-                    changeset '**/*.js'
-                    changeset '**/*.ts'
-                    changeset '**/*.tsx'
-                    changeset '**/*.jsp'
-                    changeset '**/*.css'
-                    changeset '**/*.json'
-                }
-            }
-            steps {
-                echo 'Running Vitest tests'
-                sh 'env COLORS=false FORCE_COLOR=false pnpm run test --maxWorkers=2'
-            }
-            post {
-                failure {
-                    notify currentBuild.result
-                    notifySlack('FAILURE', "Vitest tests failed: ${currentBuild.result}")
-                }
-                fixed {
-                    notify currentBuild.result
-                }
-                success {
-                    junit checksName: 'Vitest Tests', testResults: '**/ui/junit.xml'
-                }
-            }
-        }
-        stage('Playwright Component Tests (feature branch)') {
-        		when {
-                not {
-                    branch 'main'
-                }
-            		anyOf {
-                		expression { return params.FRONTEND_TESTS }
-                		changeset '**/*.ts'
-                		changeset '**/*.tsx'
-                		changeset '**/*.css'
-                		changeset '**/*.json'
-            		}
-            }
-            steps {
-                echo 'Running Playwright tests'
-                sh 'pnpm exec playwright install'
-                sh 'rm -rf src/main/webapp/ui/playwright/.cache'
-                sh 'pnpm run test-ct --only-changed=main'
-            }
-        }
-        stage('Playwright Component Tests (main branch)') {
-        		when {
-                branch 'main'
-            		anyOf {
-                		expression { return params.FRONTEND_TESTS }
-                		changeset '**/*.ts'
-                		changeset '**/*.tsx'
-                		changeset '**/*.css'
-                		changeset '**/*.json'
-            		}
-            }
-            steps {
-                echo 'Running Playwright tests'
-                sh 'pnpm exec playwright install'
-                sh 'rm -rf src/main/webapp/ui/playwright/.cache'
-                sh 'pnpm run test-ct'
-            }
-        }
         stage('Build feature branch') {
             when {
                 anyOf {
                     expression { return params.AWS_DEPLOY }
                     expression { return params.ONLY_BUILD_WAR }
-                    expression { return params.FRONTEND_TESTS }
                     changeset '**/*.js'
                     changeset '**/*.ts'
                     changeset '**/*.tsx'


### PR DESCRIPTION
Frontend CI (TypeScript check, Vitest, Playwright) now runs in GitHub Actions via [`.github/workflows/lint-and-test.yml`](.github/workflows/lint-and-test.yml) on every PR, and has done reliably for some time. The equivalent Jenkins stages were pure duplication: slower feedback, extra CI machine load, and a second place to maintain.

## What changed

Removed all frontend-related work from the `Jenkinsfile`:
- **Params:** `FRONTEND_TESTS`, `FRONTEND_TESTS_TYPESCRIPT_CHECK`
- **Stages:** Vitest (feature + main), Playwright Component Tests (feature + main), TypeScript Check, PNPM Install
- **Env config:** `COREPACK_HOME` and the `corepack-bin` `PATH` entry, which only existed so the directly-invoked `pnpm` steps could resolve a system pnpm

## Why the build stages are unaffected

The Maven build (`./mvnw ... -DgenerateReactDist`) provisions its own Node and pnpm via `frontend-maven-plugin` (`install-node-and-pnpm`), independent of the system pnpm that was just removed. `NODE_OPTIONS` is retained because the Maven-driven Vite build inherits it.

GitHub Actions coverage is equivalent or better: `tsc` and Vitest run as before, and Playwright now runs across Chromium, Firefox, and WebKit.

## Testing notes

Worth confirming a Jenkins build with `AWS_DEPLOY=true` still goes green, since that path now carries the full frontend build with no preceding pnpm step.