### PR TITLE
RSDEV-1237 Strip Inventory image links from limited-read records

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/BaseApiInventoryController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/BaseApiInventoryController.java
@@ -77,6 +77,7 @@ public class BaseApiInventoryController extends BaseApiController {
     invRecInfo.buildAndAddInventoryRecordLinks(getInventoryApiBaseURIBuilder());
     addFileLinksForAttachments(invRecInfo);
     addBarcodeLinks(invRecInfo);
+    invRecInfo.removeImageLinksForLimitedView();
   }
 
   private void addFileLinksForAttachments(ApiInventoryRecordInfo recInfo) {

--- a/src/main/java/com/researchspace/api/v1/controller/BaseApiInventoryController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/BaseApiInventoryController.java
@@ -75,9 +75,18 @@ public class BaseApiInventoryController extends BaseApiController {
 
   protected void buildAndAddInventoryRecordLinks(ApiInventoryRecordInfo invRecInfo) {
     invRecInfo.buildAndAddInventoryRecordLinks(getInventoryApiBaseURIBuilder());
+    addFileAndBarcodeLinks(invRecInfo);
+    invRecInfo.removeImageLinksForLimitedView();
+  }
+
+  /**
+   * Attachment (field file) and barcode links are added controller-side rather than by the model's
+   * link recursion. A nested record reached only through that recursion (e.g. the parent sample of
+   * a subsample) therefore needs this called on it explicitly to gain those links.
+   */
+  protected void addFileAndBarcodeLinks(ApiInventoryRecordInfo invRecInfo) {
     addFileLinksForAttachments(invRecInfo);
     addBarcodeLinks(invRecInfo);
-    invRecInfo.removeImageLinksForLimitedView();
   }
 
   private void addFileLinksForAttachments(ApiInventoryRecordInfo recInfo) {

--- a/src/main/java/com/researchspace/api/v1/controller/SubSamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SubSamplesApiController.java
@@ -87,7 +87,6 @@ public class SubSamplesApiController extends BaseApiInventoryController implemen
 
     ApiSubSample subSample = retrieveSubSampleIfExists(id, user);
     buildAndAddInventoryRecordLinks(subSample);
-    buildAndAddInventoryRecordLinks(subSample.getSampleInfo());
     return subSample;
   }
 

--- a/src/main/java/com/researchspace/api/v1/controller/SubSamplesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SubSamplesApiController.java
@@ -87,6 +87,11 @@ public class SubSamplesApiController extends BaseApiInventoryController implemen
 
     ApiSubSample subSample = retrieveSubSampleIfExists(id, user);
     buildAndAddInventoryRecordLinks(subSample);
+    // The nested parent sample's record links are built by the recursion above; its attachment and
+    // barcode links are not, so add them here (the strip has already run and does not touch them).
+    if (subSample.getSampleInfo() != null) {
+      addFileAndBarcodeLinks(subSample.getSampleInfo());
+    }
     return subSample;
   }
 

--- a/src/main/java/com/researchspace/api/v1/model/ApiContainer.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiContainer.java
@@ -213,6 +213,18 @@ public class ApiContainer extends ApiContainerInfo {
     }
   }
 
