### PR TITLE
PRT-1108 When adding a link field to an instrument template, instruments created from it complain with 'invalid' field error

### DIFF
--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -1,6 +1,7 @@
 package com.researchspace.service.inventory.impl;
 
 import com.axiope.search.InventorySearchConfig.InventorySearchDeletedOption;
+import com.researchspace.api.v1.auth.ApiRuntimeException;
 import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
 import com.researchspace.api.v1.model.ApiInstrument;
 import com.researchspace.api.v1.model.ApiInstrumentEntity;
@@ -10,6 +11,7 @@ import com.researchspace.api.v1.model.ApiInstrumentTemplate;
 import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
 import com.researchspace.api.v1.model.ApiInstrumentTemplateSearchResult;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
 import com.researchspace.core.util.ISearchResults;
@@ -32,16 +34,23 @@ import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.record.IActiveUserStrategy;
+import com.researchspace.service.inventory.DataCiteRelationType;
 import com.researchspace.service.inventory.InstrumentEntityApiManager;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.InventoryFieldNameUniquenessValidator;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.service.inventory.InventoryLinkValidator;
 import com.researchspace.service.inventory.InventoryMoveHelper;
 import com.researchspace.service.inventory.SampleApiManager;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotFoundException;
@@ -60,6 +69,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   private @Autowired InstrumentTemplateDao instrumentTemplateDao;
   private @Autowired InventoryEntityFieldDao inventoryEntityFieldDao;
   private @Autowired SampleApiManager sampleApiManager;
+  private @Autowired InventoryLinkManager inventoryLinkManager;
   private @Autowired InventoryMoveHelper inventoryMoveHelper;
   private @Autowired InventoryAuditApiManager inventoryAuditMgr;
   private @Autowired ApiFieldToModelFieldFactory apiFieldToModelFieldFactory;
@@ -177,11 +187,119 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       String newFieldContent = apiField.getContent();
       InventoryEntityField inventoryEntityField = inventoryEntityFieldList.get(i);
 
