### PR TITLE
Use native blank target for OMERO connect form

### DIFF
--- a/src/main/webapp/ui/src/eln/apps/integrations/Omero.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Omero.tsx
@@ -83,7 +83,7 @@ function Omero({ integrationState, update }: OmeroArgs): React.ReactNode {
               action="/apps/omero/connect"
               method="POST"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
             >
               <Stack spacing={1}>
                 <TextField

--- a/src/main/webapp/ui/src/eln/apps/integrations/Omero.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Omero.tsx
@@ -79,13 +79,11 @@ function Omero({ integrationState, update }: OmeroArgs): React.ReactNode {
               </li>
             </ol>
             <form
+              aria-label="OMERO credentials"
               action="/apps/omero/connect"
               method="POST"
-              onSubmit={(event) => {
-                const popupName = `rspace-omero-connect-${Date.now()}`;
-                window.open("about:blank", popupName, "noopener,noreferrer");
-                event.currentTarget.target = popupName;
-              }}
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <Stack spacing={1}>
                 <TextField

--- a/src/main/webapp/ui/src/eln/apps/integrations/__tests__/Omero.test.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/__tests__/Omero.test.tsx
@@ -1,11 +1,13 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
 import Omero from "../Omero";
 
 import "@/__tests__/__mocks__/matchMedia";
 
 describe("Omero", () => {
   test("Should have no axe violations.", async () => {
+    const user = userEvent.setup();
     const { baseElement } = render(
       <Omero
         integrationState={{
@@ -16,13 +18,14 @@ describe("Omero", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("button"));
     expect(await screen.findByRole("dialog")).toBeVisible();
 
     // @ts-expect-error toBeAccessible is from @sa11y/vitest
     await expect(baseElement).toBeAccessible();
   });
-  test("Should render username and password fields.", () => {
+  test("Should render username and password fields.", async () => {
+    const user = userEvent.setup();
     render(
       <Omero
         integrationState={{
@@ -33,7 +36,7 @@ describe("Omero", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("button"));
     expect(screen.getByRole("textbox", { name: "Username" })).toBeVisible();
     /*
      * We have to use getByLabelText instead of getByRole because password
@@ -41,5 +44,36 @@ describe("Omero", () => {
      * https://github.com/testing-library/dom-testing-library/issues/567
      */
     expect(screen.getByLabelText("Password")).toBeVisible();
+  });
+  test("Connect form should submit without opening a blank tab first.", async () => {
+    const user = userEvent.setup();
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    try {
+      render(
+        <Omero
+          integrationState={{
+            mode: "DISABLED",
+            credentials: {},
+          }}
+          update={() => {}}
+        />,
+      );
+
+      await user.click(screen.getByRole("button"));
+      await user.type(screen.getByRole("textbox", { name: "Username" }), "user");
+      await user.type(screen.getByLabelText("Password"), "password");
+      const form = screen.getByRole("form", { name: "OMERO credentials" });
+      const submit = vi.fn((event: Event) => event.preventDefault());
+      form.addEventListener("submit", submit);
+      await user.click(screen.getByRole("button", { name: "Connect" }));
+
+      expect(form).toHaveAttribute("action", "/apps/omero/connect");
+      expect(form).toHaveAttribute("method", "POST");
+      expect(form).toHaveAttribute("target", "_blank");
+      expect(submit).toHaveBeenCalledOnce();
+      expect(open).not.toHaveBeenCalled();
+    } finally {
+      open.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Description ##
Resolves [PRT-1103](https://researchspace.atlassian.net/browse/PRT-1103)[PRT-1103](https://researchspace.atlassian.net/browse/PRT-1103).

- Add an accessible label to the OMERO credentials form
- Rely on `target=_blank` and `rel=noopener` instead of opening a blank tab in JS
- Cover the submit behavior with a regression test