### PR TITLE
Fix gallery TinyMCE plugin failing to initialize

### DIFF
--- a/src/main/webapp/ui/src/tinyMCE/gallery/index.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/gallery/index.tsx
@@ -18,7 +18,8 @@ declare global {
   }
 }
 
-parent.tinymce.PluginManager.add("gallery", (editor) => {
+// biome-ignore lint/complexity/useArrowFunction: TinyMCE instantiates plugins with `new`, so this factory must be constructable (an arrow function throws "is not a constructor")
+parent.tinymce.PluginManager.add("gallery", function (editor) {
   function* renderGallery(domContainer: HTMLElement): Generator<
     {
       open: boolean;


### PR DESCRIPTION
## Description ##
The gallery plugin was registered with an arrow function. TinyMCE 5 instantiates plugins with `new e(...)`, and arrow functions have no [[Construct]] method, so this threw "TypeError: ... is not a constructor" and TinyMCE logged "Failed to initialize plugin: gallery". The plugin was never added to the editor, so the "From RSpace Gallery" button and insert menu item were missing.

Biome's useArrowFunction rule converted the original constructable `function (editor)` into an arrow in #846. Revert to a regular function and add a biome-ignore so it cannot be re-converted.