-      if (inventoryEntityField.isOptionsStoringField()) {
+      if (inventoryEntityField instanceof InventoryLinkField) {
+        applyLinkFieldValue((InventoryLinkField) inventoryEntityField, apiField, user);
+      } else if (inventoryEntityField.isOptionsStoringField()) {
         inventoryEntityField.setSelectedOptions(apiField.getSelectedOptions());
       } else {
         inventoryEntityField.setFieldData(newFieldContent);
       }
+    }
+  }
+
+  /**
+   * Applies a link value to a structured link field, going through the {@link InventoryLinkManager}
+   * so the target is parsed/validated and the Envers revision captured. Mirrors the implementation
+   * in {@link SampleApiManagerImpl}.
+   */
+  private boolean applyLinkFieldValue(
+      InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    ApiInventoryLink apiLink = apiField.getLink();
+    String target = apiLink == null ? null : apiLink.getTargetGlobalId();
+    InventoryLink existing = field.getLink();
+    if (target == null || target.trim().isEmpty()) {
+      if (existing == null) {
+        return false;
+      }
+      field.setLink(null);
+      return true;
+    }
+    Long effectivePin =
+        apiLink.derivedVersionPin() != null ? apiLink.derivedVersionPin() : apiLink.getVersionPin();
+    GlobalIdentifier incoming = parseTargetOrNull(target);
+    if (existing != null
+        && incoming != null
+        && incoming.getPrefix() == existing.getTargetPrefix()
+        && Objects.equals(incoming.getDbId(), existing.getTargetDbId())
+        && Objects.equals(effectivePin, existing.getVersionPin())
+        && Objects.equals(apiLink.getRelationType(), existing.getRelationType())) {
+      return false;
+    }
+    assertRelationAllowed(field, apiLink.getRelationType());
+    if (existing != null) {
+      field.setLink(inventoryLinkManager.updateLink(existing, apiLink, user));
+    } else {
+      field.setLink(inventoryLinkManager.createLink(apiLink, user));
+    }
+    return true;
+  }
+
+  /**
+   * Applies link values to an existing instrument's structured link fields (the update path). The
+   * DTO apply loop leaves link fields untouched because it cannot reach the service-layer {@link
+   * InventoryLinkManager}; this matches each modified link field by id and applies it here.
+   */
+  private boolean applyLinkFieldValuesOnUpdate(
+      ApiInstrument apiInstrument, Instrument dbInstrument, User user) {
+    if (apiInstrument.getFields() == null) {
+      return false;
+    }
+    boolean changed = false;
+    for (ApiInventoryEntityField apiField : apiInstrument.getFields()) {
+      if (apiField.isNewFieldRequest()
+          || apiField.isDeleteFieldRequest()
+          || apiField.getId() == null) {
+        continue;
+      }
+      Optional<InventoryEntityField> dbFieldOpt =
+          dbInstrument.getActiveFields().stream()
+              .filter(
+                  f ->
+                      f instanceof InventoryLinkField
+                          && Objects.equals(f.getId(), apiField.getId()))
+              .findFirst();
+      if (dbFieldOpt.isPresent()) {
+        rejectSelfLink(apiField.getLink(), dbInstrument);
+        changed |= applyLinkFieldValue((InventoryLinkField) dbFieldOpt.get(), apiField, user);
+      }
+    }
+    return changed;
+  }
+
+  private void assertRelationAllowed(InventoryLinkField field, String relationType) {
+    if (!DataCiteRelationType.isValid(relationType)) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.relationTypeInvalid", relationType);
+    }
+    String allowed = field.getAllowedRelationTypes();
+    if (allowed == null || allowed.trim().isEmpty()) {
+      return;
+    }
+    if (!Arrays.asList(allowed.split("\\|")).contains(relationType)) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.relationTypeNotPermitted", relationType, field.getName());
+    }
+  }
+
+  private void rejectSelfLink(ApiInventoryLink apiLink, Instrument dbInstrument) {
+    if (apiLink == null || dbInstrument.getOid() == null) {
+      return;
+    }
+    GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
+    if (target == null) {
+      return;
+    }
+    if (InventoryLinkValidator.isSelfLink(target, dbInstrument.getOid().toString())) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.selfLinkForbidden", apiLink.getTargetGlobalId());
+    }
+  }
+
+  private GlobalIdentifier parseTargetOrNull(String targetGlobalId) {
+    try {
+      return new GlobalIdentifier(targetGlobalId);
+    } catch (IllegalArgumentException | NullPointerException ex) {
+      return null;
     }
   }
 
@@ -263,6 +381,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
           identifiersHelper.createAssignRequestedIdentifiers(
               apiInstrument.getIdentifiers(), dbInstrument, user);
       contentChanged |= apiInstrument.applyChangesToDatabaseInstrument(dbInstrument, user);
+      contentChanged |= applyLinkFieldValuesOnUpdate(apiInstrument, dbInstrument, user);
       contentChanged |= saveSharingACLForIncomingApiInvRec(dbInstrument, apiInstrument);
       contentChanged |= saveIncomingInstrumentImage(dbInstrument, apiInstrument, user);
       InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNames(dbInstrument);

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -202,7 +202,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
    * so the target is parsed/validated and the Envers revision captured. Mirrors the implementation
    * in {@link SampleApiManagerImpl}.
    */
