### PR TITLE
RSDEV-1200-sample-template-link-rel-types: changes in templates links…

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/InstrumentTemplateFieldValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InstrumentTemplateFieldValidator.java
@@ -4,6 +4,7 @@ import com.researchspace.api.v1.model.ApiField;
 import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.model.inventory.Instrument;
+import com.researchspace.service.inventory.DataCiteRelationType;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -60,6 +61,25 @@ abstract class InstrumentTemplateFieldValidator implements Validator {
             "errors.inventory.template.invalid.field.content",
             new Object[] {e.getMessage()},
             e.getMessage());
+      }
+    }
+
+    // Link fields: every entry in the allowed-relation-types whitelist must be a valid DataCite
+    // relation type (a null/empty whitelist means "all relation types allowed"). Validate whenever
+    // the whitelist is present, not only when the DTO declares type==LINK: an existing-field PUT
+    // may
+    // omit `type` while still updating a link field's whitelist (persisted by DB field type), so
+    // gating on the incoming type would let an invalid whitelist bypass validation (RSDEV-1200).
+    // (Mirrors SampleTemplateFieldValidator: instrument templates support link fields too.)
+    if (apiTemplateField.getAllowedRelationTypes() != null) {
+      for (String relationType : apiTemplateField.getAllowedRelationTypes()) {
+        if (!DataCiteRelationType.isValid(relationType)) {
+          errors.rejectValue(
+              "allowedRelationTypes",
+              "errors.inventory.template.invalid.relation.type",
+              new Object[] {relationType},
+              "invalid relation type");
+        }
       }
     }
   }

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldValidator.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplateFieldValidator.java
@@ -1,7 +1,6 @@
 package com.researchspace.api.v1.controller;
 
 import com.researchspace.api.v1.model.ApiField;
-import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.model.inventory.Sample;
@@ -69,9 +68,12 @@ abstract class SampleTemplateFieldValidator implements Validator {
     }
 
     // Link fields: every entry in the allowed-relation-types whitelist must be a valid DataCite
