### PR TITLE
RSDEV-524: retire legacy Gallery export-publish endpoint

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/PublicController.java
+++ b/src/main/java/com/researchspace/webapp/controller/PublicController.java
@@ -3,12 +3,9 @@ package com.researchspace.webapp.controller;
 import com.researchspace.core.util.ResponseUtil;
 import com.researchspace.maintenance.model.ScheduledMaintenance;
 import com.researchspace.maintenance.service.MaintenanceManager;
-import com.researchspace.service.archive.IExportUtils;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.net.URLConnection;
-import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +17,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -30,35 +26,11 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/public")
 public class PublicController extends BaseController {
 
-  @Autowired private IExportUtils exportUtils;
-
   @Autowired private ResourceLoader resourceLoader;
 
   @Autowired private MaintenanceManager maintenanceMgr;
 
   private String actualImageName;
-
-  /**
-   * @param filename the filename of an exported file as it is in the file0-store - NOT the original
-   *     file name.
-   * @param res
-   * @throws URISyntaxException
-   * @throws IOException
-   * @throws Exception
-   */
-  @ResponseBody
-  // All newly issued links are /publish/filename, but it supports previously issued
-  // /publishpdf/filename links too.
-  @GetMapping({"/publishpdf/{filename:.+}", "/publish/{filename:.+}"})
-  public void getExportedPublishedFile(
-      @PathVariable("filename") String filename, HttpServletResponse res)
-      throws IOException, URISyntaxException {
-    if (filename.endsWith(".doc") || filename.endsWith(".pdf")) {
-      exportUtils.display(filename, null, res);
-    } else {
-      throw new IllegalArgumentException("Only .doc or .pdf files can be published.");
-    }
-  }
 
   /**
    * Gets a banner image according to the follwoing rules:
@@ -192,10 +164,6 @@ public class PublicController extends BaseController {
    *     for testing
    * ======================
    */
-
-  public void setExportUtils(IExportUtils exportUtils) {
-    this.exportUtils = exportUtils;
-  }
 
   protected void setResourceLoader(ResourceLoader resourceLoader) {
     this.resourceLoader = resourceLoader;

--- a/src/test/java/com/researchspace/webapp/controller/PublicControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/PublicControllerTest.java
@@ -4,11 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.maintenance.service.MaintenanceManager;
-import com.researchspace.model.User;
 import com.researchspace.properties.IPropertyHolder;
-import com.researchspace.service.archive.IExportUtils;
 import com.researchspace.testutils.RSpaceTestUtils;
-import com.researchspace.testutils.TestFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -33,7 +30,6 @@ public class PublicControllerTest {
 
   private static final String DEFAULT_LOGO_NAME = "mainLogo3.png";
   @Rule public MockitoRule mockery = MockitoJUnit.rule();
-  @Mock IExportUtils exportUtils;
   @Mock Principal principal;
   @Mock ResourceLoader resourceLoader;
   @Mock MaintenanceManager maintenanceMgr;
@@ -60,7 +56,6 @@ public class PublicControllerTest {
   public void setUp() throws Exception {
     response = new MockHttpServletResponse();
     publicController = new PublicControllerTSS();
-    publicController.setExportUtils(exportUtils);
     publicController.setProperties(properties);
     publicController.setResourceLoader(resourceLoader);
     publicController.setMaintenanceManager(maintenanceMgr);
@@ -68,20 +63,6 @@ public class PublicControllerTest {
 
   @After
   public void tearDown() throws Exception {}
-
-  @Test
-  public void publishPDF() throws Exception {
-    final User user = TestFactory.createAnyUser("any");
-    publicController.getExportedPublishedFile("fileStoreName.pdf", response);
-    Mockito.verify(exportUtils, Mockito.times(1)).display("fileStoreName.pdf", null, response);
-  }
-
-  @Test
-  public void publishWORD() throws Exception {
-    final User user = TestFactory.createAnyUser("any");
-    publicController.getExportedPublishedFile("fileStoreName.doc", response);
-    Mockito.verify(exportUtils, Mockito.times(1)).display("fileStoreName.doc", null, response);
-  }
 
   @Test
   public void testBannerWithWrongFileTypeReturnsDefault() throws Exception {


### PR DESCRIPTION
### Background
The old Gallery had a "Publish" button that generated an unauthenticated public link (`/public/publish/<exported-file-name>`) for an exported PDF or Word file. The link-generation UI was already removed when the old Gallery was retired, but the backend
retrieval endpoint survived: an unauthenticated route that streams any `.doc` or `.pdf` from the export filestore by name. With no way for users to see or manage "published" status, this is a security gap, and the feature is not being reimplemented.

### Change
- Remove `PublicController.getExportedPublishedFile` and its `/public/publish/{filename}` (plus legacy `/public/publishpdf/{filename}`) mappings.
- Remove the now-unused `IExportUtils` field, setter, and imports from `PublicController`.
- Remove the matching `publishPDF` / `publishWORD` cases and mock wiring from  `PublicControllerTest`.

Net effect: 51 deletions across two files, no additions.

### Behaviour after change
- Previously issued `/public/publish/...` links now return 404.
- No new links can be created (that UI is already gone).
- No database, Liquibase, or persisted-data changes. The feature never persisted anything; links were built client-side from the export's filestore name. The shared `exportUtils.display(...)` path used by authenticated export is untouched.

### Testing
`PublicControllerTest` compiles and passes (3 tests) after removing the publish cases.