### PR TITLE
keep filestore login dialog (and snippet preview) above the raised gallery info panel (PRT-1099)

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/components/CallableSnippetPreview.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/CallableSnippetPreview.tsx
@@ -58,7 +58,7 @@ export function CallableSnippetPreview({ children }: { children: React.ReactNode
       >
         {children}
       </SnippetPreviewContext.Provider>
-      {/* Keep above the gallery info panel, which is raised in the picker. */}
+      {/* Match the PDF preview: 2000 keeps it above the raised picker layers and legacy jQuery dialogs. */}
       <Dialog
         open={snippetFile !== null}
         fullWidth

--- a/src/main/webapp/ui/src/eln/gallery/components/CallableSnippetPreview.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/CallableSnippetPreview.tsx
@@ -58,7 +58,14 @@ export function CallableSnippetPreview({ children }: { children: React.ReactNode
       >
         {children}
       </SnippetPreviewContext.Provider>
-      <Dialog open={snippetFile !== null} fullWidth maxWidth="md" onClose={() => setSnippetFile(null)}>
+      {/* Keep above the gallery info panel, which is raised in the picker. */}
+      <Dialog
+        open={snippetFile !== null}
+        fullWidth
+        maxWidth="md"
+        onClose={() => setSnippetFile(null)}
+        sx={{ zIndex: 2000 }}
+      >
         <DialogTitle>Snippet Preview: {snippetFile?.name}</DialogTitle>
         <DialogContent dividers>
           {loading ? (

--- a/src/main/webapp/ui/src/eln/gallery/components/FilestoreLoginDialog.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/FilestoreLoginDialog.tsx
@@ -55,7 +55,8 @@ const FilestoreLoginDialog = ({
   const { addAlert } = React.useContext(AlertContext);
 
   return (
-    // Blocking auth step: keep above the gallery dialog it opens over.
+    // Blocking auth step, opened over the "Add a Filestore" stepper. Match the
+    // PDF preview: 2000 keeps it above the raised picker layers and legacy jQuery dialogs.
     <Dialog open onClose={onClose} sx={{ zIndex: 2000 }}>
       <form
         onSubmit={(e) => {

--- a/src/main/webapp/ui/src/eln/gallery/components/FilestoreLoginDialog.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/FilestoreLoginDialog.tsx
@@ -55,7 +55,8 @@ const FilestoreLoginDialog = ({
   const { addAlert } = React.useContext(AlertContext);
 
   return (
-    <Dialog open onClose={onClose}>
+    // Blocking auth step: keep above the gallery dialog it opens over.
+    <Dialog open onClose={onClose} sx={{ zIndex: 2000 }}>
       <form
         onSubmit={(e) => {
           void (async () => {


### PR DESCRIPTION
### Problem
In the document editor's gallery picker, Insert from Gallery → Filestores → Create → Add a Filestore → Choose Filesystem opens the Filestore Login dialog, but its Login button can't be clicked. The Add-a-Filestore stepper sits above the login dialog and its full-width step-label span intercepts the click.

### Cause
In the picker, gallery dialogs are raised above the default modal layer (from the RSDEV-1088 info-panel z-index change), so the stepper ended up above the login dialog, which stays at the default layer.

### Fix
Give the login dialog a top-most z-index so this blocking auth step always stays on top. The gallery snippet preview had the same picker-only stacking issue and got the same fix.

### A possible more general fix, but with larger impact

Both patches work around the same root cause: RSDEV-1088 raises the picker's inner content (Sidebar + MainPanel) into a higher z-index band, so any dialog rendered by a provider outside that band (login, previews, AppBar) stays at the default layer and falls below it, needing its own top-most z-index. Rather than patch each one, we could move the raised-z ThemeProvider to wrap the whole picker subtree and pin only the container dialog back to base modal. That fixes the whole class at once and lets us drop the per-dialog overrides, but is larger impact.