### PR TITLE
Fix DMPOnlineControllerMVCIT refresh_token test

### DIFF
--- a/src/test/java/com/researchspace/webapp/integrations/dmponline/DMPOnlineControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/dmponline/DMPOnlineControllerMVCIT.java
@@ -3,6 +3,9 @@ package com.researchspace.webapp.integrations.dmponline;
 import static com.researchspace.service.IntegrationsHandler.DMPONLINE_APP_NAME;
 import static com.researchspace.service.IntegrationsHandler.PROVIDER_USER_ID;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,19 +19,33 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.client.RestTemplate;
 
 @WebAppConfiguration
 public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
 
+  private static final String TOKEN_ENDPOINT = "https://dmponline.dmptest.dcc.ac.uk/oauth/token";
+
   private @Autowired UserConnectionManager userConnectionManager;
+  private @Autowired DMPOnlineController dmpOnlineController;
   private User user;
+  private RestTemplate restTemplate;
 
   @Before
   public void setUp() throws Exception {
     super.setUp();
     user = createInitAndLoginAnyUser();
+
+    // The controller is a shared singleton, so give it a fresh RestTemplate before each test to
+    // avoid leaking mock expectations between tests. testRefreshToken binds a MockRestServiceServer
+    // to this instance; the other tests leave it as a plain template.
+    restTemplate = new RestTemplate();
+    dmpOnlineController.setRestTemplate(restTemplate);
   }
 
   @Test
@@ -68,9 +85,15 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
   @Test
   public void testRefreshToken() throws Exception {
     // A connection must exist, otherwise refresh_token throws NOT_FOUND before reaching the
-    // shared connection-result page. With a connection present the upstream token refresh fails
-    // (no real DMPonline server in tests), exercising the error variant of that page.
+    // shared connection-result page.
     seedUserConnection();
+    // Make the upstream token refresh fail deterministically, exercising the error variant of the
+    // shared connection-result page without depending on a real DMPonline server.
+    MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+    mockServer
+        .expect(requestTo(TOKEN_ENDPOINT))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
 
     MvcResult result =
         mockMvc
@@ -78,6 +101,7 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
             .andExpect(status().is(200)) // end point exists
             .andReturn();
 
+    mockServer.verify();
     // assert is forwarded to the shared connection-result page (error variant)
     assertTrue(result.getResponse().getForwardedUrl().contains("connect/connected"));
   }
@@ -88,7 +112,7 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
         new UserConnectionId(user.getUsername(), DMPONLINE_APP_NAME, PROVIDER_USER_ID));
     connection.setAccessToken("ACCESS_TOKEN");
     connection.setRefreshToken("REFRESH_TOKEN");
-    connection.setExpireTime(299L);
+    connection.setExpireTime(System.currentTimeMillis() + 60L * 60 * 1000);
     connection.setDisplayName("DMPonline access token");
     userConnectionManager.save(connection);
   }

--- a/src/test/java/com/researchspace/webapp/integrations/dmponline/DMPOnlineControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/dmponline/DMPOnlineControllerMVCIT.java
@@ -63,6 +63,10 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
 
     // assert is forwarded to the shared connection-result page (error variant)
     assertTrue(result.getResponse().getForwardedUrl().contains("connect/connected"));
+    // the shared page serves both outcomes, so pin the error branch via its model attribute
+    assertTrue(
+        ((String) result.getModelAndView().getModel().get("connectionError"))
+            .contains("Error during token creation"));
   }
 
   @Test
@@ -82,6 +86,10 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
 
     // assert is forwarded to the shared connection-result page (error variant)
     assertTrue(result.getResponse().getForwardedUrl().contains("connect/connected"));
