### PR TITLE
Cache React Roots, fix hydration errors

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/Identifiers.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/Identifiers.tsx
@@ -208,7 +208,7 @@ const IdentifierWrapper = observer(
             label="Include Inventory fields on landing page"
           />
           {editable && (
-            <Typography variant="body2">
+            <Typography variant="body2" component="div">
               The following fields will be included:
               <ul>
                 <li>Description</li>

--- a/src/main/webapp/ui/src/components/AppBar/AboutRSpaceDialog.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/AboutRSpaceDialog.tsx
@@ -114,7 +114,7 @@ export function AboutRSpaceContent(): React.ReactElement {
       </Typography>
 
       <Box sx={{ mt: 2, mb: 3 }}>
-        <Typography variant="body2">
+        <Typography variant="body2" component="div">
           <Stack spacing={2} direction="row" sx={{ alignItems: "center" }}>
             <Link href="https://researchspace.com" target="_blank" rel="noreferrer">
               Website

--- a/src/main/webapp/ui/src/eln-inventory-integration/MaterialsListing/MaterialsListing.tsx
+++ b/src/main/webapp/ui/src/eln-inventory-integration/MaterialsListing/MaterialsListing.tsx
@@ -14,7 +14,7 @@ import Typography from "@mui/material/Typography";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import createAccentedTheme from "../../accentedTheme";
 import { ACCENT_COLOR as INVENTORY_COLOR } from "../../assets/branding/rspace/inventory";
 import AlwaysNewWindowNavigationContext from "../../components/AlwaysNewWindowNavigationContext";
@@ -27,6 +27,18 @@ import MaterialsDialog from "./MaterialsDialog";
 import PrintedMaterialsListing from "./PrintedMaterialsListing";
 
 const FAB_SIZE = 48;
+const materialsListingRoots = new WeakMap<Element, Root>();
+
+function getMaterialsListingRoot(container: Element): Root {
+  const existingRoot = materialsListingRoots.get(container);
+  if (existingRoot) {
+    return existingRoot;
+  }
+
+  const root = createRoot(container);
+  materialsListingRoots.set(container, root);
+  return root;
+}
 
 const itemTextSx = {
   whiteSpace: "nowrap",
@@ -260,7 +272,7 @@ function initListOfMaterials({
 
     if (!fieldId) return;
 
-    const root = createRoot(listingWrapper);
+    const root = getMaterialsListingRoot(listingWrapper);
     root.render(
       <Analytics>
         <MaterialsListing elnFieldId={fieldId} canEdit={canEdit} fabRightPadding={fabRightPadding} />
@@ -274,7 +286,7 @@ function initListOfMaterials({
       `.invMaterialsListing_new[data-field-id="${fieldId}"][data-document-id="${documentId}"]`,
     );
     if (newButtonWrapper) {
-      createRoot(newButtonWrapper).render(
+      getMaterialsListingRoot(newButtonWrapper).render(
         <Analytics>
           <NewMaterialsListing elnFieldId={fieldId} />
         </Analytics>,

--- a/src/main/webapp/ui/src/eln/about/index.tsx
+++ b/src/main/webapp/ui/src/eln/about/index.tsx
@@ -24,6 +24,12 @@ window.addEventListener("load", () => {
     return;
   }
 
+  // Already mounted (the load handler can run more than once in dev). Bail to
+  // avoid re-attaching a shadow root (and a duplicate React root).
+  if (domContainer.shadowRoot) {
+    return;
+  }
+
   /*
    * We use a shadow DOM so that the MUI styles do not leak
    */

--- a/src/main/webapp/ui/src/eln/apps/integrations/ApiDirect.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/ApiDirect.tsx
@@ -46,7 +46,7 @@ function ApiDirect(): React.ReactNode {
      -H "Accept: application/json" \\
      https://your-rspace-instance.com/api/v1/userDetails/whoami`}
             </Box>
-            <Typography variant="body2" sx={{ mt: 2, mb: 1 }}>
+            <Typography variant="body2" component="div" sx={{ mt: 2, mb: 1 }}>
               <strong>Python SDK:</strong>
               <Box
                 component="pre"

--- a/src/main/webapp/ui/src/eln/apps/integrations/Jupyter.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Jupyter.tsx
@@ -33,7 +33,7 @@ function Jupyter(): React.ReactNode {
             <li>
               <strong>Configure Jupyter instance for all notebooks:</strong> Follow the instructions in RSpace help docs
               to use pip to install RSpace client. Run a python cell with the following code:
-              <Typography variant="body2" sx={{ mt: 2, mb: 1 }}>
+              <Typography variant="body2" component="div" sx={{ mt: 2, mb: 1 }}>
                 <strong>One time install step:</strong>
                 <Box
                   component="pre"
@@ -52,7 +52,7 @@ function Jupyter(): React.ReactNode {
             <li>
               <strong>Configure notebook:</strong> Follow the instructions in RSpace help docs to import the
               sync_notebook script.
-              <Typography variant="body2" sx={{ mt: 2, mb: 1 }}>
+              <Typography variant="body2" component="div" sx={{ mt: 2, mb: 1 }}>
                 <strong>Do this step once per notebook:</strong>
                 <Box
                   component="pre"
@@ -70,7 +70,7 @@ function Jupyter(): React.ReactNode {
             </li>
             <li>
               <strong>Run the code:</strong>
-              <Typography variant="body2" sx={{ mt: 2, mb: 1 }}>
+              <Typography variant="body2" component="div" sx={{ mt: 2, mb: 1 }}>
                 Paste this code into <strong>the last cell in the notebook:</strong>
                 <Box
                   component="pre"

--- a/src/main/webapp/ui/src/eln/eln-external-workflows/index.tsx
+++ b/src/main/webapp/ui/src/eln/eln-external-workflows/index.tsx
@@ -1,5 +1,18 @@
-import { createRoot } from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import ExternalWorkflowInvocations from "@/eln/eln-external-workflows/ExternalWorkflowInvocations";
+
+const externalWorkflowRoots = new WeakMap<Element, Root>();
+
+function getExternalWorkflowRoot(container: Element): Root {
+  const existingRoot = externalWorkflowRoots.get(container);
+  if (existingRoot) {
+    return existingRoot;
+  }
+
+  const root = createRoot(container);
+  externalWorkflowRoots.set(container, root);
+  return root;
+}
 
 /**
  * ExternalWorkflows (eg Galaxy) represents remote computation. RSpace will display a data table
@@ -25,7 +38,7 @@ const loadUIOnPageLoad = (isForNotebookPage = false) => {
       // @ts-expect-error style does exist on HTMLDivElement
       wrapperDiv.style.position = "relative";
     }
-    const root = createRoot(wrapperDiv);
+    const root = getExternalWorkflowRoot(wrapperDiv);
     root.render(<ExternalWorkflowInvocations isForNotebookPage={isForNotebookPage} fieldId={fieldId} />);
   });
 };

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.tsx
@@ -663,6 +663,7 @@ const SetUsernamAliasAction = ({
               <DialogTitle>Set Username Alias</DialogTitle>
               <DialogContent>
                 <DialogContentText
+                  component="div"
                   variant="body2"
                   sx={{
                     mb: 2,
@@ -784,6 +785,7 @@ const DeleteAction = ({
               <DialogTitle>Deletion Confirmation</DialogTitle>
               <DialogContent>
                 <DialogContentText
+                  component="div"
                   variant="body2"
                   sx={{
                     mb: 2,

--- a/src/main/webapp/ui/src/my-rspace/directory/groups/GroupBioOntologiesManager.tsx
+++ b/src/main/webapp/ui/src/my-rspace/directory/groups/GroupBioOntologiesManager.tsx
@@ -129,7 +129,7 @@ function GroupBioOntologiesManager({ groupId, isCloud, canManageOntologies }: an
               Allow BioPortal Ontologies to be used for tag suggestions
             </DialogTitle>
             <DialogContent>
-              <DialogContentText>
+              <DialogContentText component="div">
                 Allowing BioPortal Ontologies for tags will query data from the
                 <a href={"https://bioportal.bioontology.org/ontologies"} target={"_blank"} rel="noreferrer">
                   {" "}

--- a/src/main/webapp/ui/src/tinyMCE/PreviewInfo.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/PreviewInfo.tsx
@@ -7,7 +7,7 @@ import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type React from "react";
 import { useEffect } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import { ACCENT_COLOR } from "@/assets/branding/chemistry";
 import Alerts from "@/components/Alerts/Alerts";
 import Analytics from "@/components/Analytics";
@@ -23,6 +23,18 @@ type PreviewInfoItem = Record<string, string | undefined>;
 const STOICHIOMETRY_TABLE_ONLY_ATTRIBUTE = "data-stoichiometry-table-only";
 const PREVIEW_INFO_BORDER_COLOR = `hsl(${ACCENT_COLOR.background.hue} ${ACCENT_COLOR.background.saturation}% ${ACCENT_COLOR.background.lightness}%)`;
 const queryClient = new QueryClient();
+const previewInfoRoots = new WeakMap<Element, Root>();
+
+function getPreviewInfoRoot(container: Element): Root {
+  const existingRoot = previewInfoRoots.get(container);
+  if (existingRoot) {
+    return existingRoot;
+  }
+
+  const root = createRoot(container);
+  previewInfoRoots.set(container, root);
+  return root;
+}
 
 function getStoichiometryReference(raw: string | undefined) {
   if (typeof raw !== "string") {
@@ -206,7 +218,7 @@ export default function PreviewInfo({ item }: { item: PreviewInfoItem }) {
 }
 
 function render(attributes: PreviewInfoItem, element: Element) {
-  const root = createRoot(element);
+  const root = getPreviewInfoRoot(element);
   root.render(<PreviewInfo item={{ ...attributes }} />);
 }
 
@@ -222,7 +234,7 @@ function renderChemPreview(domContainer: HTMLImageElement) {
   });
   const contents = parent.innerHTML;
 
-  const root = createRoot(parent);
+  const root = getPreviewInfoRoot(parent);
   root.render(<PreviewInfo item={{ ...attributes }} />);
   parent.insertAdjacentHTML("beforeend", contents);
 }

--- a/src/main/webapp/ui/src/tinyMCE/__tests__/PreviewInfo.test.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/__tests__/PreviewInfo.test.tsx
@@ -121,6 +121,25 @@ describe("PreviewInfo event handlers", () => {
     });
   });
 
+  it("reuses the same React root when table-only stoichiometry nodes are rendered again", () => {
+    document.body.innerHTML = `
+      <div id="div_7">
+        <div
+          id="table-only-preview"
+          data-stoichiometry-table-only="true"
+          data-stoichiometry-table='{"id":3,"revision":4}'
+        ></div>
+      </div>
+    `;
+
+    document.dispatchEvent(new CustomEvent("document-placed", { detail: 7 }));
+    document.dispatchEvent(new CustomEvent("document-placed", { detail: 7 }));
+
+    expect(mockCreateRoot).toHaveBeenCalledTimes(1);
+    expect(rootRenderCalls).toHaveLength(2);
+    expect(rootRenderCalls[0]?.container).toBe(rootRenderCalls[1]?.container);
+  });
+
   it("renders preview info into the closest span for chem-updated images", () => {
     document.body.innerHTML = `
       <div id="div_9">


### PR DESCRIPTION
## Description ##
Fixes several instances of React `createRoots` not being caching, causing console errors.

Fix invalid HTML generated by MUI `Typography`/`DialogContentText` components that were rendering block-level content inside paragraph tags.