### PR TITLE
RSDEV-1175: fixing typo after rebase

### DIFF
--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -59,7 +59,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-416-pr2-cleanup.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1154.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1131.xml"/>
-    <include relativeToChangelogFile="true" file="changeLog-RSDEV-1175.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-1175.xml"/>
 
   <!-- These two run last: recurring-changeLog.xml (runAlways diagnostics / batch re-init) then
        customUpdates-changeLog.xml. customUpdates-changeLog.xml must ALWAYS be the final include


### PR DESCRIPTION
This PR fixes the typo `changeLog-RSDEV-1175.xml` (to become `changeLog-rsdev-1175.xml`) in the `liquibase-master.xml` 