### PR TITLE
RSDEV-1144 Attribute template-derived documents to their creator

### DIFF
--- a/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/RecordManagerImpl.java
@@ -222,6 +222,10 @@ public class RecordManagerImpl implements RecordManager {
     createdDoc.setAllFieldsValid(listFields.stream().allMatch(Field::isMandatoryStateSatisfied));
     createdDoc.notifyDelta(
         DeltaType.CREATED_FROM_TEMPLATE, getTemplateCreationDeltaMsg(templateId, copy, createdDoc));
+    // the copy inherits the template owner's createdBy/modifiedBy, so reset to the creator
+    // (RSDEV-1144)
+    createdDoc.setCreatedBy(user.getUsername());
+    createdDoc.setModifiedBy(user.getUsername());
     // now update this so it is not a template
     createdDoc.removeType(RecordType.TEMPLATE);
 

--- a/src/test/java/com/researchspace/service/RecordManagerTest.java
+++ b/src/test/java/com/researchspace/service/RecordManagerTest.java
@@ -1500,6 +1500,27 @@ public class RecordManagerTest extends SpringTransactionalTest {
   }
 
   @Test
+  public void createFromSharedTemplateAttributesCreatorToUserNotTemplateOwner() throws Exception {
+    // RSDEV-1144: doc from another user's shared template is attributed to the creator.
+    TestGroup testGroup = createTestGroup(1);
+    User templateOwner = testGroup.getPi();
+    User creator = testGroup.u1();
+
+    logoutAndLoginAs(templateOwner);
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(templateOwner, "text");
+    StructuredDocument template =
+        createTemplateFromDocumentAndAddtoTemplateFolder(doc.getId(), templateOwner);
+    shareRecordWithUser(templateOwner, template, creator);
+
+    logoutAndLoginAs(creator);
+    StructuredDocument fromTemplate = createFromTemplate(creator, template, "fromSharedTemplate");
+
+    assertEquals(creator, fromTemplate.getOwner());
+    assertEquals(creator.getUsername(), fromTemplate.getCreatedBy());
+    assertEquals(creator.getUsername(), fromTemplate.getModifiedBy());
+  }
+
+  @Test
   public void filterGalleryItems() throws IOException {
     // add 3 images with defined name to Gallery
     final int TOTAL_NUM_IMAGES = 3;


### PR DESCRIPTION
## Description ##
Fixes [RSDEV-1144](https://researchspace.atlassian.net/browse/RSDEV-1144): a document created from a template shared by another user had its `createdBy` / `modifiedBy` metadata pointing to the **template owner** rather than the user who created the document.

The entity copy inherits `createdBy` / `modifiedBy` via `EditInfo.shallowCopy()`, and `DocumentCopyManagerImpl.copy` only reset the owner afterwards. This resets both audit fields to the acting user in `RecordManager.createFromTemplate`, mirroring how the copy already assigns the owner. The revision-history "created by" / initial-revision "modified by" now correctly show the creating user.

## Testing notes
- Added regression test `RecordManagerTest.createFromSharedTemplateAttributesCreatorToUserNotTemplateOwner` (PI owns/shares a template, group member creates from it, asserts creator attribution).
- Manually verified end-to-end: before the fix a doc from a shared template recorded the template owner; after, it records the creating user, in both the database and the revision-history UI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>