### PR TITLE
RSDEV-1229 Instrument Template Custom Field Behaviour Issues

### DIFF
--- a/src/main/webapp/ui/src/Inventory/InstrumentTemplate/Fields/CustomFields.tsx
+++ b/src/main/webapp/ui/src/Inventory/InstrumentTemplate/Fields/CustomFields.tsx
@@ -38,8 +38,8 @@ function CustomFields({ onErrorStateChange }: CustomFieldsArgs): ReactNode {
   const TemplateFields = observer(({ editable }: { editable: boolean }) => {
     const removeCustomField =
       (field: FieldModel) =>
-      (_b = false) => {
-        activeResult.removeCustomField(field.id, activeResult.fields.indexOf(field));
+      (b = false) => {
+        activeResult.removeCustomField(field.id, activeResult.fields.indexOf(field), b);
       };
 
     return (
@@ -56,6 +56,7 @@ function CustomFields({ onErrorStateChange }: CustomFieldsArgs): ReactNode {
               onRemove={(b) => removeCustomField(field)(b)}
               forceColumnLayout={!uiStore.isLarge}
               onMove={(index) => activeResult.moveField(field, index)}
+              recordTypeName="instrument"
             />
           ))}
       </Stack>

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/CustomField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/CustomField.tsx
@@ -17,13 +17,12 @@ import DefaultValueField from "./DefaultValueField";
 import FieldTypeMenu from "./FieldTypeMenu";
 import MoveButtons from "./MoveButtons";
 
-const deleteOptions: Array<DeleteOption> = [
-  { value: false, label: "Keep field in existing samples" },
-  {
-    value: true,
-    label: "Remove field from existing samples",
-  },
-];
+function makeDeleteOptions(recordTypeName: "sample" | "instrument"): Array<DeleteOption> {
+  return [
+    { value: false, label: `Keep field in existing ${recordTypeName}s` },
+    { value: true, label: `Remove field from existing ${recordTypeName}s` },
+  ];
+}
 
 const FieldTypeSelector = observer(({ field }: { field: FieldModel }) => {
   return (
@@ -74,6 +73,7 @@ type CustomFieldArgs = {
   onRemove: (b?: boolean) => void;
   forceColumnLayout: boolean;
   onMove: (index: number) => void;
+  recordTypeName?: "sample" | "instrument";
 };
 
 function CustomField({
@@ -84,6 +84,7 @@ function CustomField({
   onRemove,
   forceColumnLayout,
   onMove,
+  recordTypeName = "sample",
 }: CustomFieldArgs): React.ReactNode {
   const nameFieldId = useId();
 
@@ -97,10 +98,10 @@ function CustomField({
                 <strong>{field.name}</strong> {FIELD_LABEL[field.fieldType]} field will be deleted from this template.
               </Typography>
               <p>
-                New samples will not include this field.{" "}
+                New {recordTypeName}s will not include this field.{" "}
                 {field.deleteFieldOnSampleUpdate
-                  ? "The field will also be deleted from existing samples made with this template after the samples are updated to the latest template version."
-                  : "The field will not be deleted from existing samples even if the samples are updated to the latest template version."}
+                  ? `The field will also be deleted from existing ${recordTypeName}s made with this template after the ${recordTypeName}s are updated to the latest template version.`
+                  : `The field will not be deleted from existing ${recordTypeName}s even if the ${recordTypeName}s are updated to the latest template version.`}
               </p>
             </Box>
           ) : (
@@ -135,7 +136,7 @@ function CustomField({
                         <RemoveButton onClick={() => onRemove()} title="Delete new field" />
                       ) : (
                         <RemoveMenu
-                          deleteOptions={deleteOptions}
+                          deleteOptions={makeDeleteOptions(recordTypeName)}
                           onClick={(b) => onRemove(b)}
                           tooltipTitle="Delete field"
                         />

--- a/src/main/webapp/ui/src/stores/definitions/ExtraField.ts
+++ b/src/main/webapp/ui/src/stores/definitions/ExtraField.ts
@@ -45,6 +45,12 @@ export interface ExtraField {
   readonly link: ExtraInventoryLink | null;
 
   /*
+   * Client-side only. True when this field was copied from a template, false
+   * when the user added it manually. Never sent to the backend.
+   */
+  fromTemplate: boolean;
+
+  /*
    * When set, subsequent API calls to store modifications MUST ensure that the
    * extra field is deleted.
    */

--- a/src/main/webapp/ui/src/stores/models/ExtraFieldModel.ts
+++ b/src/main/webapp/ui/src/stores/models/ExtraFieldModel.ts
@@ -34,6 +34,7 @@ export default class ExtraFieldModel implements ExtraField {
   owner: InventoryRecord;
   invalidInput: boolean;
   link: ExtraInventoryLink | null = null;
+  fromTemplate = false;
 
   constructor(attrs: ExtraFieldAttrs, owner: InventoryBaseRecord) {
     makeObservable(this, {

--- a/src/main/webapp/ui/src/stores/models/InstrumentModel.tsx
+++ b/src/main/webapp/ui/src/stores/models/InstrumentModel.tsx
@@ -304,26 +304,27 @@ export default class InstrumentModel
 
     if (!this.id) {
       this.overrideFields(template.fields);
-      this.setAttributes({
-        extraFields: template.extraFields
-          .filter((ef) => !ef.deleteFieldRequest)
-          .map(
-            (ef) =>
-              new ExtraFieldModel(
-                {
-                  id: null,
-                  globalId: null,
-                  parentGlobalId: null,
-                  name: ef.name,
-                  type: ef.type.toLowerCase() as "text" | "number" | "link",
-                  content: ef.content ?? "",
-                  lastModified: null,
-                  newFieldRequest: true,
-                },
-                this,
-              ),
-          ),
-      });
+      const userAddedFields = this.extraFields.filter((ef) => !ef.fromTemplate);
+      const templateFields = template.extraFields
+        .filter((ef) => !ef.deleteFieldRequest)
+        .map((ef) => {
+          const field = new ExtraFieldModel(
+            {
+              id: null,
+              globalId: null,
+              parentGlobalId: null,
+              name: ef.name,
+              type: ef.type.toLowerCase() as "text" | "number" | "link",
+              content: ef.content ?? "",
+              lastModified: null,
+              newFieldRequest: true,
+            },
+            this,
+          );
+          field.fromTemplate = true;
+          return field;
+        });
+      this.setAttributes({ extraFields: [...userAddedFields, ...templateFields] });
       if (!this.name) this.setAttributes({ name: template.name });
       if (!this.description) this.setAttributes({ description: template.description });
       this.setAttributes({

--- a/src/main/webapp/ui/src/stores/models/InstrumentTemplateModel.tsx
+++ b/src/main/webapp/ui/src/stores/models/InstrumentTemplateModel.tsx
@@ -1,7 +1,13 @@
 import { action, makeObservable, observable, override } from "mobx";
 import type React from "react";
 import type { _LINK } from "@/util/types";
+import docLinks from "../../assets/DocLinks";
 import TemplateIllustration from "../../assets/graphics/RecordTypeGraphics/HeaderIllustrations/Template";
+import ApiService from "../../common/InvApiService";
+import HelpLinkIcon from "../../components/HelpLinkIcon";
+import { handleDetailedErrors, handleDetailedSuccesses } from "../../util/alerts";
+import { getErrorMessage } from "../../util/error";
+import { mkAlert } from "../contexts/Alert";
 import type { BarcodeAttrs } from "../definitions/Barcode";
 import { type GlobalId, type Id, inventoryRecordTypeLabels } from "../definitions/BaseRecord";
 import type { HasEditableFields, HasUneditableFields } from "../definitions/Editable";
@@ -24,6 +30,8 @@ import InventoryBaseRecord, {
   RESULT_FIELDS,
 } from "./InventoryBaseRecord";
 import Search from "./Search";
+
+const mainSearch = () => getRootStore().searchStore.search;
 
 type InstrumentTemplateEditableFields = InventoryBaseRecordEditableFields;
 
@@ -78,6 +86,8 @@ export default class InstrumentTemplateModel
       addField: action,
       removeCustomField: action,
       moveField: action,
+      update: override,
+      updateInstrumentsToLatest: action,
       paramsForBackend: override,
       populateFromJson: override,
       updateFieldsState: override,
@@ -146,12 +156,15 @@ export default class InstrumentTemplateModel
     });
   }
 
-  removeCustomField(id: Id, index: number): void {
+  removeCustomField(id: Id, index: number, deleteFromInstruments = false): void {
     if (!this.id || !id) {
       this.fields.splice(index, 1);
     } else {
       const field = this.fields.find((f) => f.id === id);
-      field?.setAttributesDirty({ deleteFieldRequest: true });
+      field?.setAttributesDirty({
+        deleteFieldRequest: true,
+        deleteFieldOnSampleUpdate: deleteFromInstruments,
+      });
     }
   }
 
@@ -234,6 +247,107 @@ export default class InstrumentTemplateModel
 
   get usableInLoM(): boolean {
     return false;
+  }
+
+  private async setActiveResultToLatest(): Promise<InstrumentTemplateModel> {
+    const id = this.id;
+    if (!id) throw new Error("id is required.");
+    const latest = await getRootStore().searchStore.getInstrumentTemplate(id, this.factory.newFactory());
+    await mainSearch().setActiveResult(latest);
+    mainSearch().replaceResult(latest);
+    return latest;
+  }
+
+  async update(): Promise<void> {
+    const oldVersion = this.version;
+    await super.update(false);
+    const latest = await this.setActiveResultToLatest();
+
+    if (this.id) {
+      await this.search.fetcher.performInitialSearch(null);
+      const instrumentsToBeUpdated = this.search.fetcher.results.filter((r) => r.owner?.isCurrentUser ?? true);
+      if (this.version !== oldVersion && instrumentsToBeUpdated.length > 0) {
+        const newToast = mkAlert({
+          message: "Update existing instruments?",
+          variant: "notice",
+          isInfinite: true,
+          actionLabel: "yes",
+          onActionClick: () => void this.updateInstrumentsToLatest(),
+        });
+        latest.addScopedToast(newToast);
+        getRootStore().uiStore.addAlert(newToast);
+      }
+    }
+  }
+
+  async updateInstrumentsToLatest(): Promise<void> {
+    if (!this.id) throw new Error("id is required.");
+    const id = this.id;
+
+    if (
+      !(await getRootStore().uiStore.confirm(
+        <span
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "8px",
+            marginBottom: "10px",
+          }}
+        >
+          <span>Update all instruments to latest template version?</span>
+          <HelpLinkIcon
+            link={docLinks.updateAllSamplesOfTemplate}
+            title="Info on updating instruments to latest template version."
+            size="small"
+          />
+        </span>,
+        <>
+          All of your instruments created from this template will be updated to pick up the structural changes that have
+          been made to the template since the instrument was created or last updated, such as the addition, deletion and
+          reordering of fields, and the change to available options in choice and radio fields.&nbsp;
+          <strong>This action cannot be undone.</strong>
+        </>,
+        "Update all",
+      ))
+    )
+      return;
+    try {
+      const { data } = await ApiService.post<{
+        errorCount: number;
+        results: Array<{
+          error: { errors: Array<string> };
+          record: Record<string, unknown> & { globalId: GlobalId };
+        }>;
+      }>(`instrumentTemplates/${id.toString()}/actions/updateInstrumentsToLatestTemplateVersion`, {});
+      handleDetailedErrors(
+        data.errorCount,
+        data.results.map((response) => ({ response })),
+        "update",
+        () => this.updateInstrumentsToLatest(),
+        "",
+      );
+      const factory = this.factory.newFactory();
+      handleDetailedSuccesses(
+        data.results
+          .filter((r) => !r.error)
+          .map((r) => {
+            const newRecord = factory.newRecord(r.record);
+            newRecord.populateFromJson(factory, r.record, null);
+            return newRecord;
+          }),
+        "updated",
+      );
+    } catch (error) {
+      getRootStore().uiStore.addAlert(
+        mkAlert({
+          title: "Updating instruments to latest template version failed.",
+          message: getErrorMessage(error, "Unknown reason"),
+          variant: "error",
+        }),
+      );
+      console.error("Could not update instruments to latest template version.", error);
+    }
   }
 
   get createOptions(): ReadonlyArray<CreateOption> {

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/setTemplate.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/setTemplate.test.ts
@@ -6,7 +6,11 @@ vi.mock("../../../../common/InvApiService", () => ({ default: { query: vi.fn(), 
 vi.mock("../../../../stores/stores/getRootStore", () => ({
   default: () => ({
     trackingStore: { trackEvent: vi.fn() },
-    uiStore: { addAlert: vi.fn() },
+    uiStore: {
+      addAlert: vi.fn(),
+      setPageNavigationConfirmation: vi.fn(),
+      setDirty: vi.fn(),
+    },
   }),
 }));
 
@@ -181,6 +185,94 @@ describe("InstrumentModel.setTemplate", () => {
       const instrument = makeUnsavedInstrument();
       await instrument.setTemplate(template);
       expect(fetchSpy).toHaveBeenCalledOnce();
+    });
+
+    test("preserves user-added extra fields when changing templates", async () => {
+      const templateA = makeMockInstrumentTemplate({
+        extraFields: [
+          {
+            id: 1,
+            globalId: "EF1",
+            name: "Template A Field",
+            lastModified: null,
+            type: "text",
+            content: "",
+            parentGlobalId: "NT1",
+          },
+        ],
+      });
+      const templateB = makeMockInstrumentTemplate({
+        extraFields: [
+          {
+            id: 2,
+            globalId: "EF2",
+            name: "Template B Field",
+            lastModified: null,
+            type: "text",
+            content: "",
+            parentGlobalId: "NT1",
+          },
+        ],
+      });
+      vi.spyOn(templateA, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      vi.spyOn(templateB, "fetchAdditionalInfo").mockResolvedValue(undefined);
+
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(templateA);
+      instrument.addExtraField({
+        id: null,
+        globalId: null,
+        parentGlobalId: null,
+        name: "User Added Field",
+        type: "text",
+        content: "my value",
+        lastModified: null,
+      });
+      await instrument.setTemplate(templateB);
+
+      const names = instrument.extraFields.map((ef) => ef.name);
+      expect(names).toContain("User Added Field");
+      expect(names).toContain("Template B Field");
+      expect(names).not.toContain("Template A Field");
+    });
+
+    test("replaces previous template extra fields when changing templates", async () => {
+      const templateA = makeMockInstrumentTemplate({
+        extraFields: [
+          {
+            id: 1,
+            globalId: "EF1",
+            name: "Calibration Date",
+            lastModified: null,
+            type: "text",
+            content: "",
+            parentGlobalId: "NT1",
+          },
+        ],
+      });
+      const templateB = makeMockInstrumentTemplate({
+        extraFields: [
+          {
+            id: 2,
+            globalId: "EF2",
+            name: "Warranty Expiry",
+            lastModified: null,
+            type: "text",
+            content: "",
+            parentGlobalId: "NT1",
+          },
+        ],
+      });
+      vi.spyOn(templateA, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      vi.spyOn(templateB, "fetchAdditionalInfo").mockResolvedValue(undefined);
+
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(templateA);
+      await instrument.setTemplate(templateB);
+
+      const names = instrument.extraFields.map((ef) => ef.name);
+      expect(names).not.toContain("Calibration Date");
+      expect(names).toContain("Warranty Expiry");
     });
   });
 

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentTemplateModel/update.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentTemplateModel/update.test.ts
@@ -1,0 +1,114 @@
+import { runInAction } from "mobx";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import InvApiService from "../../../../common/InvApiService";
+import { instrumentTemplateAttrs, makeMockInstrumentTemplate } from "./mocking";
+
+const { mockAddAlert, mockGetInstrumentTemplate, mockSetActiveResult, mockReplaceResult } = vi.hoisted(() => ({
+  mockAddAlert: vi.fn(),
+  mockGetInstrumentTemplate: vi.fn(),
+  mockSetActiveResult: vi.fn(),
+  mockReplaceResult: vi.fn(),
+}));
+
+vi.mock("../../../../common/InvApiService", () => ({
+  default: {
+    query: vi.fn(),
+    get: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../stores/stores/getRootStore", () => ({
+  default: () => ({
+    authStore: { isSynchronizing: false },
+    trackingStore: { trackEvent: vi.fn() },
+    uiStore: {
+      addAlert: mockAddAlert,
+      setPageNavigationConfirmation: vi.fn(),
+      setDirty: vi.fn(),
+    },
+    searchStore: {
+      getInstrumentTemplate: mockGetInstrumentTemplate,
+      search: {
+        replaceResult: mockReplaceResult,
+        setActiveResult: mockSetActiveResult,
+        activeResult: null,
+      },
+    },
+  }),
+}));
+
+function mockPutReturningVersion(version: number) {
+  vi.mocked(InvApiService.update).mockResolvedValueOnce({
+    data: instrumentTemplateAttrs({ id: 5, version }),
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    // biome-ignore lint/suspicious/noExplicitAny: test setup
+    config: {} as any,
+  });
+}
+
+describe("InstrumentTemplateModel.update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("shows update toast when version bumps and current user has instruments", async () => {
+    const template = makeMockInstrumentTemplate({ id: 5, version: 1 });
+    mockPutReturningVersion(2);
+
+    const latestTemplate = makeMockInstrumentTemplate({ id: 5, version: 2 });
+    mockGetInstrumentTemplate.mockResolvedValueOnce(latestTemplate);
+    mockSetActiveResult.mockResolvedValueOnce(undefined);
+
+    vi.spyOn(template.search.fetcher, "performInitialSearch").mockImplementationOnce(async () => {
+      runInAction(() => {
+        (template.search.fetcher as unknown as { results: unknown[] }).results = [{ owner: { isCurrentUser: true } }];
+      });
+    });
+    vi.spyOn(latestTemplate, "addScopedToast").mockImplementation(() => {});
+
+    await template.update();
+
+    expect(mockAddAlert).toHaveBeenCalledWith(expect.objectContaining({ variant: "notice" }));
+  });
+
+  test("does not show toast when the version does not change", async () => {
+    const template = makeMockInstrumentTemplate({ id: 5, version: 1 });
+    mockPutReturningVersion(1);
+
+    const latestTemplate = makeMockInstrumentTemplate({ id: 5, version: 1 });
+    mockGetInstrumentTemplate.mockResolvedValueOnce(latestTemplate);
+    mockSetActiveResult.mockResolvedValueOnce(undefined);
+
+    vi.spyOn(template.search.fetcher, "performInitialSearch").mockImplementationOnce(async () => {
+      runInAction(() => {
+        (template.search.fetcher as unknown as { results: unknown[] }).results = [{ owner: { isCurrentUser: true } }];
+      });
+    });
+
+    await template.update();
+
+    expect(mockAddAlert).not.toHaveBeenCalledWith(expect.objectContaining({ variant: "notice" }));
+  });
+
+  test("does not show toast when no instruments are owned by the current user", async () => {
+    const template = makeMockInstrumentTemplate({ id: 5, version: 1 });
+    mockPutReturningVersion(2);
+
+    const latestTemplate = makeMockInstrumentTemplate({ id: 5, version: 2 });
+    mockGetInstrumentTemplate.mockResolvedValueOnce(latestTemplate);
+    mockSetActiveResult.mockResolvedValueOnce(undefined);
+
+    vi.spyOn(template.search.fetcher, "performInitialSearch").mockImplementationOnce(async () => {
+      runInAction(() => {
+        (template.search.fetcher as unknown as { results: unknown[] }).results = [];
+      });
+    });
+
+    await template.update();
+
+    expect(mockAddAlert).not.toHaveBeenCalledWith(expect.objectContaining({ variant: "notice" }));
+  });
+});

--- a/src/main/webapp/ui/src/stores/stores/SearchStore.tsx
+++ b/src/main/webapp/ui/src/stores/stores/SearchStore.tsx
@@ -15,7 +15,7 @@ import BasketModel from "../models/Basket";
 import ContainerModel, { type ContainerAttrs } from "../models/ContainerModel";
 import MemoisedFactory from "../models/Factory/MemoisedFactory";
 import InstrumentModel, { type InstrumentAttrs } from "../models/InstrumentModel";
-import InstrumentTemplateModel from "../models/InstrumentTemplateModel";
+import InstrumentTemplateModel, { type InstrumentTemplateAttrs } from "../models/InstrumentTemplateModel";
 import type InventoryBaseRecord from "../models/InventoryBaseRecord";
 import SampleModel from "../models/SampleModel";
 import Search from "../models/Search";
@@ -440,6 +440,11 @@ export default class SearchStore {
       typeof version === "number" ? `${id}/versions/${version}` : `${id}`,
     );
     return new TemplateModel(factory, data);
+  }
+
+  async getInstrumentTemplate(id: number, factory: Factory): Promise<InstrumentTemplateModel> {
+    const { data } = await ApiService.get<InstrumentTemplateAttrs>("instrumentTemplates", `${id}`);
+    return new InstrumentTemplateModel(factory, data);
   }
 
   get activeResultIsBeingEdited(): boolean {


### PR DESCRIPTION
## Description ##
Addresses:  https://researchspace.atlassian.net/browse/RSDEV-1229

Summary of changes from Claude:

1. Preserve user-added extra fields when changing Instrument Template during 
  creation
  - ExtraField.ts / ExtraFieldModel.ts -- added client-side fromTemplate: 
  boolean flag to distinguish template-sourced fields from user-added ones
  - InstrumentModel.tsx -- updated setTemplate() to retain user-added extra
  fields and replace only template-sourced ones when the template changes
  
  2. "Update existing instruments?" post-save prompt
  - SearchStore.tsx -- added getInstrumentTemplate() to re-fetch a template
  after save
  - InstrumentTemplateModel.tsx -- added update() override,
  setActiveResultToLatest() helper, and updateInstrumentsToLatest() method
  calling POST 
  instrumentTemplates/{id}/actions/updateInstrumentsToLatestTemplateVersion
  - __tests__/InstrumentTemplateModel/update.test.ts -- new test file covering
  the three toast-show/no-show scenarios

  3. Dialog title layout fix
  - InstrumentTemplateModel.tsx -- wrapped the confirmation dialog title in a
  flex container with justifyContent: "space-between" so the help icon sits 
  right-aligned on the same line as the wrapped title text
  
  4. Keep/remove option when deleting a Custom Field from an Instrument Template
  - Template/Fields/CustomField.tsx -- replaced static deleteOptions with
  makeDeleteOptions(recordTypeName), added recordTypeName?: "sample" | 
  "instrument" prop (default "sample"), and updated all label/confirmation
  strings to use the prop
  - InstrumentTemplate/Fields/CustomFields.tsx -- passed b (the keep/remove
  boolean) through to removeCustomField, added recordTypeName="instrument" prop
  to <CustomField> 
  - InstrumentTemplateModel.tsx -- updated removeCustomField() to accept and
  forward deleteFromInstruments as deleteFieldOnSampleUpdate to the field model
