### PR TITLE
RSDEV-1198: Fix TimeField crash on complex templates after MUI v9 upgrade

### DIFF
--- a/src/main/webapp/ui/src/components/Inputs/TimeField.tsx
+++ b/src/main/webapp/ui/src/components/Inputs/TimeField.tsx
@@ -7,9 +7,19 @@ import { TimePicker } from "@mui/x-date-pickers/TimePicker";
 import { format, isValid, parse } from "date-fns";
 import { enGB } from "date-fns/locale";
 
+const TIME_FORMAT = "HH:mm";
+
 export type TimeFieldArgs = {
   onChange: (event: { target: { value: string | null } }) => void;
-  value: string;
+  /*
+   * FieldModel stores a time field's value as a Date object (it parses the
+   * "HH:mm" string on the way in), whereas other callers pass the "HH:mm"
+   * string directly. Accept both, plus null/empty. Passing a non-string
+   * straight to date-fns `parse` throws ("dateString.match is not a
+   * function"), which is what broke complex templates after the MUI v9
+   * upgrade; parseTimeFieldValue handles each shape instead.
+   */
+  value: string | Date | null;
   disabled?: boolean;
   id?: string;
 };
@@ -20,9 +30,7 @@ export default function TimeField({
   onChange,
   id,
 }: TimeFieldArgs): React.ReactNode {
-  const parsedValue = value ? parse(value, "HH:mm", new Date()) : null;
-  const pickerValue =
-    parsedValue && isValid(parsedValue) ? parsedValue : null;
+  const pickerValue = parseTimeFieldValue(value);
 
   return (
     <Grid container spacing={0}>
@@ -36,10 +44,15 @@ export default function TimeField({
           >
             <TimePicker
               value={pickerValue}
+              format={TIME_FORMAT}
+              ampm={false}
               onChange={(newValue) => {
                 onChange({
                   target: {
-                    value: newValue ? format(newValue, "HH:mm") : null,
+                    value:
+                      newValue && isValid(newValue)
+                        ? format(newValue, TIME_FORMAT)
+                        : null,
                   },
                 });
               }}
@@ -68,4 +81,24 @@ export default function TimeField({
       )}
     </Grid>
   );
+}
+
+/**
+ * Resolves the various shapes a time value can arrive in (a Date from
+ * FieldModel, an "HH:mm" string from other callers, or null/empty) to the Date
+ * the picker expects, or null when there is no valid value. Crucially it never
+ * hands a non-string to date-fns `parse`, which throws on one.
+ */
+function parseTimeFieldValue(value: string | Date | null): Date | null {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return isValid(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const parsed = parse(value, TIME_FORMAT, new Date());
+    return isValid(parsed) ? parsed : null;
+  }
+  return null;
 }

--- a/src/main/webapp/ui/src/components/Inputs/__tests__/TimeField.test.tsx
+++ b/src/main/webapp/ui/src/components/Inputs/__tests__/TimeField.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@/__tests__/customQueries";
+import TimeField from "../TimeField";
+
+describe("TimeField", () => {
+  test("renders a Date value (as FieldModel supplies for time fields) without crashing", () => {
+    // Regression: complex templates feed a Date here; date-fns parse threw on
+    // it after the MUI v9 upgrade ("dateString.match is not a function"),
+    // crashing the whole template form. Rendering at all is the key assertion.
+    render(
+      <TimeField value={new Date(2026, 0, 1, 12, 30)} onChange={() => {}} />,
+    );
+    expect(screen.getByDisplayValue("12:30")).toBeInTheDocument();
+  });
+
+  test("renders an HH:mm string value", () => {
+    render(<TimeField value="09:05" onChange={() => {}} />);
+    expect(screen.getByDisplayValue("09:05")).toBeInTheDocument();
+  });
+
+  test("renders a null value without crashing", () => {
+    render(<TimeField value={null} onChange={() => {}} />);
+    expect(screen.getByDisplayValue("")).toBeInTheDocument();
+  });
+
+  test("shows the no-value label when disabled with no value", () => {
+    render(<TimeField value="" onChange={() => {}} disabled />);
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Complex Inventory templates (and samples created from them) crash to a blank form whenever they contain a Time field. The error surfaces in the `TimeField` component and is caught by the surrounding `ErrorBoundary`:

```
TypeError: dateString.match is not a function
  at parse (date-fns) ... at TimeField (TimeField.tsx)
```

### Root cause

This is a regression from the MUI v9 upgrade (#788), present on `main`; it is not specific to any feature branch. For a time field, `FieldModel` stores the value as a `Date` object (it parses the `"HH:mm"` string on the way in). The v9 rewrite of `TimeField` passed that value straight to date-fns v4 `parse(value, "HH:mm", ...)`, and date-fns calls `.match()` on its argument, which throws for a non-string (`Date` or number). The previous implementation handed the value directly to the picker, so it never hit `parse`.

### Fix

Make `TimeField` robust, mirroring the already-working `DateField`:

- Accept `string | Date | null` and resolve it via a defensive `parseTimeFieldValue` that handles a `Date`, an `"HH:mm"` string, or null/empty, and never passes a non-string to date-fns `parse`.
- Pass an explicit `format="HH:mm"` and `ampm={false}` rather than relying on locale-derived format.
- Guard the `onChange` `format()` call with `isValid` so an invalid picker value yields `null` instead of throwing.

The type widening is backward compatible, so the other `TimeField` callers are unaffected.

### Testing

- New `TimeField.test.tsx`: the `Date`-value case reproduced the crash before the fix and is green after; plus `"HH:mm"` string, null, and disabled cases. `getByDisplayValue("12:30")` confirms the value renders.
- Inputs + Inventory Template suites pass (198 tests); `tsc` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)