### PR TITLE
Wrap MenuItem in MenuList for MUI v9 context

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Import/Fields/FieldTypeMenuItem.tsx
+++ b/src/main/webapp/ui/src/Inventory/Import/Fields/FieldTypeMenuItem.tsx
@@ -8,6 +8,7 @@ import IconButton from "@mui/material/IconButton";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import MenuItem from "@mui/material/MenuItem";
+import MenuList from "@mui/material/MenuList";
 import Paper from "@mui/material/Paper";
 import React, { useState, forwardRef } from "react";
 import Typography from "@mui/material/Typography";
@@ -140,7 +141,13 @@ const FieldTypeMenuItem = forwardRef<HTMLLIElement, FieldTypeMenuItemArgs>(
                   width: "100%",
                 }}
               >
-                {menuItem}
+                {/*
+                 * MUI v9's MenuItem requires a surrounding MenuList/Menu
+                 * context; when used standalone (as the type-selector trigger)
+                 * it must be wrapped in a MenuList, otherwise it throws
+                 * "MenuListContext is missing".
+                 */}
+                <MenuList disablePadding>{menuItem}</MenuList>
               </Paper>
               <Box
                 sx={{

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/FieldTypeMenuItem.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/FieldTypeMenuItem.tsx
@@ -5,6 +5,7 @@ import Stack from "@mui/material/Stack";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import MenuItem from "@mui/material/MenuItem";
+import MenuList from "@mui/material/MenuList";
 import Paper from "@mui/material/Paper";
 import { FIELD_DATA, type FieldType } from "@/stores/models/FieldTypes";
 import { Observer } from "mobx-react-lite";
@@ -50,7 +51,15 @@ const FieldTypeMenuItem = forwardRef<HTMLLIElement, FieldTypeMenuItemArgs>(
             menuItem
           ) : (
             <Box sx={{ height: 72 }}>
-              <Paper>{menuItem}</Paper>
+              {/*
+               * MUI v9's MenuItem requires a surrounding MenuList/Menu context;
+               * when used standalone (as the type-selector trigger) it must be
+               * wrapped in a MenuList, otherwise it throws "MenuListContext is
+               * missing". See FieldTypeMenu for the trigger usage.
+               */}
+              <Paper>
+                <MenuList disablePadding>{menuItem}</MenuList>
+              </Paper>
             </Box>
           )
         }


### PR DESCRIPTION
## Description ##
MenuItem now requires a surrounding MenuList/Menu context in MUI v9. When used standalone (as the type-selector trigger), wrap it in MenuList to avoid "MenuListContext is missing" error.

- Import MenuList and wrap menuItem in both Import and Template FieldTypeMenuItem
- Use disablePadding to preserve layout