### PR TITLE
Fix Biome lint/format on RSDEV-1175 DataCite frontend files

### DIFF
--- a/src/main/webapp/ui/src/modules/api/components/ApiDocsPage.tsx
+++ b/src/main/webapp/ui/src/modules/api/components/ApiDocsPage.tsx
@@ -1,8 +1,5 @@
+import { type ApiReferenceConfigurationWithMultipleSources, ApiReferenceReact } from "@scalar/api-reference-react";
 import React from "react";
-import {
-  ApiReferenceReact,
-  type ApiReferenceConfigurationWithMultipleSources,
-} from "@scalar/api-reference-react";
 import "@scalar/api-reference-react/style.css";
 
 /**

--- a/src/main/webapp/ui/src/stores/stores/AuthStore.ts
+++ b/src/main/webapp/ui/src/stores/stores/AuthStore.ts
@@ -8,17 +8,17 @@ import { mkAlert } from "../contexts/Alert";
 import type { RootStore } from "./RootStore";
 import {
   type ApiInventorySystemSettings,
+  dataciteSettingsToIgsnPayload,
   type SystemSettings,
   systemSettingsFromApiResponse,
-  dataciteSettingsToIgsnPayload,
 } from "./systemSettingsMapping";
 
 /* The public view is for a document made accessible to non RSpace users, List Of Materials access initialises AuthStore */
 const publicView = document.getElementById("public_document_view") !== null;
 
 export type {
-  IntegrationState,
   DataCiteServerUrl,
+  IntegrationState,
   SystemSettings,
 } from "./systemSettingsMapping";
 
@@ -116,10 +116,7 @@ export default class AuthStore {
 
   async getSystemSettings(): Promise<void> {
     try {
-      const { data } = await InvApiService.get<ApiInventorySystemSettings>(
-        "system/settings",
-        ""
-      );
+      const { data } = await InvApiService.get<ApiInventorySystemSettings>("system/settings", "");
       // the endpoint now returns identifiersSettings keyed by type; the dialog uses the IGSN entry
       this.setSystemSettings(systemSettingsFromApiResponse(data));
     } catch (error) {
@@ -137,7 +134,7 @@ export default class AuthStore {
 
   async updateSystemSettings<SettingFor extends keyof SystemSettings>(
     _settingFor: SettingFor,
-    newSettings: SystemSettings[SettingFor]
+    newSettings: SystemSettings[SettingFor],
   ): Promise<void> {
     try {
       // PUT now takes a single identifier-settings object routed by `provider`. The dialog only
@@ -147,10 +144,7 @@ export default class AuthStore {
       // The UI strategic solution that will handle both configurations
       // (PDINST Datacite, PDINST b2inst and IGSN datacite)
       // will be handled by the jira ticket https://researchspace.atlassian.net/browse/RSDEV-1180
-      await InvApiService.put<void>(
-        "system/settings",
-        dataciteSettingsToIgsnPayload(newSettings)
-      );
+      await InvApiService.put<void>("system/settings", dataciteSettingsToIgsnPayload(newSettings));
       this.rootStore.uiStore.addAlert(
         mkAlert({
           message: `System Settings have been updated.`,

--- a/src/main/webapp/ui/src/stores/stores/__tests__/systemSettingsMapping.test.ts
+++ b/src/main/webapp/ui/src/stores/stores/__tests__/systemSettingsMapping.test.ts
@@ -1,8 +1,8 @@
-import { test, describe, expect } from "vitest";
+import { describe, expect, test } from "vitest";
 import {
-  systemSettingsFromApiResponse,
-  dataciteSettingsToIgsnPayload,
   type ApiInventorySystemSettings,
+  dataciteSettingsToIgsnPayload,
+  systemSettingsFromApiResponse,
 } from "../systemSettingsMapping";
 
 describe("systemSettingsFromApiResponse", () => {

--- a/src/main/webapp/ui/src/stores/stores/systemSettingsMapping.ts
+++ b/src/main/webapp/ui/src/stores/stores/systemSettingsMapping.ts
@@ -10,14 +10,9 @@
 
 export type IntegrationState = "true" | "false";
 
-export type DataCiteServerUrl =
-  | "https://api.datacite.org"
-  | "https://api.test.datacite.org";
+export type DataCiteServerUrl = "https://api.datacite.org" | "https://api.test.datacite.org";
 
-export type IdentifierProvider =
-  | "IGSN_DATACITE"
-  | "PIDINST_DATACITE"
-  | "PIDINST_B2INST";
+export type IdentifierProvider = "IGSN_DATACITE" | "PIDINST_DATACITE" | "PIDINST_B2INST";
 
 /** The datacite-shaped settings the dialog reads and edits. */
 export type DataciteSettings = {
@@ -57,9 +52,7 @@ const DEFAULT_DATACITE_SETTINGS: DataciteSettings = {
  * Adapts the API response to the dialog's datacite model, using only the IGSN entry and dropping
  * the `provider` field. Falls back to safe defaults if the IGSN entry is absent.
  */
-export function systemSettingsFromApiResponse(
-  response: ApiInventorySystemSettings
-): SystemSettings {
+export function systemSettingsFromApiResponse(response: ApiInventorySystemSettings): SystemSettings {
   const igsn = response?.identifiersSettings?.IGSN;
   if (!igsn) {
     return { datacite: { ...DEFAULT_DATACITE_SETTINGS } };
@@ -79,9 +72,7 @@ export function systemSettingsFromApiResponse(
  * Wraps the datacite settings into a single IGSN identifier-settings object for PUT
  * /system/settings, which is now routed by `provider`.
  */
-export function dataciteSettingsToIgsnPayload(
-  datacite: DataciteSettings
-): IdentifierSettings {
+export function dataciteSettingsToIgsnPayload(datacite: DataciteSettings): IdentifierSettings {
   return {
     provider: "IGSN_DATACITE",
     enabled: datacite.enabled,


### PR DESCRIPTION
## Description

The RSDEV-1175 PIDINST/DataCite work (#849, #863) landed on `main` with Biome
`organize-imports`/`format` violations that fail the `frontend-checks` CI job
(it runs `biome ci --error-on-warnings`). `main` is currently red on these.

This applies the safe Biome auto-fixes (`pnpm run lint:fix`) — purely
import-ordering and formatting, **no logic changes** — to the four affected
files:

- `src/main/webapp/ui/src/stores/stores/systemSettingsMapping.ts`
- `src/main/webapp/ui/src/stores/stores/__tests__/systemSettingsMapping.test.ts`
- `src/main/webapp/ui/src/stores/stores/AuthStore.ts`
- `src/main/webapp/ui/src/modules/api/components/ApiDocsPage.tsx`

After this, `pnpm run lint:ci` passes (1365 files, 0 errors).

## Testing

- `pnpm run lint:ci` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)