### PR TITLE
RSDEV-1093: reduce Inventory/ELN tag search debounce 1000ms -> 300ms

### DIFF
--- a/src/main/webapp/ui/src/components/Tags/TagsCombobox.tsx
+++ b/src/main/webapp/ui/src/components/Tags/TagsCombobox.tsx
@@ -561,7 +561,7 @@ function TagsComboboxContent<
   }, [value]);
 
   const [debounceTimeout, setDebounceTimeout] = useState<NodeJS.Timeout | null>(null);
-  function debounce<FuncReturn>(func: () => FuncReturn, timeout: number = 1000): () => void {
+  function debounce<FuncReturn>(func: () => FuncReturn, timeout: number = 300): () => void {
     return () => {
       if (debounceTimeout) {
         clearTimeout(debounceTimeout);


### PR DESCRIPTION
## Description

The tag search autocomplete felt sluggish. The dominant cause was the 1000ms debounce in `TagsCombobox`: filtered results only fired a full second after the user stopped typing, even though the server responds in ~14ms. This lowers the debounce to 300ms (the standard autocomplete range), which still coalesces a burst of keystrokes into one request.

One line: `debounce` default `timeout` 1000 -> 300.

## Testing

Tested locally with 3k tags with no noticeable lag

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
