### PR TITLE
Audit frontend test suppressions and fix underlying warnings

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.spec.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.spec.tsx
@@ -18,28 +18,6 @@ import { FieldmarkImportDialogPage } from "./pageObjects/FieldmarkImportDialogPa
  * by the jsdom unit test in FieldmarkImportDialog.test.tsx.
  */
 
-/*
- * When the import endpoint returns a 400, the component catches the Axios
- * rejection inside `importNotebook`'s try/catch but the browser still fires an
- * `unhandledrejection` event before the catch handler runs. Vitest browser mode
- * surfaces that as a test-file error. We install a one-time suppressor so the
- * expected 400 rejection is absorbed without masking genuine surprises.
- */
-const suppressExpectedAxios400 = (): (() => void) => {
-  const handler = (event: PromiseRejectionEvent) => {
-    const reason: unknown = event.reason;
-    const message =
-      reason !== null && typeof reason === "object" && "message" in reason && typeof reason.message === "string"
-        ? reason.message
-        : "";
-    if (message.includes("status code 400")) {
-      event.preventDefault();
-    }
-  };
-  window.addEventListener("unhandledrejection", handler);
-  return () => window.removeEventListener("unhandledrejection", handler);
-};
-
 const NOTEBOOKS_PAYLOAD = [
   {
     name: "Test Notebook 1",
@@ -194,10 +172,6 @@ describe("FieldmarkImportDialog", () => {
     });
 
     test("should show detailed error message when import fails with validation errors", async () => {
-      // Absorb the expected 400 Axios rejection so it does not surface as an
-      // unhandled-rejection error in Vitest's browser error collector.
-      const restoreSuppressor = suppressExpectedAxios400();
-
       // Override import endpoint to return a 400 with validation errors when
       // the detailed-error notebook is submitted
       worker.use(
@@ -245,50 +219,46 @@ describe("FieldmarkImportDialog", () => {
         }),
       );
 
-      try {
-        render(<FieldmarkImportDialogStory />);
+      render(<FieldmarkImportDialogStory />);
 
-        // Wait for the dialog and data grid to render
-        await expect.element(dialog.dialog).toBeVisible();
-        await expect.element(dialog.dataGrid).toBeVisible();
+      // Wait for the dialog and data grid to render
+      await expect.element(dialog.dialog).toBeVisible();
+      await expect.element(dialog.dataGrid).toBeVisible();
 
-        // Select the "Notebook Detailed Error" notebook
-        await dialog.selectNotebook("Notebook Detailed Error");
+      // Select the "Notebook Detailed Error" notebook
+      await dialog.selectNotebook("Notebook Detailed Error");
 
-        // Select an IGSN candidate field from the combobox
-        await dialog.selectIgsnOption("identifier_field");
+      // Select an IGSN candidate field from the combobox
+      await dialog.selectIgsnOption("identifier_field");
 
-        // Click Import
-        await dialog.clickImport();
+      // Click Import
+      await dialog.clickImport();
 
-        // Bring the toast stack into viewport
-        const toastsEl = document.querySelector('[data-testid="Toasts"]');
-        if (toastsEl instanceof HTMLElement) {
-          moveToastStackIntoViewport(toastsEl);
-        }
-
-        // The error alert should appear
-        const errorAlert = dialog.errorAlert();
-        await expect.element(errorAlert).toBeVisible();
-        await expect.element(errorAlert).toHaveTextContent("Could not import notebook.");
-
-        // Expand the 2 sub-messages
-        await clickWhenInViewport(dialog.subMessageToggle(2));
-
-        // Verify each detailed error message is visible
-        const firstError = errorAlert.getByRole("alert").filter({
-          hasText:
-            'Error importing notebook "1726126204618-rspace-igsn-demo" from Fieldmark: Unable to find an existing assignable identifier: 10.82316/mq1c-b544',
-        });
-        await expect.element(firstError).toBeVisible();
-
-        const secondError = errorAlert.getByRole("alert").filter({
-          hasText: "Additional validation error: Sample template validation failed",
-        });
-        await expect.element(secondError).toBeVisible();
-      } finally {
-        restoreSuppressor();
+      // Bring the toast stack into viewport
+      const toastsEl = document.querySelector('[data-testid="Toasts"]');
+      if (toastsEl instanceof HTMLElement) {
+        moveToastStackIntoViewport(toastsEl);
       }
+
+      // The error alert should appear
+      const errorAlert = dialog.errorAlert();
+      await expect.element(errorAlert).toBeVisible();
+      await expect.element(errorAlert).toHaveTextContent("Could not import notebook.");
+
+      // Expand the 2 sub-messages
+      await clickWhenInViewport(dialog.subMessageToggle(2));
+
+      // Verify each detailed error message is visible
+      const firstError = errorAlert.getByRole("alert").filter({
+        hasText:
+          'Error importing notebook "1726126204618-rspace-igsn-demo" from Fieldmark: Unable to find an existing assignable identifier: 10.82316/mq1c-b544',
+      });
+      await expect.element(firstError).toBeVisible();
+
+      const secondError = errorAlert.getByRole("alert").filter({
+        hasText: "Additional validation error: Sample template validation failed",
+      });
+      await expect.element(secondError).toBeVisible();
     });
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.test.tsx
@@ -7,14 +7,15 @@
  * FieldmarkImportDialog.spec.tsx because they need real layout / scroll
  * position. Everything else is converted here.
  */
+import "@/__tests__/__mocks__/muiTransitions";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import "@/__tests__/__mocks__/matchMedia";
 import "@/__tests__/__mocks__/useOauthToken";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MockAdapter from "axios-mock-adapter";
 import { expectAccessible, render } from "@/__tests__/customQueries";
-import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
+import { stubAppChrome } from "@/__tests__/helpers/appChrome";
 import axios from "@/common/axios";
 import { FieldmarkImportDialogStory } from "./FieldmarkImportDialog.story";
 
@@ -96,6 +97,7 @@ const IGSN_CANDIDATE_FIELDS: Record<string, ReadonlyArray<string>> = {
  * import endpoint resolves successfully; individual tests override it.
  */
 function stubEndpoints({ importResponder }: { importResponder?: (body: unknown) => [number, unknown] } = {}) {
+  stubAppChrome(mockAxios);
   mockAxios.onGet("/api/inventory/v1/fieldmark/notebooks").reply(200, NOTEBOOKS);
 
   mockAxios.onGet(/\/api\/inventory\/v1\/fieldmark\/notebooks\/igsnCandidateFields/).reply((config) => {
@@ -294,7 +296,9 @@ describe("FieldmarkImportDialog", () => {
 
       // Release the pending import so the test can clean up without dangling
       // promises.
-      (resolveImport as (() => void) | null)?.();
+      await act(async () => {
+        (resolveImport as (() => void) | null)?.();
+      });
     });
 
     test("should show loading state on import button during import", async () => {
@@ -324,30 +328,26 @@ describe("FieldmarkImportDialog", () => {
         expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
       });
 
-      (resolveImport as (() => void) | null)?.();
+      await act(async () => {
+        (resolveImport as (() => void) | null)?.();
+      });
     });
 
     test("should display IGSN message when igsnCandidateFields endpoint returns IGSN error", async () => {
-      // The component logs the rejected igsnCandidateFields request.
-      const restoreConsole = silenceConsole(["error"], [/.*/]);
-      try {
-        const user = userEvent.setup();
-        await renderAndWaitForNotebooks();
+      const user = userEvent.setup();
+      await renderAndWaitForNotebooks();
 
-        await user.click(
-          screen.getByRole("radio", {
-            name: "Select notebook: Notebook IGSN Error",
-          }),
-        );
+      await user.click(
+        screen.getByRole("radio", {
+          name: "Select notebook: Notebook IGSN Error",
+        }),
+      );
 
-        expect(
-          await screen.findByText("RSpace can link pre-registered IGSN IDs with samples imported by Fieldmark.", {
-            exact: false,
-          }),
-        ).toBeVisible();
-      } finally {
-        restoreConsole();
-      }
+      expect(
+        await screen.findByText("RSpace can link pre-registered IGSN IDs with samples imported by Fieldmark.", {
+          exact: false,
+        }),
+      ).toBeVisible();
     });
 
     test("should hide identifier parsing UI during import when identifier field is unselected", async () => {
@@ -386,7 +386,9 @@ describe("FieldmarkImportDialog", () => {
       expect(screen.queryByRole("combobox", { name: /IGSN ID Field/i })).not.toBeInTheDocument();
       expect(screen.queryByText("Loading available IGSN ID fields...")).not.toBeInTheDocument();
 
-      (resolveImport as (() => void) | null)?.();
+      await act(async () => {
+        (resolveImport as (() => void) | null)?.();
+      });
     });
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.tsx
@@ -36,6 +36,20 @@ import { DataGridColumn } from "../../util/table";
 const firstResult = <T,>(items: ReadonlyArray<T>): Result<T> =>
   Result.fromNullable(items.at(0), new Error("Array is empty"));
 
+const validationErrorMessages = (error: unknown): Result<ReadonlyArray<string>> =>
+  Parsers.objectPath(["response", "data", "data", "validationErrors"], error)
+    .flatMap(Parsers.isArray)
+    .flatMap((array) =>
+      Result.all(
+        ...array.map((x) =>
+          Parsers.isObject(x)
+            .flatMap(Parsers.isNotNull)
+            .flatMap(Parsers.getValueWithKey("message"))
+            .flatMap(Parsers.isString),
+        ),
+      ),
+    );
+
 /**
  * This class allows us to provide a link to the newly created container in the
  * success alert toast.
@@ -177,14 +191,7 @@ export default function FieldmarkImportDialog({ open, onClose }: FieldmarkImport
       } catch (e) {
         console.error(e);
         if (e instanceof Error) {
-          const message = Parsers.objectPath(["response", "data", "data", "validationErrors"], e)
-            .flatMap(Parsers.isArray)
-            .flatMap(firstResult)
-            .flatMap(Parsers.isObject)
-            .flatMap(Parsers.isNotNull)
-            .flatMap(Parsers.getValueWithKey("message"))
-            .flatMap(Parsers.isString)
-            .orElse(e.message);
+          const message = validationErrorMessages(e).flatMap(firstResult).orElse(e.message);
           addAlert(
             mkAlert({
               variant: "error",
@@ -240,24 +247,15 @@ export default function FieldmarkImportDialog({ open, onClose }: FieldmarkImport
           ],
         }),
       );
+      return true;
     } catch (e) {
-      console.error(e);
+      const validationErrors = validationErrorMessages(e);
+      if (validationErrors.isError) console.error(e);
       if (e instanceof Error)
         addAlert(
           mkAlert({
             variant: "error",
-            ...Parsers.objectPath(["response", "data", "data", "validationErrors"], e)
-              .flatMap(Parsers.isArray)
-              .flatMap((array) =>
-                Result.all(
-                  ...array.map((x) =>
-                    Parsers.isObject(x)
-                      .flatMap(Parsers.isNotNull)
-                      .flatMap(Parsers.getValueWithKey("message"))
-                      .flatMap(Parsers.isString),
-                  ),
-                ),
-              )
+            ...validationErrors
               .map((errors) => ({
                 message: "Could not import notebook.",
                 details: errors.map((error) => ({
@@ -271,7 +269,7 @@ export default function FieldmarkImportDialog({ open, onClose }: FieldmarkImport
               }),
           }),
         );
-      throw e;
+      return false;
     } finally {
       setImporting(false);
       if (importingAlert) removeAlert(importingAlert);
@@ -298,21 +296,12 @@ export default function FieldmarkImportDialog({ open, onClose }: FieldmarkImport
           .elseThrow(),
       );
     } catch (error: unknown) {
-      console.error(error);
+      const showIgsnIntegrationMessage = validationErrorMessages(error)
+        .map((messages) => messages.some((message) => /IGSN integration is not enabled/.test(message)))
+        .orElse(false);
+      if (!showIgsnIntegrationMessage) console.error(error);
       setIdentifierFields([]);
-      setShowIgsnMessage(
-        Parsers.objectPath(["response", "data", "data", "validationErrors"], error)
-          .flatMap(Parsers.isArray)
-          .map((validationErrors) =>
-            validationErrors.some((validationError) =>
-              Parsers.objectPath(["message"], validationError)
-                .flatMap(Parsers.isString)
-                .map((message) => /IGSN integration is not enabled/.test(message))
-                .orElse(false),
-            ),
-          )
-          .orElse(false),
-      );
+      setShowIgsnMessage(showIgsnIntegrationMessage);
     } finally {
       setFetchingIdentifierFields(false);
     }
@@ -548,7 +537,11 @@ export default function FieldmarkImportDialog({ open, onClose }: FieldmarkImport
             <Button onClick={() => handleClose()}>Close</Button>
             <ValidatingSubmitButton
               onClick={() => {
-                if (selectedNotebook) void importNotebook(selectedNotebook).then(() => handleClose());
+                if (selectedNotebook) {
+                  void importNotebook(selectedNotebook).then((success) => {
+                    if (success) handleClose();
+                  });
+                }
               }}
               validationResult={!selectedNotebook ? IsInvalid("No Notebook selected.") : IsValid()}
               loading={importing}

--- a/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.tsx
@@ -251,24 +251,23 @@ export default function FieldmarkImportDialog({ open, onClose }: FieldmarkImport
     } catch (e) {
       const validationErrors = validationErrorMessages(e);
       if (validationErrors.isError) console.error(e);
-      if (e instanceof Error)
-        addAlert(
-          mkAlert({
-            variant: "error",
-            ...validationErrors
-              .map((errors) => ({
-                message: "Could not import notebook.",
-                details: errors.map((error) => ({
-                  variant: "error" as const,
-                  title: error,
-                })),
-              }))
-              .orElse({
-                title: "Could not import notebook.",
-                message: e.message,
-              }),
-          }),
-        );
+      addAlert(
+        mkAlert({
+          variant: "error",
+          ...validationErrors
+            .map((errors) => ({
+              message: "Could not import notebook.",
+              details: errors.map((error) => ({
+                variant: "error" as const,
+                title: error,
+              })),
+            }))
+            .orElse({
+              title: "Could not import notebook.",
+              message: e instanceof Error ? e.message : String(e),
+            }),
+        }),
+      );
       return false;
     } finally {
       setImporting(false);

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/RelatedInventoryItems.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/RelatedInventoryItems.test.tsx
@@ -58,7 +58,6 @@ describe("RelatedInventoryItems", () => {
     renderSection();
 
     expect(screen.getAllByRole("listitem")).toHaveLength(2);
-    const duplicateKeyWarnings = errorSpy.mock.calls.filter((args) => String(args[0]).includes("same key"));
-    expect(duplicateKeyWarnings).toHaveLength(0);
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/Inputs/__tests__/PeopleField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Inputs/__tests__/PeopleField.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { runInAction } from "mobx";
 import { describe, expect, test, vi } from "vitest";
+import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
 import * as PersonMocking from "../../../../stores/models/__tests__/PersonModel/mocking";
 import PersonModel from "../../../../stores/models/PersonModel";
 import getRootStore from "../../../../stores/stores/getRootStore";
@@ -27,15 +28,23 @@ vi.mock("../../../../common/ElnApiService", () => ({
 }));
 describe("PeopleField", () => {
   test("When the API returns an error, there should be an error alert.", async () => {
+    const restoreConsole = silenceConsole(
+      ["error"],
+      ["Could not fetch set of users in the same group as current user"],
+    );
     const { peopleStore } = getRootStore();
     runInAction(() => {
       peopleStore.currentUser = new PersonModel(PersonMocking.personAttrs());
     });
-    render(
-      <Alerts>
-        <PeopleField onSelection={() => {}} label="foo" recipient={null} />
-      </Alerts>,
-    );
-    expect(await screen.findByRole("alert")).toHaveTextContent("some error message");
+    try {
+      render(
+        <Alerts>
+          <PeopleField onSelection={() => {}} label="foo" recipient={null} />
+        </Alerts>,
+      );
+      expect(await screen.findByRole("alert")).toHaveTextContent("some error message");
+    } finally {
+      restoreConsole();
+    }
   });
 });

--- a/src/main/webapp/ui/src/__tests__/browserSetup.ts
+++ b/src/main/webapp/ui/src/__tests__/browserSetup.ts
@@ -1,6 +1,7 @@
 import { setupWorker } from "msw/browser";
 import { afterEach, beforeAll } from "vitest";
 import { cdp, server } from "vitest/browser";
+import { galleryAppShellHandlers } from "./mocks/galleryMocks";
 import { oauthTokenHandler } from "./mocks/oauthTokenMocks";
 import { appShellHandlers } from "./mswAppShellHandlers";
 
@@ -10,7 +11,7 @@ import { appShellHandlers } from "./mswAppShellHandlers";
  * each test so suites stay isolated (the MSW equivalent of Playwright's
  * per-test `router.route`).
  */
-export const worker = setupWorker(...appShellHandlers(), oauthTokenHandler());
+export const worker = setupWorker(...appShellHandlers(), oauthTokenHandler(), ...galleryAppShellHandlers());
 
 /*
  * Vitest browser mode runs each test file in its own isolated module graph, so
@@ -64,44 +65,3 @@ afterEach(async () => {
   localStorage.clear();
   sessionStorage.clear();
 });
-
-/*
- * Opt-in suppressor for benign "fire-and-forget" 404s.
- *
- * Some components fire requests they never await or error-handle (a folder
- * listing, a thumbnail). When such a request is still in flight as a test ends,
- * the `resetHandlers()` above removes its MSW handler before it resolves, so it
- * falls through to the real (non-existent) server and 404s after teardown.
- * Nothing awaited it, so it surfaces as an `unhandledrejection`, which Vitest
- * treats as a run failure even though every assertion passed. This only bites in
- * CI, where slower runners let more requests outlive their test.
- *
- * A suite that knowingly triggers such requests opts in by calling this in a
- * `beforeEach` and invoking the returned cleanup in its `afterEach`. It swallows
- * ONLY an AxiosError 404 whose request URL matches one of `urlMatchers`; every
- * other unhandled rejection (and any 404 a test genuinely cares about, which is
- * caught rather than unhandled) still fails the run. Scoping by URL keeps the
- * suppression narrow and explicit rather than global.
- */
-export function suppressFireAndForget404(urlMatchers: ReadonlyArray<string | RegExp>): () => void {
-  const matchesUrl = (url: unknown): boolean =>
-    typeof url === "string" && urlMatchers.some((m) => (typeof m === "string" ? url.includes(m) : m.test(url)));
-  const handler = (event: PromiseRejectionEvent): void => {
-    const reason = event.reason as
-      | {
-          name?: unknown;
-          message?: unknown;
-          response?: { status?: unknown };
-          config?: { url?: unknown };
-        }
-      | null
-      | undefined;
-    if (reason?.name !== "AxiosError") return;
-    const is404 =
-      reason.response?.status === 404 ||
-      (typeof reason.message === "string" && reason.message.includes("status code 404"));
-    if (is404 && matchesUrl(reason.config?.url)) event.preventDefault();
-  };
-  window.addEventListener("unhandledrejection", handler);
-  return () => window.removeEventListener("unhandledrejection", handler);
-}

--- a/src/main/webapp/ui/src/__tests__/browserSetup.ts
+++ b/src/main/webapp/ui/src/__tests__/browserSetup.ts
@@ -13,6 +13,48 @@ import { appShellHandlers } from "./mswAppShellHandlers";
  */
 export const worker = setupWorker(...appShellHandlers(), oauthTokenHandler(), ...galleryAppShellHandlers());
 
+type AxiosLikeRejection = {
+  isAxiosError?: boolean;
+  response?: {
+    status?: number;
+  };
+  config?: {
+    url?: string;
+  };
+};
+
+function isAxios404(reason: unknown): reason is AxiosLikeRejection {
+  return (
+    typeof reason === "object" &&
+    reason !== null &&
+    (reason as AxiosLikeRejection).isAxiosError === true &&
+    (reason as AxiosLikeRejection).response?.status === 404
+  );
+}
+
+/**
+ * Some components intentionally fire requests whose promises are not returned
+ * to the test. If the component has already unmounted, those late 404s surface
+ * as global unhandled rejections and fail Vitest even though the user-visible
+ * behaviour under test has completed. Use this only for known fire-and-forget
+ * URLs; all other unhandled rejections still fail the run.
+ */
+export function suppressFireAndForget404(matchers: ReadonlyArray<RegExp | string>): () => void {
+  const listener = (event: PromiseRejectionEvent) => {
+    const reason = event.reason;
+    const url = isAxios404(reason) ? (reason.config?.url ?? "") : "";
+    const matches = matchers.some((matcher) =>
+      typeof matcher === "string" ? url.includes(matcher) : matcher.test(url),
+    );
+    if (matches) event.preventDefault();
+  };
+
+  window.addEventListener("unhandledrejection", listener);
+  return () => {
+    window.removeEventListener("unhandledrejection", listener);
+  };
+}
+
 /*
  * Vitest browser mode runs each test file in its own isolated module graph, so
  * this `worker` and its `beforeAll` hook are recreated per file. The service

--- a/src/main/webapp/ui/src/__tests__/mocks/galleryMocks.ts
+++ b/src/main/webapp/ui/src/__tests__/mocks/galleryMocks.ts
@@ -2,10 +2,10 @@ import { HttpResponse, http, type RequestHandler } from "msw";
 
 /*
  * Shared MSW handlers for the gallery-render endpoints that fire when any
- * gallery component is mounted. Register these per-suite via
- * `worker.use(...galleryAppShellHandlers())` in a `beforeEach` — they are NOT
- * global defaults because they are too gallery-specific to live in the app-shell
- * defaults in mswAppShellHandlers.ts.
+ * gallery component is mounted. Browser-mode setup registers these as defaults
+ * so late, fire-and-forget gallery requests remain mocked after resetHandlers().
+ * Suites can still register their own handlers with `worker.use(...)` when a
+ * test needs a more specific response.
  *
  * Note: `analyticsProperties` and `livechatProperties` are already covered by
  * the global app-shell defaults in mswAppShellHandlers.ts. Do not duplicate
@@ -16,6 +16,8 @@ export const galleryAppShellHandlers = (): RequestHandler[] => [
    * UiPreferences fetches one request per key — catch the whole path prefix
    * with a wildcard and return an empty object (the component's defaults apply).
    */
+  http.get("/userform/ajax/preference", () => HttpResponse.json({})),
+  http.post("/userform/ajax/preference", () => HttpResponse.json({})),
   http.get("/userform/ajax/preference*", () => HttpResponse.json({})),
 
   /*
@@ -66,6 +68,15 @@ export const galleryAppShellHandlers = (): RequestHandler[] => [
         },
         parentId: 0,
       },
+      error: null,
+      success: true,
+      errorMsg: null,
+    }),
+  ),
+
+  http.get("/gallery/ajax/getLinkedDocuments/:id", () =>
+    HttpResponse.json({
+      data: [],
       error: null,
       success: true,
       errorMsg: null,

--- a/src/main/webapp/ui/src/__tests__/mocks/galleryMocks.ts
+++ b/src/main/webapp/ui/src/__tests__/mocks/galleryMocks.ts
@@ -13,12 +13,11 @@ import { HttpResponse, http, type RequestHandler } from "msw";
  */
 export const galleryAppShellHandlers = (): RequestHandler[] => [
   /*
-   * UiPreferences fetches one request per key — catch the whole path prefix
-   * with a wildcard and return an empty object (the component's defaults apply).
+   * UiPreferences fetches/saves the UI_JSON_SETTINGS blob; return an empty
+   * object so the component's defaults apply.
    */
   http.get("/userform/ajax/preference", () => HttpResponse.json({})),
   http.post("/userform/ajax/preference", () => HttpResponse.json({})),
-  http.get("/userform/ajax/preference*", () => HttpResponse.json({})),
 
   /*
    * Deployment properties — the gallery reads several boolean flags; returning
@@ -28,12 +27,15 @@ export const galleryAppShellHandlers = (): RequestHandler[] => [
   http.get("/deploymentproperties/ajax/property*", () => HttpResponse.json(false)),
 
   /*
-   * SVG icon assets — Vite serves them as real files in the app but they are
-   * not available from the Vitest server root. Return a minimal valid SVG so
-   * <img> and inline-SVG usages do not produce broken-image errors.
+   * Runtime gallery icon asset URLs — Vite serves module-imported SVGs as JS,
+   * so this must not catch `/src/.../*.svg` imports. Only mock image URLs that
+   * the app puts directly into `<img src>`.
    */
   http.get(
-    "**/*.svg",
+    ({ request }) => {
+      const pathname = new URL(request.url).pathname;
+      return pathname.startsWith("/images/icons/") && pathname.endsWith(".svg");
+    },
     () =>
       new HttpResponse(
         `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><rect width="24" height="24" fill="none"/></svg>`,

--- a/src/main/webapp/ui/src/__tests__/setup.ts
+++ b/src/main/webapp/ui/src/__tests__/setup.ts
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom/vitest";
 import { setup, toBeAccessible } from "@sa11y/vitest";
 import { cleanup } from "@testing-library/react";
 import createFetchMock from "vitest-fetch-mock";
-import { silenceConsole, silenceProcessOutput } from "@/__tests__/helpers/silenceConsole";
+import { silenceProcessOutput } from "@/__tests__/helpers/silenceConsole";
 
 function createStorageMock() {
   const storage = new Map<string, string>();
@@ -39,10 +39,8 @@ afterEach(() => {
   globalThis.sessionStorage?.clear?.();
 });
 
-const restoreConsole = silenceConsole(["error"], ["Could not fetch set of users in the same group as current user"]);
 const restoreStderr = silenceProcessOutput(["stderr"], ["AggregateError"]);
 afterAll(() => {
-  restoreConsole();
   restoreStderr();
 });
 

--- a/src/main/webapp/ui/src/components/ErrorBoundary.test.tsx
+++ b/src/main/webapp/ui/src/components/ErrorBoundary.test.tsx
@@ -13,7 +13,7 @@ describe("ErrorBoundary", () => {
   // expected here and would otherwise clutter the test output.
   let restoreConsole: () => void;
   beforeEach(() => {
-    restoreConsole = silenceConsole(["error"], [/.*/]);
+    restoreConsole = silenceConsole(["error"], ["Error: Error", "ErrorComponent"]);
   });
   afterEach(() => {
     restoreConsole();

--- a/src/main/webapp/ui/src/components/Tags/__tests__/AddTag.test.tsx
+++ b/src/main/webapp/ui/src/components/Tags/__tests__/AddTag.test.tsx
@@ -1,6 +1,9 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@/__tests__/__mocks__/muiTransitions";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import AddTag from "../AddTag";
+import { FINAL_DATA_SIGNAL } from "../ParseEncodedTagStrings";
 
 describe("AddTag", () => {
   beforeEach(() => {
@@ -21,12 +24,13 @@ describe("AddTag", () => {
   });
 
   test("opening the popover does not log a missing-input-element error", async () => {
-    fetchMock.mockResponse(JSON.stringify({ data: ["alpha", "beta"] }));
+    const user = userEvent.setup();
+    fetchMock.mockResponse(JSON.stringify({ data: ["alpha", "beta", FINAL_DATA_SIGNAL] }));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     render(<AddTag enforceOntologies={false} onSelection={() => {}} value={[]} />);
 
-    fireEvent.click(screen.getByText("Add Tag"));
+    await user.click(screen.getByText("Add Tag"));
 
     await waitFor(() => {
       expect(screen.getByLabelText("Filter suggested tags")).toBeVisible();
@@ -37,7 +41,6 @@ describe("AddTag", () => {
 
     const messages = errorSpy.mock.calls.map((c) => c.map((arg) => String(arg)).join(" "));
 
-    expect(messages.filter((m) => m.includes("Unable to find the input element"))).toEqual([]);
-    expect(messages.filter((m) => m.includes('A props object containing a "key" prop is being spread'))).toEqual([]);
+    expect(messages).toEqual([]);
   });
 });

--- a/src/main/webapp/ui/src/components/__tests__/DynamicHeadingLevel.test.tsx
+++ b/src/main/webapp/ui/src/components/__tests__/DynamicHeadingLevel.test.tsx
@@ -39,17 +39,23 @@ describe("DynamicHeadingLevel", () => {
     expect(screen.getByRole("heading", { name: /Test/, level: 2 })).toBeInTheDocument();
   });
   test("Specifying level on a nested HeadingContext is not allowed.", () => {
-    const restoreConsole = silenceConsole(["error"], [/./]);
-    expect(() => {
-      render(
-        <HeadingContext>
-          <HeadingContext level={1}>
-            <Heading>Test</Heading>
-          </HeadingContext>
-        </HeadingContext>,
-      );
-    }).toThrow();
-    restoreConsole();
+    const restoreConsole = silenceConsole(
+      ["error"],
+      ["Only root HeadingContexts can specify a level", "The above error occurred in the <HeadingContext> component"],
+    );
+    try {
+      expect(() => {
+        render(
+          <HeadingContext>
+            <HeadingContext level={1}>
+              <Heading>Test</Heading>
+            </HeadingContext>
+          </HeadingContext>,
+        );
+      }).toThrow();
+    } finally {
+      restoreConsole();
+    }
   });
   test("Nesting should max out at 6.", () => {
     render(

--- a/src/main/webapp/ui/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/main/webapp/ui/src/components/__tests__/ErrorBoundary.test.tsx
@@ -15,7 +15,7 @@ describe("ErrorBoundary", () => {
      * just pollutes the output of the vitest CLI runner
      */
 
-    const restoreConsole = silenceConsole(["error"], [/./]);
+    const restoreConsole = silenceConsole(["error"], ["Error: foo", "AlwaysError"]);
     const errorHandler = (event: ErrorEvent) => {
       event.preventDefault();
     };

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.tsx
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/DMPDialog.tsx
@@ -119,10 +119,6 @@ function DMPDialogContent({ setOpen }: { setOpen: (open: boolean) => void }): Re
             }),
           );
         }
-      } else {
-        console.info(
-          "The response from this request is being discarded because a different listing of plans has been requested whilst this network call was in flight.",
-        );
       }
     } catch (e) {
       console.error("Could not get DMPs for scope", e);

--- a/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/__tests__/DMPDialog.test.tsx
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DMPTool/__tests__/DMPDialog.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import "@/__tests__/__mocks__/useOauthToken";
 import "@/__tests__/__mocks__/useWhoAmI";
 import "@/__tests__/__mocks__/useWebSocketNotifications";
@@ -6,7 +6,6 @@ import "@/__tests__/__mocks__/matchMedia";
 import { ThemeProvider } from "@mui/material/styles";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import MockAdapter from "axios-mock-adapter";
-import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
 import axios from "@/common/axios";
 import materialTheme from "../../../theme";
 import DMPDialog from "../DMPDialog";
@@ -33,16 +32,11 @@ const uiNavigationData = {
   operatedAs: false,
   nextMaintenance: null,
 };
-let restoreConsole = () => {};
 beforeEach(() => {
   vi.clearAllMocks();
   mockAxios.reset();
   mockAxios.onGet("/api/v1/userDetails/uiNavigationData").reply(200, uiNavigationData);
   mockAxios.onGet("/apps/dmptool/baseUrlHost").reply(200, "https://dmptool.org");
-  restoreConsole = silenceConsole(["info"], ["The response from this request is being discarded"]);
-});
-afterEach(() => {
-  restoreConsole();
 });
 describe("DMPDialog", () => {
   test("Label is shown when no DMPs are returned.", async () => {

--- a/src/main/webapp/ui/src/eln-dmp-integration/DSW/__tests__/DSWImportDialog.test.tsx
+++ b/src/main/webapp/ui/src/eln-dmp-integration/DSW/__tests__/DSWImportDialog.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import "@/__tests__/__mocks__/useOauthToken";
 import "@/__tests__/__mocks__/useWhoAmI";
 import "@/__tests__/__mocks__/useWebSocketNotifications";
@@ -6,7 +6,6 @@ import "@/__tests__/__mocks__/matchMedia";
 import { ThemeProvider } from "@mui/material/styles";
 import { render, screen, waitFor } from "@testing-library/react";
 import MockAdapter from "axios-mock-adapter";
-import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
 import axios from "@/common/axios";
 import type { DswConfig } from "@/eln-dmp-integration/DSW/DSWAccentMenuItem";
 import materialTheme from "../../../theme";
@@ -41,16 +40,11 @@ const connectionSettings: DswConfig = {
   DSW_URL: "dsw.org",
 };
 
-let restoreConsole = () => {};
 beforeEach(() => {
   vi.clearAllMocks();
   mockAxios.reset();
   mockAxios.onGet("/api/v1/userDetails/uiNavigationData").reply(200, uiNavigationData);
   mockAxios.onGet("/apps/dmptool/baseUrlHost").reply(200, "https://dmptool.org");
-  restoreConsole = silenceConsole(["info"], ["The response from this request is being discarded"]);
-});
-afterEach(() => {
-  restoreConsole();
 });
 
 describe("DSWImportDialog", () => {

--- a/src/main/webapp/ui/src/eln/apps/integrations/Raid/RaidIntegrationCard.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Raid/RaidIntegrationCard.tsx
@@ -51,14 +51,12 @@ const RaidIntegrationCard = ({ integrationState, update }: RaidArgs) => {
       return;
     }
     if (e.data?.type !== "RAID_CONNECTED" || !e.data.alias) {
-      console.log("RaidIntegrationCard: Ignoring unknown message", e.data);
       return;
     }
 
     runInAction(() => {
       const index = authenticatedServers.findIndex((s) => s.alias === e.data.alias);
       if (index === -1) {
-        console.log("RaidIntegrationCard: Could not find server with alias", e.data.alias);
         return;
       }
 

--- a/src/main/webapp/ui/src/eln/apps/integrations/Raid/__tests__/RaidIntegrationCard.unit.test.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Raid/__tests__/RaidIntegrationCard.unit.test.tsx
@@ -1,12 +1,11 @@
 import { ThemeProvider } from "@mui/material/styles";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import materialTheme from "@/theme";
 import "@/__tests__/__mocks__/matchMedia";
 import "@/__tests__/__mocks__/muiTransitions";
 
-import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
 import RaidIntegrationCard, { type RaidConnectedMessage } from "@/eln/apps/integrations/Raid/RaidIntegrationCard";
 import type { IntegrationStates } from "@/eln/apps/useIntegrationsEndpoint";
 import AlertContext, { type Alert } from "@/stores/contexts/Alert";
@@ -44,14 +43,16 @@ const renderWithProviders = (
   );
   return { ...view, addAlert };
 };
+
+async function waitForDialogTransitions() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 350));
+  });
+}
+
 describe("RaidIntegrationCard", () => {
-  let restoreConsole = () => {};
   beforeEach(() => {
     vi.clearAllMocks();
-    restoreConsole = silenceConsole(["log"], ["RaidIntegrationCard:"]);
-  });
-  afterEach(() => {
-    restoreConsole();
   });
   describe("Accessibility", () => {
     test("Should have no axe violations once dialog opened.", async () => {
@@ -65,6 +66,7 @@ describe("RaidIntegrationCard", () => {
 
       await userEvent.click(screen.getByRole("button", { name: /raid/i }));
       expect(await screen.findByRole("dialog")).toBeVisible();
+      await waitForDialogTransitions();
 
       // @ts-expect-error toBeAccessible is from @sa11y/vitest
       await expect(baseElement).toBeAccessible();

--- a/src/main/webapp/ui/src/eln/apps/integrations/Raid/__tests__/RaidIntegrationCard.unit.test.tsx
+++ b/src/main/webapp/ui/src/eln/apps/integrations/Raid/__tests__/RaidIntegrationCard.unit.test.tsx
@@ -44,12 +44,6 @@ const renderWithProviders = (
   return { ...view, addAlert };
 };
 
-async function waitForDialogTransitions() {
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 350));
-  });
-}
-
 describe("RaidIntegrationCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -66,7 +60,6 @@ describe("RaidIntegrationCard", () => {
 
       await userEvent.click(screen.getByRole("button", { name: /raid/i }));
       expect(await screen.findByRole("dialog")).toBeVisible();
-      await waitForDialogTransitions();
 
       // @ts-expect-error toBeAccessible is from @sa11y/vitest
       await expect(baseElement).toBeAccessible();

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.test.tsx
@@ -361,17 +361,19 @@ describe("ActionsMenu", () => {
 
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-      const user = userEvent.setup();
-      renderStory(<ActionsMenuWithNonFolder />);
-      await openMenu(user);
-      expect(await screen.findByRole("menuitem", { name: /move to s3/i })).toBeVisible();
+      try {
+        const user = userEvent.setup();
+        renderStory(<ActionsMenuWithNonFolder />);
+        await openMenu(user);
+        expect(await screen.findByRole("menuitem", { name: /move to s3/i })).toBeVisible();
 
-      const muiErrors = errorSpy.mock.calls
-        .map((args) => args.map((a) => String(a)).join(" "))
-        .filter((msg) => /MUI.*Unsupported|MUI error #9/i.test(msg));
-      expect(muiErrors).toHaveLength(0);
-
-      errorSpy.mockRestore();
+        const errorMessages = errorSpy.mock.calls.map((args) => args.map((a) => String(a)).join(" "));
+        const muiErrors = errorMessages.filter((msg) => /MUI.*Unsupported|MUI error #9/i.test(msg));
+        expect(muiErrors).toHaveLength(0);
+        expect(errorMessages).toEqual([]);
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
 
     test("Move to iRODS and Move to S3 should be hidden when netfilestores is disabled", async () => {

--- a/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/ActionsMenu.tsx
@@ -158,7 +158,7 @@ const UploadNewVersionMenuItem = ({
         )
         .map(([file, extension]) => (
           <input
-            key={null}
+            key="upload-new-version-input"
             ref={newVersionInputRef}
             accept={`.${extension}`}
             hidden
@@ -779,7 +779,7 @@ function ActionsMenu({ refreshListing, section, folderId }: ActionsMenuArgs): Re
             .asSet()
             .only.map((file) => (
               <RenameDialog
-                key={null}
+                key={`rename-${idToString(file.id).orElse(file.name)}`}
                 open={renameOpen}
                 onClose={() => {
                   setRenameOpen(false);
@@ -837,7 +837,7 @@ function ActionsMenu({ refreshListing, section, folderId }: ActionsMenuArgs): Re
             {getShareDialogSelection()
               .map(({ globalIds, names }) => (
                 <ShareDialog
-                  key={globalIds.join(",")}
+                  key={`share-${globalIds.join(",")}`}
                   open={shareOpen}
                   onClose={() => {
                     setShareOpen(false);
@@ -878,7 +878,7 @@ function ActionsMenu({ refreshListing, section, folderId }: ActionsMenuArgs): Re
               )
                 .map((exportIds) => (
                   <ExportDialog
-                    key={exportIds.join(",")}
+                    key={`export-${exportIds.join(",")}`}
                     open={exportOpen}
                     onClose={() => {
                       setExportOpen(false);
@@ -928,7 +928,7 @@ function ActionsMenu({ refreshListing, section, folderId }: ActionsMenuArgs): Re
               )
                 .map((selectedIds) => (
                   <MoveToIrods
-                    key={selectedIds.join(",")}
+                    key={`move-to-irods-${selectedIds.join(",")}`}
                     selectedIds={selectedIds}
                     dialogOpen={irodsOpen}
                     setDialogOpen={(newState) => {
@@ -970,7 +970,7 @@ function ActionsMenu({ refreshListing, section, folderId }: ActionsMenuArgs): Re
                 if (sources !== null) {
                   return (
                     <MoveToS3
-                      key={sources.map((s) => s.sourcePath).join(",")}
+                      key={`transfer-to-s3-${sources.map((s) => s.sourcePath).join(",")}`}
                       transferSources={sources}
                       dialogOpen={s3Open}
                       setDialogOpen={onClose}
@@ -985,7 +985,7 @@ function ActionsMenu({ refreshListing, section, folderId }: ActionsMenuArgs): Re
                 )
                   .map((selectedIds) => (
                     <MoveToS3
-                      key={selectedIds.join(",")}
+                      key={`move-to-s3-${selectedIds.join(",")}`}
                       selectedIds={selectedIds}
                       dialogOpen={s3Open}
                       setDialogOpen={onClose}
@@ -1005,7 +1005,7 @@ function ActionsMenu({ refreshListing, section, folderId }: ActionsMenuArgs): Re
             .get()
             .map((filestore) => (
               <AccentMenuItem
-                key={filestore.id}
+                key={`logout-${filestore.id}`}
                 title="Log Out"
                 subheader={logOutAllowed
                   .get()

--- a/src/main/webapp/ui/src/eln/gallery/components/Carousel.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Carousel.test.tsx
@@ -1,28 +1,13 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { expectAccessible } from "@/__tests__/customQueries";
 import "@/__tests__/__mocks__/matchMedia";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MockAdapter from "axios-mock-adapter";
-import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
 import axios from "@/common/axios";
 import { SimpleCarousel } from "./Carousel.story";
 
 const mockAxios = new MockAdapter(axios);
-
-/*
- * Each preview in the carousel loads its content asynchronously after mount, so
- * those background state updates settle outside `act(...)` once the synchronous
- * assertions have run. These warnings are expected here and are silenced so
- * they don't drown out genuine failures.
- */
-let restoreConsole: () => void;
-beforeEach(() => {
-  restoreConsole = silenceConsole(["error"], [/not wrapped in act/]);
-});
-afterEach(() => {
-  restoreConsole();
-});
 
 beforeEach(() => {
   mockAxios.reset();
@@ -38,9 +23,16 @@ beforeEach(() => {
   mockAxios.onAny().reply(200, {});
 });
 
+async function waitForPreviewImages() {
+  await waitFor(() => {
+    expect(screen.getAllByRole("img", { name: /preview of image/i, hidden: true })).toHaveLength(8);
+  });
+}
+
 describe("Carousel", () => {
   test("Should have no axe violations", async () => {
     const { baseElement } = render(<SimpleCarousel />);
+    await waitForPreviewImages();
 
     /*
      * The original Playwright spec filtered out the `landmark-one-main`,
@@ -55,6 +47,7 @@ describe("Carousel", () => {
   test("Should show an indicator of progress through listing.", async () => {
     const user = userEvent.setup();
     render(<SimpleCarousel />);
+    await waitForPreviewImages();
 
     expect(screen.getByRole("status", { name: "Current file index" })).toHaveTextContent("1 / 8");
 
@@ -66,6 +59,7 @@ describe("Carousel", () => {
   test("Moving to a different file resets the zoom level", async () => {
     const user = userEvent.setup();
     render(<SimpleCarousel />);
+    await waitForPreviewImages();
 
     await user.click(screen.getByRole("button", { name: /zoom in/i }));
     await user.click(screen.getByRole("button", { name: /next/i }));

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.spec.tsx
@@ -2,7 +2,7 @@ import { cleanup, render } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { page, userEvent } from "vitest/browser";
-import { suppressFireAndForget404, worker } from "@/__tests__/browserSetup";
+import { worker } from "@/__tests__/browserSetup";
 import { galleryAppShellHandlers } from "@/__tests__/mocks/galleryMocks";
 import { expectNoAxeViolations } from "@/__tests__/pageObjects/accessibility";
 import { BunchOfImages, NestedFoldersWithImageFile } from "./MainPanel.story";
@@ -117,29 +117,6 @@ function outerFolderListingHandler() {
 }
 
 /*
- * Install the fire-and-forget 404 suppressor once for the entire file.
- *
- * Gallery tests expand folders and select files, which fire fire-and-forget
- * requests (listing, thumbnail, linked-documents) the component never awaits.
- * One of these can still be in-flight when a test ends; the `resetHandlers()`
- * in browserSetup.ts's afterEach drops its MSW mock, the request bypasses MSW
- * and 404s against the Vite dev server, then surfaces as an unhandled rejection
- * that fails the run on slow CI runners.
- *
- * Using beforeAll/afterAll (rather than beforeEach/afterEach) is essential:
- * Vitest runs the spec file's afterEach BEFORE the setup file's afterEach, so
- * a per-test suppressor installed/removed in spec afterEach would be gone by
- * the time resetHandlers() fires (setup afterEach). With beforeAll/afterAll the
- * suppressor outlives resetHandlers() — afterAll runs AFTER the setup file's
- * last afterEach — so late-arriving 404s are still caught.
- */
-const restoreFireAndForget404 = suppressFireAndForget404([
-  "/gallery/getUploadedFiles",
-  "/gallery/getThumbnail",
-  "/gallery/ajax/getLinkedDocuments",
-]);
-
-/*
  * This suite pins the viewport to 1280×720 (see beforeEach). The viewport is a
  * property of the shared browser instance, not of this file's iframe, so it
  * would otherwise leak to whichever spec file runs next and skew its layout-
@@ -151,7 +128,6 @@ beforeAll(() => {
   originalViewport = { width: window.innerWidth, height: window.innerHeight };
 });
 afterAll(async () => {
-  restoreFireAndForget404();
   if (originalViewport) {
     await page.viewport(originalViewport.width, originalViewport.height);
   }

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.spec.tsx
@@ -3,7 +3,6 @@ import { HttpResponse, http } from "msw";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { page, userEvent } from "vitest/browser";
 import { worker } from "@/__tests__/browserSetup";
-import { galleryAppShellHandlers } from "@/__tests__/mocks/galleryMocks";
 import { expectNoAxeViolations } from "@/__tests__/pageObjects/accessibility";
 import { BunchOfImages, NestedFoldersWithImageFile } from "./MainPanel.story";
 import { MainPanelPage } from "./pageObjects/MainPanelPage";
@@ -56,26 +55,14 @@ function uninstallClipboardStub(): void {
 
 // ── Per-suite MSW handlers ─────────────────────────────────────────────────────
 
-function linkedDocumentsHandler() {
-  return http.get("/gallery/ajax/getLinkedDocuments/:id", () =>
-    HttpResponse.json({
-      data: [],
-      error: null,
-      success: true,
-      errorMsg: null,
-    }),
-  );
-}
-
 /*
  * When the TreeView expands the Outer folder (id=1), it calls
  * `useGalleryListing` which fetches `/gallery/getUploadedFiles?currentFolderId=1&...`.
  *
- * This handler MUST be registered before `galleryAppShellHandlers()` in the
- * `worker.use(...)` call because the app-shell handlers contain a wildcard catch-all
- * for `/gallery/getUploadedFiles` that returns an empty listing. MSW resolves
- * handlers in registration order (first match wins within a single `worker.use()`
- * call), so our specific folder handler must appear first.
+ * Registered via `worker.use(...)`, which always takes priority over the
+ * default `/gallery/getUploadedFiles` wildcard catch-all from
+ * `galleryAppShellHandlers()` in browserSetup.ts, regardless of registration
+ * order.
  */
 function outerFolderListingHandler() {
   return http.get("/gallery/getUploadedFiles", ({ request }) => {
@@ -145,13 +132,7 @@ beforeEach(async () => {
    */
   await page.viewport(1280, 720);
 
-  /*
-   * IMPORTANT: outerFolderListingHandler must be registered BEFORE
-   * galleryAppShellHandlers() because the app-shell handlers contain a
-   * wildcard catch-all for `/gallery/getUploadedFiles` that would otherwise
-   * intercept the folder-specific request first.
-   */
-  worker.use(linkedDocumentsHandler(), outerFolderListingHandler(), ...galleryAppShellHandlers());
+  worker.use(outerFolderListingHandler());
 });
 
 afterEach(() => {

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.test.tsx
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import "@/__tests__/__mocks__/muiTransitions";
+import { beforeEach, describe, expect, test } from "vitest";
 import { expectAccessible } from "@/__tests__/customQueries";
 import "@/__tests__/__mocks__/useOauthToken";
 import "@/__tests__/__mocks__/matchMedia";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MockAdapter from "axios-mock-adapter";
+import { stubAppChrome } from "@/__tests__/helpers/appChrome";
 import axios from "@/common/axios";
 import { MoveToIrodsDialogWithOneFile, MoveToIrodsDialogWithTwoFiles } from "./MoveToIrods.story";
 
@@ -55,27 +57,9 @@ const OPERATION_SUCCESS_RESPONSE = {
   fileInfoDetails: [{ recordId: 123, fileName: "test.jpg", succeeded: true }],
 };
 
-/*
- * The dialog's AppBar / analytics bootstrap fires a handful of background
- * requests on mount whose async state updates settle outside `act(...)`. The
- * resulting "not wrapped in act" warnings are irrelevant to the behaviour
- * under test, so console.error is muted for the duration of each test (using a
- * single, non-chaining spy to avoid recursion) and restored afterwards.
- */
-function createConsoleErrorSpy() {
-  return vi.spyOn(console, "error").mockImplementation(() => {});
-}
-
-let consoleErrorSpy: ReturnType<typeof createConsoleErrorSpy>;
-beforeEach(() => {
-  consoleErrorSpy = createConsoleErrorSpy();
-});
-afterEach(() => {
-  consoleErrorSpy.mockRestore();
-});
-
 beforeEach(() => {
   mockAxios.reset();
+  stubAppChrome(mockAxios);
 
   // Default: two iRODS filestores on two different filesystems, plus an S3 one
   // that must be filtered out.
@@ -99,6 +83,12 @@ async function selectDestination(user: ReturnType<typeof userEvent.setup>, name:
   await user.click(await screen.findByRole("menuitem", { name }));
 }
 
+async function waitForDialogTransitions() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 350));
+  });
+}
+
 describe("MoveToIrods", () => {
   describe("Accessibility", () => {
     test("Should have no axe violations, including the visible login form", async () => {
@@ -110,6 +100,7 @@ describe("MoveToIrods", () => {
       // scanned for label-association violations too.
       await selectDestination(user, /lab data/i);
       expect(await screen.findByRole("textbox", { name: /username/i })).toBeVisible();
+      await waitForDialogTransitions();
       await expectAccessible(baseElement);
     });
   });

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToIrods.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { expectAccessible } from "@/__tests__/customQueries";
 import "@/__tests__/__mocks__/useOauthToken";
 import "@/__tests__/__mocks__/matchMedia";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MockAdapter from "axios-mock-adapter";
 import { stubAppChrome } from "@/__tests__/helpers/appChrome";
@@ -83,12 +83,6 @@ async function selectDestination(user: ReturnType<typeof userEvent.setup>, name:
   await user.click(await screen.findByRole("menuitem", { name }));
 }
 
-async function waitForDialogTransitions() {
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 350));
-  });
-}
-
 describe("MoveToIrods", () => {
   describe("Accessibility", () => {
     test("Should have no axe violations, including the visible login form", async () => {
@@ -100,7 +94,6 @@ describe("MoveToIrods", () => {
       // scanned for label-association violations too.
       await selectDestination(user, /lab data/i);
       expect(await screen.findByRole("textbox", { name: /username/i })).toBeVisible();
-      await waitForDialogTransitions();
       await expectAccessible(baseElement);
     });
   });

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.test.tsx
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import "@/__tests__/__mocks__/muiTransitions";
+import { beforeEach, describe, expect, test } from "vitest";
 import { expectAccessible } from "@/__tests__/customQueries";
 import "@/__tests__/__mocks__/useOauthToken";
 import "@/__tests__/__mocks__/matchMedia";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MockAdapter from "axios-mock-adapter";
+import { stubAppChrome } from "@/__tests__/helpers/appChrome";
 import axios from "@/common/axios";
 import {
   MoveToS3DialogInTransferMode,
@@ -33,27 +35,9 @@ const OPERATION_SUCCESS_RESPONSE = {
   fileInfoDetails: [{ recordId: 123, fileName: "test.jpg", succeeded: true }],
 };
 
-/*
- * The dialog's AppBar / analytics bootstrap fires a handful of background
- * requests on mount whose async state updates settle outside `act(...)`. The
- * resulting "not wrapped in act" warnings are irrelevant to the behaviour
- * under test, so console.error is muted for the duration of each test (using a
- * single, non-chaining spy to avoid recursion) and restored afterwards.
- */
-function createConsoleErrorSpy() {
-  return vi.spyOn(console, "error").mockImplementation(() => {});
-}
-
-let consoleErrorSpy: ReturnType<typeof createConsoleErrorSpy>;
-beforeEach(() => {
-  consoleErrorSpy = createConsoleErrorSpy();
-});
-afterEach(() => {
-  consoleErrorSpy.mockRestore();
-});
-
 beforeEach(() => {
   mockAxios.reset();
+  stubAppChrome(mockAxios);
 
   // Default: one S3 filestore available
   mockAxios.onGet("/api/v1/gallery/filestores").reply(200, [S3_FILESTORE]);
@@ -73,6 +57,12 @@ async function selectMyS3Bucket(user: ReturnType<typeof userEvent.setup>) {
   await user.click(await screen.findByRole("menuitem", { name: /my s3 bucket/i }));
 }
 
+async function waitForDialogTransitions() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 350));
+  });
+}
+
 describe("MoveToS3", () => {
   describe("Accessibility", () => {
     test("Should have no axe violations", async () => {
@@ -80,6 +70,7 @@ describe("MoveToS3", () => {
       expect(await screen.findByRole("heading", { name: /move to s3/i })).toBeVisible();
       // Wait for the filestore listing to resolve before scanning.
       await screen.findByRole("button", { name: /select a filestore/i });
+      await waitForDialogTransitions();
       await expectAccessible(baseElement);
     });
   });

--- a/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MoveToS3.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { expectAccessible } from "@/__tests__/customQueries";
 import "@/__tests__/__mocks__/useOauthToken";
 import "@/__tests__/__mocks__/matchMedia";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MockAdapter from "axios-mock-adapter";
 import { stubAppChrome } from "@/__tests__/helpers/appChrome";
@@ -57,12 +57,6 @@ async function selectMyS3Bucket(user: ReturnType<typeof userEvent.setup>) {
   await user.click(await screen.findByRole("menuitem", { name: /my s3 bucket/i }));
 }
 
-async function waitForDialogTransitions() {
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 350));
-  });
-}
-
 describe("MoveToS3", () => {
   describe("Accessibility", () => {
     test("Should have no axe violations", async () => {
@@ -70,7 +64,6 @@ describe("MoveToS3", () => {
       expect(await screen.findByRole("heading", { name: /move to s3/i })).toBeVisible();
       // Wait for the filestore listing to resolve before scanning.
       await screen.findByRole("button", { name: /select a filestore/i });
-      await waitForDialogTransitions();
       await expectAccessible(baseElement);
     });
   });

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.spec.tsx
@@ -1,7 +1,6 @@
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { worker } from "@/__tests__/browserSetup";
-import { galleryAppShellHandlers } from "@/__tests__/mocks/galleryMocks";
+import { suppressFireAndForget404 } from "@/__tests__/browserSetup";
 import { TreeViewPage } from "./pageObjects/TreeViewPage";
 import { TreeViewWithFiles } from "./TreeView.story";
 
@@ -12,6 +11,9 @@ import { TreeViewWithFiles } from "./TreeView.story";
  */
 
 const treeView = new TreeViewPage();
+
+// Restores the fire-and-forget 404 suppressor installed in beforeEach.
+let restoreFireAndForget404: (() => void) | undefined;
 
 beforeEach(() => {
   /*
@@ -26,10 +28,10 @@ beforeEach(() => {
     "/gallery/getThumbnail",
     "/gallery/ajax/getLinkedDocuments",
   ]);
-  worker.use(oauthTokenHandler(), ...galleryAppShellHandlers());
 });
 
 afterEach(() => {
+  restoreFireAndForget404?.();
   cleanup();
 });
 

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.spec.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { suppressFireAndForget404, worker } from "@/__tests__/browserSetup";
+import { worker } from "@/__tests__/browserSetup";
 import { galleryAppShellHandlers } from "@/__tests__/mocks/galleryMocks";
 import { TreeViewPage } from "./pageObjects/TreeViewPage";
 import { TreeViewWithFiles } from "./TreeView.story";
@@ -12,9 +12,6 @@ import { TreeViewWithFiles } from "./TreeView.story";
  */
 
 const treeView = new TreeViewPage();
-
-// Restores the fire-and-forget 404 suppressor installed in beforeEach.
-let restoreFireAndForget404: (() => void) | undefined;
 
 beforeEach(() => {
   /*
@@ -29,11 +26,10 @@ beforeEach(() => {
     "/gallery/getThumbnail",
     "/gallery/ajax/getLinkedDocuments",
   ]);
-  worker.use(...galleryAppShellHandlers());
+  worker.use(oauthTokenHandler(), ...galleryAppShellHandlers());
 });
 
 afterEach(() => {
-  restoreFireAndForget404?.();
   cleanup();
 });
 

--- a/src/main/webapp/ui/src/stores/stores/__tests__/PeopleStore/fetchMembersOfSameGroup.test.ts
+++ b/src/main/webapp/ui/src/stores/stores/__tests__/PeopleStore/fetchMembersOfSameGroup.test.ts
@@ -26,7 +26,10 @@ vi.mock("../../../../common/ElnApiService", () => ({
 }));
 describe("fetchMembersOfSameGroup", () => {
   test("Error message should be returned as promise.reject", async () => {
-    const restoreConsole = silenceConsole(["error"], [/./]);
+    const restoreConsole = silenceConsole(
+      ["error"],
+      ["Could not fetch set of users in the same group as current user"],
+    );
     const { peopleStore } = getRootStore();
     runInAction(() => {
       peopleStore.currentUser = new PersonModel(PersonMocking.personAttrs());

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/EditableStoichiometryDialogSection.test.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/EditableStoichiometryDialogSection.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type React from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
 import EditableStoichiometryDialogSection from "@/tinyMCE/stoichiometry/dialog/EditableStoichiometryDialogSection";
 import type { RefreshedStoichiometry } from "@/tinyMCE/stoichiometry/useEditableStoichiometryTable";
 
@@ -35,12 +36,6 @@ type MockUseEditableStoichiometryTableArgs = {
 const mockUpdateInventoryStock = vi.fn();
 const mockUseEditableStoichiometryTable =
   vi.fn<(args: MockUseEditableStoichiometryTableArgs) => MockEditableStoichiometryTableResult>();
-
-function createConsoleErrorSpy() {
-  return vi.spyOn(console, "error").mockImplementation(() => {});
-}
-
-let consoleErrorSpy: ReturnType<typeof createConsoleErrorSpy>;
 
 vi.mock("@/tinyMCE/stoichiometry/useEditableStoichiometryTable", () => ({
   useEditableStoichiometryTable: ({
@@ -95,7 +90,6 @@ vi.mock("@/tinyMCE/stoichiometry/StoichiometryTable", async () => {
 describe("EditableStoichiometryDialogSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    consoleErrorSpy = createConsoleErrorSpy();
 
     mockUseEditableStoichiometryTable.mockImplementation(
       ({ onStoichiometryRefreshed }: MockUseEditableStoichiometryTableArgs) => {
@@ -135,10 +129,6 @@ describe("EditableStoichiometryDialogSection", () => {
         };
       },
     );
-  });
-
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
   });
 
   it("passes a stoichiometry refresh callback to the hook", () => {
@@ -187,116 +177,126 @@ describe("EditableStoichiometryDialogSection", () => {
   it("shows an inline error alert when save fails", async () => {
     const user = userEvent.setup();
     const saveError = new Error("Save mutation failed");
+    const restoreConsole = silenceConsole(["error"], ["Save failed"]);
 
-    mockUseEditableStoichiometryTable.mockImplementation(
-      ({ onStoichiometryRefreshed }: MockUseEditableStoichiometryTableArgs) => {
-        mockUpdateInventoryStock.mockImplementation(() => {
-          const refreshedStoichiometry = {
-            id: 1,
-            revision: 2,
-          };
+    try {
+      mockUseEditableStoichiometryTable.mockImplementation(
+        ({ onStoichiometryRefreshed }: MockUseEditableStoichiometryTableArgs) => {
+          mockUpdateInventoryStock.mockImplementation(() => {
+            const refreshedStoichiometry = {
+              id: 1,
+              revision: 2,
+            };
 
-          onStoichiometryRefreshed?.(refreshedStoichiometry);
+            onStoichiometryRefreshed?.(refreshedStoichiometry);
 
-          return Promise.resolve({
-            refreshedStoichiometry,
-            results: [],
+            return Promise.resolve({
+              refreshedStoichiometry,
+              results: [],
+            });
           });
-        });
 
-        return {
-          hasChanges: true,
-          isBusy: false,
-          isSaving: false,
-          save: vi.fn().mockRejectedValue(saveError),
-          deleteTable: vi.fn(),
-          tableController: {
-            allMolecules: [],
-            linkedInventoryQuantityInfoByGlobalId: new Map(),
-            isGettingMoleculeInfo: false,
-            addReagent: vi.fn(async () => {}),
-            deleteReagent: vi.fn(),
-            updateInventoryStock: mockUpdateInventoryStock,
-            pickInventoryLink: vi.fn(),
-            removeInventoryLink: vi.fn(),
-            undoRemoveInventoryLink: vi.fn(),
-            selectLimitingReagent: vi.fn(),
-            processRowUpdate: vi.fn(),
-          },
-        };
-      },
-    );
+          return {
+            hasChanges: true,
+            isBusy: false,
+            isSaving: false,
+            save: vi.fn().mockRejectedValue(saveError),
+            deleteTable: vi.fn(),
+            tableController: {
+              allMolecules: [],
+              linkedInventoryQuantityInfoByGlobalId: new Map(),
+              isGettingMoleculeInfo: false,
+              addReagent: vi.fn(async () => {}),
+              deleteReagent: vi.fn(),
+              updateInventoryStock: mockUpdateInventoryStock,
+              pickInventoryLink: vi.fn(),
+              removeInventoryLink: vi.fn(),
+              undoRemoveInventoryLink: vi.fn(),
+              selectLimitingReagent: vi.fn(),
+              processRowUpdate: vi.fn(),
+            },
+          };
+        },
+      );
 
-    render(
-      <EditableStoichiometryDialogSection
-        currentStoichiometry={{ id: 1, revision: 1 }}
-        chemId={null}
-        onClose={() => {}}
-        onDelete={() => {}}
-        setCurrentStoichiometry={vi.fn()}
-      />,
-    );
+      render(
+        <EditableStoichiometryDialogSection
+          currentStoichiometry={{ id: 1, revision: 1 }}
+          chemId={null}
+          onClose={() => {}}
+          onDelete={() => {}}
+          setCurrentStoichiometry={vi.fn()}
+        />,
+      );
 
-    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+      await user.click(screen.getByRole("button", { name: "Save Changes" }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent("Save mutation failed");
+      expect(await screen.findByRole("alert")).toHaveTextContent("Save mutation failed");
+    } finally {
+      restoreConsole();
+    }
   });
 
   it("shows an inline error alert when delete fails", async () => {
     const user = userEvent.setup();
     const deleteError = new Error("Delete mutation failed");
+    const restoreConsole = silenceConsole(["error"], ["Delete failed"]);
 
-    mockUseEditableStoichiometryTable.mockImplementation(
-      ({ onStoichiometryRefreshed }: MockUseEditableStoichiometryTableArgs) => {
-        mockUpdateInventoryStock.mockImplementation(() => {
-          const refreshedStoichiometry = {
-            id: 1,
-            revision: 2,
-          };
+    try {
+      mockUseEditableStoichiometryTable.mockImplementation(
+        ({ onStoichiometryRefreshed }: MockUseEditableStoichiometryTableArgs) => {
+          mockUpdateInventoryStock.mockImplementation(() => {
+            const refreshedStoichiometry = {
+              id: 1,
+              revision: 2,
+            };
 
-          onStoichiometryRefreshed?.(refreshedStoichiometry);
+            onStoichiometryRefreshed?.(refreshedStoichiometry);
 
-          return Promise.resolve({
-            refreshedStoichiometry,
-            results: [],
+            return Promise.resolve({
+              refreshedStoichiometry,
+              results: [],
+            });
           });
-        });
 
-        return {
-          hasChanges: false,
-          isBusy: false,
-          isSaving: false,
-          save: vi.fn(),
-          deleteTable: vi.fn().mockRejectedValue(deleteError),
-          tableController: {
-            allMolecules: [],
-            linkedInventoryQuantityInfoByGlobalId: new Map(),
-            isGettingMoleculeInfo: false,
-            addReagent: vi.fn(async () => {}),
-            deleteReagent: vi.fn(),
-            updateInventoryStock: mockUpdateInventoryStock,
-            pickInventoryLink: vi.fn(),
-            removeInventoryLink: vi.fn(),
-            undoRemoveInventoryLink: vi.fn(),
-            selectLimitingReagent: vi.fn(),
-            processRowUpdate: vi.fn(),
-          },
-        };
-      },
-    );
+          return {
+            hasChanges: false,
+            isBusy: false,
+            isSaving: false,
+            save: vi.fn(),
+            deleteTable: vi.fn().mockRejectedValue(deleteError),
+            tableController: {
+              allMolecules: [],
+              linkedInventoryQuantityInfoByGlobalId: new Map(),
+              isGettingMoleculeInfo: false,
+              addReagent: vi.fn(async () => {}),
+              deleteReagent: vi.fn(),
+              updateInventoryStock: mockUpdateInventoryStock,
+              pickInventoryLink: vi.fn(),
+              removeInventoryLink: vi.fn(),
+              undoRemoveInventoryLink: vi.fn(),
+              selectLimitingReagent: vi.fn(),
+              processRowUpdate: vi.fn(),
+            },
+          };
+        },
+      );
 
-    render(
-      <EditableStoichiometryDialogSection
-        currentStoichiometry={{ id: 1, revision: 1 }}
-        chemId={null}
-        onClose={() => {}}
-        onDelete={() => {}}
-        setCurrentStoichiometry={vi.fn()}
-      />,
-    );
+      render(
+        <EditableStoichiometryDialogSection
+          currentStoichiometry={{ id: 1, revision: 1 }}
+          chemId={null}
+          onClose={() => {}}
+          onDelete={() => {}}
+          setCurrentStoichiometry={vi.fn()}
+        />,
+      );
 
-    await user.click(screen.getByRole("button", { name: "Delete" }));
+      await user.click(screen.getByRole("button", { name: "Delete" }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent("Delete mutation failed");
+      expect(await screen.findByRole("alert")).toHaveTextContent("Delete mutation failed");
+    } finally {
+      restoreConsole();
+    }
   });
 });

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/useEditableStoichiometryTable.test.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/useEditableStoichiometryTable.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
 import { inventoryQueryKeys } from "@/modules/inventory/queries";
 import { stoichiometryQueryKeys } from "@/modules/stoichiometry/queries";
 import type { StoichiometryRequest } from "@/modules/stoichiometry/schema";
@@ -523,36 +524,36 @@ describe("useEditableStoichiometryTable", () => {
         mutations: { retry: false },
       },
     });
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const restoreConsole = silenceConsole(["error"], ["Modifying the role of a molecule is not supported"]);
     let latestValue: ReturnType<typeof useEditableStoichiometryTable> | null = null;
 
-    renderWithProviders({
-      queryClient,
-      activeChemId: 123,
-      onValue: (value) => {
-        latestValue = value;
-      },
-    });
+    try {
+      renderWithProviders({
+        queryClient,
+        activeChemId: 123,
+        onValue: (value) => {
+          latestValue = value;
+        },
+      });
 
-    await waitFor(() => {
-      expect(latestValue?.allMolecules).toHaveLength(4);
-    });
+      await waitFor(() => {
+        expect(latestValue?.allMolecules).toHaveLength(4);
+      });
 
-    // biome-ignore lint/style/noNonNullAssertion: latestValue is set asynchronously before this access
-    const originalRow = latestValue!.allMolecules.find(({ id }) => id === 6)!;
-    let returnedRow: EditableMolecule | undefined;
+      // biome-ignore lint/style/noNonNullAssertion: latestValue is set asynchronously before this access
+      const originalRow = latestValue!.allMolecules.find(({ id }) => id === 6)!;
+      let returnedRow: EditableMolecule | undefined;
 
-    act(() => {
-      returnedRow = latestValue?.tableController.processRowUpdate({ ...originalRow, role: "REACTANT" }, originalRow);
-    });
+      act(() => {
+        returnedRow = latestValue?.tableController.processRowUpdate({ ...originalRow, role: "REACTANT" }, originalRow);
+      });
 
-    expect(returnedRow).toEqual(originalRow);
-    // biome-ignore lint/style/noNonNullAssertion: latestValue is set asynchronously before this access
-    expect(latestValue!.allMolecules.find(({ id }) => id === 6)?.role).toBe("PRODUCT");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error updating row:",
-      "Modifying the role of a molecule is not supported",
-    );
+      expect(returnedRow).toEqual(originalRow);
+      // biome-ignore lint/style/noNonNullAssertion: latestValue is set asynchronously before this access
+      expect(latestValue!.allMolecules.find(({ id }) => id === 6)?.role).toBe("PRODUCT");
+    } finally {
+      restoreConsole();
+    }
   });
 
   it.each([


### PR DESCRIPTION
## Description ##
Fixes various warnings and errors that were being manually suppressed by Vitest.

- Remove unnecessary console error suppressions where component bugs fixed
- Narrow remaining suppressions to specific messages instead of catch-all regexes
- Fix React keys (key={null} → semantic IDs) and remove console logs
- Register MSW handlers globally; remove per-test suppressors
- Wrap async operations in act() to silence state-update warnings
- Refactor error handling for cleaner test flow (return bool vs throw)