### PR TITLE
RSDEV-1232 Instruments and Instrument Templates Not Supported by GlobalID Resolver

### DIFF
--- a/src/main/java/com/researchspace/webapp/controller/GlobalLookupController.java
+++ b/src/main/java/com/researchspace/webapp/controller/GlobalLookupController.java
@@ -64,6 +64,8 @@ public class GlobalLookupController extends BaseController {
     prefixToUrl.put(GlobalIdPrefix.IT, "/inventory/sampletemplate/");
     prefixToUrl.put(GlobalIdPrefix.IC, "/inventory/container/");
     prefixToUrl.put(GlobalIdPrefix.BE, "/inventory/search?parentGlobalId=BE");
+    prefixToUrl.put(GlobalIdPrefix.IN, "/inventory/instrument/");
+    prefixToUrl.put(GlobalIdPrefix.NT, "/inventory/instrumenttemplate/");
   }
 
   /** Inventory record types whose version-suffixed global IDs open the versioned viewer. */


### PR DESCRIPTION
## Description ##
Addresses https://researchspace.atlassian.net/browse/RSDEV-1232
Adds Instrument and Instrument Template prefix to GlobalID lookup.
NOTE:  Instrument and Instrument Template versioning is still unsupported, so use of the endpoint with versioned IDs will still fail.  This will be addressed in an upcoming ticket.