-    // relation type. A null/empty whitelist is permitted and means "all relation types allowed".
-    if (apiTemplateField.getType() == ApiFieldType.LINK
-        && apiTemplateField.getAllowedRelationTypes() != null) {
+    // relation type (a null/empty whitelist means "all relation types allowed"). Validate whenever
+    // the whitelist is present, not only when the DTO declares type==LINK: an existing-field PUT
+    // may
+    // omit `type` while still updating a link field's whitelist (persisted by DB field type), so
+    // gating on the incoming type would let an invalid whitelist bypass validation (RSDEV-1200).
+    if (apiTemplateField.getAllowedRelationTypes() != null) {
       for (String relationType : apiTemplateField.getAllowedRelationTypes()) {
         if (!DataCiteRelationType.isValid(relationType)) {
           errors.rejectValue(

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -233,6 +234,20 @@ public class ApiInventoryEntityField extends ApiField {
     if (getMandatory() != null) {
       if (!getMandatory().equals(dbField.isMandatory())) {
         dbField.setMandatory(getMandatory());
+        contentChanged = true;
+      }
+    }
+
+    // a link field's value lives in its InventoryLink, but its allowed-relation-types whitelist
+    // is template meta-data and must be re-applied on edit. Without this an edited whitelist is
+    // dropped and the field keeps the set captured at create time (RSDEV-1200). The frontend
+    // sends the list (empty == "all") for link fields, so a non-null incoming list is
+    // authoritative.
+    if (dbField instanceof InventoryLinkField && getAllowedRelationTypes() != null) {
+      InventoryLinkField dbLinkField = (InventoryLinkField) dbField;
+      String newWhitelist = joinRelationTypes(getAllowedRelationTypes());
+      if (!Objects.equals(newWhitelist, dbLinkField.getAllowedRelationTypes())) {
+        dbLinkField.setAllowedRelationTypes(newWhitelist);
         contentChanged = true;
       }
     }

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -666,7 +666,12 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       dbInstrument = (Instrument) getIfExists(dbInstrument.getId());
       if (!dbTemplate.getVersion().equals(dbInstrument.getTemplateLinkedVersion())) {
         boolean updated = dbInstrument.updateToLatestTemplateVersion();
-        if (updated) {
+        // the model sync above does not copy link-field allowed-relation-types whitelists, so an
+        // existing instrument would otherwise keep its create-time whitelist after a template edit
+        // (RSDEV-1200) — mirror the sample path and re-apply them here.
+        boolean whitelistsChanged =
+            syncLinkFieldWhitelistsFromTemplate(dbInstrument.getActiveFields());
+        if (updated || whitelistsChanged) {
           saveDbInstrumentUpdate(dbInstrument, user);
         }
       }

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
@@ -25,6 +25,8 @@ import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.SubSample;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.permissions.ACLElement;
 import com.researchspace.model.permissions.ConstraintBasedPermission;
 import com.researchspace.model.permissions.PermissionDomain;
@@ -50,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 import lombok.extern.slf4j.Slf4j;
@@ -77,6 +80,35 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   private @Autowired InventoryFileApiManager inventoryFileApiManager;
   @Autowired @Lazy private DocumentTagManager documentTagManager;
   private @Autowired FileStoreMetaManager fileMetaManagerImpl;
+
+  /**
+   * Copies each template link field's allowed-relation-types whitelist onto the matching record
+   * link field. The model's per-field template sync ({@code
+   * InventoryEntityField#updateToLatestTemplateDefinition}) copies name/columnIndex/mandatory/
+   * deletion but not the link whitelist, so without this an existing record (sample or instrument)
+   * keeps the whitelist captured when it was created and never picks up a later template edit
+   * (RSDEV-1200). New records are unaffected: they clone the template field via {@code
+   * shallowCopy()}, which copies the whitelist. A record link field with no connected template link
+   * field is left untouched.
+   *
+   * @return true if any record field's whitelist was changed
+   */
+  static boolean syncLinkFieldWhitelistsFromTemplate(List<InventoryEntityField> recordFields) {
+    boolean changed = false;
+    for (InventoryEntityField field : recordFields) {
+      if (field instanceof InventoryLinkField
+          && field.getTemplateField() instanceof InventoryLinkField) {
+        InventoryLinkField recordLink = (InventoryLinkField) field;
+        String templateWhitelist =
+            ((InventoryLinkField) field.getTemplateField()).getAllowedRelationTypes();
+        if (!Objects.equals(recordLink.getAllowedRelationTypes(), templateWhitelist)) {
+          recordLink.setAllowedRelationTypes(templateWhitelist);
+          changed = true;
+        }
+      }
+    }
+    return changed;
+  }
 
   protected void updateOntologyOnUpdate(
       ApiInventoryRecordInfo original, ApiInventoryRecordInfo updated, User user) {

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -1049,6 +1049,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<Sample>
                 .map(InventoryLinkField.class::cast)
                 .collect(Collectors.toList());
         dbSample.updateToLatestTemplateVersion();
+        syncLinkFieldWhitelistsFromTemplate(dbSample.getActiveFields());
         linkFieldsBeforeUpdate.forEach(field -> softDeleteLinkOfDeletedLinkField(field, user));
         saveDbSampleUpdate(dbSample, user);
       }

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatePutValidatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatePutValidatorTest.java
@@ -83,4 +83,66 @@ public class InstrumentTemplatePutValidatorTest extends InventoryRecordValidatio
 
     assertEquals(0, e.getErrorCount());
   }
+
+  @Test
+  public void rejectsLinkFieldWithInvalidRelationType() {
+    // RSDEV-1200: instrument templates support link fields, so an invalid allowed-relation-type
+    // must be rejected here just as it is for sample templates.
+    ApiInstrumentTemplate put = new ApiInstrumentTemplate();
+    ApiInventoryEntityField link = new ApiInventoryEntityField();
+    link.setId(123L);
+    link.setType(ApiFieldType.LINK);
+    link.setAllowedRelationTypes(java.util.List.of("NotADataCiteRelationType"));
+    put.setFields(java.util.List.of(link));
+
+    Errors e = new BeanPropertyBindingResult(put, "templatePut");
+    putValidator.validate(put, e);
+
+    // the field error is registered under a nested path (e.g. fields[0].allowedRelationTypes),
+    // so match by error code rather than by top-level field name.
+    assertTrue(
+        e.getFieldErrors().stream()
+            .anyMatch(fe -> "errors.inventory.template.invalid.relation.type".equals(fe.getCode())),
+        "expected an invalid-relation-type error, got: " + e.getAllErrors());
+  }
+
+  @Test
+  public void acceptsLinkFieldWithValidRelationTypes() {
+    ApiInstrumentTemplate put = new ApiInstrumentTemplate();
+    ApiInventoryEntityField link = new ApiInventoryEntityField();
+    link.setId(123L);
+    link.setType(ApiFieldType.LINK);
+    link.setAllowedRelationTypes(java.util.List.of("References", "IsCitedBy"));
+    put.setFields(java.util.List.of(link));
+
+    Errors e = new BeanPropertyBindingResult(put, "templatePut");
+    putValidator.validate(put, e);
+
+    assertTrue(
+        e.getFieldErrors().stream()
+            .noneMatch(
+                fe -> "errors.inventory.template.invalid.relation.type".equals(fe.getCode())),
+        "unexpected invalid-relation-type error, got: " + e.getAllErrors());
+  }
+
+  @Test
+  public void rejectsInvalidRelationTypeOnExistingFieldPutWithoutType() {
+    // RSDEV-1200: an existing-field PUT may omit `type`, but the whitelist is still persisted by
+    // the
+    // DB field type, so it must be validated whenever present - not only when the DTO says
+    // type==LINK. Otherwise an invalid whitelist bypasses validation and is stored anyway.
+    ApiInstrumentTemplate put = new ApiInstrumentTemplate();
+    ApiInventoryEntityField existingLink = new ApiInventoryEntityField();
+    existingLink.setId(123L); // existing field, no type provided
+    existingLink.setAllowedRelationTypes(java.util.List.of("NotADataCiteRelationType"));
+    put.setFields(java.util.List.of(existingLink));
+
+    Errors e = new BeanPropertyBindingResult(put, "templatePut");
+    putValidator.validate(put, e);
+
+    assertTrue(
+        e.getFieldErrors().stream()
+            .anyMatch(fe -> "errors.inventory.template.invalid.relation.type".equals(fe.getCode())),
+        "expected an invalid-relation-type error, got: " + e.getAllErrors());
+  }
 }

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplateLinkFieldMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplateLinkFieldMVCIT.java
@@ -148,6 +148,93 @@ public class SampleTemplateLinkFieldMVCIT extends API_MVC_InventoryTestBase {
     assertEquals(target.getGlobalId(), updatedField.getLink().getTargetGlobalId());
   }
 
+  @Test
+  public void editedAllowedRelationTypesWhitelistIsPersistedOnTemplateUpdate() throws Exception {
+    // RSDEV-1200: the whitelist was captured at create time but the template-update path
+    // dropped it, so editing the allowed relation types and saving left the field at the
+    // initially saved set. This drives the change through the full HTTP -> controller ->
+    // manager -> DTO path and reloads the template to prove the new set persists.
+    ApiSampleTemplate savedTemplate = createTemplateWithLinkField();
+    Long linkFieldId = findLinkField(savedTemplate.getFields()).getId();
+    assertEquals(
+        List.of("References", "IsDerivedFrom"),
+        findLinkField(savedTemplate.getFields()).getAllowedRelationTypes());
+
+    // edit the whitelist to a different (still valid DataCite) set and save the template
+    String updateJson =
+        "{\"fields\":[{"
+            + "\"id\":"
+            + linkFieldId
+            + ","
+            + "\"type\":\"link\","
+            + "\"allowedRelationTypes\":[\"IsCitedBy\",\"Cites\"]"
+            + "}]}";
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/sampleTemplates/" + savedTemplate.getId(), anyUser, updateJson))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiSampleTemplate updated = getFromJsonResponseBody(result, ApiSampleTemplate.class);
+    assertEquals(
+        List.of("IsCitedBy", "Cites"),
+        findLinkField(updated.getFields()).getAllowedRelationTypes(),
+        "the edited whitelist should be returned by the update");
+
+    // reload the template (the "subsequent edit" the user saw stuck at the old set)
+    ApiSampleTemplate reloaded =
+        sampleApiManager.getApiSampleTemplateById(savedTemplate.getId(), anyUser);
+    assertEquals(
+        List.of("IsCitedBy", "Cites"),
+        findLinkField(reloaded.getFields()).getAllowedRelationTypes(),
+        "the edited whitelist should persist across reload");
+  }
+
+  @Test
+  public void editedWhitelistPropagatesToExistingSamplesOnUpdateToLatestTemplateVersion()
+      throws Exception {
+    // RSDEV-1200 follow-on: editing the template whitelist must reach pre-existing samples when
+    // they are synced to the latest template version, not only samples created after the edit.
+    ApiSampleTemplate savedTemplate = createTemplateWithLinkField();
+    Long templateLinkFieldId = findLinkField(savedTemplate.getFields()).getId();
+
+    // a sample created before the edit inherits the original whitelist
+    ApiSampleWithFullSubSamples apiSample =
+        new ApiSampleWithFullSubSamples("existing sample from link template");
+    apiSample.setTemplateId(savedTemplate.getId());
+    ApiSampleWithFullSubSamples created = sampleApiManager.createNewApiSample(apiSample, anyUser);
+    assertEquals(
+        List.of("References", "IsDerivedFrom"),
+        findLinkField(sampleApiManager.getApiSampleById(created.getId(), anyUser).getFields())
+            .getAllowedRelationTypes());
+
+    // edit the template's link-field whitelist (bumps the template version)
+    String updateJson =
+        "{\"fields\":[{"
+            + "\"id\":"
+            + templateLinkFieldId
+            + ","
+            + "\"type\":\"link\","
+            + "\"allowedRelationTypes\":[\"IsCitedBy\",\"Cites\"]"
+            + "}]}";
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(
+                apiKey, "/sampleTemplates/" + savedTemplate.getId(), anyUser, updateJson))
+        .andExpect(status().isOk());
+
+    // sync the existing sample to the latest template version
+    sampleApiManager.updateSampleToLatestTemplateVersion(created.getId(), anyUser);
+
+    ApiSample synced = sampleApiManager.getApiSampleById(created.getId(), anyUser);
+    assertEquals(
+        List.of("IsCitedBy", "Cites"),
+        findLinkField(synced.getFields()).getAllowedRelationTypes(),
+        "the existing sample should acquire the template's edited whitelist after the sync");
+  }
+
   private ApiSampleTemplate createTemplateWithLinkField() throws Exception {
     return createTemplateWithLinkField(false);
   }

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplateValidatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplateValidatorTest.java
@@ -3,10 +3,13 @@ package com.researchspace.api.v1.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
 import com.researchspace.api.v1.model.ApiSampleTemplatePost;
 import com.researchspace.model.units.RSUnitDef;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -147,6 +150,29 @@ public class SampleTemplateValidatorTest extends InventoryRecordValidationTestBa
     ApiSampleTemplate put = newValidPut();
     put.setDefaultUnitId(null);
     assertNoDefaultUnitError(validate(putValidator, put));
+  }
+
+  // --- link fields: allowed-relation-types must be valid even on a type-less existing-field PUT
+  // ---
+
+  @Test
+  public void putRejectsInvalidRelationTypeOnExistingLinkFieldWithoutType() {
+    // RSDEV-1200: an existing-field PUT may omit `type`, but the whitelist is still persisted by
+    // the
+    // DB field type, so it must be validated whenever present - not only when the DTO says
+    // type==LINK. Otherwise an invalid whitelist bypasses validation and is stored anyway.
+    ApiSampleTemplate put = newValidPut();
+    ApiInventoryEntityField existingLink = new ApiInventoryEntityField();
+    existingLink.setId(123L); // existing field, no type provided
+    existingLink.setAllowedRelationTypes(List.of("NotADataCiteRelationType"));
+    put.setFields(List.of(existingLink));
+
+    Errors errors = validate(putValidator, put);
+
+    assertTrue(
+        errors.getFieldErrors().stream()
+            .anyMatch(fe -> "errors.inventory.template.invalid.relation.type".equals(fe.getCode())),
+        "expected an invalid-relation-type error, got: " + errors.getAllErrors());
   }
 
   // --- helpers --------------------------------------------------------------------------

--- a/src/test/java/com/researchspace/api/v1/model/ApiInventoryEntityFieldLinkContentTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiInventoryEntityFieldLinkContentTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.inventory.field.InventoryTextField;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,6 +44,51 @@ class ApiInventoryEntityFieldLinkContentTest {
 
     assertFalse(apiField.applyChangesToDatabaseField(dbField, null));
     assertEquals(null, dbField.getData());
+  }
+
+  @Test
+  void editedAllowedRelationTypesWhitelistIsAppliedToTemplateLinkField() {
+    // the whitelist is set on create but was dropped on edit (RSDEV-1200): the template
+    // update path applied name/columnIndex/definition/mandatory/content but not the
+    // link field's allowed-relation-types whitelist, so it stayed at the initial value.
+    InventoryLinkField dbField = new InventoryLinkField();
+    dbField.setName("related");
+    dbField.setAllowedRelationTypes("References");
+
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setAllowedRelationTypes(List.of("References", "IsDerivedFrom"));
+
+    assertTrue(apiField.applyChangesToDatabaseTemplateField(dbField, null));
+    assertEquals("References|IsDerivedFrom", dbField.getAllowedRelationTypes());
+  }
+
+  @Test
+  void unchangedAllowedRelationTypesWhitelistReportsNoChange() {
+    InventoryLinkField dbField = new InventoryLinkField();
+    dbField.setAllowedRelationTypes("References|IsDerivedFrom");
+
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setAllowedRelationTypes(List.of("References", "IsDerivedFrom"));
+
+    assertFalse(apiField.applyChangesToDatabaseTemplateField(dbField, null));
+    assertEquals("References|IsDerivedFrom", dbField.getAllowedRelationTypes());
+  }
+
+  @Test
+  void clearingAllowedRelationTypesWhitelistPersistsAsAll() {
+    // an empty list means "all relation types permitted"; it must clear a previously set
+    // whitelist (stored null) rather than be ignored.
+    InventoryLinkField dbField = new InventoryLinkField();
+    dbField.setAllowedRelationTypes("References");
+
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setAllowedRelationTypes(List.of());
+
+    assertTrue(apiField.applyChangesToDatabaseTemplateField(dbField, null));
+    assertEquals(null, dbField.getAllowedRelationTypes());
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/InstrumentEntityApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InstrumentEntityApiManagerTest.java
@@ -422,6 +422,58 @@ public class InstrumentEntityApiManagerTest extends SpringTransactionalTest {
   }
 
   @Test
+  public void updateInstrumentToLatestTemplateVersion_propagatesEditedLinkWhitelist() {
+    // RSDEV-1200: an existing instrument synced to a newer template version must pick up the
+    // template's edited link-field allowed-relation-types whitelist, mirroring the sample path.
+    ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
+    templatePost.setName("instr-link-tmpl-" + getRandomAlphabeticString("n"));
+    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
+    linkField.setName("related");
+    linkField.setType(ApiFieldType.LINK);
+    linkField.setAllowedRelationTypes(List.of("References", "IsDerivedFrom"));
+    templatePost.getFields().add(linkField);
+    ApiInstrumentTemplate template =
+        instrumentApiMgr.createInstrumentTemplate(templatePost, testUser);
+    Long templateLinkFieldId = findInstrumentLinkField(template.getFields()).getId();
+
+    // an instrument created before the edit inherits the original whitelist
+    ApiInstrument instrumentReq = new ApiInstrument();
+    instrumentReq.setName("existing-instrument");
+    instrumentReq.setTemplateId(template.getId());
+    ApiInstrument instrument = instrumentApiMgr.createNewApiInstrument(instrumentReq, testUser);
+    assertEquals(
+        List.of("References", "IsDerivedFrom"),
+        findInstrumentLinkField(
+                instrumentApiMgr.getApiInstrumentById(instrument.getId(), testUser).getFields())
+            .getAllowedRelationTypes());
+
+    // edit the template link-field whitelist (bumps the template version)
+    ApiInventoryEntityField editField = new ApiInventoryEntityField();
+    editField.setId(templateLinkFieldId);
+    editField.setType(ApiFieldType.LINK);
+    editField.setAllowedRelationTypes(List.of("IsCitedBy", "Cites"));
+    ApiInstrumentTemplate edit = new ApiInstrumentTemplate();
+    edit.setId(template.getId());
+    edit.setFields(List.of(editField));
+    instrumentApiMgr.updateApiInstrumentTemplate(edit, testUser);
+
+    // sync the existing instrument and assert it acquired the edited whitelist
+    instrumentApiMgr.updateInstrumentToLatestTemplateVersion(instrument.getId(), testUser);
+    ApiInstrument synced = instrumentApiMgr.getApiInstrumentById(instrument.getId(), testUser);
+    assertEquals(
+        List.of("IsCitedBy", "Cites"),
+        findInstrumentLinkField(synced.getFields()).getAllowedRelationTypes(),
+        "existing instrument should acquire the template's edited whitelist after sync");
+  }
+
+  private ApiInventoryEntityField findInstrumentLinkField(List<ApiInventoryEntityField> fields) {
+    return fields.stream()
+        .filter(f -> ApiFieldType.LINK.equals(f.getType()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("expected a link field in the instrument fields"));
+  }
+
+  @Test
   public void getInstrumentsLinkingOldTemplateVersion_returnsLaggingInstruments() {
     // Create a template + an instrument from it (linked at version 1)
     ApiInstrumentTemplate template = createBasicInstrumentTemplateForUser(testUser);

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
@@ -1,5 +1,6 @@
 package com.researchspace.service.inventory.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -14,10 +15,13 @@ import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.model.inventory.field.InventoryTextField;
 import com.researchspace.service.inventory.InventoryLinkManager;
 import com.researchspace.testutils.TestFactory;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -208,6 +212,62 @@ class SampleApiManagerImplLinkFieldTest {
     assertTrue(changed);
     assertSame(created, dbField.getLink());
     verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+  }
+
+  @Test
+  void existingSampleLinkFieldAcquiresTemplatesUpdatedWhitelist() {
+    // RSDEV-1200: when an existing sample is synced to a newer template version, the model's
+    // per-field sync copies name/columnIndex/mandatory/deletion but not the link whitelist, so
+    // the sample kept the whitelist captured at creation. (New samples are fine: they clone the
+    // template field via shallowCopy(), which copies the whitelist.)
+    InventoryLinkField templateField = new InventoryLinkField();
+    templateField.setAllowedRelationTypes("IsCitedBy|Cites");
+    InventoryLinkField sampleField = new InventoryLinkField();
+    sampleField.setAllowedRelationTypes("References");
+    sampleField.setTemplateField(templateField);
+
+    List<InventoryEntityField> sampleFields = List.of(sampleField);
+    assertTrue(InventoryApiManagerImpl.syncLinkFieldWhitelistsFromTemplate(sampleFields));
+    assertEquals("IsCitedBy|Cites", sampleField.getAllowedRelationTypes());
+  }
+
+  @Test
+  void clearingTheTemplateWhitelistClearsItOnExistingSampleLinkField() {
+    // template whitelist removed (back to "all" relation types == null): the sample must follow
+    InventoryLinkField templateField = new InventoryLinkField();
+    templateField.setAllowedRelationTypes(null);
+    InventoryLinkField sampleField = new InventoryLinkField();
+    sampleField.setAllowedRelationTypes("References");
+    sampleField.setTemplateField(templateField);
+
+    List<InventoryEntityField> sampleFields = List.of(sampleField);
+    assertTrue(InventoryApiManagerImpl.syncLinkFieldWhitelistsFromTemplate(sampleFields));
+    assertNull(sampleField.getAllowedRelationTypes());
+  }
+
+  @Test
+  void unchangedTemplateWhitelistIsANoop() {
+    InventoryLinkField templateField = new InventoryLinkField();
+    templateField.setAllowedRelationTypes("References|IsDerivedFrom");
+    InventoryLinkField sampleField = new InventoryLinkField();
+    sampleField.setAllowedRelationTypes("References|IsDerivedFrom");
+    sampleField.setTemplateField(templateField);
+
+    List<InventoryEntityField> sampleFields = List.of(sampleField);
+    assertFalse(InventoryApiManagerImpl.syncLinkFieldWhitelistsFromTemplate(sampleFields));
+    assertEquals("References|IsDerivedFrom", sampleField.getAllowedRelationTypes());
+  }
+
+  @Test
+  void nonLinkAndTemplatelessFieldsAreLeftUntouched() {
+    // a non-link field and a link field with no connected template field must be skipped (no NPE)
+    InventoryTextField textField = new InventoryTextField("notes");
+    InventoryLinkField orphanLinkField = new InventoryLinkField();
+    orphanLinkField.setAllowedRelationTypes("References");
+
+    List<InventoryEntityField> sampleFields = List.of(textField, orphanLinkField);
+    assertFalse(InventoryApiManagerImpl.syncLinkFieldWhitelistsFromTemplate(sampleFields));
+    assertEquals("References", orphanLinkField.getAllowedRelationTypes());
   }
 
   @Test


### PR DESCRIPTION
… allowed relationship types are now persisted correctly and now propogate to existing samples.

## Description ##
Fixes a bug in RSDEV-1131 whereby the allowed relationship types were not persisted for templates links and were also not propagated to existing samples created from them
