### PR TITLE
Fix crash when a server error alert renders a raw error object

### DIFF
--- a/src/main/webapp/ui/src/my-rspace/profile/Autoshare/DisableAutoshareDialog.tsx
+++ b/src/main/webapp/ui/src/my-rspace/profile/Autoshare/DisableAutoshareDialog.tsx
@@ -13,6 +13,7 @@ import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import React, { useContext } from "react";
 import axios from "@/common/axios";
 import AlertContext, { mkAlert } from "@/stores/contexts/Alert";
+import { getErrorMessage } from "@/util/error";
 import materialTheme from "../../../theme";
 
 // biome-ignore lint/suspicious/noExplicitAny: initial biome migration
@@ -68,7 +69,7 @@ function DisableAutoshareDialog({
       .catch((error: any) => {
         addAlert(
           mkAlert({
-            message: error.response.data || "Something went wrong. Please, contact support if the issue persists.",
+            message: getErrorMessage(error, "Something went wrong. Please, contact support if the issue persists."),
             variant: "warning",
             isInfinite: true,
           }),

--- a/src/main/webapp/ui/src/my-rspace/profile/Autoshare/EnableAutoshareDialog.tsx
+++ b/src/main/webapp/ui/src/my-rspace/profile/Autoshare/EnableAutoshareDialog.tsx
@@ -13,6 +13,7 @@ import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import React, { useContext } from "react";
 import axios from "@/common/axios";
 import AlertContext, { mkAlert } from "@/stores/contexts/Alert";
+import { getErrorMessage } from "@/util/error";
 import materialTheme from "../../../theme";
 
 // biome-ignore lint/suspicious/noExplicitAny: initial biome migration
@@ -74,7 +75,7 @@ function EnableAutoshareDialog({
       .catch((error: any) => {
         addAlert(
           mkAlert({
-            message: error.response.data || "Something went wrong. Please, contact support if the issue persists.",
+            message: getErrorMessage(error, "Something went wrong. Please, contact support if the issue persists."),
             variant: "warning",
             isInfinite: true,
           }),

--- a/src/main/webapp/ui/src/my-rspace/profile/OAuthDialog.tsx
+++ b/src/main/webapp/ui/src/my-rspace/profile/OAuthDialog.tsx
@@ -16,6 +16,7 @@ import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import React, { useContext, useRef } from "react";
 import axios from "@/common/axios";
 import AlertContext, { mkAlert } from "@/stores/contexts/Alert";
+import { getErrorMessage } from "@/util/error";
 import materialTheme from "../../theme";
 
 // biome-ignore lint/suspicious/noExplicitAny: initial biome migration
@@ -89,7 +90,13 @@ export default function OAuthDialog(props: any) {
         })
         // biome-ignore lint/suspicious/noExplicitAny: initial biome migration
         .catch((error: any) => {
-          addAlert(mkAlert({ message: error.response.data, variant: "warning", isInfinite: true }));
+          addAlert(
+            mkAlert({
+              message: getErrorMessage(error, "There was a problem while creating your application."),
+              variant: "warning",
+              isInfinite: true,
+            }),
+          );
         });
     }
   };

--- a/src/main/webapp/ui/src/tinyMCE/SnapGene/EnzymeTable.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/SnapGene/EnzymeTable.tsx
@@ -13,6 +13,7 @@ import TableRow from "@mui/material/TableRow";
 import React, { useContext, useEffect } from "react";
 import axios from "@/common/axios";
 import AlertContext, { mkAlert } from "@/stores/contexts/Alert";
+import { getErrorMessage } from "@/util/error";
 import EnhancedTableHead from "../../components/EnhancedTableHead";
 import LoadingCircular from "../../components/LoadingCircular";
 import { getSorting, paginationOptions } from "../../util/table";
@@ -65,7 +66,13 @@ export default function EnzymeTable(props: any) {
         generateEnzymeList(response.data.enzymes);
       })
       .catch((error) => {
-        addAlert(mkAlert({ message: error.response.data, variant: "warning", isInfinite: true }));
+        addAlert(
+          mkAlert({
+            message: getErrorMessage(error, "Could not load the enzyme table."),
+            variant: "warning",
+            isInfinite: true,
+          }),
+        );
       })
       .finally(() => {
         setLoading(false);

--- a/src/main/webapp/ui/src/tinyMCE/SnapGene/FastaView.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/SnapGene/FastaView.tsx
@@ -4,6 +4,7 @@ import Typography from "@mui/material/Typography";
 import React, { useCallback, useContext, useEffect } from "react";
 import axios from "@/common/axios";
 import AlertContext, { mkAlert } from "@/stores/contexts/Alert";
+import { getErrorMessage } from "@/util/error";
 import LoadingCircular from "../../components/LoadingCircular";
 
 type FastaViewProps = {
@@ -30,7 +31,13 @@ export default function FastaView({ id, setDisabled }: FastaViewProps) {
         setSequence(response.data);
       })
       .catch((error) => {
-        addAlert(mkAlert({ message: error.response.data, variant: "warning", isInfinite: true }));
+        addAlert(
+          mkAlert({
+            message: getErrorMessage(error, "Could not load the FASTA sequence."),
+            variant: "warning",
+            isInfinite: true,
+          }),
+        );
       })
       .finally(() => {
         setLoading(false);

--- a/src/main/webapp/ui/src/tinyMCE/SnapGene/OrfTable.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/SnapGene/OrfTable.tsx
@@ -13,6 +13,7 @@ import TableRow from "@mui/material/TableRow";
 import React, { useContext, useEffect } from "react";
 import axios from "@/common/axios";
 import AlertContext, { mkAlert } from "@/stores/contexts/Alert";
+import { getErrorMessage } from "@/util/error";
 import EnhancedTableHead from "../../components/EnhancedTableHead";
 import LoadingCircular from "../../components/LoadingCircular";
 import { getSorting, paginationOptions } from "../../util/table";
@@ -86,7 +87,13 @@ export default function OrfTable(props: any) {
         filterResults(response.data.ORFs);
       })
       .catch((error) => {
-        addAlert(mkAlert({ message: error.response.data, variant: "warning", isInfinite: true }));
+        addAlert(
+          mkAlert({
+            message: getErrorMessage(error, "Could not load the ORF table."),
+            variant: "warning",
+            isInfinite: true,
+          }),
+        );
       })
       .finally(() => {
         setLoading(false);


### PR DESCRIPTION
## Description ##
Six call sites passed axios's error.response.data straight into mkAlert's message, assuming it was always a string. RSpace's standard error envelope is actually {exceptionMessage, tstamp, errorId}, and rendering that object as a JSX child throws "Objects are not valid as a React child", which sends the whole surface to its ErrorBoundary fallback instead of showing a toast.

The legacy RS.confirm this replaced masked the same bug silently (it used dangerouslySetInnerHTML, which just coerces objects to "[object Object]"), so it never crashed, just showed a useless message.

Found via manual browser verification: dispatching a SnapGene event for a non-existent record ID crashed the Enzyme Sites tab. Use the existing getErrorMessage() helper (src/main/webapp/ui/src/util/error.ts), which already knows how to pull exceptionMessage/message out of an Axios error, in FastaView, OrfTable, EnzymeTable, OAuthDialog, EnableAutoshareDialog, and DisableAutoshareDialog.
