### PR TITLE
Fix preview image resize measurement

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Container/Content/ImageView/PreviewImage.spec.tsx
+++ b/src/main/webapp/ui/src/Inventory/Container/Content/ImageView/PreviewImage.spec.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+import { IMAGE_LOCATIONS, VisualContainerWithEdgeLocations, VisualContainerWithLocations } from "./PreviewImage.story";
+import { PreviewImagePage } from "./pageObjects/PreviewImagePage";
+
+/*
+ * Browser mode is required: jsdom has no ResizeObserver, returns zeros from
+ * getBoundingClientRect, and doesn't reproduce the DOMRect prototype-getter
+ * semantics that regressed the size extraction (PRT-1107).
+ *
+ * The regression signal is positional, not presence: with the size missing the
+ * markers still render, they just stack at (0,0). The assertions therefore check
+ * position, and use distinctness/spans rather than exact pixels so they don't
+ * couple to LocationWrapper's icon-offset constants.
+ */
+describe("PreviewImage", () => {
+  afterEach(cleanup);
+
+  test("renders each location marker at a distinct position tracking its coordinates", async () => {
+    render(<VisualContainerWithLocations />);
+    const previewImage = new PreviewImagePage();
+
+    await expect.element(previewImage.marker(1)).toBeInTheDocument();
+    await expect.element(previewImage.image).toBeVisible();
+
+    // Poll until the image settles on its real size; the observer can fire once
+    // with a transient (smaller) size first.
+    await expect.poll(() => previewImage.markerOffset(3).left - previewImage.markerOffset(1).left).toBeGreaterThan(50);
+
+    const offsets = IMAGE_LOCATIONS.map((_, i) => previewImage.markerOffset(i + 1));
+
+    for (const { left, top } of offsets) {
+      expect(Number.isFinite(left)).toBe(true);
+      expect(Number.isFinite(top)).toBe(true);
+    }
+    // Not collapsed onto the origin (the failure mode this guards against).
+    expect(offsets.some(({ left, top }) => Math.abs(left) > 1 || Math.abs(top) > 1)).toBe(true);
+
+    // Rising-diagonal coordinates → strictly increasing left and top.
+    expect(offsets[1].left).toBeGreaterThan(offsets[0].left);
+    expect(offsets[2].left).toBeGreaterThan(offsets[1].left);
+    expect(offsets[1].top).toBeGreaterThan(offsets[0].top);
+    expect(offsets[2].top).toBeGreaterThan(offsets[1].top);
+
+    // Equal coordinate spacing → roughly equal pixel spacing.
+    const leftStep1 = offsets[1].left - offsets[0].left;
+    const leftStep2 = offsets[2].left - offsets[1].left;
+    expect(leftStep2).toBeCloseTo(leftStep1, -1);
+  });
+
+  // Edge coordinates: minimum (0,0) and maximum (1000,1000). The corner-to-corner
+  // pixel span should equal the full rendered image size; with the bug both
+  // markers collapse onto the origin and the span drops to ~0.
+  test("places minimum (0,0) and maximum (1000,1000) markers a full image apart", async () => {
+    render(<VisualContainerWithEdgeLocations />);
+    const previewImage = new PreviewImagePage();
+
+    await expect.element(previewImage.marker(1)).toBeInTheDocument();
+    await expect.element(previewImage.marker(2)).toBeInTheDocument();
+    await expect.element(previewImage.image).toBeVisible();
+
+    await expect.poll(() => previewImage.markerOffset(2).left - previewImage.markerOffset(1).left).toBeGreaterThan(50);
+
+    const { width, height } = previewImage.imageSize();
+    const min = previewImage.markerOffset(1);
+    const max = previewImage.markerOffset(2);
+
+    expect(max.left).toBeGreaterThan(min.left);
+    expect(max.top).toBeGreaterThan(min.top);
+    // ~5px tolerance for sub-pixel layout across engines.
+    expect(max.left - min.left).toBeCloseTo(width, -1);
+    expect(max.top - min.top).toBeCloseTo(height, -1);
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/Container/Content/ImageView/PreviewImage.story.tsx
+++ b/src/main/webapp/ui/src/Inventory/Container/Content/ImageView/PreviewImage.story.tsx
@@ -1,0 +1,89 @@
+import { ThemeProvider } from "@mui/material/styles";
+import type React from "react";
+import SearchContext from "../../../../stores/contexts/Search";
+import { mockFactory } from "../../../../stores/definitions/__tests__/Factory/mocking";
+import { makeMockContainer } from "../../../../stores/models/__tests__/ContainerModel/mocking";
+import type ContainerModel from "../../../../stores/models/ContainerModel";
+import LocationModel from "../../../../stores/models/LocationModel";
+import Search from "../../../../stores/models/Search";
+import materialTheme from "../../../../theme";
+import type { BlobUrl } from "../../../../util/types";
+import PreviewImage from "./PreviewImage";
+
+// A 400x300 solid-teal PNG. A fixed-pixel PNG (not an SVG) renders at identical
+// dimensions across chromium/firefox/webkit, so marker positions are deterministic.
+export const LOCATIONS_IMAGE =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAEsCAIAAABi1XKVAAAD70lEQVR4nO3UsQkAIBDAwJ/Eia2d1xXsJHBwA6TKrH0AEuZ7AcAjwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8gwLCDDsIAMwwIyDAvIMCwgw7CADMMCMgwLyDAsIMOwgAzDAjIMC8i44C0SV9mfVtgAAAAASUVORK5CYII=";
+
+// Rising diagonal on the 0-1000 coordinate space; ids fix the displayed 1..3
+// ordering (sortedLocations sorts by id).
+export const IMAGE_LOCATIONS = [
+  { id: 50, coordX: 250, coordY: 250 },
+  { id: 51, coordX: 500, coordY: 500 },
+  { id: 52, coordX: 750, coordY: 750 },
+];
+
+// The extremes of the coordinate space: (0,0) top-left corner, (1000,1000)
+// bottom-right, displayed as 1 and 2.
+export const EDGE_LOCATIONS = [
+  { id: 60, coordX: 0, coordY: 0 },
+  { id: 61, coordX: 1000, coordY: 1000 },
+];
+
+function buildVisualContainer(
+  locations: ReadonlyArray<{ id: number; coordX: number; coordY: number }>,
+): ContainerModel {
+  const container = makeMockContainer({
+    name: "A visual container",
+    globalId: "IC1",
+    cType: "IMAGE",
+    locations: [],
+    locationsCount: locations.length,
+    contentSummary: {
+      totalCount: 0,
+      subSampleCount: 0,
+      containerCount: 0,
+    },
+  });
+  container.locations = locations.map(
+    ({ id, coordX, coordY }) => new LocationModel({ id, coordX, coordY, content: null, parentContainer: container }),
+  );
+  container.initializedLocations = true;
+  container.locationsImage = LOCATIONS_IMAGE as BlobUrl;
+  return container;
+}
+
+function renderPreview(container: ContainerModel): React.ReactNode {
+  const search = new Search({ factory: mockFactory() });
+  return (
+    <ThemeProvider theme={materialTheme}>
+      <SearchContext.Provider
+        value={{
+          search,
+          differentSearchForSettingActiveResult: search,
+          scopedResult: container,
+        }}
+      >
+        <PreviewImage />
+      </SearchContext.Provider>
+    </ThemeProvider>
+  );
+}
+
+/**
+ * PreviewImage showing a visual (IMAGE) container with three location markers
+ * on its background image. This is the view rendered in the container details
+ * "Locations and Content" section and in the move-picker destination panel.
+ */
+export function VisualContainerWithLocations(): React.ReactNode {
+  return renderPreview(buildVisualContainer(IMAGE_LOCATIONS));
+}
+
+/**
+ * PreviewImage for a visual container whose two markers sit at the extremes of
+ * the coordinate space (0,0) and (1000,1000) — the top-left and bottom-right
+ * corners of the image.
+ */
+export function VisualContainerWithEdgeLocations(): React.ReactNode {
+  return renderPreview(buildVisualContainer(EDGE_LOCATIONS));
+}

--- a/src/main/webapp/ui/src/Inventory/Container/Content/ImageView/PreviewImage.tsx
+++ b/src/main/webapp/ui/src/Inventory/Container/Content/ImageView/PreviewImage.tsx
@@ -1,5 +1,4 @@
 import Box from "@mui/material/Box";
-import { pick } from "es-toolkit";
 import { observer } from "mobx-react-lite";
 import React, { useContext, useLayoutEffect, useRef, useState } from "react";
 import SearchContext from "../../../../stores/contexts/Search";
@@ -28,7 +27,8 @@ function PreviewImage(): React.ReactNode {
   } | null>(null);
   const resizeObserver = useRef(
     new ResizeObserver((entries) => {
-      setImageDimensions(pick(entries[0].target.getBoundingClientRect(), ["width", "height"]));
+      const { width, height } = entries[0].target.getBoundingClientRect();
+      setImageDimensions({ width, height });
     }),
   );
   const imgRef = useRef<HTMLImageElement | null>(null);

--- a/src/main/webapp/ui/src/Inventory/Container/Content/ImageView/pageObjects/PreviewImagePage.ts
+++ b/src/main/webapp/ui/src/Inventory/Container/Content/ImageView/pageObjects/PreviewImagePage.ts
@@ -1,0 +1,31 @@
+import { type Locator, page } from "vitest/browser";
+
+/**
+ * Page object for PreviewImage, as mounted by PreviewImage.story.tsx.
+ * Encapsulates locators and geometry reads; assertions live in the spec.
+ */
+export class PreviewImagePage {
+  get image(): Locator {
+    return page.getByRole("img", { name: "Container preview" });
+  }
+
+  /** The marker for the nth (1-based) location, located by its displayed number. */
+  marker(n: number): Locator {
+    return page.getByText(String(n), { exact: true });
+  }
+
+  imageSize(): { width: number; height: number } {
+    const { width, height } = (this.image.element() as HTMLElement).getBoundingClientRect();
+    return { width, height };
+  }
+
+  /** The nth marker's position relative to the image's top-left, from painted geometry. */
+  markerOffset(n: number): { left: number; top: number } {
+    const imageRect = (this.image.element() as HTMLElement).getBoundingClientRect();
+    const markerRect = (this.marker(n).element() as HTMLElement).getBoundingClientRect();
+    return {
+      left: markerRect.left - imageRect.left,
+      top: markerRect.top - imageRect.top,
+    };
+  }
+}


### PR DESCRIPTION
## Description ##
- Read `width` and `height` directly from `getBoundingClientRect()`
- Avoid `pick()` returning an empty object for DOMRect prototype getters