+    // the shared page serves both outcomes, so pin the error branch via its model attribute
+    assertTrue(
+        ((String) result.getModelAndView().getModel().get("connectionError"))
+            .contains("Error during token refresh"));
   }
 
   private void seedUserConnection() {

--- a/src/test/java/com/researchspace/webapp/integrations/dmponline/DMPOnlineControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/dmponline/DMPOnlineControllerMVCIT.java
@@ -3,9 +3,6 @@ package com.researchspace.webapp.integrations.dmponline;
 import static com.researchspace.service.IntegrationsHandler.DMPONLINE_APP_NAME;
 import static com.researchspace.service.IntegrationsHandler.PROVIDER_USER_ID;
 import static org.junit.Assert.assertTrue;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -19,33 +16,19 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.web.client.RestTemplate;
 
 @WebAppConfiguration
 public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
 
-  private static final String TOKEN_ENDPOINT = "https://dmponline.dmptest.dcc.ac.uk/oauth/token";
-
   private @Autowired UserConnectionManager userConnectionManager;
-  private @Autowired DMPOnlineController dmpOnlineController;
   private User user;
-  private RestTemplate restTemplate;
 
   @Before
   public void setUp() throws Exception {
     super.setUp();
     user = createInitAndLoginAnyUser();
-
-    // The controller is a shared singleton, so give it a fresh RestTemplate before each test to
-    // avoid leaking mock expectations between tests. testRefreshToken binds a MockRestServiceServer
-    // to this instance; the other tests leave it as a plain template.
-    restTemplate = new RestTemplate();
-    dmpOnlineController.setRestTemplate(restTemplate);
   }
 
   @Test
@@ -85,15 +68,11 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
   @Test
   public void testRefreshToken() throws Exception {
     // A connection must exist, otherwise refresh_token throws NOT_FOUND before reaching the
-    // shared connection-result page.
+    // shared connection-result page. With a connection present the upstream token refresh fails
+    // (no reachable DMPonline server in the test environment), exercising the error variant of
+    // that page. Like testCallback / testIsConnectionAlive above, this calls the real endpoint and
+    // asserts the error-page forward rather than mocking the HTTP call.
     seedUserConnection();
-    // Make the upstream token refresh fail deterministically, exercising the error variant of the
-    // shared connection-result page without depending on a real DMPonline server.
-    MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
-    mockServer
-        .expect(requestTo(TOKEN_ENDPOINT))
-        .andExpect(method(HttpMethod.POST))
-        .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
 
     MvcResult result =
         mockMvc
@@ -101,7 +80,6 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
             .andExpect(status().is(200)) // end point exists
             .andReturn();
 
-    mockServer.verify();
     // assert is forwarded to the shared connection-result page (error variant)
     assertTrue(result.getResponse().getForwardedUrl().contains("connect/connected"));
   }

--- a/src/test/java/com/researchspace/webapp/integrations/dmponline/DMPOnlineControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/dmponline/DMPOnlineControllerMVCIT.java
@@ -1,6 +1,7 @@
 package com.researchspace.webapp.integrations.dmponline;
 
 import static com.researchspace.service.IntegrationsHandler.DMPONLINE_APP_NAME;
+import static com.researchspace.service.IntegrationsHandler.PROVIDER_USER_ID;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.researchspace.api.v1.controller.API_MVC_TestBase;
 import com.researchspace.model.User;
 import com.researchspace.model.oauth.UserConnection;
+import com.researchspace.model.oauth.UserConnectionId;
 import com.researchspace.service.UserConnectionManager;
 import java.util.Optional;
 import org.junit.Before;
@@ -65,6 +67,11 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
 
   @Test
   public void testRefreshToken() throws Exception {
+    // A connection must exist, otherwise refresh_token throws NOT_FOUND before reaching the
+    // shared connection-result page. With a connection present the upstream token refresh fails
+    // (no real DMPonline server in tests), exercising the error variant of that page.
+    seedUserConnection();
+
     MvcResult result =
         mockMvc
             .perform(post("/apps/dmponline/refresh_token").principal(user::getUsername))
@@ -73,6 +80,17 @@ public class DMPOnlineControllerMVCIT extends API_MVC_TestBase {
 
     // assert is forwarded to the shared connection-result page (error variant)
     assertTrue(result.getResponse().getForwardedUrl().contains("connect/connected"));
+  }
+
+  private void seedUserConnection() {
+    UserConnection connection = new UserConnection();
+    connection.setId(
+        new UserConnectionId(user.getUsername(), DMPONLINE_APP_NAME, PROVIDER_USER_ID));
+    connection.setAccessToken("ACCESS_TOKEN");
+    connection.setRefreshToken("REFRESH_TOKEN");
+    connection.setExpireTime(299L);
+    connection.setDisplayName("DMPonline access token");
+    userConnectionManager.save(connection);
   }
 
   @Test


### PR DESCRIPTION
## Description
https://github.com/rspace-os/rspace-web/pull/866/changes introduced a change that caused an existing test to fail.

`DMPOnlineControllerMVCIT.testRefreshToken` posted to `/apps/dmponline/refresh_token` without any `UserConnection` present, so the controller threw `NOT_FOUND` before ever reaching the shared connection-result page. The test therefore never exercised the path it claims to.

This change seeds a `UserConnection` for the user before the request. With a connection present the upstream token refresh fails (there is no real DMPonline server in tests), which exercises the error variant of the shared connection-result page and forwards to `connect/connected` as the assertion expects.

No production code changed — test only.

## Testing

`mvn verify -Denvironment=drop-recreate-db -Dtest=DMPOnlineControllerMVCIT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>