### PR TITLE
PRT-1091: only show gallery "Related inventory items" panel for media files

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/InfoPanel.tsx
@@ -649,7 +649,9 @@ const InfoPanelContent = observer(
           />
         </Box>
         {file.linkedDocuments}
-        <ReferencingInventoryItemsPanel file={file} />
+        {/* Inventory items can only link to gallery media files (GL...); folders (GF),
+            snippets (ST) etc. 404 and would show a spurious error. See PRT-1091. */}
+        {file.globalId?.startsWith("GL") && <ReferencingInventoryItemsPanel file={file} />}
       </Stack>
     );
   },


### PR DESCRIPTION
## Description

The gallery info panel rendered the "Related inventory items" panel for **every** single-selected item. For folders (`FL`/`GF`), snippets (`ST`) and other non-media records, the `/workspace/getReferencingInventoryItems/{globalId}` endpoint returns 404 (not a supported link target), which surfaced as a spurious **"Error loading related inventory items"** (PRT-1091).

Inventory items can only link to gallery media files (`GL`), so gate the panel on the file's Global ID prefix being `GL`. Non-media entries now render cleanly and skip a pointless request; media files with no links still show "No related inventory items".

## Testing

Verified on a local dev stack:
- **Folder (`GF9`):** no panel, no error, no network call.
- **Image (`GL26`):** panel renders, endpoint returns 200, shows "No related inventory items".

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
