### PR TITLE
RSDEV-416: clean liquibase changelogs part 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
                 ./mvnw clean package -DgenerateReactDist -DskipTests=true \
                 -Denvironment=keepdbintact -Dspring.profiles.active=prod -DRS.logLevel=INFO \
                 -Djava-version=${MAVEN_TOOLCHAIN_JAVA_VERSION} -Djava-vendor=${MAVEN_TOOLCHAIN_JAVA_VENDOR} \
-                -Dliquibase.context=run,dev-test -DpropertyFileDirPlaceholder=\\$\\{propertyFileDir\\}
+                -DpropertyFileDirPlaceholder=\\$\\{propertyFileDir\\}
                 '''
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,20 @@
           <include>deployments/${deployment}/**</include>
           <include>deployments/defaultDeployment.properties</include>
         </includes>
+        <!-- RSDEV-416: applicationContext-dao.xml is excluded from filtering (re-added unfiltered
+          below) so its ${liquibase.context} / ${rs.hibernate.searchIndex.*} placeholders resolve from
+          deployment.properties at runtime, never baked in at build time. -->
+        <excludes>
+          <exclude>applicationContext-dao.xml</exclude>
+        </excludes>
+      </resource>
+
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <includes>
+          <include>applicationContext-dao.xml</include>
+        </includes>
       </resource>
 
       <!-- including this folder in the previous section meant that the large font files could be clipped and therefore not work-->
@@ -2335,8 +2349,6 @@
       </build>
       <properties>
         <jdbc.db.maven>rspace_hib</jdbc.db.maven>
-        <!-- only dev-test changesets should be run on top of auto-generated schema -->
-        <liquibase.context>dev-test</liquibase.context>
         <context.path>/</context.path>
         <ssl.enabled>false</ssl.enabled>
         <jdbc.url>jdbc:mysql://localhost:3306/${jdbc.db.maven}?useSSL=false</jdbc.url>
@@ -2371,6 +2383,17 @@
               <!-- see Spring application-resources.xml which uses this variable
                 as well for deployment-dependent property files. -->
               <include>deployments/defaultDeployment.properties</include>
+            </includes>
+            <!-- RSDEV-416: keep applicationContext-dao.xml unfiltered (runtime-resolved Liquibase context) -->
+            <excludes>
+              <exclude>applicationContext-dao.xml</exclude>
+            </excludes>
+          </resource>
+          <resource>
+            <directory>src/main/resources</directory>
+            <filtering>false</filtering>
+            <includes>
+              <include>applicationContext-dao.xml</include>
             </includes>
           </resource>
           <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -295,9 +295,8 @@
           <include>deployments/${deployment}/**</include>
           <include>deployments/defaultDeployment.properties</include>
         </includes>
-        <!-- RSDEV-416: applicationContext-dao.xml is excluded from filtering (re-added unfiltered
-          below) so its ${liquibase.context} / ${rs.hibernate.searchIndex.*} placeholders resolve from
-          deployment.properties at runtime, never baked in at build time. -->
+        <!-- applicationContext-dao.xml is not filtered (re-added unfiltered below) so its
+          placeholders resolve from deployment.properties at runtime. -->
         <excludes>
           <exclude>applicationContext-dao.xml</exclude>
         </excludes>
@@ -2384,7 +2383,8 @@
                 as well for deployment-dependent property files. -->
               <include>deployments/defaultDeployment.properties</include>
             </includes>
-            <!-- RSDEV-416: keep applicationContext-dao.xml unfiltered (runtime-resolved Liquibase context) -->
+            <!-- applicationContext-dao.xml is not filtered (re-added unfiltered below) so its
+              placeholders resolve from deployment.properties at runtime. -->
             <excludes>
               <exclude>applicationContext-dao.xml</exclude>
             </excludes>

--- a/src/main/java/com/researchspace/dao/FileMetadataDao.java
+++ b/src/main/java/com/researchspace/dao/FileMetadataDao.java
@@ -21,6 +21,14 @@ public interface FileMetadataDao extends GenericDao<FileProperty, Long> {
   List<FileProperty> findProperties(Map<String, String> wheres);
 
   /**
+   * Counts FileProperty rows with no associated FileStoreRoot (root_id is null) - a data-integrity
+   * diagnostic; the count should be 0.
+   *
+   * @return number of FileProperty rows whose root_id is null
+   */
+  long countFilePropertiesWithoutRoot();
+
+  /**
    * Runs through FileProperties owned by the user and collects File references to the resources.
    *
    * @return non-null but possibly empty list of Files pointing to user resources,

--- a/src/main/java/com/researchspace/dao/hibernate/FileMetadataHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FileMetadataHibernate.java
@@ -99,6 +99,16 @@ public class FileMetadataHibernate extends GenericDaoHibernate<FileProperty, Lon
     return extractSizeFromResult(count);
   }
 
+  @Override
+  public long countFilePropertiesWithoutRoot() {
+    Number count =
+        (Number)
+            getSession()
+                .createSQLQuery("select count(*) from FileProperty where root_id is null")
+                .uniqueResult();
+    return count == null ? 0L : count.longValue();
+  }
+
   private Long extractSizeFromResult(String count) {
     return (!isEmpty(count)) ? parseLong(count) : 0;
   }

--- a/src/main/java/com/researchspace/service/FileStoreMetaManager.java
+++ b/src/main/java/com/researchspace/service/FileStoreMetaManager.java
@@ -19,6 +19,14 @@ public interface FileStoreMetaManager extends GenericManager<FileProperty, Long>
    */
   List<FileProperty> findProperties(Map<String, String> wheres);
 
+  /**
+   * Counts FileProperty rows with no associated FileStoreRoot (a data-integrity diagnostic; should
+   * be 0).
+   *
+   * @return number of FileProperty rows whose root is null
+   */
+  long countFilePropertiesWithoutRoot();
+
   boolean doesUserOwnDocWithHash(User user, String contentsHash);
 
   FileProperty getByHash(String contentsHash);

--- a/src/main/java/com/researchspace/service/impl/FileStoreMetaManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/FileStoreMetaManagerImpl.java
@@ -43,6 +43,11 @@ public class FileStoreMetaManagerImpl extends GenericManagerImpl<FileProperty, L
   }
 
   @Override
+  public long countFilePropertiesWithoutRoot() {
+    return fileDao.countFilePropertiesWithoutRoot();
+  }
+
+  @Override
   public boolean doesUserOwnDocWithHash(User user, String contentsHash) {
     return fileDao.doesUserOwnDocWithHash(user, contentsHash);
   }

--- a/src/main/java/com/researchspace/service/impl/FileStoreRootDetector.java
+++ b/src/main/java/com/researchspace/service/impl/FileStoreRootDetector.java
@@ -25,6 +25,20 @@ public class FileStoreRootDetector extends AbstractAppInitializor {
   public void onAppStartup(ApplicationContext applicationContext) {
     setupInternalFileStore();
     setupExtFileStore();
+    warnIfFilePropertiesWithoutRoot();
+  }
+
+  /**
+   * Startup diagnostic (formerly the runAlways Liquibase changeset 1-35-16-4-7a, moved here in
+   * RSDEV-416): warn if any FileProperty has no associated FileStoreRoot.
+   */
+  private void warnIfFilePropertiesWithoutRoot() {
+    long orphaned = fileStoreMeta.countFilePropertiesWithoutRoot();
+    if (orphaned > 0) {
+      log.warn(
+          "There are {} FileProperty row(s) not associated with a FileStoreRoot (root_id is null).",
+          orphaned);
+    }
   }
 
   public void onInitialAppDeployment() {

--- a/src/main/java/com/researchspace/service/impl/FileStoreRootDetector.java
+++ b/src/main/java/com/researchspace/service/impl/FileStoreRootDetector.java
@@ -28,13 +28,22 @@ public class FileStoreRootDetector extends AbstractAppInitializor {
     warnIfFilePropertiesWithoutRoot();
   }
 
-  /** Startup diagnostic: warn if any FileProperty has no associated FileStoreRoot. */
+  /**
+   * Startup diagnostic: warn if any FileProperty has no associated FileStoreRoot. Never aborts
+   * startup - any error is logged and swallowed (matching the warn-only Liquibase check it
+   * replaced).
+   */
   private void warnIfFilePropertiesWithoutRoot() {
-    long orphaned = fileStoreMeta.countFilePropertiesWithoutRoot();
-    if (orphaned > 0) {
-      log.warn(
-          "There are {} FileProperty row(s) not associated with a FileStoreRoot (root_id is null).",
-          orphaned);
+    try {
+      long orphaned = fileStoreMeta.countFilePropertiesWithoutRoot();
+      if (orphaned > 0) {
+        log.warn(
+            "There are {} FileProperty row(s) not associated with a FileStoreRoot (root_id is"
+                + " null).",
+            orphaned);
+      }
+    } catch (Exception e) {
+      log.warn("Could not run the FileProperty/FileStoreRoot integrity diagnostic", e);
     }
   }
 

--- a/src/main/java/com/researchspace/service/impl/FileStoreRootDetector.java
+++ b/src/main/java/com/researchspace/service/impl/FileStoreRootDetector.java
@@ -28,10 +28,7 @@ public class FileStoreRootDetector extends AbstractAppInitializor {
     warnIfFilePropertiesWithoutRoot();
   }
 
-  /**
-   * Startup diagnostic (formerly the runAlways Liquibase changeset 1-35-16-4-7a, moved here in
-   * RSDEV-416): warn if any FileProperty has no associated FileStoreRoot.
-   */
+  /** Startup diagnostic: warn if any FileProperty has no associated FileStoreRoot. */
   private void warnIfFilePropertiesWithoutRoot() {
     long orphaned = fileStoreMeta.countFilePropertiesWithoutRoot();
     if (orphaned > 0) {

--- a/src/main/resources/applicationContext-dao.xml
+++ b/src/main/resources/applicationContext-dao.xml
@@ -9,8 +9,9 @@
     <bean depends-on="appContextRetriever, loggingInitializer" id="liquibase" class="liquibase.integration.spring.SpringLiquibase">
         <property name="dataSource" ref="dataSource" />
         <property name="changeLog" value="classpath:sqlUpdates/liquibase-master.xml" />
-        <!-- contexts specifies the runtime contexts to use. variable is substituted 
-            by Maven at build time. -->
+        <!-- contexts specifies the runtime Liquibase contexts. This file is deliberately excluded
+            from Maven resource filtering (see pom.xml), so ${liquibase.context} is resolved at runtime
+            from deployment.properties and is never fixed at build time. -->
         <property name="contexts" value="${liquibase.context}" />
     </bean>
 

--- a/src/main/resources/applicationContext-dao.xml
+++ b/src/main/resources/applicationContext-dao.xml
@@ -9,9 +9,8 @@
     <bean depends-on="appContextRetriever, loggingInitializer" id="liquibase" class="liquibase.integration.spring.SpringLiquibase">
         <property name="dataSource" ref="dataSource" />
         <property name="changeLog" value="classpath:sqlUpdates/liquibase-master.xml" />
-        <!-- contexts specifies the runtime Liquibase contexts. This file is deliberately excluded
-            from Maven resource filtering (see pom.xml), so ${liquibase.context} is resolved at runtime
-            from deployment.properties and is never fixed at build time. -->
+        <!-- Runtime Liquibase contexts. This file is excluded from Maven filtering (see pom.xml),
+            so ${liquibase.context} resolves from deployment.properties at runtime. -->
         <property name="contexts" value="${liquibase.context}" />
     </bean>
 

--- a/src/main/resources/sqlUpdates/DatabaseChangeGuidelines.md
+++ b/src/main/resources/sqlUpdates/DatabaseChangeGuidelines.md
@@ -1,8 +1,7 @@
 Guidelines for database changes
 -------------------------------
 
-Checklist before adding a changeset. If you're not  sure about what is the right thing to do,
-please ask rather than 'commit-and-hope'.
+Checklist before adding a changeset. If you're not sure about what is the right thing to do, please ask rather than 'commit-and-hope'.
 
 This document is written in Markdown format.
 
@@ -11,11 +10,11 @@ This document is written in Markdown format.
 - Add the entity on `HibernateTest.recordClasses()` method
 - Update `DatabaseCleaner cleanup ()` to clean up the table during test runs. 
 - Explicitly set charset and collation:  `character set utf8mb4 collate  utf8mb4_unicode_ci`.
-  (As an example, see src/main/resources/sqlUpdates/changeLog-1.76.xml : ```<sql>alter table ClustermarketEquipment engine=InnoDB, CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;</sql>```)
+  (As an example, see src/main/resources/sqlUpdates/changeLog-1.100.xml : ```<sql>alter table ExternalStorageLocation engine=InnoDB, CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;</sql>```)
   This is to overcome variations in collation between different OS/MariaDB countries.
 - Does it need an accompanying _AUD table to record revision history? 
 - If it has FK references to any BaseRecord or User/Group table, we need to update `UserDeletionManagerImpl` to support the 'Delete User' use case.
-- If you've written some JUnit tests that extend from RealTRansactionSpringTestBase (i.e. test  cases that run real transactions) then remember to add to the 'DatabaseCleaner.cleanUp' method
+- If you've written some JUnit tests that extend from RealTransactionSpringTestBase (i.e. test cases that run real transactions) then remember to add to the 'DatabaseCleaner.cleanUp' method
   the table name in the list of tables to delete after a test run -  this keeps the database clean between test runs. The order in which rows are removed is important, to avoid FK constraint errors.
 - Is this a table that is defined as a Hibernate entity? Sometimes a 3rd party library (e.g. liquibase, spring-social, chemistry tables) requires its own table that is not created or managed by Hibernate. In this case you may need to edit scripts in the *maven* folder.
 - Ensure your Java @Entity-annotated class implements Serializable. 
@@ -38,10 +37,10 @@ Hibernate ID mapping is set to `@GeneratedValue(strategy=GenerationType.AUTO)` s
 ID generation in code and in the DB are compatible.
 
 ### Are you adding reference data for a new integration (App)?
-There are various naming conventions, please [IntegrationAndAppNotes](integrationAndAppNotes.md).
+There are various naming conventions, please see [IntegrationAndAppNotes](integrationAndAppNotes.md).
 
 ### Have  you added a human-readable comment to each changeset?
-- If altering a table structure ( add /remove change columns) is there an audit (_AUD) table
+- If altering a table structure (add /remove change columns) is there an audit (_AUD) table
  that also needs to be changed in the same way?
 - when adding/modifying audit table columns, remember that they don't generally have not-null constraints (apart from id/REV columns).
 - If you are adding such constraint make sure you know the consequences, and double check if constraint is actually applied on your local database when testing.
@@ -86,7 +85,7 @@ If the customer tries to update directly from N-1 -> N+1, this will fail when pe
 The customer can remedy this by performing sequential updates, i.e. update to N before updating to N + 1. This must be mentioned in the release notes.
 
 When deploying RSpace liquibase changes there are 3 scenarios to consider:
-1. A new deployment on-prem where we run all changesets from 0.15 onwards on a database created from the baseline.sql (this is the case with pangolin8086 as well)
+1. A new deployment on-prem where we run all post-1.98.1 changesets on a database created from the baseline.sql (this is the case with pangolin8086 as well)
 - to remedy java update problem the update could have a precondition stopping it from running on a new database. Java updates are meant to fix pre-existing production data, they are generally not necessary for newly created data.
 2. A new deployment onto an AMI that has been cumulatively updated over time and might have some content on it, but only in sysadmin account. This covers both FB versions and also AWS customer deployments
 - to remedy java update problem the AMI used for FB/AWS should be updated to start on version N, rather than N-1. 
@@ -97,7 +96,7 @@ When deploying RSpace liquibase changes there are 3 scenarios to consider:
 If the Java update is making changes to data, e.g. altering or processing field data, this can take a long time
  if the database is big, e.g. community.r.c. So
  
- * log progress if iterating in a loop, so that the person updating can see that the update is proceeeding OK and not hanging.
+ * log progress if iterating in a loop, so that the person updating can see that the update is proceeding OK and not hanging.
  * Consider using batch updates
  * Consider writing a specific database query to load only the necessary columns, rather than use Hibernate entities which
    load many other related tables and data.
@@ -129,7 +128,7 @@ E.g.,
             </column>
         </createTable>
         <sql>alter table UserPasswordChange engine=InnoDB;</sql>
-    </changeset>
+    </changeSet>
 
 Then append them into the current version's changeset file in *src/main/resources/sqlUpdates/changeLog-xxxx.xml*
 
@@ -148,9 +147,15 @@ create a separate database called `rspace_hib`, you can do that with the followi
         CREATE DATABASE rspace_hib collate 'utf8mb4_unicode_ci';
         GRANT ALL ON rspace_hib.* TO 'rspacedbuser'@'localhost';
 
-Then run a build with `-Denvironment=drop-recreate-hibernate-db` (rather than the standard
-`-Denvironment=drop-recreate-db`): the `hibernate4-maven-plugin` `export` goal drops/recreates
-`rspace_hib` and populates it with the schema generated from the Hibernate/JPA annotations.
+Then populate `rspace_hib` with the schema generated from the Hibernate/JPA annotations:
+
+    mvn process-classes -Denvironment=drop-recreate-hibernate-db
+
+The `-Denvironment=drop-recreate-hibernate-db` activates the `mysql-clean-hibernate` profile, which
+drops/recreates `rspace_hib` (in the `initialize` phase) and then runs the `hibernate4-maven-plugin`
+`export` goal (bound to `process-classes`) to write the annotation-derived schema into it. Running up
+to `process-classes` is enough; do not pass `-Dmaven.test.skip=true` (the drop/recreate step is gated
+on it).
 
 This is a DDL-only comparison, so `rspace_hib` should contain *only* the Hibernate-generated schema.
 Do not boot the webapp against `rspace_hib`, and do not run the Liquibase seed/changesets on it: the
@@ -172,12 +177,6 @@ This changeset file describes the changes that should be applied to convert the 
 database schema to be the same as `rspace_hib`. There will likely be some existing differences 
 relating to constraints, field types etc., so search for the ones related to your recent changes.
 
-Note for Windows OS users: look into pom.xml generateDiff task, and remove timestamp,
-otherwise nothing is generated.
-
-When using auto-generated changesets you may want to merge some of the changesets together,  
-the ones generated by the plugin are very fine-grained.
-
 ## If there is a problem...
 
 *Problem 1 - checksum problems*
@@ -196,14 +195,14 @@ If you get a liquibase error that you need to fix, it might be faster to use the
  
  E.g. download liquibase ( the same version as is declared in pom.xml) and run e.g.
  
-    ./liquibase --changeLogFile=/path/to/rspace/src/main/resources/sqlUpdates/changeLog-0.25.xml --username=rspacedbuser --password=rspacedbpwd --url=jdbc:mysql://localhost:3306/rspace  --contexts=dev-test update
+    ./liquibase --changeLogFile=/path/to/rspace/src/main/resources/sqlUpdates/liquibase-master.xml --username=rspacedbuser --password=rspacedbpwd --url=jdbc:mysql://localhost:3306/rspace --contexts=dev-test update
  
 You'll need to add the jdbc connector.jar into the lib/ folder of the liquibase install folder to make this work.
 Some links in your changesets may need to be temporarily altered to absolute paths to make this work.
 
 ### After you've committed....
 
-5. Jenkins will apply Liquibase changes each evening into its own 'testLiquibaseUpdate' database.
-6. If the database update run passes on Jenkins, it will build for the staging server.
+1. Jenkins will apply Liquibase changes each evening into its own 'testLiquibaseUpdate' database.
+2. If the database update run passes on Jenkins, it will build for the staging server.
 
 In this way, the staging application at $STAGING will only update if database changes have been integrated successfully.

--- a/src/main/resources/sqlUpdates/DatabaseChangeGuidelines.md
+++ b/src/main/resources/sqlUpdates/DatabaseChangeGuidelines.md
@@ -148,9 +148,14 @@ create a separate database called `rspace_hib`, you can do that with the followi
         CREATE DATABASE rspace_hib collate 'utf8mb4_unicode_ci';
         GRANT ALL ON rspace_hib.* TO 'rspacedbuser'@'localhost';
 
-Then you should start the RSpace with `-Denvironment=drop-recreate-hibernate-db` param (rather than
-standard `-Denvironment=drop-recreate-db`), which will generate the schema out of the annotations,
-then start the webapp but with all data coming from `rspace_hib` database.
+Then run a build with `-Denvironment=drop-recreate-hibernate-db` (rather than the standard
+`-Denvironment=drop-recreate-db`): the `hibernate4-maven-plugin` `export` goal drops/recreates
+`rspace_hib` and populates it with the schema generated from the Hibernate/JPA annotations.
+
+This is a DDL-only comparison, so `rspace_hib` should contain *only* the Hibernate-generated schema.
+Do not boot the webapp against `rspace_hib`, and do not run the Liquibase seed/changesets on it: the
+seed targets tables that are not Hibernate entities (e.g. the Spring Batch `BATCH_*` tables) and would
+fail or add noise to the diff.
 
 Next, you can compare a regular database schema created from baseline script and  liquibase updates 
 (i.e. one in your regular `rspace` database), to the schema auto-generated from Hibernate/JPA 

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-271.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-271.xml
@@ -5,7 +5,7 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <!-- DigitalCommonsData integration -->
-    <changeSet id="2024-07-29a" context="run,dev-test" author="nico">
+    <changeSet id="2024-07-29a" context="run" author="nico">
         <comment>Create a new system properties for DigitalCommonsData</comment>
         <insert tableName="PropertyDescriptor">
             <column name="id" type="NUMERIC" value="NULL"/>
@@ -27,7 +27,7 @@
         </insert>
     </changeSet>
 
-    <changeSet id="2024-07-29b" context="run,dev-test" author="nico">
+    <changeSet id="2024-07-29b" context="run" author="nico">
         <comment>Create a new app - DigitalCommonsData</comment>
         <insert tableName="App">
             <column name="id" type="NUMERIC" value="NULL" />

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-346.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-346.xml
@@ -5,7 +5,7 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
 
-    <changeSet id="2024-10-22n" context="run,dev-test" author="nico">
+    <changeSet id="2024-10-22n" context="run" author="nico">
         <comment>Update label for Digital Commons Data</comment>
         <update tableName="App">
             <column name="label" value="Digital Commons Data / Mendeley Data"></column>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-369.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-369.xml
@@ -5,7 +5,7 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <!-- Fieldmark integration -->
-    <changeSet id="2024-10-09a" context="run,dev-test" author="nico">
+    <changeSet id="2024-10-09a" context="run" author="nico">
         <comment>Create a new app - Fieldmark</comment>
         <insert tableName="App">
             <column name="id" type="NUMERIC" value="NULL" />
@@ -15,7 +15,7 @@
         </insert>
     </changeSet>
 
-    <changeSet id="2024-10-09b" context="run,dev-test" author="nico">
+    <changeSet id="2024-10-09b" context="run" author="nico">
         <comment>Create a new system properties for Fieldmark</comment>
         <insert tableName="PropertyDescriptor">
             <column name="id" type="NUMERIC" value="NULL"/>
@@ -37,7 +37,7 @@
         </insert>
     </changeSet>
 
-    <changeSet id="2024-10-09c" context="run,dev-test" author="nico">
+    <changeSet id="2024-10-09c" context="run" author="nico">
         <comment>Property Descriptor for Fieldmark App</comment>
         <insert tableName="PropertyDescriptor">
             <column name="id" type="NUMERIC" value="NULL"/>
@@ -47,7 +47,7 @@
         </insert>
     </changeSet>
 
-    <changeSet id="2024-10-09d" context="run,dev-test" author="nico">
+    <changeSet id="2024-10-09d" context="run" author="nico">
         <comment>AppConfigElementDescriptor for Fieldmark App: id, descriptor_id, app_id</comment>
         <sql>insert into AppConfigElementDescriptor (descriptor_id, app_id)
                  select pd.id as descriptor_id, app.id as app_id

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-416-pr2-cleanup.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-416-pr2-cleanup.xml
@@ -1,0 +1,45 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <!-- RSDEV-416 PR2: drop obsolete transient/backup tables. They were also removed from the
+         baseline DDL (rs-dbbaseline-utf8.sql), so on a fresh install the table will not exist and
+         each changeset MARK_RANs via its tableExists precondition; on existing customer DBs (which
+         never load the baseline) the leftover table is dropped. -->
+
+    <!-- BR_AUD_TEMP and SD_AUD_TEMP were checked on demos.r.c and do not have any records older
+         than 2016-11, so they are obsolete migration leftovers and safe to drop. -->
+    <changeSet id="rsdev-416-pr2-drop-br-aud-temp" author="matthias" context="run">
+        <preConditions onFail="MARK_RAN" onError="MARK_RAN" onFailMessage="BR_AUD_TEMP not present; nothing to drop">
+            <tableExists tableName="BR_AUD_TEMP"/>
+        </preConditions>
+        <comment>Drop obsolete BR_AUD_TEMP transient table</comment>
+        <dropTable tableName="BR_AUD_TEMP"/>
+    </changeSet>
+
+    <changeSet id="rsdev-416-pr2-drop-sd-aud-temp" author="matthias" context="run">
+        <preConditions onFail="MARK_RAN" onError="MARK_RAN" onFailMessage="SD_AUD_TEMP not present; nothing to drop">
+            <tableExists tableName="SD_AUD_TEMP"/>
+        </preConditions>
+        <comment>Drop obsolete SD_AUD_TEMP transient table</comment>
+        <dropTable tableName="SD_AUD_TEMP"/>
+    </changeSet>
+
+    <changeSet id="rsdev-416-pr2-drop-utf8-general-pre-rspac2515" author="matthias" context="run">
+        <preConditions onFail="MARK_RAN" onError="MARK_RAN" onFailMessage="utf8_general_pre_rspac2515 not present; nothing to drop">
+            <tableExists tableName="utf8_general_pre_rspac2515"/>
+        </preConditions>
+        <comment>Drop obsolete utf8_general_pre_rspac2515 transient table (RSPAC-2515 charset-migration leftover)</comment>
+        <dropTable tableName="utf8_general_pre_rspac2515"/>
+    </changeSet>
+
+    <changeSet id="rsdev-416-pr2-drop-filestoreroot-bk-spac964" author="matthias" context="run">
+        <preConditions onFail="MARK_RAN" onError="MARK_RAN" onFailMessage="FileStoreRoot_Bk_spac964 not present; nothing to drop">
+            <tableExists tableName="FileStoreRoot_Bk_spac964"/>
+        </preConditions>
+        <comment>Drop obsolete FileStoreRoot_Bk_spac964 backup table (RSPAC-964 migration leftover)</comment>
+        <dropTable tableName="FileStoreRoot_Bk_spac964"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-416-pr2-cleanup.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-416-pr2-cleanup.xml
@@ -3,13 +3,11 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <!-- RSDEV-416 PR2: drop obsolete transient/backup tables. They were also removed from the
-         baseline DDL (rs-dbbaseline-utf8.sql), so on a fresh install the table will not exist and
-         each changeset MARK_RANs via its tableExists precondition; on existing customer DBs (which
-         never load the baseline) the leftover table is dropped. -->
+    <!-- Drop obsolete transient/backup tables. Each is guarded by a tableExists precondition, so
+         it is a no-op (MARK_RAN) where the table is already absent. -->
 
-    <!-- BR_AUD_TEMP and SD_AUD_TEMP were checked on demos.r.c and do not have any records older
-         than 2016-11, so they are obsolete migration leftovers and safe to drop. -->
+    <!-- BR_AUD_TEMP and SD_AUD_TEMP were checked on demos.r.c and have no records older than
+         2016-11, so they are safe to drop. -->
     <changeSet id="rsdev-416-pr2-drop-br-aud-temp" author="matthias" context="run">
         <preConditions onFail="MARK_RAN" onError="MARK_RAN" onFailMessage="BR_AUD_TEMP not present; nothing to drop">
             <tableExists tableName="BR_AUD_TEMP"/>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-416-pr2-cleanup.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-416-pr2-cleanup.xml
@@ -40,4 +40,27 @@
         <dropTable tableName="FileStoreRoot_Bk_spac964"/>
     </changeSet>
 
+    <!-- RSForm.defaultUnitId / subSampleName (and the _AUD copies) are orphaned columns: not mapped
+         by the RSForm entity and referenced by no code. They were most likely added to RSForm in
+         error - they duplicate the inventory Sample/SampleTemplate columns, on a table that is not an
+         inventory entity. Guarded by columnExists so fresh installs (where the baseline no longer
+         defines them) MARK_RAN. -->
+    <changeSet id="rsdev-416-pr2-drop-rsform-orphan-cols" author="matthias" context="run">
+        <preConditions onFail="MARK_RAN" onError="MARK_RAN" onFailMessage="RSForm orphan columns absent; nothing to drop">
+            <columnExists tableName="RSForm" columnName="defaultUnitId"/>
+        </preConditions>
+        <comment>Drop unused RSForm.defaultUnitId and RSForm.subSampleName</comment>
+        <dropColumn tableName="RSForm" columnName="defaultUnitId"/>
+        <dropColumn tableName="RSForm" columnName="subSampleName"/>
+    </changeSet>
+
+    <changeSet id="rsdev-416-pr2-drop-rsform-aud-orphan-cols" author="matthias" context="run">
+        <preConditions onFail="MARK_RAN" onError="MARK_RAN" onFailMessage="RSForm_AUD orphan columns absent; nothing to drop">
+            <columnExists tableName="RSForm_AUD" columnName="defaultUnitId"/>
+        </preConditions>
+        <comment>Drop unused RSForm_AUD.defaultUnitId and RSForm_AUD.subSampleName</comment>
+        <dropColumn tableName="RSForm_AUD" columnName="defaultUnitId"/>
+        <dropColumn tableName="RSForm_AUD" columnName="subSampleName"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-416-pr2-cleanup.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-416-pr2-cleanup.xml
@@ -6,7 +6,7 @@
     <!-- Drop obsolete transient/backup tables. Each is guarded by a tableExists precondition, so
          it is a no-op (MARK_RAN) where the table is already absent. -->
 
-    <!-- BR_AUD_TEMP and SD_AUD_TEMP were checked on demos.r.c and have no records older than
+    <!-- BR_AUD_TEMP and SD_AUD_TEMP were checked on demos.r.c and have no records newer than
          2016-11, so they are safe to drop. -->
     <changeSet id="rsdev-416-pr2-drop-br-aud-temp" author="matthias" context="run">
         <preConditions onFail="MARK_RAN" onError="MARK_RAN" onFailMessage="BR_AUD_TEMP not present; nothing to drop">

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-855.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-855.xml
@@ -5,7 +5,7 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <!-- RaID integration -->
-    <changeSet id="2025-10-20a" context="run,dev-test" author="nico">
+    <changeSet id="2025-10-20a" context="run" author="nico">
         <comment>Create a new system properties for RaID</comment>
         <insert tableName="PropertyDescriptor">
             <column name="id" type="NUMERIC" value="NULL"/>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-dmp-assistant.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-dmp-assistant.xml
@@ -7,7 +7,7 @@
     <!-- The author rename from "agent" changes these changeSets' Liquibase identity, so
          databases that already ran them under the old author would re-execute the inserts.
          The preconditions mark the renamed changeSets as ran when the rows already exist. -->
-    <changeSet id="2026-05-26a" context="run,dev-test" author="nhanlon">
+    <changeSet id="2026-05-26a" context="run" author="nhanlon">
         <preConditions onError="MARK_RAN" onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from App where name = 'app.dmpassistant'</sqlCheck>
         </preConditions>
@@ -20,7 +20,7 @@
         </insert>
     </changeSet>
 
-    <changeSet id="2026-05-26b" context="run,dev-test" author="nhanlon">
+    <changeSet id="2026-05-26b" context="run" author="nhanlon">
         <preConditions onError="MARK_RAN" onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from PropertyDescriptor where name = 'dmpassistant.available'</sqlCheck>
         </preConditions>

--- a/src/main/resources/sqlUpdates/initial-seed-changeLog.xml
+++ b/src/main/resources/sqlUpdates/initial-seed-changeLog.xml
@@ -35,17 +35,6 @@
                  splitStatements="true" stripComments="true" endDelimiter=";"/>
     </changeSet>
 
-    <changeSet id="rsdev-416-seed-dev-test-bk" author="matthias" context="dev-test">
-        <preConditions onFail="MARK_RAN" onError="MARK_RAN"
-                       onFailMessage="dev-test backup table skipped: not a fresh install"
-                       onErrorMessage="dev-test backup table skipped: not a fresh install">
-            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM DATABASECHANGELOG WHERE FILENAME NOT LIKE '%initial-seed-changeLog.xml'</sqlCheck>
-        </preConditions>
-        <comment>RSPAC-964 dev-test backup table, recreated (empty) for schema parity with main; the `external` column is dropped because the original backup predated it. Kept in its own changeset rather than the seed SQL so the DDL's implicit commit cannot split the seed's DML.</comment>
-        <sql>create table if not exists FileStoreRoot_Bk_spac964 select * from FileStoreRoot</sql>
-        <sql>alter table FileStoreRoot_Bk_spac964 drop column external</sql>
-    </changeSet>
-
     <changeSet id="rsdev-416-seed-cloud" author="matthias" context="cloud">
         <preConditions onFail="MARK_RAN" onError="MARK_RAN"
                        onFailMessage="cloud seed skipped: not a fresh install (existing role ids differ from the seeded -1..-4)"

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -56,6 +56,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1111.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1136-remove-offline-work.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1135.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-416-pr2-cleanup.xml"/>
 
 
   <!-- These two run last: recurring-changeLog.xml (runAlways diagnostics / batch re-init) then

--- a/src/main/resources/sqlUpdates/liquibaseConfig/rs-dbbaseline-utf8.sql
+++ b/src/main/resources/sqlUpdates/liquibaseConfig/rs-dbbaseline-utf8.sql
@@ -236,32 +236,6 @@ CREATE TABLE `BATCH_STEP_EXECUTION_SEQ` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
-DROP TABLE IF EXISTS `BR_AUD_TEMP`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8mb4 */;
-CREATE TABLE `BR_AUD_TEMP` (
-  `id` bigint(20) NOT NULL,
-  `REV` int(11) NOT NULL,
-  `REVTYPE` tinyint(4) DEFAULT NULL,
-  `deleted` bit(1) DEFAULT NULL,
-  `createdBy` varchar(255) DEFAULT NULL,
-  `creationDate` datetime DEFAULT NULL,
-  `creationDateMillis` bigint(20) DEFAULT NULL,
-  `description` varchar(250) DEFAULT NULL,
-  `modificationDate` datetime DEFAULT NULL,
-  `modificationDateMillis` bigint(20) DEFAULT NULL,
-  `modifiedBy` varchar(255) DEFAULT NULL,
-  `name` varchar(255) DEFAULT NULL,
-  `iconId` bigint(20) DEFAULT NULL,
-  `acl` varchar(2500) DEFAULT NULL,
-  `signed` bit(1) DEFAULT NULL,
-  `type` varchar(255) DEFAULT NULL,
-  `witnessed` bit(1) DEFAULT NULL,
-  `owner_id` bigint(20) DEFAULT NULL,
-  PRIMARY KEY (`id`,`REV`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
 DROP TABLE IF EXISTS `Barcode`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8mb4 */;
@@ -2001,21 +1975,6 @@ CREATE TABLE `Role_permissionStrings` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
-DROP TABLE IF EXISTS `SD_AUD_TEMP`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8mb4 */;
-CREATE TABLE `SD_AUD_TEMP` (
-  `id` bigint(20) NOT NULL,
-  `REV` int(11) NOT NULL,
-  `deltaString` varchar(2000) DEFAULT NULL,
-  `docTag` varchar(255) DEFAULT NULL,
-  `temporaryDoc` bit(1) DEFAULT NULL,
-  `version` bigint(20) DEFAULT NULL,
-  `form_id` bigint(20) DEFAULT NULL,
-  PRIMARY KEY (`id`,`REV`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
 DROP TABLE IF EXISTS `Sample`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8mb4 */;
@@ -2925,14 +2884,6 @@ CREATE TABLE `user_role` (
   KEY `FK143BF46ADE6F978E` (`user_id`),
   CONSTRAINT `FK143BF46A3944D3AE` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`),
   CONSTRAINT `FK143BF46ADE6F978E` FOREIGN KEY (`user_id`) REFERENCES `User` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
-DROP TABLE IF EXISTS `utf8_general_pre_rspac2515`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8mb4 */;
-CREATE TABLE `utf8_general_pre_rspac2515` (
-  `tableName` varchar(64) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/src/main/resources/sqlUpdates/liquibaseConfig/rs-dbbaseline-utf8.sql
+++ b/src/main/resources/sqlUpdates/liquibaseConfig/rs-dbbaseline-utf8.sql
@@ -1749,8 +1749,6 @@ CREATE TABLE `RSForm` (
   `systemForm` bit(1) NOT NULL,
   `temporary` bit(1) NOT NULL,
   `DTYPE` varchar(31) NOT NULL,
-  `defaultUnitId` int(11) DEFAULT NULL,
-  `subSampleName` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `stableid` (`stableId`),
   KEY `FK90A082A5813663E7` (`previousVersion_id`),
@@ -1794,8 +1792,6 @@ CREATE TABLE `RSForm_AUD` (
   `systemForm` bit(1) DEFAULT NULL,
   `temporary` bit(1) DEFAULT NULL,
   `DTYPE` varchar(31) NOT NULL,
-  `defaultUnitId` int(11) DEFAULT NULL,
-  `subSampleName` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`,`REV`),
   KEY `FK71D0D5F6DF74E053` (`REV`),
   CONSTRAINT `FK71D0D5F6DF74E053` FOREIGN KEY (`REV`) REFERENCES `REVINFO` (`REV`)

--- a/src/main/resources/sqlUpdates/recurring-changeLog.xml
+++ b/src/main/resources/sqlUpdates/recurring-changeLog.xml
@@ -3,23 +3,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <!-- RSDEV-416: runAlways changeset(s) that execute on every startup, preserved here when their
-         original pre-1.98.1 changelogs were squashed. Kept verbatim (same id/author) so behaviour is
-         unchanged.
-
-         PR2 review outcome (RSDEV-416):
-         * Kept: 1-35-16-4-7b - HALT diagnostic enforcing at most one current FileStoreRoot. A real
-           invariant; halting before further changesets/startup if the filestore state is wrong is intended.
-         * Moved to Java: 1-35-16-4-7a (warned if a FileProperty had a null root_id) is now an
-           onAppStartup health check (see FileStoreRootDetector), where startup diagnostics belong.
-         * Dropped: 2016-07-29d - its sqlCheck was buggy (queried FileProperty.id where its sibling
-           migration 2016-07-29c correctly used FileProperty.root_id), and a corrected version would
-           false-HALT external (S3/Egnyte) filestore deployments whose roots are not file: URIs.
-         * Dropped: 17-09-13a - re-seeded BATCH_*_SEQ "after test clean-up"; now redundant, as the
-           run-seed (initial-seed-run.sql) inserts those rows on fresh install and nothing empties them
-           (DatabaseCleaner does not touch the *_SEQ tables).
-         Already dropped in PR1 (obsolete): changeLog-1.49 29-01-17/29-01-17b (RSPAC-1446 notification
-         relink) and data-changeLog 3a (cleared the checksum of pre-1.98.1 changeset 25-08-14a). -->
+    <!-- runAlways changesets: diagnostics run on every startup. -->
 
     <changeSet id="1-35-16-4-7b" author="richard" runAlways="true">
         <preConditions onFailMessage="There should be 1 current filestoreroot row if a root has been set.">

--- a/src/main/resources/sqlUpdates/recurring-changeLog.xml
+++ b/src/main/resources/sqlUpdates/recurring-changeLog.xml
@@ -3,22 +3,23 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <!-- RSDEV-416: runAlways changesets that previously executed on every startup and are NOT obsolete,
-         preserved here when their original pre-1.98.1 changelogs were squashed. They are kept verbatim
-         (same id/author) so behaviour is unchanged. To be reviewed in PR2 / phase 2 (RSDEV-416): decide
-         whether each is still worth running on every startup, or can be dropped.
+    <!-- RSDEV-416: runAlways changeset(s) that execute on every startup, preserved here when their
+         original pre-1.98.1 changelogs were squashed. Kept verbatim (same id/author) so behaviour is
+         unchanged.
 
-         Kept: filestore integrity diagnostics + Spring Batch sequence re-init.
-         Dropped (obsolete, not preserved): changeLog-1.49 29-01-17/29-01-17b (RSPAC-1446 notification
-         relink, no-ops on modern DBs) and data-changeLog 3a (cleared the checksum of changeset
-         25-08-14a, which is itself pre-1.98.1 and removed). -->
-
-    <changeSet id="1-35-16-4-7a" author="richard" runAlways="true">
-        <preConditions onFail="WARN" onError="WARN" onFailMessage="There are some FileProperty rows that are not associated with a FileStoreRoot!">
-            <sqlCheck expectedResult="0">select count(*) from FileProperty where root_id is null;</sqlCheck>
-        </preConditions>
-        <comment>This is a diagnostic to ensure that there are no FileProperty rows being added which don't have a root.</comment>
-    </changeSet>
+         PR2 review outcome (RSDEV-416):
+         * Kept: 1-35-16-4-7b - HALT diagnostic enforcing at most one current FileStoreRoot. A real
+           invariant; halting before further changesets/startup if the filestore state is wrong is intended.
+         * Moved to Java: 1-35-16-4-7a (warned if a FileProperty had a null root_id) is now an
+           onAppStartup health check (see FileStoreRootDetector), where startup diagnostics belong.
+         * Dropped: 2016-07-29d - its sqlCheck was buggy (queried FileProperty.id where its sibling
+           migration 2016-07-29c correctly used FileProperty.root_id), and a corrected version would
+           false-HALT external (S3/Egnyte) filestore deployments whose roots are not file: URIs.
+         * Dropped: 17-09-13a - re-seeded BATCH_*_SEQ "after test clean-up"; now redundant, as the
+           run-seed (initial-seed-run.sql) inserts those rows on fresh install and nothing empties them
+           (DatabaseCleaner does not touch the *_SEQ tables).
+         Already dropped in PR1 (obsolete): changeLog-1.49 29-01-17/29-01-17b (RSPAC-1446 notification
+         relink) and data-changeLog 3a (cleared the checksum of pre-1.98.1 changeset 25-08-14a). -->
 
     <changeSet id="1-35-16-4-7b" author="richard" runAlways="true">
         <preConditions onFailMessage="There should be 1 current filestoreroot row if a root has been set.">
@@ -30,23 +31,6 @@
             </or>
         </preConditions>
         <comment>This is a diagnostic to ensure that there is only one current root, if there is a root set at all</comment>
-    </changeSet>
-
-    <changeSet id="2016-07-29d" author="richard" runAlways="true" context="run and !dev-test">
-        <preConditions onErrorMessage="There are some FileStoreRoots used in FileProperty that are not valid URIs">
-            <sqlCheck expectedResult="0">select count(*) from FileProperty where id in (select id from FileStoreRoot where fileStoreRoot not like ('file%'))</sqlCheck>
-        </preConditions>
-        <comment>Diagnostic: FileStoreRoots referenced by FileProperty should be valid file URIs.</comment>
-    </changeSet>
-
-    <changeSet id="17-09-13a" author="richard" context="dev-test,run" runAlways="true">
-        <comment>Initialises Batch ID generation system if batch tables are empty following some test clean-up.
-       These statements from Spring batch core jar o.s.batch.core package</comment>
-        <sql>
-            INSERT INTO BATCH_STEP_EXECUTION_SEQ (ID, UNIQUE_KEY) select * from (select 0 as ID, '0' as UNIQUE_KEY) as tmp where not exists(select * from BATCH_STEP_EXECUTION_SEQ);
-            INSERT INTO BATCH_JOB_SEQ (ID, UNIQUE_KEY) select * from (select 0 as ID, '0' as UNIQUE_KEY) as tmp where not exists(select * from BATCH_JOB_SEQ);
-            INSERT INTO BATCH_JOB_EXECUTION_SEQ (ID, UNIQUE_KEY) select * from (select 0 as ID, '0' as UNIQUE_KEY) as tmp where not exists(select * from BATCH_JOB_EXECUTION_SEQ);
-        </sql>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/sqlUpdates/rsdev-292-custom.xml
+++ b/src/main/resources/sqlUpdates/rsdev-292-custom.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
-  <changeSet id="2024-09-13c" context="run, dev-test" author="fraser">
+  <changeSet id="2024-09-13c" context="run" author="fraser">
     <comment>RSDEV-292: Populate new contentsHash column for existing files</comment>
     <customChange
       class="com.researchspace.dao.customliquibaseupdates.hashfilecontents.StoreFileContentsHashForInventoryFileProperties_rsdev292">

--- a/src/main/resources/sqlUpdates/rsdev-310-perform-hash-apiKeys.xml
+++ b/src/main/resources/sqlUpdates/rsdev-310-perform-hash-apiKeys.xml
@@ -4,14 +4,14 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <!-- Update apiKeys that have not been SHA256 hashed -->
-    <changeSet id="2024-09-25a" context="dev-test,run" author="nico">
+    <changeSet id="2024-09-25a" context="run" author="nico">
         <comment>Update ApiKeys that have not been SHA256 hashed in the Database</comment>
         <customChange
                 class="com.researchspace.dao.customliquibaseupdates.CryptingApiKeysAndUpdateDatabase_RSDEV310">
         </customChange>
     </changeSet>
 
-    <changeSet  id="2024-09-25b" context="dev-test,run" author="nico">
+    <changeSet  id="2024-09-25b" context="run" author="nico">
         <preConditions onFail="WARN">
             <sqlCheck expectedResult="0">select count(*) from UserApiKey where length(apiKey) = 32;</sqlCheck>
         </preConditions>


### PR DESCRIPTION
Summary

The PR is a follow-up cleanup to the 1.98.1 Liquibase baseline squash (#836), as described in [RSDEV-416](https://researchspace.atlassian.net/browse/RSDEV-416) - in "PR2, post-1.98.1 cleanup" part of jira ticket.

Changes

Liquibase context vocabulary

- Reclassified the 13 changesets tagged run,dev-test (and the spelling variants dev-test,run / run, dev-test) to plain run. These are all production reference data or data migrations (app registrations for DigitalCommonsData / Fieldmark / RaID / DMP Assistant and their system properties, the contentsHash backfill, and the ApiKey SHA-256 hashing). They already run in production (Liquibase OR-s contexts), so the `,dev-test` was redundant.
- Behaviour-preserving: context is not part of a Liquibase changeset checksum, and these already ran under run on existing databases, so nothing re-runs. 

liquibase.context resolved at runtime, not baked in at build time

- Previously the "Building feature branch" Jenkins stage baked -Dliquibase.context=run,dev-test into the WAR (Maven filtered ${liquibase.context} in applicationContext-dao.xml at package time), after which neither deployment.properties nor a Tomcat -D could change it.
- Dropped that -D and excluded applicationContext-dao.xml from Maven resource filtering, so ${liquibase.context} now always resolves from deployment.properties at runtime. (Its other two placeholders are runtime values too; none is a build-time Maven property.)
- Deployment note: feature-branch / QA servers must set liquibase.context=run,dev-test in their own deployment.properties to get test data; the dev deployment already does. Production/Community resolve run / run,cloud as before.

Every-startup (runAlways) changesets in recurring-changeLog.xml

- Kept 1-35-16-4-7b (halts startup unless there is at most one current FileStoreRoot — a real invariant).
- Moved to Java: the "warn if a FileProperty has no FileStoreRoot" diagnostic is now an onAppStartup check in FileStoreRootDetector (new FileStoreMetaManager.countFilePropertiesWithoutRoot()), where startup diagnostics belong.
- Dropped 2016-07-29d: its precondition query was buggy (it compared FileProperty.id to FileStoreRoot.id instead of FileProperty.root_id), and a corrected version would wrongly HALT startup on external (S3/Egnyte) filestore deployments whose roots are not file: URIs.
- Dropped 17-09-13a: re-seeded the Spring Batch BATCH_*_SEQ rows, now redundant since the seed inserts them on fresh install and nothing empties them.

generateDiff / mysql-clean-hibernate dev tooling

- Reframed as a pure DDL comparison: rspace_hib is populated only by the Hibernate export goal and compared against the Liquibase-built rspace schema, with no webapp boot and no seed applied to rspace_hib. Removed the stray liquibase.context=dev-test profile default and updated DatabaseChangeGuidelines.md.

Removed obsolete transient/backup tables

- Dropped BR_AUD_TEMP, SD_AUD_TEMP, utf8_general_pre_rspac2515 (removed from the baseline DDL and dropped on existing databases via a new changeLog-rsdev-416-pr2-cleanup.xml) and FileStoreRoot_Bk_spac964 (no longer seeded; dropped via the same changelog).
- Each drop changeset is guarded by a tableExists precondition, so it MARK_RANs (no-op) where the table is already absent. BR_AUD_TEMP / SD_AUD_TEMP were checked on a production-like database and hold no records newer than 2016-11.

Removed orphaned columns
 
- Dropped RSForm.defaultUnitId and RSForm.subSampleName (and the RSForm_AUD copies) via the same changeLog-rsdev-416-pr2-cleanup.xml. They are not mapped by the RSForm entity and referenced by no code, most likely added to RSForm in error (they duplicate the inventory Sample/SampleTemplate columns, on a table that is not an inventory entity). Removed from the baseline DDL and dropped on existing DBs, guarded by columnExists (MARK_RAN where absent). Surfaced by the Hibernate-vs-Liquibase generateDiff.

Investigated, no action needed

- Net-zero add-then-drop column/table pairs: none exist; every post-1.98.1 drop removes baseline-era schema.
- FK backing-index name parity: a full per-index diff of a fresh install from this branch vs a fresh main install differs only by the two dropped tables' primary keys, so index names already match and nothing needs renaming.

Compatibility / upgrade safety

- Existing customers: the context reclassification re-runs nothing (already executed under run); the table-drop and column-drop changesets only drop the named leftover tables (guarded). No baseline reload on upgrade.
- Fresh installs: baseline no longer creates the obsolete tables, and the drop changesets MARK_RAN.

Verification

- Fresh drop-recreate-db boots clean and the cleanup changesets behave as expected (drops applied / MARK_RAN as appropriate).