### PR TITLE
fix for gallery info panel covering dialog/menu controls in narrow viewport (RSDEV-1088)

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.tsx
@@ -955,7 +955,7 @@ export const InfoPanelForSmallViewports: React.ComponentType<{
       anchor="bottom"
       open={mobileInfoPanelOpen}
       sx={{
-        zIndex: 1400,
+        // z-index stays at the default drawer level; the picker raises it via theme.
         [`& .${paperClasses.root}`]: {
           height: `calc(90% - ${CLOSED_MOBILE_INFO_PANEL_HEIGHT}px)`,
           overflow: "visible",

--- a/src/main/webapp/ui/src/eln/gallery/picker/index.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/picker/index.tsx
@@ -165,35 +165,35 @@ const Picker = observer(
                       supports2xZoom: true,
                     }}
                   />
-                  <Box
-                    sx={{
-                      display: "flex",
-                      height: "calc(100% - 48px)",
-                    }}
-                  >
-                    <Sidebar
-                      selectedSection={selectedSection}
-                      setSelectedSection={(mediaType) => {
-                        setSelectedSection(mediaType);
-                        setPath([]);
-                        setAppliedSearchTerm("");
-                      }}
-                      drawerOpen={drawerOpen}
-                      setDrawerOpen={setDrawerOpen}
-                      folderId={folderId}
-                      refreshListing={refreshListing}
-                      id={sidebarId}
-                    />
+                  <ThemeProvider theme={raisedZIndexTheme}>
                     <Box
                       sx={{
-                        height: "100%",
                         display: "flex",
-                        flexDirection: "column",
-                        flexGrow: 1,
-                        width: "calc(100% - 200px)",
+                        height: "calc(100% - 48px)",
                       }}
                     >
-                      <ThemeProvider theme={raisedZIndexTheme}>
+                      <Sidebar
+                        selectedSection={selectedSection}
+                        setSelectedSection={(mediaType) => {
+                          setSelectedSection(mediaType);
+                          setPath([]);
+                          setAppliedSearchTerm("");
+                        }}
+                        drawerOpen={drawerOpen}
+                        setDrawerOpen={setDrawerOpen}
+                        folderId={folderId}
+                        refreshListing={refreshListing}
+                        id={sidebarId}
+                      />
+                      <Box
+                        sx={{
+                          height: "100%",
+                          display: "flex",
+                          flexDirection: "column",
+                          flexGrow: 1,
+                          width: "calc(100% - 200px)",
+                        }}
+                      >
                         <MainPanel
                           selectedSection={selectedSection}
                           path={path}
@@ -212,25 +212,25 @@ const Picker = observer(
                           appliedSearchTerm={appliedSearchTerm}
                           setAppliedSearchTerm={setAppliedSearchTerm}
                         />
-                      </ThemeProvider>
-                      <DialogActions>
-                        <Button onClick={() => onClose()}>Cancel</Button>
-                        <ValidatingSubmitButton
-                          validationResult={
-                            selection.size > 0
-                              ? Result.all(...selection.asSet().map(validateSelection)).map(() => null)
-                              : Result.Error([new Error("Select at least one file to proceed.")])
-                          }
-                          loading={false}
-                          onClick={() => {
-                            onSubmit(selection.asSet());
-                          }}
-                        >
-                          Add
-                        </ValidatingSubmitButton>
-                      </DialogActions>
+                        <DialogActions>
+                          <Button onClick={() => onClose()}>Cancel</Button>
+                          <ValidatingSubmitButton
+                            validationResult={
+                              selection.size > 0
+                                ? Result.all(...selection.asSet().map(validateSelection)).map(() => null)
+                                : Result.Error([new Error("Select at least one file to proceed.")])
+                            }
+                            loading={false}
+                            onClick={() => {
+                              onSubmit(selection.asSet());
+                            }}
+                          >
+                            Add
+                          </ValidatingSubmitButton>
+                        </DialogActions>
+                      </Box>
                     </Box>
-                  </Box>
+                  </ThemeProvider>
                 </Dialog>
               </OpenFolderProvider>
             </CallableSnippetPreview>

--- a/src/main/webapp/ui/src/eln/gallery/picker/index.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/picker/index.tsx
@@ -5,7 +5,7 @@ import DialogActions from "@mui/material/DialogActions";
 import { dialogContentClasses } from "@mui/material/DialogContent";
 import Grow from "@mui/material/Grow";
 import { paperClasses } from "@mui/material/Paper";
-import { ThemeProvider } from "@mui/material/styles";
+import { ThemeProvider, useTheme } from "@mui/material/styles";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import { FilestoreLoginProvider } from "@/eln/gallery/components/FilestoreLoginDialog";
@@ -47,6 +47,16 @@ const Picker = observer(
     const sidebarId = React.useId();
     const viewport = useViewportDimensions();
     const selection = useGallerySelection();
+    const theme = useTheme();
+    // Float the info panel above this dialog, but keep its menus/dialogs above
+    // the panel: drawer just over the dialog, modal just over the drawer.
+    const raisedZIndexTheme = React.useMemo(
+      () => ({
+        ...theme,
+        zIndex: { ...theme.zIndex, drawer: theme.zIndex.modal + 1, modal: theme.zIndex.modal + 2 },
+      }),
+      [theme],
+    );
     const [appliedSearchTerm, setAppliedSearchTerm] = React.useState("");
     const [orderBy, setOrderBy] = useUiPreference<"name" | "modificationDate">(PREFERENCES.GALLERY_SORT_BY, {
       defaultValue: "modificationDate",
@@ -183,24 +193,26 @@ const Picker = observer(
                         width: "calc(100% - 200px)",
                       }}
                     >
-                      <MainPanel
-                        selectedSection={selectedSection}
-                        path={path}
-                        setSelectedSection={(mediaType) => {
-                          setSelectedSection(mediaType);
-                          setPath([]);
-                          setAppliedSearchTerm("");
-                        }}
-                        galleryListing={galleryListing}
-                        folderId={folderId}
-                        refreshListing={refreshListing}
-                        sortOrder={sortOrder}
-                        orderBy={orderBy}
-                        setSortOrder={setSortOrder}
-                        setOrderBy={setOrderBy}
-                        appliedSearchTerm={appliedSearchTerm}
-                        setAppliedSearchTerm={setAppliedSearchTerm}
-                      />
+                      <ThemeProvider theme={raisedZIndexTheme}>
+                        <MainPanel
+                          selectedSection={selectedSection}
+                          path={path}
+                          setSelectedSection={(mediaType) => {
+                            setSelectedSection(mediaType);
+                            setPath([]);
+                            setAppliedSearchTerm("");
+                          }}
+                          galleryListing={galleryListing}
+                          folderId={folderId}
+                          refreshListing={refreshListing}
+                          sortOrder={sortOrder}
+                          orderBy={orderBy}
+                          setSortOrder={setSortOrder}
+                          setOrderBy={setOrderBy}
+                          appliedSearchTerm={appliedSearchTerm}
+                          setAppliedSearchTerm={setAppliedSearchTerm}
+                        />
+                      </ThemeProvider>
                       <DialogActions>
                         <Button onClick={() => onClose()}>Cancel</Button>
                         <ValidatingSubmitButton


### PR DESCRIPTION
### Problem
The fix for [RSDEV-1088](https://researchspace.atlassian.net/browse/RSDEV-1088).

On mobile portrait viewports the floating info panel blocked controls beneath it: the **Move** dialog buttons were unclickable, and the last items on Actions menu, like the **Delete** item, were hidden. This is reproduceable in desktop view, if you narrow the UI below 600px.

**Cause:** the panel's `SwipeableDrawer` hard-coded `zIndex: 1400`, above MUI's dialog/menu layer (`1300`), so its closed peek strip floated over the bottom of any open dialog or menu. The `1400` was only needed so the panel floats above the **picker dialog**.

### Solution
- `InfoPanel.tsx`: removed the explicit z-index so the drawer uses the default (`theme.zIndex.drawer`), below dialogs/menus on the main page.
- `picker/index.tsx`: wrap `MainPanel` in a `ThemeProvider` that raises the band only for the picker (drawer just above the dialog, modal just above the drawer), so the panel floats above the picker dialog while its own menus/dialogs stay above the panel.

Result: panel sits below action overlays in both contexts. `tsc` + lint clean, existing ActionsMenu/MoveDialog tests pass.