### PR TITLE
Mock the inventory OAuth token endpoint globally in browser tests

### DIFF
--- a/src/main/webapp/ui/src/Inventory/Identifiers/IGSN/IgsnTable.spec.tsx
+++ b/src/main/webapp/ui/src/Inventory/Identifiers/IGSN/IgsnTable.spec.tsx
@@ -2,7 +2,6 @@ import { cleanup, render } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { worker } from "@/__tests__/browserSetup";
-import { oauthTokenHandler } from "@/__tests__/mocks/inventoryMocks";
 import { SimpleIgsnTable } from "./IgsnTable.story";
 import { IgsnTablePage } from "./pageObjects/IgsnTablePage";
 
@@ -120,10 +119,7 @@ const IDENTIFIERS_PAYLOAD = [
 const table = new IgsnTablePage();
 
 beforeEach(() => {
-  worker.use(
-    oauthTokenHandler(),
-    http.get("/api/inventory/v1/identifiers", () => HttpResponse.json(IDENTIFIERS_PAYLOAD)),
-  );
+  worker.use(http.get("/api/inventory/v1/identifiers", () => HttpResponse.json(IDENTIFIERS_PAYLOAD)));
 });
 
 afterEach(() => {

--- a/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.spec.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/FieldmarkImportDialog.spec.tsx
@@ -2,7 +2,6 @@ import { cleanup, render } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { worker } from "@/__tests__/browserSetup";
-import { oauthTokenHandler } from "@/__tests__/mocks/inventoryMocks";
 import { clickWhenInViewport, moveToastStackIntoViewport } from "@/__tests__/pageObjects/viewport";
 import { FieldmarkImportDialogStory } from "./FieldmarkImportDialog.story";
 import { FieldmarkImportDialogPage } from "./pageObjects/FieldmarkImportDialogPage";
@@ -148,7 +147,6 @@ const dialog = new FieldmarkImportDialogPage();
 
 beforeEach(() => {
   worker.use(
-    oauthTokenHandler(),
     http.get("/api/inventory/v1/fieldmark/notebooks", () => HttpResponse.json(NOTEBOOKS_PAYLOAD)),
     ...igsnCandidateFieldsHandlers(),
     importSuccessHandler(),

--- a/src/main/webapp/ui/src/__tests__/browserSetup.ts
+++ b/src/main/webapp/ui/src/__tests__/browserSetup.ts
@@ -1,6 +1,7 @@
 import { setupWorker } from "msw/browser";
 import { afterEach, beforeAll } from "vitest";
 import { cdp, server } from "vitest/browser";
+import { oauthTokenHandler } from "./mocks/oauthTokenMocks";
 import { appShellHandlers } from "./mswAppShellHandlers";
 
 /*
@@ -9,7 +10,7 @@ import { appShellHandlers } from "./mswAppShellHandlers";
  * each test so suites stay isolated (the MSW equivalent of Playwright's
  * per-test `router.route`).
  */
-export const worker = setupWorker(...appShellHandlers());
+export const worker = setupWorker(...appShellHandlers(), oauthTokenHandler());
 
 /*
  * Vitest browser mode runs each test file in its own isolated module graph, so

--- a/src/main/webapp/ui/src/__tests__/mocks/galleryMocks.ts
+++ b/src/main/webapp/ui/src/__tests__/mocks/galleryMocks.ts
@@ -10,9 +10,6 @@ import { HttpResponse, http, type RequestHandler } from "msw";
  * Note: `analyticsProperties` and `livechatProperties` are already covered by
  * the global app-shell defaults in mswAppShellHandlers.ts. Do not duplicate
  * them here.
- *
- * Note: the inventory OAuth token handler is in inventoryMocks.ts — import
- * `oauthTokenHandler` from there when a gallery suite also needs it.
  */
 export const galleryAppShellHandlers = (): RequestHandler[] => [
   /*

--- a/src/main/webapp/ui/src/__tests__/mocks/oauthTokenMocks.ts
+++ b/src/main/webapp/ui/src/__tests__/mocks/oauthTokenMocks.ts
@@ -1,12 +1,9 @@
 import { HttpResponse, http, type RequestHandler } from "msw";
 
 /*
- * A static, far-future-expiry JWT for the inventory OAuth token endpoint.
- * The Playwright tests signed one per-test with `jsonwebtoken`, but that is a
- * Node-only library and cannot run in the browser. The client only *decodes*
- * this token to read its `exp` (see common/JwtService.ts → jwt-decode), it
- * never verifies the signature, so a fixed token with exp = 4102444800
- * (year 2100) is always valid.
+ * A static, far-future-expiry JWT for the browser-test OAuth token endpoint.
+ * The client only decodes this token to read its `exp`; it never verifies the
+ * signature, so a fixed token with exp = 4102444800 (year 2100) is always valid.
  */
 export const OAUTH_TOKEN =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6NDEwMjQ0NDgwMCwicmVmcmVzaFRva2VuSGFzaCI6ImZlMTVmYTNkNWUzZDVhNDdlMzNlOWUzNDIyOWIxZWEyMzE0YWQ2ZTZmMTNmYTQyYWRkY2E0ZjE0Mzk1ODJhNGQifQ.dumm-signature_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";

--- a/src/main/webapp/ui/src/eln/gallery/components/MainPanel.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/MainPanel.spec.tsx
@@ -4,7 +4,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi 
 import { page, userEvent } from "vitest/browser";
 import { suppressFireAndForget404, worker } from "@/__tests__/browserSetup";
 import { galleryAppShellHandlers } from "@/__tests__/mocks/galleryMocks";
-import { oauthTokenHandler } from "@/__tests__/mocks/inventoryMocks";
 import { expectNoAxeViolations } from "@/__tests__/pageObjects/accessibility";
 import { BunchOfImages, NestedFoldersWithImageFile } from "./MainPanel.story";
 import { MainPanelPage } from "./pageObjects/MainPanelPage";
@@ -176,7 +175,7 @@ beforeEach(async () => {
    * wildcard catch-all for `/gallery/getUploadedFiles` that would otherwise
    * intercept the folder-specific request first.
    */
-  worker.use(oauthTokenHandler(), linkedDocumentsHandler(), outerFolderListingHandler(), ...galleryAppShellHandlers());
+  worker.use(linkedDocumentsHandler(), outerFolderListingHandler(), ...galleryAppShellHandlers());
 });
 
 afterEach(() => {

--- a/src/main/webapp/ui/src/eln/gallery/components/TreeView.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/TreeView.spec.tsx
@@ -2,7 +2,6 @@ import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { suppressFireAndForget404, worker } from "@/__tests__/browserSetup";
 import { galleryAppShellHandlers } from "@/__tests__/mocks/galleryMocks";
-import { oauthTokenHandler } from "@/__tests__/mocks/inventoryMocks";
 import { TreeViewPage } from "./pageObjects/TreeViewPage";
 import { TreeViewWithFiles } from "./TreeView.story";
 
@@ -30,7 +29,7 @@ beforeEach(() => {
     "/gallery/getThumbnail",
     "/gallery/ajax/getLinkedDocuments",
   ]);
-  worker.use(oauthTokenHandler(), ...galleryAppShellHandlers());
+  worker.use(...galleryAppShellHandlers());
 });
 
 afterEach(() => {

--- a/src/main/webapp/ui/src/tinyMCE/pubchem/ImportDialog.spec.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/pubchem/ImportDialog.spec.tsx
@@ -3,7 +3,6 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { userEvent } from "vitest/browser";
 import { worker } from "@/__tests__/browserSetup";
-import { oauthTokenHandler } from "@/__tests__/mocks/inventoryMocks";
 import { expectNoAxeViolations } from "@/__tests__/pageObjects/accessibility";
 import { ImportDialogStory } from "./ImportDialog.story";
 import { PubchemImportDialogPage } from "./pageObjects/PubchemImportDialogPage";
@@ -52,7 +51,7 @@ const pubchemSearchHandler = () =>
 const dialog = new PubchemImportDialogPage();
 
 beforeEach(() => {
-  worker.use(oauthTokenHandler(), pubchemSearchHandler());
+  worker.use(pubchemSearchHandler());
 });
 
 afterEach(() => {

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryDialog.spec.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryDialog.spec.tsx
@@ -5,11 +5,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { worker } from "@/__tests__/browserSetup";
 import { emulateHighContrast, expectNoAxeViolations } from "@/__tests__/pageObjects/accessibility";
 import StoichiometryDialogEntrypoint from "../StoichiometryDialogEntrypoint";
-import {
-  chemistryIntegrationHandler,
-  createDialogStoichiometryResponse,
-  oauthTokenHandler,
-} from "./mocks/stoichiometryMocks";
+import { chemistryIntegrationHandler, createDialogStoichiometryResponse } from "./mocks/stoichiometryMocks";
 import { StoichiometryDialogPage } from "./pageObjects/StoichiometryDialogPage";
 import {
   StoichiometryDialogWithCalculateButtonStory,
@@ -52,7 +48,7 @@ const dialog = new StoichiometryDialogPage();
 
 beforeEach(() => {
   networkRequests.length = 0;
-  worker.use(oauthTokenHandler(), chemistryIntegrationHandler(), ...dialogStoichiometryHandlers());
+  worker.use(chemistryIntegrationHandler(), ...dialogStoichiometryHandlers());
   worker.events.on("request:start", ({ request }) => {
     networkRequests.push({
       method: request.method,

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryTable.spec.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryTable.spec.tsx
@@ -11,7 +11,6 @@ import {
   galleryPickerSupportHandlers,
   type MockRouteResponse,
   moleculeInfoHandler,
-  oauthTokenHandler,
   pubchemSearchHandler,
 } from "./mocks/stoichiometryMocks";
 import { InventoryUpdateDialogPage, StoichiometryTablePage } from "./pageObjects/StoichiometryTablePage";
@@ -35,7 +34,6 @@ beforeEach(() => {
     inventorySubSampleRequestCount: 0,
   };
   worker.use(
-    oauthTokenHandler(),
     http.get("/api/v1/stoichiometry", () => HttpResponse.json(mocks.response)),
     http.get("/api/inventory/v1/subSamples/:id", ({ params }) => {
       mocks.inventorySubSampleRequestCount += 1;

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/mocks/stoichiometryMocks.ts
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/mocks/stoichiometryMocks.ts
@@ -1,7 +1,5 @@
 import { HttpResponse, http, type RequestHandler } from "msw";
 
-export { OAUTH_TOKEN, oauthTokenHandler } from "@/__tests__/mocks/inventoryMocks";
-
 /*
  * Shared MSW fixtures + handlers for the stoichiometry browser-mode tests.
  * Responses are expressed as MSW request handlers, registered per-test via


### PR DESCRIPTION
## Description ##
useOauthToken's background token refresh hits /userform/ajax/inventoryOauthToken, which isn't mocked outside Inventory-specific tests. In CI this produced unhandled AxiosError 404 rejections across unrelated browser specs (MainPanel, ImportDialog, FieldmarkImportDialog, CallablePdfPreview, etc.), failing the browser-tests run even though every individual test passed.

Extract the mock into oauthTokenMocks.ts and wire it into the global browserSetup.ts MSW worker so every browser test has it by default; inventoryMocks.ts now re-exports it for existing Inventory-specific imports.