+  @Override
+  public void removeImageLinksForLimitedView() {
+    super.removeImageLinksForLimitedView();
+
+    List<ApiInventoryRecordInfo> storedContent = getStoredContent();
+    if (storedContent != null) {
+      for (ApiInventoryRecordInfo item : storedContent) {
+        item.removeImageLinksForLimitedView();
+      }
+    }
+  }
+
   public ApiContainerInfo toContainerInfoWithIdOnly() {
     ApiContainerInfo apiContainerInfo = new ApiContainerInfo();
     apiContainerInfo.setId(getId());

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
@@ -588,9 +588,21 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
    * (it 403s). Applied after link-building so it also covers the listing and
    * subsample-from-parent-sample paths, which add these links even though the single-record path
    * does not.
+   *
+   * <p>Subclasses whose {@link #buildAndAddInventoryRecordLinks} recurses into nested records
+   * (container content, a sample's subsamples, a subsample's parent sample) must override this to
+   * recurse the same way, otherwise the nested records keep advertising images the viewer cannot
+   * fetch.
    */
   public void removeImageLinksForLimitedView() {
-    if (isLimitedReadItem() && links != null) {
+    if (isLimitedReadItem()) {
+      removeImageLinks();
+    }
+  }
+
+  /** Unconditionally removes the image/thumbnail links. */
+  protected void removeImageLinks() {
+    if (links != null) {
       links.removeIf(
           link ->
               ApiLinkItem.IMAGE_REL.equals(link.getRel())

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryRecordInfo.java
@@ -583,6 +583,21 @@ public abstract class ApiInventoryRecordInfo extends IdentifiableNameableApiObje
     buildAndAddSelfLink(getSelfLinkEndpoint(), "" + getId(), baseUrlBuilder);
   }
 
+  /**
+   * Removes the image/thumbnail links for a limited-read item, whose viewer cannot fetch the image
+   * (it 403s). Applied after link-building so it also covers the listing and
+   * subsample-from-parent-sample paths, which add these links even though the single-record path
+   * does not.
+   */
+  public void removeImageLinksForLimitedView() {
+    if (isLimitedReadItem() && links != null) {
+      links.removeIf(
+          link ->
+              ApiLinkItem.IMAGE_REL.equals(link.getRel())
+                  || ApiLinkItem.THUMBNAIL_REL.equals(link.getRel()));
+    }
+  }
+
   protected abstract String getSelfLinkEndpoint();
 
   void addMainImageLink(UriComponentsBuilder baseUrlBuilder) {

--- a/src/main/java/com/researchspace/api/v1/model/ApiSample.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSample.java
@@ -96,6 +96,18 @@ public class ApiSample extends ApiSampleWithoutSubSamples {
   }
 
   @Override
+  public void removeImageLinksForLimitedView() {
+    super.removeImageLinksForLimitedView();
+
+    List<ApiSubSampleInfo> subSamples = getSubSamples();
+    if (subSamples != null) {
+      for (ApiSubSampleInfo subSample : subSamples) {
+        subSample.removeImageLinksForLimitedView();
+      }
+    }
+  }
+
+  @Override
   protected void nullifyListsForLimitedView(ApiInventoryRecordInfo apiInvRec) {
     ApiSample apiSample = (ApiSample) apiInvRec;
     super.nullifyListsForLimitedView(apiSample);

--- a/src/main/java/com/researchspace/api/v1/model/ApiSampleWithFullSubSamples.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSampleWithFullSubSamples.java
@@ -95,4 +95,13 @@ public class ApiSampleWithFullSubSamples extends ApiSampleWithoutSubSamples {
       subSample.buildAndAddInventoryRecordLinks(inventoryApiBaseUrl);
     }
   }
+
+  @Override
+  public void removeImageLinksForLimitedView() {
+    super.removeImageLinksForLimitedView();
+
+    for (ApiSubSample subSample : getSubSamples()) {
+      subSample.removeImageLinksForLimitedView();
+    }
+  }
 }

--- a/src/main/java/com/researchspace/api/v1/model/ApiSubSampleInfoWithSampleInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSubSampleInfoWithSampleInfo.java
@@ -68,6 +68,19 @@ public class ApiSubSampleInfoWithSampleInfo extends ApiSubSampleInfo {
   }
 
   @Override
+  public void removeImageLinksForLimitedView() {
+    super.removeImageLinksForLimitedView();
+
+    /* The limited-view copy keeps the raw parent sample, whose permitted actions are never
+     * evaluated for the viewer, so its own limited-read check cannot fire. A limited-read
+     * subsample implies the viewer cannot fetch the sample's image either, so strip it
+     * unconditionally. */
+    if (isLimitedReadItem() && getSampleInfo() != null) {
+      getSampleInfo().removeImageLinks();
+    }
+  }
+
+  @Override
   protected void populateLimitedViewCopy(ApiInventoryRecordInfo apiInvRecCopy) {
     super.populateLimitedViewCopy(apiInvRecCopy);
     ApiSubSampleInfoWithSampleInfo publicViewCopy = (ApiSubSampleInfoWithSampleInfo) apiInvRecCopy;

--- a/src/main/java/com/researchspace/api/v1/model/ApiSubSampleInfoWithSampleInfo.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiSubSampleInfoWithSampleInfo.java
@@ -61,9 +61,11 @@ public class ApiSubSampleInfoWithSampleInfo extends ApiSubSampleInfo {
   public void buildAndAddInventoryRecordLinks(UriComponentsBuilder inventoryApiBaseUrl) {
     super.buildAndAddInventoryRecordLinks(inventoryApiBaseUrl);
 
-    if (!isCustomImage() && (getSampleInfo() != null)) {
+    if (getSampleInfo() != null) {
       getSampleInfo().buildAndAddInventoryRecordLinks(inventoryApiBaseUrl);
-      addImageLinksFromParentSample(inventoryApiBaseUrl, getSampleInfo());
+      if (!isCustomImage()) {
+        addImageLinksFromParentSample(inventoryApiBaseUrl, getSampleInfo());
+      }
     }
   }
 

--- a/src/test/java/com/researchspace/api/v1/model/ApiInventoryRecordInfoTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiInventoryRecordInfoTest.java
@@ -177,6 +177,23 @@ public class ApiInventoryRecordInfoTest {
     assertFalse(hasImageOrThumbnailLink(limitedReadChild.getSampleInfo()));
   }
 
+  /**
+   * The nested sample's links must be built regardless of the subsample having its own image
+   * (getSubSampleById relies on this recursion; only the copied-from-parent image links are
+   * conditional on the subsample not having a custom image).
+   */
+  @Test
+  public void customImageSubSampleStillGetsParentSampleLinksBuilt() {
+    ApiSubSample subSample = limitedReadSubSampleOfImagedSample();
+    subSample.setPermittedActions(List.of(ApiInventoryRecordPermittedAction.READ));
+    subSample.setCustomImage(true);
+
+    subSample.buildAndAddInventoryRecordLinks(BASE_URL);
+
+    assertFalse(subSample.getSampleInfo().getLinks().isEmpty());
+    assertTrue(hasImageOrThumbnailLink(subSample.getSampleInfo()));
+  }
+
   private ApiSubSample limitedReadSubSampleOfImagedSample() {
     ApiSampleWithoutSubSamples parentSample = new ApiSampleWithoutSubSamples();
     parentSample.setId(1L);

--- a/src/test/java/com/researchspace/api/v1/model/ApiInventoryRecordInfoTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiInventoryRecordInfoTest.java
@@ -3,9 +3,15 @@ package com.researchspace.api.v1.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
+import com.researchspace.model.FileProperty;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.web.util.UriComponentsBuilder;
 
 public class ApiInventoryRecordInfoTest {
   private ApiInventoryRecordInfo testee;
@@ -93,5 +99,58 @@ public class ApiInventoryRecordInfoTest {
     testee.setApiTagInfo(tagPlusMeta);
     original.setApiTagInfo(tagPlusMeta2);
     assertTrue(ApiInventoryRecordInfo.tagDifferenceExists(original, testee));
+  }
+
+  /** A limited-read viewer can't fetch the image (it 403s), so its link is stripped. */
+  @Test
+  public void limitedReadItemHasImageLinksStripped() {
+    ApiInventoryRecordInfo rec = imagedRecord();
+    rec.setPermittedActions(List.of(ApiInventoryRecordPermittedAction.LIMITED_READ));
+
+    rec.buildAndAddInventoryRecordLinks(BASE_URL);
+    assertTrue("links should be built before stripping", hasImageOrThumbnailLink(rec));
+
+    rec.removeImageLinksForLimitedView();
+
+    assertFalse(hasImageOrThumbnailLink(rec));
+  }
+
+  @Test
+  public void fullyReadableItemKeepsImageLinks() {
+    ApiInventoryRecordInfo rec = imagedRecord();
+    rec.setPermittedActions(List.of(ApiInventoryRecordPermittedAction.READ));
+
+    rec.buildAndAddInventoryRecordLinks(BASE_URL);
+    rec.removeImageLinksForLimitedView();
+
+    assertTrue(hasImageOrThumbnailLink(rec));
+  }
+
+  private static final UriComponentsBuilder BASE_URL =
+      UriComponentsBuilder.fromHttpUrl("http://localhost:8080/api/inventory/v1");
+
+  private ApiInventoryRecordInfo imagedRecord() {
+    ApiInventoryRecordInfo rec =
+        new ApiInventoryRecordInfo() {
+          @Override
+          protected String getSelfLinkEndpoint() {
+            return "containers";
+          }
+        };
+    rec.setId(1L);
+    rec.setCustomImage(true);
+    FileProperty fp = mock(FileProperty.class);
+    when(fp.getContentsHash()).thenReturn("contentshash");
+    rec.setImageFileProperty(fp);
+    rec.setThumbnailFileProperty(fp);
+    return rec;
+  }
+
+  private boolean hasImageOrThumbnailLink(ApiInventoryRecordInfo rec) {
+    return rec.getLinks().stream()
+        .anyMatch(
+            l ->
+                ApiLinkItem.IMAGE_REL.equals(l.getRel())
+                    || ApiLinkItem.THUMBNAIL_REL.equals(l.getRel()));
   }
 }

--- a/src/test/java/com/researchspace/api/v1/model/ApiInventoryRecordInfoTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiInventoryRecordInfoTest.java
@@ -126,6 +126,73 @@ public class ApiInventoryRecordInfoTest {
     assertTrue(hasImageOrThumbnailLink(rec));
   }
 
+  /**
+   * The limited-view copy of a subsample keeps the raw parent sample, whose permitted actions are
+   * never evaluated for the viewer, so both the subsample's from-parent image links and the nested
+   * sample's own links must be stripped off the limited-read subsample.
+   */
+  @Test
+  public void limitedReadSubSampleHasParentSampleImageLinksStripped() {
+    ApiSubSample subSample = limitedReadSubSampleOfImagedSample();
+
+    subSample.buildAndAddInventoryRecordLinks(BASE_URL);
+    assertTrue("subsample should get image links from parent", hasImageOrThumbnailLink(subSample));
+    assertTrue(hasImageOrThumbnailLink(subSample.getSampleInfo()));
+
+    subSample.removeImageLinksForLimitedView();
+
+    assertFalse(hasImageOrThumbnailLink(subSample));
+    assertFalse(hasImageOrThumbnailLink(subSample.getSampleInfo()));
+  }
+
+  @Test
+  public void fullyReadableSubSampleKeepsParentSampleImageLinks() {
+    ApiSubSample subSample = limitedReadSubSampleOfImagedSample();
+    subSample.setPermittedActions(List.of(ApiInventoryRecordPermittedAction.READ));
+
+    subSample.buildAndAddInventoryRecordLinks(BASE_URL);
+    subSample.removeImageLinksForLimitedView();
+
+    assertTrue(hasImageOrThumbnailLink(subSample));
+    assertTrue(hasImageOrThumbnailLink(subSample.getSampleInfo()));
+  }
+
+  /** Content of a readable container must still be stripped per-item, not just the container. */
+  @Test
+  public void limitedReadContainerContentHasImageLinksStripped() {
+    ApiSubSample limitedReadChild = limitedReadSubSampleOfImagedSample();
+    ApiContainerLocationWithContent location = new ApiContainerLocationWithContent(1, 1);
+    location.setContent(limitedReadChild);
+    ApiContainer container = new ApiContainer();
+    container.setId(3L);
+    container.setPermittedActions(List.of(ApiInventoryRecordPermittedAction.READ));
+    container.setLocations(List.of(location));
+
+    container.buildAndAddInventoryRecordLinks(BASE_URL);
+    assertTrue(hasImageOrThumbnailLink(limitedReadChild));
+
+    container.removeImageLinksForLimitedView();
+
+    assertFalse(hasImageOrThumbnailLink(limitedReadChild));
+    assertFalse(hasImageOrThumbnailLink(limitedReadChild.getSampleInfo()));
+  }
+
+  private ApiSubSample limitedReadSubSampleOfImagedSample() {
+    ApiSampleWithoutSubSamples parentSample = new ApiSampleWithoutSubSamples();
+    parentSample.setId(1L);
+    parentSample.setCustomImage(true);
+    FileProperty fp = mock(FileProperty.class);
+    when(fp.getContentsHash()).thenReturn("contentshash");
+    parentSample.setImageFileProperty(fp);
+    parentSample.setThumbnailFileProperty(fp);
+
+    ApiSubSample subSample = new ApiSubSample();
+    subSample.setId(2L);
+    subSample.setSampleInfo(parentSample);
+    subSample.setPermittedActions(List.of(ApiInventoryRecordPermittedAction.LIMITED_READ));
+    return subSample;
+  }
+
   private static final UriComponentsBuilder BASE_URL =
       UriComponentsBuilder.fromHttpUrl("http://localhost:8080/api/inventory/v1");
 


### PR DESCRIPTION
## Description

The Inventory API advertised `image`/`thumbnail` `_links` on records a viewer only has `LIMITED_READ` on. The frontend fetches them, the 401 is misread by the axios interceptor as an expired OAuth token, and the whole Inventory app remounts (the tree reload / white flash in RSDEV-1237). Not advertising the links removes the trigger.

`ApiInventoryRecordInfo.removeImageLinksForLimitedView()` is applied once in `BaseApiInventoryController` after all links are built, and recursed wherever `buildAndAddInventoryRecordLinks` recurses:

- container / workbench `locations[].content`
- sample subsamples
- the parent sample nested under a limited-read subsample (whose `permittedActions` were never evaluated, so a per-record strip could not reach it)

Also drops a pre-existing double-build of the nested sample's links in `getSubSampleById`, which re-added the stripped links and duplicated every nested link.


Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
