### PR TITLE
Fix stoichiometry inventory-update dialog race condition

### DIFF
--- a/src/main/webapp/ui/src/components/SubmitSpinnerButton.tsx
+++ b/src/main/webapp/ui/src/components/SubmitSpinnerButton.tsx
@@ -49,11 +49,14 @@ function SubmitSpinnerButton({
       <Box
         sx={{
           position: "absolute",
-          marginLeft: 10,
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          display: "flex",
           opacity: loading ? 1 : 0,
         }}
       >
-        <FontAwesomeIcon icon={faSpinner} spin size="lg" style={{ marginRight: "10px" }} />
+        <FontAwesomeIcon icon={faSpinner} spin size="lg" />
       </Box>
       {progress !== null && typeof progress !== "undefined" ? (
         <Box

--- a/src/main/webapp/ui/src/modules/inventory/queries.ts
+++ b/src/main/webapp/ui/src/modules/inventory/queries.ts
@@ -116,8 +116,14 @@ export function useSubSampleQuantitiesQuery({
     () =>
       new Map(
         uniqueInventoryItemGlobalIds.flatMap((inventoryItemGlobalId, index) => {
-          const result = queryResults[index]?.data;
-          return result ? [[inventoryItemGlobalId, result] as const] : [];
+          const queryResult = queryResults[index];
+          if (queryResult?.data) {
+            return [[inventoryItemGlobalId, queryResult.data] as const];
+          }
+          if (queryResult?.isError) {
+            return [[inventoryItemGlobalId, { status: "error" } as const] as const];
+          }
+          return [];
         }),
       ),
     [queryResults, uniqueInventoryItemGlobalIds],

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryInventoryUpdateDialog.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryInventoryUpdateDialog.tsx
@@ -1,39 +1,13 @@
-import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import Alert from "@mui/material/Alert";
-import AlertTitle from "@mui/material/AlertTitle";
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import DialogActions from "@mui/material/DialogActions";
-import DialogContent from "@mui/material/DialogContent";
-import DialogTitle from "@mui/material/DialogTitle";
-import Paper from "@mui/material/Paper";
-import Stack from "@mui/material/Stack";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
-import Typography from "@mui/material/Typography";
-import { useMutation } from "@tanstack/react-query";
 import React from "react";
 import { Dialog } from "@/components/DialogBoundary";
 import type { InventoryQuantityQueryResult } from "@/modules/inventory/queries";
-import StoichiometryInventoryUpdateMoleculeRow from "@/tinyMCE/stoichiometry/StoichiometryInventoryUpdateMoleculeRow";
+import StoichiometryInventoryUpdateDialogContent, {
+  type InventoryStockUpdateResult,
+} from "@/tinyMCE/stoichiometry/StoichiometryInventoryUpdateDialogContent";
 import type { EditableMolecule } from "@/tinyMCE/stoichiometry/types";
-import { getInventoryUpdateEligibility } from "@/tinyMCE/stoichiometry/utils";
-export type InventoryStockUpdateResult = {
-  refreshedStoichiometry?: {
-    id: number;
-    revision: number;
-  };
-  results: ReadonlyArray<{
-    moleculeId: number;
-    moleculeName: string;
-    success: boolean;
-    errorMessage: string | null;
-  }>;
-};
+
+export type { InventoryStockUpdateResult };
+
 type StoichiometryInventoryUpdateDialogProps = {
   open: boolean;
   molecules: ReadonlyArray<EditableMolecule>;
@@ -41,17 +15,12 @@ type StoichiometryInventoryUpdateDialogProps = {
   onSave?: (selectedMoleculeIds: number[]) => Promise<InventoryStockUpdateResult>;
   onClose: () => void;
 };
-function getDefaultValues(
-  molecules: ReadonlyArray<EditableMolecule>,
-  linkedInventoryQuantityInfoByGlobalId: ReadonlyMap<string, InventoryQuantityQueryResult>,
-): number[] {
-  return molecules
-    .filter((molecule) => {
-      const eligibility = getInventoryUpdateEligibility(molecule, linkedInventoryQuantityInfoByGlobalId);
-      return eligibility.disabledReason === null && molecule.inventoryLink?.stockDeducted !== true;
-    })
-    .map(({ id }) => id);
-}
+
+/**
+ * Thin shell around the Update Inventory Stock dialog. All state lives in the
+ * content component, which MUI mounts fresh on each open and unmounts on
+ * close, so opening the dialog is what resets it.
+ */
 export default function StoichiometryInventoryUpdateDialog({
   open,
   molecules,
@@ -60,95 +29,10 @@ export default function StoichiometryInventoryUpdateDialog({
   onClose,
 }: StoichiometryInventoryUpdateDialogProps): React.ReactNode {
   const titleId = React.useId();
-  const wasOpenRef = React.useRef(false);
-  const [selectedMoleculeIds, setSelectedMoleculeIds] = React.useState<number[]>([]);
-  const saveMutation = useMutation({
-    mutationFn: async (moleculeIds: number[]) => {
-      if (!onSave) {
-        return {
-          results: [],
-        } satisfies InventoryStockUpdateResult;
-      }
-      return onSave(moleculeIds);
-    },
-  });
-  const failedResults = saveMutation.data?.results.filter(({ success }) => !success) ?? [];
-  const saveFeedback =
-    saveMutation.isSuccess && failedResults.length > 0
-      ? "Current stock amounts were refreshed. Re-select any remaining molecules to retry."
-      : null;
-  const saveError = (() => {
-    if (saveMutation.isError) {
-      const message = saveMutation.error.message;
-      return `${message} Current stock amounts were refreshed where possible.`;
-    }
-    if (failedResults.length === 0) {
-      return null;
-    }
-    return (
-      Array.from(
-        new Set(
-          failedResults
-            .map(({ errorMessage }) => errorMessage)
-            .filter((message): message is string => Boolean(message)),
-        ),
-      ).join(" ") || null
-    );
-  })();
-  const hasInvalidSelectedRows = selectedMoleculeIds.some((selectedMoleculeId) => {
-    const selectedMolecule = molecules.find(({ id }) => id === selectedMoleculeId);
-    if (!selectedMolecule) {
-      return true;
-    }
-    return (
-      getInventoryUpdateEligibility(selectedMolecule, linkedInventoryQuantityInfoByGlobalId).disabledReason !== null
-    );
-  });
-  const selectionError = hasInvalidSelectedRows ? "Re-select any invalid molecules before saving." : null;
-  const resetDialogState = React.useCallback(() => {
-    setSelectedMoleculeIds(getDefaultValues(molecules, linkedInventoryQuantityInfoByGlobalId));
-    saveMutation.reset();
-  }, [linkedInventoryQuantityInfoByGlobalId, molecules, saveMutation]);
-  React.useEffect(() => {
-    if (open && !wasOpenRef.current) {
-      resetDialogState();
-    }
-    wasOpenRef.current = open;
-  }, [open, resetDialogState]);
-  const handleClose = React.useCallback(() => {
-    resetDialogState();
-    onClose();
-  }, [onClose, resetDialogState]);
-  const handleSubmit = React.useCallback(async () => {
-    if (selectedMoleculeIds.length === 0) {
-      saveMutation.reset();
-      return;
-    }
-    if (hasInvalidSelectedRows) {
-      saveMutation.reset();
-      return;
-    }
-    if (!onSave) {
-      handleClose();
-      return;
-    }
-    saveMutation.reset();
-    try {
-      const result = await saveMutation.mutateAsync(selectedMoleculeIds);
-      const hasFailures = result.results.some(({ success }) => !success);
-      if (!hasFailures) {
-        handleClose();
-        return;
-      }
-      setSelectedMoleculeIds([]);
-    } catch {
-      setSelectedMoleculeIds([]);
-    }
-  }, [handleClose, hasInvalidSelectedRows, onSave, saveMutation, selectedMoleculeIds]);
   return (
     <Dialog
       open={open}
-      onClose={handleClose}
+      onClose={onClose}
       maxWidth="lg"
       fullWidth
       aria-labelledby={titleId}
@@ -160,128 +44,13 @@ export default function StoichiometryInventoryUpdateDialog({
         },
       }}
     >
-      <Box
-        component="form"
-        sx={{
-          display: "contents",
-        }}
-        onSubmit={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          void handleSubmit();
-        }}
-      >
-        <DialogTitle id={titleId}>Update Inventory Stock</DialogTitle>
-        <DialogContent>
-          <Stack spacing={2}>
-            <Typography variant="body2" color="text.secondary">
-              Select the molecules from this stoichiometry table whose linked inventory stock should be updated.
-            </Typography>
-            <Alert
-              severity="warning"
-              icon={
-                <WarningAmberIcon
-                  aria-label="Action irreversible warning"
-                  fontSize="small"
-                  sx={{
-                    color: "warning.main",
-                  }}
-                />
-              }
-            >
-              <AlertTitle>WARNING: This action is irreversible</AlertTitle>
-
-              <Typography variant="body2" gutterBottom>
-                <strong>This will permanently reduce inventory quantities.</strong>
-              </Typography>
-              <Typography variant="body2" gutterBottom>
-                Stock cannot be automatically replenished if you change quantities later, delete this stoichiometry
-                table, delete the document, or unlink samples.
-              </Typography>
-              <Typography variant="body2">
-                Only proceed if you have actually used these materials in your experiment.
-              </Typography>
-            </Alert>
-            {selectionError && <Alert severity="warning">{selectionError}</Alert>}
-            {saveFeedback && <Alert severity="info">{saveFeedback}</Alert>}
-            {saveError && <Alert severity="error">{saveError}</Alert>}
-            <TableContainer
-              component={Paper}
-              variant="outlined"
-              sx={{
-                maxHeight: 560,
-                overflowY: "auto",
-                borderRadius: 1,
-              }}
-            >
-              <Table stickyHeader size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell
-                      padding="checkbox"
-                      aria-label="Select molecule"
-                      width={52}
-                      sx={{
-                        px: 0.5,
-                      }}
-                    />
-                    <TableCell width="55%">Molecule</TableCell>
-                    <TableCell align="right" width="15%">
-                      In Stock
-                    </TableCell>
-                    <TableCell align="right" width="15%">
-                      Will Use
-                    </TableCell>
-                    <TableCell align="right" width="15%">
-                      Remaining
-                    </TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {molecules.map((molecule) => {
-                    const eligibility = getInventoryUpdateEligibility(molecule, linkedInventoryQuantityInfoByGlobalId);
-                    const { disabledReason, helperText, stockDisplay } = eligibility;
-                    const disabled = disabledReason !== null;
-                    const selected = !disabled && selectedMoleculeIds.includes(molecule.id);
-                    return (
-                      <StoichiometryInventoryUpdateMoleculeRow
-                        key={molecule.id}
-                        molecule={molecule}
-                        selected={selected}
-                        disabled={disabled}
-                        helperText={helperText}
-                        stockDisplay={stockDisplay}
-                        onToggle={() => {
-                          if (disabled) {
-                            return;
-                          }
-                          saveMutation.reset();
-                          setSelectedMoleculeIds((currentIds) =>
-                            selected ? currentIds.filter((id) => id !== molecule.id) : [...currentIds, molecule.id],
-                          );
-                        }}
-                      />
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button type="button" onClick={handleClose}>
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            variant="contained"
-            color="callToAction"
-            disabled={selectedMoleculeIds.length === 0 || hasInvalidSelectedRows || saveMutation.isPending}
-          >
-            {saveMutation.isPending ? "Saving..." : "Save"}
-          </Button>
-        </DialogActions>
-      </Box>
+      <StoichiometryInventoryUpdateDialogContent
+        titleId={titleId}
+        molecules={molecules}
+        linkedInventoryQuantityInfoByGlobalId={linkedInventoryQuantityInfoByGlobalId}
+        onSave={onSave}
+        onClose={onClose}
+      />
     </Dialog>
   );
 }

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryInventoryUpdateDialog.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryInventoryUpdateDialog.tsx
@@ -16,11 +16,6 @@ type StoichiometryInventoryUpdateDialogProps = {
   onClose: () => void;
 };
 
-/**
- * Thin shell around the Update Inventory Stock dialog. All state lives in the
- * content component, which MUI mounts fresh on each open and unmounts on
- * close, so opening the dialog is what resets it.
- */
 export default function StoichiometryInventoryUpdateDialog({
   open,
   molecules,

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryInventoryUpdateDialogContent.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryInventoryUpdateDialogContent.tsx
@@ -1,0 +1,270 @@
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import { useMutation } from "@tanstack/react-query";
+import React from "react";
+import type { InventoryQuantityQueryResult } from "@/modules/inventory/queries";
+import StoichiometryInventoryUpdateMoleculeRow from "@/tinyMCE/stoichiometry/StoichiometryInventoryUpdateMoleculeRow";
+import type { EditableMolecule } from "@/tinyMCE/stoichiometry/types";
+import { getInventoryUpdateEligibility } from "@/tinyMCE/stoichiometry/utils";
+
+export type InventoryStockUpdateResult = {
+  refreshedStoichiometry?: {
+    id: number;
+    revision: number;
+  };
+  results: ReadonlyArray<{
+    moleculeId: number;
+    moleculeName: string;
+    success: boolean;
+    errorMessage: string | null;
+  }>;
+};
+
+type StoichiometryInventoryUpdateDialogContentProps = {
+  titleId: string;
+  molecules: ReadonlyArray<EditableMolecule>;
+  linkedInventoryQuantityInfoByGlobalId: ReadonlyMap<string, InventoryQuantityQueryResult>;
+  onSave?: (selectedMoleculeIds: number[]) => Promise<InventoryStockUpdateResult>;
+  onClose: () => void;
+};
+
+function getDefaultValues(
+  molecules: ReadonlyArray<EditableMolecule>,
+  linkedInventoryQuantityInfoByGlobalId: ReadonlyMap<string, InventoryQuantityQueryResult>,
+): number[] {
+  return molecules
+    .filter((molecule) => {
+      const eligibility = getInventoryUpdateEligibility(molecule, linkedInventoryQuantityInfoByGlobalId);
+      return eligibility.disabledReason === null && molecule.inventoryLink?.stockDeducted !== true;
+    })
+    .map(({ id }) => id);
+}
+
+/**
+ * The stateful body of the Update Inventory Stock dialog. It is only mounted
+ * while the dialog is open (MUI's `Dialog` unmounts its children when
+ * closed), so each open session starts from a fresh mount: the default
+ * selection is computed in the `useState` initializer and all state is
+ * discarded on close, with no reset effects or refs. Correct preselection
+ * relies on the toolbar disabling the opening button until every linked
+ * molecule's inventory quantity has resolved.
+ */
+export default function StoichiometryInventoryUpdateDialogContent({
+  titleId,
+  molecules,
+  linkedInventoryQuantityInfoByGlobalId,
+  onSave,
+  onClose,
+}: StoichiometryInventoryUpdateDialogContentProps): React.ReactNode {
+  const [selectedMoleculeIds, setSelectedMoleculeIds] = React.useState<number[]>(() =>
+    getDefaultValues(molecules, linkedInventoryQuantityInfoByGlobalId),
+  );
+  const saveMutation = useMutation({
+    mutationFn: async (moleculeIds: number[]) => {
+      if (!onSave) {
+        return {
+          results: [],
+        } satisfies InventoryStockUpdateResult;
+      }
+      return onSave(moleculeIds);
+    },
+  });
+  const failedResults = saveMutation.data?.results.filter(({ success }) => !success) ?? [];
+  const saveFeedback =
+    saveMutation.isSuccess && failedResults.length > 0
+      ? "Current stock amounts were refreshed. Re-select any remaining molecules to retry."
+      : null;
+  const saveError = (() => {
+    if (saveMutation.isError) {
+      const message = saveMutation.error.message;
+      return `${message} Current stock amounts were refreshed where possible.`;
+    }
+    if (failedResults.length === 0) {
+      return null;
+    }
+    return (
+      Array.from(
+        new Set(
+          failedResults
+            .map(({ errorMessage }) => errorMessage)
+            .filter((message): message is string => Boolean(message)),
+        ),
+      ).join(" ") || null
+    );
+  })();
+  const hasInvalidSelectedRows = selectedMoleculeIds.some((selectedMoleculeId) => {
+    const selectedMolecule = molecules.find(({ id }) => id === selectedMoleculeId);
+    if (!selectedMolecule) {
+      return true;
+    }
+    return (
+      getInventoryUpdateEligibility(selectedMolecule, linkedInventoryQuantityInfoByGlobalId).disabledReason !== null
+    );
+  });
+  const selectionError = hasInvalidSelectedRows ? "Re-select any invalid molecules before saving." : null;
+  const handleSubmit = React.useCallback(async () => {
+    if (selectedMoleculeIds.length === 0) {
+      saveMutation.reset();
+      return;
+    }
+    if (hasInvalidSelectedRows) {
+      saveMutation.reset();
+      return;
+    }
+    if (!onSave) {
+      onClose();
+      return;
+    }
+    saveMutation.reset();
+    try {
+      const result = await saveMutation.mutateAsync(selectedMoleculeIds);
+      const hasFailures = result.results.some(({ success }) => !success);
+      if (!hasFailures) {
+        onClose();
+        return;
+      }
+      setSelectedMoleculeIds([]);
+    } catch {
+      setSelectedMoleculeIds([]);
+    }
+  }, [onClose, hasInvalidSelectedRows, onSave, saveMutation, selectedMoleculeIds]);
+  return (
+    <Box
+      component="form"
+      sx={{
+        display: "contents",
+      }}
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void handleSubmit();
+      }}
+    >
+      <DialogTitle id={titleId}>Update Inventory Stock</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2}>
+          <Typography variant="body2" color="text.secondary">
+            Select the molecules from this stoichiometry table whose linked inventory stock should be updated.
+          </Typography>
+          <Alert
+            severity="warning"
+            icon={
+              <WarningAmberIcon
+                aria-label="Action irreversible warning"
+                fontSize="small"
+                sx={{
+                  color: "warning.main",
+                }}
+              />
+            }
+          >
+            <AlertTitle>WARNING: This action is irreversible</AlertTitle>
+
+            <Typography variant="body2" gutterBottom>
+              <strong>This will permanently reduce inventory quantities.</strong>
+            </Typography>
+            <Typography variant="body2" gutterBottom>
+              Stock cannot be automatically replenished if you change quantities later, delete this stoichiometry table,
+              delete the document, or unlink samples.
+            </Typography>
+            <Typography variant="body2">
+              Only proceed if you have actually used these materials in your experiment.
+            </Typography>
+          </Alert>
+          {selectionError && <Alert severity="warning">{selectionError}</Alert>}
+          {saveFeedback && <Alert severity="info">{saveFeedback}</Alert>}
+          {saveError && <Alert severity="error">{saveError}</Alert>}
+          <TableContainer
+            component={Paper}
+            variant="outlined"
+            sx={{
+              maxHeight: 560,
+              overflowY: "auto",
+              borderRadius: 1,
+            }}
+          >
+            <Table stickyHeader size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell
+                    padding="checkbox"
+                    aria-label="Select molecule"
+                    width={52}
+                    sx={{
+                      px: 0.5,
+                    }}
+                  />
+                  <TableCell width="55%">Molecule</TableCell>
+                  <TableCell align="right" width="15%">
+                    In Stock
+                  </TableCell>
+                  <TableCell align="right" width="15%">
+                    Will Use
+                  </TableCell>
+                  <TableCell align="right" width="15%">
+                    Remaining
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {molecules.map((molecule) => {
+                  const eligibility = getInventoryUpdateEligibility(molecule, linkedInventoryQuantityInfoByGlobalId);
+                  const { disabledReason, helperText, stockDisplay } = eligibility;
+                  const disabled = disabledReason !== null;
+                  const selected = !disabled && selectedMoleculeIds.includes(molecule.id);
+                  return (
+                    <StoichiometryInventoryUpdateMoleculeRow
+                      key={molecule.id}
+                      molecule={molecule}
+                      selected={selected}
+                      disabled={disabled}
+                      helperText={helperText}
+                      stockDisplay={stockDisplay}
+                      onToggle={() => {
+                        if (disabled) {
+                          return;
+                        }
+                        saveMutation.reset();
+                        setSelectedMoleculeIds((currentIds) =>
+                          selected ? currentIds.filter((id) => id !== molecule.id) : [...currentIds, molecule.id],
+                        );
+                      }}
+                    />
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button type="button" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          color="callToAction"
+          disabled={selectedMoleculeIds.length === 0 || hasInvalidSelectedRows || saveMutation.isPending}
+        >
+          {saveMutation.isPending ? "Saving..." : "Save"}
+        </Button>
+      </DialogActions>
+    </Box>
+  );
+}

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryTableToolbar.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryTableToolbar.tsx
@@ -58,9 +58,20 @@ const StoichiometryTableToolbar = ({
   const [galleryDialogOpen, setGalleryDialogOpen] = React.useState(false);
   const [inventoryUpdateDialogOpen, setInventoryUpdateDialogOpen] = React.useState(false);
   const [exportMenuAnchorEl, setExportMenuAnchorEl] = React.useState<HTMLButtonElement | null>(null);
+  // Gate the dialog on quantity data so it always opens with complete data
+  // and can compute its default selection on mount, with no reconciliation of
+  // late-arriving results. Failed fetches still resolve into the map (as
+  // error entries), so this only stays true while requests are in flight or
+  // the OAuth token is unavailable.
+  const isLoadingInventoryQuantities = allMolecules.some((molecule) => {
+    const globalId = molecule.inventoryLink?.inventoryItemGlobalId;
+    return globalId != null && !linkedInventoryQuantityInfoByGlobalId.has(globalId);
+  });
   const inventoryUpdateDisabledTooltip = hasChanges
     ? "Save the stoichiometry table before updating inventory stock."
-    : "";
+    : isLoadingInventoryQuantities
+      ? "Loading inventory stock information..."
+      : "";
   return (
     <Toolbar
       style={{
@@ -88,7 +99,7 @@ const StoichiometryTableToolbar = ({
                 sx={{
                   mr: 1,
                 }}
-                disabled={hasChanges}
+                disabled={hasChanges || isLoadingInventoryQuantities}
                 onClick={() => {
                   setInventoryUpdateDialogOpen(true);
                 }}

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryTableToolbar.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryTableToolbar.tsx
@@ -97,7 +97,11 @@ const StoichiometryTableToolbar = ({
                 aria-label="Update Inventory Stock"
                 aria-busy={isLoadingInventoryQuantities}
                 size="small"
-                startIcon={isLoadingInventoryQuantities ? <CircularProgress size={16} color="inherit" /> : null}
+                startIcon={
+                  isLoadingInventoryQuantities ? (
+                    <CircularProgress size={16} color="inherit" aria-hidden="true" />
+                  ) : null
+                }
                 sx={{
                   mr: 1,
                 }}

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryTableToolbar.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/StoichiometryTableToolbar.tsx
@@ -95,7 +95,9 @@ const StoichiometryTableToolbar = ({
             <span>
               <Button
                 aria-label="Update Inventory Stock"
+                aria-busy={isLoadingInventoryQuantities}
                 size="small"
+                startIcon={isLoadingInventoryQuantities ? <CircularProgress size={16} color="inherit" /> : null}
                 sx={{
                   mr: 1,
                 }}

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryInventoryUpdateDialog.test.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryInventoryUpdateDialog.test.tsx
@@ -151,7 +151,7 @@ describe("StoichiometryInventoryUpdateDialog", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Save" }));
+    await user.click(await screen.findByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledWith([1]);
@@ -238,7 +238,7 @@ describe("StoichiometryInventoryUpdateDialog", () => {
 
     renderWithProviders(<Wrapper />);
 
-    expect(screen.getByRole("checkbox", { name: "Cyclopentane" })).toBeChecked();
+    expect(await screen.findByRole("checkbox", { name: "Cyclopentane" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Cyclopentadiene" })).toBeChecked();
 
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -263,7 +263,7 @@ describe("StoichiometryInventoryUpdateDialog", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("shows a warning for already deducted molecules without auto-selecting them", () => {
+  it("shows a warning for already deducted molecules without auto-selecting them", async () => {
     renderWithProviders(
       <StoichiometryInventoryUpdateDialog
         open
@@ -280,7 +280,7 @@ describe("StoichiometryInventoryUpdateDialog", () => {
       />,
     );
 
-    expect(screen.getByRole("checkbox", { name: "Cyclopentane" })).toBeEnabled();
+    expect(await screen.findByRole("checkbox", { name: "Cyclopentane" })).toBeEnabled();
     expect(screen.getByRole("checkbox", { name: "Cyclopentane" })).not.toBeChecked();
     expect(
       screen.getByText(
@@ -326,7 +326,7 @@ describe("StoichiometryInventoryUpdateDialog", () => {
 
     renderWithProviders(<Wrapper />);
 
-    const saveButton = screen.getByRole("button", { name: "Save" });
+    const saveButton = await screen.findByRole("button", { name: "Save" });
     expect(saveButton).toBeEnabled();
 
     await user.click(screen.getByText("Invalidate selection"));
@@ -358,7 +358,7 @@ describe("StoichiometryInventoryUpdateDialog", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Save" }));
+    await user.click(await screen.findByRole("button", { name: "Save" }));
 
     await screen.findByText("Network down Current stock amounts were refreshed where possible.");
     expect(screen.getByRole("checkbox", { name: "Cyclopentane" })).not.toBeChecked();

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryTable.test.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryTable.test.tsx
@@ -223,39 +223,41 @@ const subSampleResponses: Record<number, unknown> = {
   125: { id: 125, globalId: "SS125", quantity: { numericValue: 25, unitId: 3 } },
 };
 
+function resolveRoutedFetch(request: Request) {
+  const url = request.url;
+
+  if (url.includes("/userform/ajax/inventoryOauthToken")) {
+    const payload = {
+      iss: "http://localhost:8080",
+      iat: Date.now(),
+      exp: Math.floor(Date.now() / 1000) + 300,
+      refreshTokenHash: "fe15fa3d5e3d5a47e33e9e34229b1ea2314ad6e6f13fa42addca4f1439582a4d",
+    };
+    return Promise.resolve(JSON.stringify({ data: Jwt.sign(payload, "dummySecretKey") }));
+  }
+
+  if (url.includes("/api/v1/stoichiometry")) {
+    return Promise.resolve(JSON.stringify(createMockStoichiometryResponse()));
+  }
+
+  const subSampleMatch = url.match(/\/api\/inventory\/v1\/subSamples\/(\d+)/);
+  if (subSampleMatch) {
+    const id = Number(subSampleMatch[1]);
+    const body = subSampleResponses[id];
+    if (!body) {
+      return Promise.resolve({
+        status: 404,
+        body: JSON.stringify({ message: "Not Found" }),
+      });
+    }
+    return Promise.resolve(JSON.stringify(body));
+  }
+
+  return Promise.resolve({ status: 404, body: "{}" });
+}
+
 function routeFetch() {
-  fetchMock.mockResponse((request) => {
-    const url = request.url;
-
-    if (url.includes("/userform/ajax/inventoryOauthToken")) {
-      const payload = {
-        iss: "http://localhost:8080",
-        iat: Date.now(),
-        exp: Math.floor(Date.now() / 1000) + 300,
-        refreshTokenHash: "fe15fa3d5e3d5a47e33e9e34229b1ea2314ad6e6f13fa42addca4f1439582a4d",
-      };
-      return Promise.resolve(JSON.stringify({ data: Jwt.sign(payload, "dummySecretKey") }));
-    }
-
-    if (url.includes("/api/v1/stoichiometry")) {
-      return Promise.resolve(JSON.stringify(createMockStoichiometryResponse()));
-    }
-
-    const subSampleMatch = url.match(/\/api\/inventory\/v1\/subSamples\/(\d+)/);
-    if (subSampleMatch) {
-      const id = Number(subSampleMatch[1]);
-      const body = subSampleResponses[id];
-      if (!body) {
-        return Promise.resolve({
-          status: 404,
-          body: JSON.stringify({ message: "Not Found" }),
-        });
-      }
-      return Promise.resolve(JSON.stringify(body));
-    }
-
-    return Promise.resolve({ status: 404, body: "{}" });
-  });
+  fetchMock.mockResponse(resolveRoutedFetch);
 }
 
 /**
@@ -487,10 +489,38 @@ describe("StoichiometryTable", () => {
       expect(await screen.findByRole("dialog", { name: /Gallery Picker/i }, { timeout: 10000 })).toBeVisible();
     });
 
+    it("keeps Update Inventory Stock disabled until inventory quantities load", async () => {
+      let releaseSubSampleResponses: () => void = () => {};
+      const subSampleGate = new Promise<void>((resolve) => {
+        releaseSubSampleResponses = resolve;
+      });
+      fetchMock.mockResponse(async (request) => {
+        if (/\/api\/inventory\/v1\/subSamples\/\d+/.test(request.url)) {
+          await subSampleGate;
+        }
+        return resolveRoutedFetch(request);
+      });
+
+      await renderLoadedTable();
+
+      const button = screen.getByRole("button", { name: "Update Inventory Stock" });
+      expect(button).toBeDisabled();
+
+      releaseSubSampleResponses();
+
+      await waitFor(() => {
+        expect(button).toBeEnabled();
+      });
+    });
+
     it("opens the inventory stock update dialog listing the current molecules", async () => {
       const { user } = await renderLoadedTable();
 
-      await user.click(screen.getByRole("button", { name: "Update Inventory Stock" }));
+      const updateStockButton = screen.getByRole("button", { name: "Update Inventory Stock" });
+      await waitFor(() => {
+        expect(updateStockButton).toBeEnabled();
+      });
+      await user.click(updateStockButton);
 
       const dialog = await screen.findByRole("dialog", {
         name: /Update Inventory Stock/i,

--- a/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryTable.test.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/stoichiometry/__tests__/StoichiometryTable.test.tsx
@@ -240,9 +240,10 @@ function resolveRoutedFetch(request: Request) {
     return Promise.resolve(JSON.stringify(createMockStoichiometryResponse()));
   }
 
-  const subSampleMatch = url.match(/\/api\/inventory\/v1\/subSamples\/(\d+)/);
-  if (subSampleMatch) {
-    const id = Number(subSampleMatch[1]);
+  const subSampleUrlMarker = "/api/inventory/v1/subSamples/";
+  const subSampleMarkerIndex = url.indexOf(subSampleUrlMarker);
+  if (subSampleMarkerIndex !== -1) {
+    const id = Number(url.slice(subSampleMarkerIndex + subSampleUrlMarker.length));
     const body = subSampleResponses[id];
     if (!body) {
       return Promise.resolve({
@@ -495,7 +496,7 @@ describe("StoichiometryTable", () => {
         releaseSubSampleResponses = resolve;
       });
       fetchMock.mockResponse(async (request) => {
-        if (/\/api\/inventory\/v1\/subSamples\/\d+/.test(request.url)) {
+        if (request.url.includes("/api/inventory/v1/subSamples/")) {
           await subSampleGate;
         }
         return resolveRoutedFetch(request);

--- a/src/main/webapp/ui/vitest.browser.config.ts
+++ b/src/main/webapp/ui/vitest.browser.config.ts
@@ -96,6 +96,7 @@ const firefoxCiSkippedFiles =
         "**/tinyMCE/stoichiometry/__tests__/StoichiometryTable.spec.tsx",
         "**/tinyMCE/stoichiometry/__tests__/StoichiometryDialog.spec.tsx",
         "**/eln/gallery/components/CallableImagePreview.spec.tsx",
+        "**/eln/gallery/components/MainPanel.spec.tsx",
         "**/tinyMCE/pubchem/ImportDialog.spec.tsx",
         "**/Inventory/components/FieldmarkImportDialog.spec.tsx",
         "**/Inventory/Identifiers/IGSN/IgsnTable.spec.tsx",


### PR DESCRIPTION
## Description ##
The Update Inventory Stock dialog computed its default molecule selection from linkedInventoryQuantityInfoByGlobalId, but that map is populated asynchronously by per-molecule inventory quantity queries. If the dialog was opened before all queries resolved, or before an open->close->open cycle finished resetting state via a ref-tracked effect, it could preselect molecules based on incomplete or stale quantity data.

- Split the dialog into a thin shell (StoichiometryInventoryUpdateDialog) and a stateful content component (StoichiometryInventoryUpdateDialogContent). All state now lives in the content component and is initialized once via a useState initializer; since MUI's Dialog unmounts its children on close, each open is a fresh mount with no reset effects/refs needed.
- Gate the "Update Inventory Stock" toolbar button on all linked molecules' inventory quantities having resolved (StoichiometryTableToolbar), so the dialog can no longer open with an incomplete quantity map.
- Fix useSubSampleQuantitiesQuery so a query that throws (network failure, unparseable response) also lands an error entry in the returned map, matching the existing !response.ok handling. Without this, a thrown query error left the molecule out of the map entirely and the toolbar's loading check never resolved, permanently disabling the button.