### PR TITLE
Fix notebook/document crash: photoswipe.jsp head dropped under SiteMesh 3

### DIFF
--- a/src/main/webapp/WEB-INF/pages/workspace/editor/include/photoswipe.jsp
+++ b/src/main/webapp/WEB-INF/pages/workspace/editor/include/photoswipe.jsp
@@ -1,6 +1,10 @@
 <%@ include file="/common/taglibs.jsp" %>
 
-    <head>
+    <%-- No <head> wrapper: this fragment is jsp:included into the body of its callers
+         (notebookFooter.jsp, structuredDocumentMainPanel.jsp). Under SiteMesh 3's
+         first-<head>-wins nesting, a second in-body <head> is silently dropped, which
+         would drop photoswipe.js and leave populatePhotoswipeImageArray undefined.
+         Body-level <link>/<script>/<style> survive inlining and load before document.ready. --%>
         <link rel="stylesheet" href="<rst:assetUrl value='/scripts/bower_components/photoswipe/dist/photoswipe.css'/>" />
         <link rel="stylesheet"
             href="<rst:assetUrl value='/scripts/bower_components/photoswipe/dist/default-skin/default-skin.css'/>" />
@@ -34,7 +38,6 @@
                 line-height:18px;
             }
         </style>
-    </head>
 
     <!-- Root element of PhotoSwipe. Must have class pswp. -->
     <div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">


### PR DESCRIPTION
## Description

The SiteMesh 2.4.2 → 3.1.1 upgrade (#900) regressed notebook rendering. `photoswipe.jsp` wrapped its `<script>`/`<link>`/`<style>` in its own `<head>`, but the fragment is `jsp:include`d into the **body** of its callers (`notebookFooter.jsp`, `structuredDocumentMainPanel.jsp`). Under SiteMesh 3's first-`<head>`-wins nesting, that second in-body `<head>` is silently dropped, so `photoswipe.js` never loaded and `populatePhotoswipeImageArray` was undefined when `journal.js`/`documentView.js` called it on entry load:

```
Uncaught ReferenceError: populatePhotoswipeImageArray is not defined
    at HTMLDocument.<anonymous> (journal.js:382)
    at Object._loadPage (journal.js:395)
```

Fix: remove the `<head>` wrapper so the assets sit at body level, where they survive SiteMesh inlining and load before `document.ready`. This is the same pattern #900 applied to `admin.jsp`. One change covers all four consumers (notebook editor, public notebook view, workspace document editor, public document view). No styling regression: the Photoswipe CSS is also loaded in `notebookHeader.jsp`.

## Steps to reproduce (before this fix)

1. Log in and create a new notebook
2. Create a new notebook entry inside the notebook and save
3. The notebook entry never loads

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>