### PR TITLE
PRT-1100 Instrument Templates shows double Add new Field when editing it

### DIFF
--- a/src/main/java/com/researchspace/api/v1/model/ApiInstrumentTemplatePost.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInstrumentTemplatePost.java
@@ -18,16 +18,8 @@ public class ApiInstrumentTemplatePost extends ApiInstrumentEntityInfo {
   @JsonProperty("fields")
   protected List<ApiInventoryEntityField> fields = new ArrayList<>();
 
-  @JsonProperty("extraFields")
-  protected List<ApiExtraField> extraFields = new ArrayList<>();
-
   @JsonProperty(value = "sharedWith")
   private List<ApiGroupInfoWithSharedFlag> sharedWith;
-
-  @Override
-  public List<ApiExtraField> getExtraFields() {
-    return extraFields;
-  }
 
   public ApiInstrumentTemplatePost(InstrumentTemplate template) {
     super(template);

--- a/src/main/webapp/resources/rspace_api_inventory_specs_2_24_0.yaml
+++ b/src/main/webapp/resources/rspace_api_inventory_specs_2_24_0.yaml
@@ -3864,8 +3864,6 @@ components:
         - properties:
             fields:
               $ref: "#/components/schemas/SampleFieldList"
-            extraFields:
-              $ref: "#/components/schemas/ExtraFieldList"
             sharedWith:
               $ref: "#/components/schemas/GroupShareInfoList"
     InstrumentTemplatePost:
@@ -3884,8 +3882,6 @@ components:
           format: int64
         fields:
           $ref: "#/components/schemas/SampleFieldList"
-        extraFields:
-          $ref: "#/components/schemas/ExtraFieldList"
       example:
         name: Microscope template
         description: A template for the lab's microscopes

--- a/src/main/webapp/ui/src/Inventory/InstrumentTemplate/Form.tsx
+++ b/src/main/webapp/ui/src/Inventory/InstrumentTemplate/Form.tsx
@@ -7,7 +7,6 @@ import AccessPermissions from "../components/Fields/AccessPermissions";
 import AttachmentsField from "../components/Fields/Attachments/Attachments";
 import BarcodesField from "../components/Fields/Barcodes/FormField";
 import DescriptionField from "../components/Fields/Description";
-import ExtraFields from "../components/Fields/ExtraFields/ExtraFields";
 import ImageField from "../components/Fields/Image";
 import NameField from "../components/Fields/Name";
 import OwnerField from "../components/Fields/Owner";
@@ -98,10 +97,6 @@ const CustomFieldSection = observer(({ activeResult }: ExtraFieldSectionArgs) =>
       recordType="instrumentTemplate"
     >
       <CustomFields onErrorStateChange={(field, value) => setFormSectionError(formSectionError, field, value)} />
-      <ExtraFields
-        onErrorStateChange={(field, value) => setFormSectionError(formSectionError, field, value)}
-        result={activeResult}
-      />
     </StepperPanel>
   );
 });

--- a/src/main/webapp/ui/src/stores/models/Search.ts
+++ b/src/main/webapp/ui/src/stores/models/Search.ts
@@ -1001,20 +1001,22 @@ export default class Search implements SearchInterface {
           ontologyVersion: tag.version.map(encodeTagString).orElse(null),
         })),
         newBase64Image,
-        fields: instrument.fields.map((f) => {
-          const params = { ...(f.paramsForBackend as Record<string, unknown>) };
-          if (!includeContentForFields.has(params.id as Id)) {
-            params.content = "";
-            params.selectedOptions = null;
-          }
-          return params;
-        }),
-        extraFields: instrument.extraFields.map(({ name: fieldName, type, content, id }) => ({
-          name: fieldName,
-          type: type.toLowerCase(),
-          content: includeContentForFields.has(id) ? content : "",
-          definition: null,
-        })),
+        fields: [
+          ...instrument.fields.map((f) => {
+            const params = { ...(f.paramsForBackend as Record<string, unknown>) };
+            if (!includeContentForFields.has(params.id as Id)) {
+              params.content = "";
+              params.selectedOptions = null;
+            }
+            return params;
+          }),
+          ...instrument.extraFields.map(({ name: fieldName, type, content, id }) => ({
+            name: fieldName,
+            type: type.toLowerCase(),
+            content: includeContentForFields.has(id) ? content : "",
+            definition: null,
+          })),
+        ],
       };
       const { data } = await ApiService.post<InstrumentTemplateAttrs>("instrumentTemplates", args);
       const factory = this.factory.newFactory();


### PR DESCRIPTION
## Description ##
Addresses https://researchspace.atlassian.net/browse/PRT-1100

Explanation of changes from Claude:
ExtraFields is removed from InstrumentTemplate/Form.tsx
  (eliminating the second "Add New Field" button), and
  createInstrumentTemplateFromInstrument in Search.ts now merges extra fields
  into the fields array rather than sending them as a separate extraFields key,
  matching the behaviour of sampleCreationParams.