-  private boolean applyLinkFieldValue(
+  boolean applyLinkFieldValue(
       InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
     ApiInventoryLink apiLink = apiField.getLink();
     String target = apiLink == null ? null : apiLink.getTargetGlobalId();

--- a/src/main/webapp/ui/src/Inventory/Instrument/Fields/TemplateFields.tsx
+++ b/src/main/webapp/ui/src/Inventory/Instrument/Fields/TemplateFields.tsx
@@ -16,6 +16,7 @@ import { truncateIsoTimestamp } from "../../../stores/definitions/Units";
 import type InstrumentModel from "../../../stores/models/InstrumentModel";
 import AttachmentField from "../../components/Fields/Attachments/AttachmentField";
 import FormField from "../../components/Inputs/FormField";
+import LinkFieldValue from "../../Sample/Fields/TemplateFields/LinkFieldValue";
 
 type TemplateFieldsArgs = {
   onErrorStateChange: (fieldName: string, hasError: boolean) => void;
@@ -249,6 +250,28 @@ function TemplateFields({ onErrorStateChange, instrument }: TemplateFieldsArgs):
                 field.setError(false);
                 onErrorStateChange(`template_${field.name}`, (field.mandatory && !field.hasContent) || field.error);
               }}
+            />
+          )}
+        />
+      );
+    }
+
+    if (field.type === "link") {
+      return (
+        <FormField
+          {...commonProps}
+          key={field.name}
+          value={field.link?.targetGlobalId ?? ""}
+          doNotAttachIdToLabel
+          hideLabel
+          renderInput={() => (
+            <LinkFieldValue
+              field={field}
+              sourceGlobalId={instrument.globalId ?? ""}
+              disabled={!instrument.isFieldEditable("fields")}
+              onChange={() =>
+                onErrorStateChange(`template_${field.name}`, (field.mandatory && !field.hasContent) || field.error)
+              }
             />
           )}
         />

--- a/src/main/webapp/ui/src/Inventory/Instrument/Fields/__tests__/TemplateFields.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Instrument/Fields/__tests__/TemplateFields.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import "@/__tests__/__mocks__/matchMedia";
+import { ThemeProvider } from "@mui/material/styles";
+import { render, screen } from "@/__tests__/customQueries";
+import { makeMockInstrument } from "@/stores/models/__tests__/InstrumentModel/mocking";
+import materialTheme from "@/theme";
+import TemplateFields from "../TemplateFields";
+
+// Stub the target-picker dialogs -- they pull in the store/ApiService chain and are
+// tested independently.
+vi.mock("@/Inventory/components/Fields/Link/LinkTargetBrowser", () => ({
+  default: () => null,
+}));
+vi.mock("@/Inventory/components/Fields/Link/ElnRecordPicker", () => ({
+  default: () => null,
+}));
+// RecordTypeIcon needs app context to resolve its icon; irrelevant here.
+vi.mock("@/components/RecordTypeIcon", () => ({ default: () => null }));
+// Target existence checks hit the server; default to "exists".
+vi.mock("@/Inventory/components/Fields/Link/linkTargetExists", () => ({
+  checkLinkTargetExists: vi.fn(() => Promise.resolve(true)),
+}));
+// Version-summary hook; default to no summary so unrelated assertions are unaffected.
+vi.mock("@/Inventory/components/Fields/Link/useLinkTargetSummary", () => ({
+  default: () => null,
+}));
+// Version-lock dialog fetches revision history; stub with a no-op.
+vi.mock("@/Inventory/components/Fields/Link/VersionLockDialog", () => ({
+  default: () => null,
+}));
+// LinkField has its own tests; stub it so we can assert it is used for the committed-link
+// display without pulling in its info/version dialog chain.
+vi.mock("@/Inventory/components/Fields/Link/LinkField", () => ({
+  default: ({ link }: { link: { relationType: string; targetGlobalId: string } }) => (
+    <div data-testid="link-field-display">
+      <span>{link.relationType}</span>
+      <span>{link.targetGlobalId}</span>
+    </div>
+  ),
+}));
+
+const LINK_FIELD_ATTRS = {
+  id: 10,
+  globalId: "IF10",
+  name: "Reference",
+  type: "link" as const,
+  content: null,
+  selectedOptions: null,
+  definition: null,
+  columnIndex: 1,
+  attachment: null,
+  mandatory: false,
+  allowedRelationTypes: ["References"],
+  link: null,
+};
+
+function renderTemplateFields(instrument: ReturnType<typeof makeMockInstrument>) {
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <TemplateFields onErrorStateChange={() => {}} instrument={instrument} />
+    </ThemeProvider>,
+  );
+}
+
+describe("TemplateFields -- link field", () => {
+  it("renders the link editor, not 'Unknown field type', when the field is editable", () => {
+    const instrument = makeMockInstrument({ fields: [LINK_FIELD_ATTRS] });
+    instrument.currentlyEditableFields.add("fields");
+
+    renderTemplateFields(instrument);
+
+    expect(screen.queryByText(/unknown field type/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /apply link/i })).toBeInTheDocument();
+  });
+
+  it("renders 'None' placeholder, not 'Unknown field type', when view-only with no link set", () => {
+    const instrument = makeMockInstrument({ fields: [LINK_FIELD_ATTRS] });
+    // fields is not in currentlyEditableFields by default, so isFieldEditable("fields") === false
+
+    renderTemplateFields(instrument);
+
+    expect(screen.queryByText(/unknown field type/i)).not.toBeInTheDocument();
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+
+  it("renders the committed link card, not 'Unknown field type', when view-only with a committed link", () => {
+    const instrument = makeMockInstrument({
+      fields: [
+        {
+          ...LINK_FIELD_ATTRS,
+          link: { relationType: "References", targetGlobalId: "SA20", versionPin: null },
+        },
+      ],
+    });
+    // fields is not in currentlyEditableFields by default
+
+    renderTemplateFields(instrument);
+
+    expect(screen.queryByText(/unknown field type/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("link-field-display")).toBeInTheDocument();
+    expect(screen.getByText("References")).toBeInTheDocument();
+    expect(screen.getByText("SA20")).toBeInTheDocument();
+  });
+});

--- a/src/test/java/com/researchspace/service/inventory/InstrumentEntityApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InstrumentEntityApiManagerTest.java
@@ -20,8 +20,10 @@ import com.researchspace.api.v1.model.ApiInstrumentTemplate;
 import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
 import com.researchspace.api.v1.model.ApiInstrumentTemplateSearchResult;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.api.v1.model.ApiUser;
 import com.researchspace.model.Group;
 import com.researchspace.model.PaginationCriteria;
@@ -951,5 +953,118 @@ public class InstrumentEntityApiManagerTest extends SpringTransactionalTest {
     assertEquals(1, created.getFields().size());
     assertEquals("Status", created.getFields().get(0).getName());
     assertEquals(ApiFieldType.RADIO, created.getFields().get(0).getType());
+  }
+
+  // --- link field persistence (create / update / clear paths) ---
+
+  @Test
+  public void linkFieldValue_persistedWhenInstrumentCreatedFromTemplate() {
+    ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
+    templatePost.setName("link-tmpl-create-" + getRandomAlphabeticString("n"));
+    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
+    linkField.setName("ref");
+    linkField.setType(ApiFieldType.LINK);
+    templatePost.getFields().add(linkField);
+    ApiInstrumentTemplate template =
+        instrumentApiMgr.createInstrumentTemplate(templatePost, testUser);
+
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(testUser, "link-create-target");
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("linked-from-create");
+    request.setTemplateId(template.getId());
+    ApiInventoryEntityField fieldWithLink = new ApiInventoryEntityField();
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setTargetGlobalId(target.getGlobalId());
+    apiLink.setRelationType("References");
+    fieldWithLink.setLink(apiLink);
+    request.setFields(List.of(fieldWithLink));
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+
+    ApiInstrument retrieved = instrumentApiMgr.getApiInstrumentById(created.getId(), testUser);
+    ApiInventoryLink storedLink = findInstrumentLinkField(retrieved.getFields()).getLink();
+    assertNotNull(storedLink, "link should be persisted on the field after creation");
+    assertEquals(target.getGlobalId(), storedLink.getTargetGlobalId());
+    assertEquals("References", storedLink.getRelationType());
+  }
+
+  @Test
+  public void linkFieldValue_persistedWhenInstrumentUpdated() {
+    ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
+    templatePost.setName("link-tmpl-update-" + getRandomAlphabeticString("n"));
+    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
+    linkField.setName("ref");
+    linkField.setType(ApiFieldType.LINK);
+    templatePost.getFields().add(linkField);
+    ApiInstrumentTemplate template =
+        instrumentApiMgr.createInstrumentTemplate(templatePost, testUser);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("to-be-linked");
+    request.setTemplateId(template.getId());
+    ApiInstrument instrument = instrumentApiMgr.createNewApiInstrument(request, testUser);
+    assertNull(findInstrumentLinkField(instrument.getFields()).getLink(), "no link before update");
+
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(testUser, "link-update-target");
+    Long fieldId = findInstrumentLinkField(instrument.getFields()).getId();
+
+    ApiInventoryEntityField fieldUpdate = new ApiInventoryEntityField();
+    fieldUpdate.setId(fieldId);
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setTargetGlobalId(target.getGlobalId());
+    apiLink.setRelationType("References");
+    fieldUpdate.setLink(apiLink);
+    ApiInstrument update = new ApiInstrument();
+    update.setId(instrument.getId());
+    update.setFields(List.of(fieldUpdate));
+    instrumentApiMgr.updateApiInstrument(update, testUser);
+
+    ApiInstrument retrieved = instrumentApiMgr.getApiInstrumentById(instrument.getId(), testUser);
+    ApiInventoryLink storedLink = findInstrumentLinkField(retrieved.getFields()).getLink();
+    assertNotNull(storedLink, "link should be persisted after update");
+    assertEquals(target.getGlobalId(), storedLink.getTargetGlobalId());
+    assertEquals("References", storedLink.getRelationType());
+  }
+
+  @Test
+  public void linkFieldValue_clearedWhenInstrumentUpdated() {
+    ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
+    templatePost.setName("link-tmpl-clear-" + getRandomAlphabeticString("n"));
+    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
+    linkField.setName("ref");
+    linkField.setType(ApiFieldType.LINK);
+    templatePost.getFields().add(linkField);
+    ApiInstrumentTemplate template =
+        instrumentApiMgr.createInstrumentTemplate(templatePost, testUser);
+
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(testUser, "link-clear-target");
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("to-be-cleared");
+    request.setTemplateId(template.getId());
+    ApiInventoryEntityField fieldWithLink = new ApiInventoryEntityField();
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setTargetGlobalId(target.getGlobalId());
+    apiLink.setRelationType("References");
+    fieldWithLink.setLink(apiLink);
+    request.setFields(List.of(fieldWithLink));
+    ApiInstrument instrument = instrumentApiMgr.createNewApiInstrument(request, testUser);
+    assertNotNull(
+        findInstrumentLinkField(instrument.getFields()).getLink(), "link set on creation");
+
+    Long fieldId = findInstrumentLinkField(instrument.getFields()).getId();
+    ApiInventoryEntityField clearField = new ApiInventoryEntityField();
+    clearField.setId(fieldId);
+    // no link payload: clears the existing link
+    ApiInstrument clearUpdate = new ApiInstrument();
+    clearUpdate.setId(instrument.getId());
+    clearUpdate.setFields(List.of(clearField));
+    instrumentApiMgr.updateApiInstrument(clearUpdate, testUser);
+
+    ApiInstrument retrieved = instrumentApiMgr.getApiInstrumentById(instrument.getId(), testUser);
+    assertNull(
+        findInstrumentLinkField(retrieved.getFields()).getLink(),
+        "link should be cleared after update with no link payload");
   }
 }

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -1,0 +1,198 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.testutils.TestFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the link-field persistence logic in {@link InstrumentEntityApiManagerImpl}.
+ *
+ * <p>The {@code applyLinkFieldValue} method is the creation/update hot-path for structured
+ * link-type template fields on instruments. It mirrors the equivalent in {@link
+ * SampleApiManagerImpl}; these tests guard against independent drift or regression.
+ */
+@ExtendWith(MockitoExtension.class)
+class InstrumentEntityApiManagerImplLinkFieldTest {
+
+  @Mock private InventoryLinkManager inventoryLinkManager;
+  private InstrumentEntityApiManagerImpl manager;
+
+  private User user;
+  private InventoryLinkField dbField;
+  private InventoryLink dbLink;
+
+  @BeforeEach
+  void setUp() {
+    manager = new InstrumentEntityApiManagerImpl();
+    ReflectionTestUtils.setField(manager, "inventoryLinkManager", inventoryLinkManager);
+    user = TestFactory.createAnyUser("any");
+    dbLink = new InventoryLink();
+    dbLink.setRelationType("References");
+    dbLink.setTargetGlobalId("SA2");
+    dbLink.setTargetPrefix(GlobalIdPrefix.SA);
+    dbLink.setTargetDbId(2L);
+    dbField = new InventoryLinkField();
+    dbField.setName("related sample");
+    dbField.setLink(dbLink);
+  }
+
+  private ApiInventoryEntityField apiLinkField(
+      String targetGlobalId, String relationType, Long versionPin) {
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setTargetGlobalId(targetGlobalId);
+    apiLink.setRelationType(relationType);
+    apiLink.setVersionPin(versionPin);
+    apiField.setLink(apiLink);
+    return apiField;
+  }
+
+  @Test
+  void unchangedLinkLeavesTheExistingRowAlone() {
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void pinnedSuffixedTargetMatchingStoredBaseIdIsUnchanged() {
+    dbLink.setVersionPin(4L);
+    ApiInventoryEntityField apiField = apiLinkField("SA2v4", "References", null);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void retargetUpdatesTheExistingRowInPlace() {
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "References", null);
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+    verify(inventoryLinkManager, never()).createLink(any(), any());
+  }
+
+  @Test
+  void versionPinChangeUpdatesTheExistingRowInPlace() {
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", 4L);
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+  }
+
+  @Test
+  void relationTypeChangeUpdatesTheExistingRowInPlace() {
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "IsCitedBy", null);
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+  }
+
+  @Test
+  void clearingTheValueDereferencesTheRowForOrphanRemoval() {
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    assertNull(dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void invalidRelationTypeIsRejectedWithCleanError() {
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "NotARelation", null);
+
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class, () -> manager.applyLinkFieldValue(dbField, apiField, user));
+    assertEquals("errors.inventory.field.link.relationTypeInvalid", ex.getErrorCode());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void relationOutsideTemplateWhitelistIsRejected() {
+    dbField.setAllowedRelationTypes("References|IsPartOf");
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "Cites", null);
+
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class, () -> manager.applyLinkFieldValue(dbField, apiField, user));
+    assertEquals("errors.inventory.field.link.relationTypeNotPermitted", ex.getErrorCode());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void relationInsideTemplateWhitelistIsAccepted() {
+    dbField.setAllowedRelationTypes("References|IsPartOf");
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "IsPartOf", null);
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    assertTrue(manager.applyLinkFieldValue(dbField, apiField, user));
+  }
+
+  @Test
+  void clearingAnAlreadyEmptyFieldIsANoop() {
+    dbField.setLink(null);
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertFalse(changed);
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void anEmptyFieldGainsItsFirstLinkViaCreate() {
+    dbField.setLink(null);
+    InventoryLink created = new InventoryLink();
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "References", null);
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    assertSame(created, dbField.getLink());
+    verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+  }
+}


### PR DESCRIPTION
## Description ##
Addresses https://researchspace.atlassian.net/browse/PRT-1108

Code change summary from Claude:

Two bugs prevented link-type fields defined in an Instrument Template from
  working correctly on Instruments created from that template.

  1. Frontend -- "Unknown field type: link" display error
  (src/main/webapp/ui/src/Inventory/Instrument/Fields/TemplateFields.tsx)

  TemplateFields.tsx rendered the custom fields of an instrument created from a
  template but had no handler for field.type === "link". It fell through to a
  generic "Unknown field type" message. A link branch was added, importing the
  existing LinkFieldValue component from the Sample TemplateFields directory and
   rendering it with the instrument's globalId and isFieldEditable -- matching
  the equivalent handler already present in
  Sample/Fields/TemplateFields/Fields.tsx.

  2. Backend -- link data silently discarded on save
  (src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiMan
  agerImpl.java)
  
  The instrument manager had two gaps compared to the equivalent
  SampleApiManagerImpl:

  - Creation path: saveNewApiFieldsIntoInstrumentFields had no branch for
  InventoryLinkField, so link field content was dropped on save. An instanceof 
  InventoryLinkField check was added as the first branch in the per-field loop,
  routing link fields through a new applyLinkFieldValue method that calls
  InventoryLinkManager.createLink().
  - Update path: updateApiInstrument had no equivalent of the sample manager's
  applyLinkFieldValuesOnUpdate call. The generic DTO apply-changes loop
  intentionally short-circuits on link fields (it cannot access
  InventoryLinkManager), so without a second pass, editing a link field value on
   an existing instrument was silently lost. A new applyLinkFieldValuesOnUpdate
  method was added and called after applyChangesToDatabaseInstrument, matching
  each incoming link field by ID and applying the create/update/clear logic
  through InventoryLinkManager.