### PR TITLE
Instruments UI Fails To Load If Inventory Has Been Used Previously

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.tsx
@@ -188,6 +188,7 @@ function mergeWithDefaults(stored: PartialFormSectionsState): FormSectionsState 
 }
 
 export default function SynchroniseFormSections({ children }: SynchroniseFormSectionsArgs): React.ReactNode {
+  // Temporary solution.  See https://researchspace.atlassian.net/browse/RSDEV-1221 for a preferred implementation.
   const [storedState, setFormSectionExpandedState] = useUiPreference(PREFERENCES.INVENTORY_FORM_SECTIONS_EXPANDED, {
     defaultValue: defaultFormSectionExpandedState(),
   });

--- a/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.tsx
@@ -171,7 +171,11 @@ function setAllSectionValues<T extends RecordType>(
   return result;
 }
 
-function mergeWithDefaults(stored: FormSectionsState): FormSectionsState {
+type PartialFormSectionsState = Partial<{
+  [K in RecordType]: Partial<FormSectionsState[K]>;
+}>;
+
+function mergeWithDefaults(stored: PartialFormSectionsState): FormSectionsState {
   const defaults = defaultFormSectionExpandedState();
   const result = {} as FormSectionsState;
   for (const recordType of Object.keys(defaults) as Array<RecordType>) {
@@ -187,7 +191,10 @@ export default function SynchroniseFormSections({ children }: SynchroniseFormSec
   const [storedState, setFormSectionExpandedState] = useUiPreference(PREFERENCES.INVENTORY_FORM_SECTIONS_EXPANDED, {
     defaultValue: defaultFormSectionExpandedState(),
   });
-  const formSectionExpandedState = mergeWithDefaults(storedState);
+  const formSectionExpandedState = React.useMemo(
+    () => mergeWithDefaults(storedState as PartialFormSectionsState),
+    [storedState],
+  );
   return (
     <FormSectionsContext.Provider
       value={{

--- a/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Stepper/SynchroniseFormSections.tsx
@@ -171,13 +171,23 @@ function setAllSectionValues<T extends RecordType>(
   return result;
 }
 
+function mergeWithDefaults(stored: FormSectionsState): FormSectionsState {
+  const defaults = defaultFormSectionExpandedState();
+  const result = {} as FormSectionsState;
+  for (const recordType of Object.keys(defaults) as Array<RecordType>) {
+    (result as Record<string, unknown>)[recordType] = {
+      ...defaults[recordType],
+      ...(stored[recordType] ?? {}),
+    };
+  }
+  return result;
+}
+
 export default function SynchroniseFormSections({ children }: SynchroniseFormSectionsArgs): React.ReactNode {
-  const [formSectionExpandedState, setFormSectionExpandedState] = useUiPreference(
-    PREFERENCES.INVENTORY_FORM_SECTIONS_EXPANDED,
-    {
-      defaultValue: defaultFormSectionExpandedState(),
-    },
-  );
+  const [storedState, setFormSectionExpandedState] = useUiPreference(PREFERENCES.INVENTORY_FORM_SECTIONS_EXPANDED, {
+    defaultValue: defaultFormSectionExpandedState(),
+  });
+  const formSectionExpandedState = mergeWithDefaults(storedState);
   return (
     <FormSectionsContext.Provider
       value={{

--- a/src/main/webapp/ui/src/Inventory/components/Stepper/__tests__/SynchroniseFormSections.mergeWithDefaults.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Stepper/__tests__/SynchroniseFormSections.mergeWithDefaults.test.tsx
@@ -1,0 +1,155 @@
+import { render } from "@testing-library/react";
+import { type ReactNode, useContext, useEffect } from "react";
+import { describe, expect, test, vi } from "vitest";
+import FormSectionsContext from "../../../../stores/contexts/FormSections";
+import SynchroniseFormSections from "../SynchroniseFormSections";
+
+const mockUseUiPreference = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/api/useUiPreference", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/api/useUiPreference")>("@/hooks/api/useUiPreference");
+  return {
+    ...actual,
+    UiPreferences: ({ children }: { children: ReactNode }) => children,
+    default: mockUseUiPreference,
+  };
+});
+
+// Simulates a preference object saved before instrument / instrumentTemplate were added.
+const staleStateWithoutInstruments = {
+  container: {
+    information: false,
+    overview: true,
+    details: false,
+    barcodes: false,
+    identifiers: false,
+    attachments: false,
+    permissions: false,
+    customFields: false,
+    locationsAndContent: true,
+  },
+  sample: {
+    information: false,
+    overview: true,
+    details: false,
+    barcodes: false,
+    identifiers: false,
+    attachments: false,
+    permissions: false,
+    customFields: false,
+    subsamples: true,
+  },
+  subSample: {
+    information: false,
+    overview: true,
+    details: true,
+    barcodes: false,
+    identifiers: false,
+    attachments: false,
+    permissions: false,
+    customFields: false,
+    notes: false,
+  },
+  sampleTemplate: {
+    overview: true,
+    details: false,
+    permissions: false,
+    customFields: false,
+    samples: true,
+  },
+  mixed: {
+    information: false,
+    overview: true,
+    details: false,
+    barcodes: false,
+  },
+  // instrument and instrumentTemplate are intentionally absent
+};
+
+function captureIsExpanded(type: string, section: string): { getValue: () => boolean | undefined } {
+  const captured = { value: undefined as boolean | undefined };
+  function Probe() {
+    const ctx = useContext(FormSectionsContext);
+    useEffect(() => {
+      captured.value = ctx?.isExpanded(type as Parameters<NonNullable<typeof ctx>["isExpanded"]>[0], section);
+    }, [ctx]);
+    return null;
+  }
+  render(
+    <SynchroniseFormSections>
+      <Probe />
+    </SynchroniseFormSections>,
+  );
+  return { getValue: () => captured.value };
+}
+
+describe("SynchroniseFormSections — stale persisted preferences (missing instrument keys)", () => {
+  test("does not throw when both instrument and instrumentTemplate keys are absent", () => {
+    mockUseUiPreference.mockReturnValue([staleStateWithoutInstruments, vi.fn()]);
+    expect(() =>
+      render(
+        <SynchroniseFormSections>
+          <span />
+        </SynchroniseFormSections>,
+      ),
+    ).not.toThrow();
+  });
+
+  test("isExpanded('instrument', 'details') returns the default (false) when instrument key is absent", () => {
+    mockUseUiPreference.mockReturnValue([staleStateWithoutInstruments, vi.fn()]);
+    const { getValue } = captureIsExpanded("instrument", "details");
+    expect(getValue()).toBe(false);
+  });
+
+  test("isExpanded('instrument', 'overview') returns the default (true) when instrument key is absent", () => {
+    mockUseUiPreference.mockReturnValue([staleStateWithoutInstruments, vi.fn()]);
+    const { getValue } = captureIsExpanded("instrument", "overview");
+    expect(getValue()).toBe(true);
+  });
+
+  test("isExpanded('instrumentTemplate', 'details') returns the default (false) when instrumentTemplate key is absent", () => {
+    mockUseUiPreference.mockReturnValue([staleStateWithoutInstruments, vi.fn()]);
+    const { getValue } = captureIsExpanded("instrumentTemplate", "details");
+    expect(getValue()).toBe(false);
+  });
+
+  test("isExpanded('instrumentTemplate', 'instruments') returns the default (true) when instrumentTemplate key is absent", () => {
+    mockUseUiPreference.mockReturnValue([staleStateWithoutInstruments, vi.fn()]);
+    const { getValue } = captureIsExpanded("instrumentTemplate", "instruments");
+    expect(getValue()).toBe(true);
+  });
+
+  test("isExpanded('instrument', 'details') returns the default when only instrument key is absent", () => {
+    mockUseUiPreference.mockReturnValue([
+      {
+        ...staleStateWithoutInstruments,
+        instrumentTemplate: {
+          overview: true,
+          details: false,
+          barcodes: false,
+          attachments: false,
+          permissions: false,
+          customFields: false,
+          instruments: true,
+        },
+        // instrument key still absent
+      },
+      vi.fn(),
+    ]);
+    const { getValue } = captureIsExpanded("instrument", "details");
+    expect(getValue()).toBe(false);
+  });
+
+  test("stored values for present keys are not overwritten by the merge", () => {
+    mockUseUiPreference.mockReturnValue([
+      {
+        ...staleStateWithoutInstruments,
+        // container.overview was collapsed by a previous user interaction
+        container: { ...staleStateWithoutInstruments.container, overview: false },
+      },
+      vi.fn(),
+    ]);
+    const { getValue } = captureIsExpanded("container", "overview");
+    expect(getValue()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description ##
Resolves https://researchspace.atlassian.net/browse/PRT-1094
Summary of changes by Claude:

SynchroniseFormSections.tsx
  
  The root cause was that instrument and instrumentTemplate are newly added
  record type keys in FormSectionsState. The useUiPreference hook loads a
  previously persisted preference object from the server, and for users who had
  used Inventory before these types were introduced, that stored object has no
  instrument or instrumentTemplate keys. When isExpanded tried to read
  formSectionExpandedState["instrument"]["details"], it threw because
  formSectionExpandedState["instrument"] was undefined.

  The fix adds a mergeWithDefaults helper that does a two-level merge of the
  loaded preference with defaultFormSectionExpandedState(): for each record type
   defined in the defaults, any missing top-level key is filled in from the
  defaults, and any missing section key within an existing record type is also
  filled in. The result is passed to the context as formSectionExpandedState
  instead of the raw loaded value, ensuring the state is always structurally
  complete regardless of when the preference was last written.

  Sidebar.tsx

  InstrumentNavItem and InstrumentTemplateNavItem had their getRef prop typed as
   RefObject<HTMLDivElement> while the caller and all other nav items use
  RefObject<HTMLDivElement | null>. The | null was added to both to align with
  the rest of the file and resolve the TypeScript errors.


## Testing notes
If possible, test that users that have and have not used the Inventory before the Instruments UI features were added, and ensure that new Instruments and Instrument Templates can be created without issue.
