### PR TITLE
Remove outdated `produces` keywords in OpenAPI Spec

### DIFF
--- a/src/main/webapp/resources/rspace_api_inventory_specs_2_24_0.yaml
+++ b/src/main/webapp/resources/rspace_api_inventory_specs_2_24_0.yaml
@@ -3073,8 +3073,6 @@ paths:
       description: >
         Publishes External Identifier (IGSN/PIDINST) and connected record.
 
-      produces:
-        - application/json
       tags:
         - External Identifiers
       parameters:
@@ -3088,8 +3086,6 @@ paths:
       description: >
         Retracts External Identifier (IGSN/PIDINST) and hides previously published connected record.
 
-      produces:
-        - application/json
       tags:
         - External Identifiers
       parameters:
@@ -3103,8 +3099,6 @@ paths:
       summary: Test connection settings saved for the DataCite IGSN integration
       description: >
         Test connection settings saved for the DataCite IGSN integration
-      produces:
-        - application/json
       tags:
         - External Identifiers
       responses:
@@ -3116,8 +3110,6 @@ paths:
       summary: Test connection settings saved for the DataCite PIDINST integration
       description: >
         Test connection settings saved for the DataCite PIDINST integration
-      produces:
-        - application/json
       tags:
         - External Identifiers
       responses:


### PR DESCRIPTION
## Description ##
Remove outdated `produces` keywords in OpenAPI Spec.