### PR TITLE
Disable Biome colors in pre-commit lint

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,4 +32,4 @@ pre-commit:
     # under a second, so we run it project-wide like tsc rather than per-file.
     biome:
       glob: "src/main/webapp/ui/**/*.{ts,tsx,css}"
-      run: pnpm run lint:ci
+      run: pnpm run lint:ci --colors=off


### PR DESCRIPTION
## Description ##
- Pass `--colors=off` to the Biome CI lint hook
- Prevent colored output from cluttering Lefthook logs

