### PR TITLE
Don't show loading spinner for React Islands when loading i18n

### DIFF
--- a/src/main/webapp/ui/src/App.tsx
+++ b/src/main/webapp/ui/src/App.tsx
@@ -63,7 +63,7 @@ window.addEventListener("load", () => {
   if (domContainer) {
     const root = createRoot(domContainer);
     root.render(
-      <I18nRoot namespaces={["inventory", "common"]}>
+      <I18nRoot namespaces={["inventory", "common"]} fullPage>
         <App />
       </I18nRoot>,
     );

--- a/src/main/webapp/ui/src/App.tsx
+++ b/src/main/webapp/ui/src/App.tsx
@@ -10,6 +10,7 @@ import { ACCENT_COLOR as INVENTORY_COLOR } from "./assets/branding/rspace/invent
 import Analytics from "./components/Analytics";
 import { ERROR_MSG } from "./components/ErrorBoundary";
 import GoogleLoginProvider from "./components/GoogleLoginProvider";
+import LoaderCircular from "./components/LoadingCircular";
 import I18nRoot from "./modules/common/i18n/I18nRoot";
 import Router from "./Router";
 import useStores from "./stores/use-stores";
@@ -63,7 +64,7 @@ window.addEventListener("load", () => {
   if (domContainer) {
     const root = createRoot(domContainer);
     root.render(
-      <I18nRoot namespaces={["inventory", "common", "about"]} fullPage>
+      <I18nRoot namespaces={["inventory", "common", "about"]} fallback={<LoaderCircular />}>
         <App />
       </I18nRoot>,
     );

--- a/src/main/webapp/ui/src/App.tsx
+++ b/src/main/webapp/ui/src/App.tsx
@@ -63,7 +63,7 @@ window.addEventListener("load", () => {
   if (domContainer) {
     const root = createRoot(domContainer);
     root.render(
-      <I18nRoot namespaces={["inventory", "common"]} fullPage>
+      <I18nRoot namespaces={["inventory", "common", "about"]} fullPage>
         <App />
       </I18nRoot>,
     );

--- a/src/main/webapp/ui/src/CreateGroup/CreateGroup.tsx
+++ b/src/main/webapp/ui/src/CreateGroup/CreateGroup.tsx
@@ -14,6 +14,7 @@ import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import axios from "@/common/axios";
+import LoaderCircular from "@/components/LoadingCircular";
 import i18n from "@/modules/common/i18n";
 import I18nRoot from "@/modules/common/i18n/I18nRoot";
 import materialTheme from "../theme";
@@ -369,7 +370,7 @@ const selfService = $("#selfServiceLabGroup").length !== 0;
 const projectGroup = $("#projectGroup").length !== 0;
 const root = createRoot(domContainer as HTMLElement);
 root.render(
-  <I18nRoot namespaces={["groups"]}>
+  <I18nRoot namespaces={["groups"]} fallback={<LoaderCircular />}>
     <CreateGroup />
   </I18nRoot>,
 );

--- a/src/main/webapp/ui/src/Inventory/components/Layout/Header.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Layout/Header.tsx
@@ -23,6 +23,7 @@ function Header({ sidebarId }: HeaderArgs): React.ReactNode {
       <AppBar
         variant="page"
         currentPage="inventory"
+        ambientI18n
         sidebarToggle={
           <SidebarToggle sidebarId={sidebarId} setSidebarOpen={handleToggleOpen} sidebarOpen={uiStore.sidebarOpen} />
         }

--- a/src/main/webapp/ui/src/Toolbar/FileTreeToolbar.tsx
+++ b/src/main/webapp/ui/src/Toolbar/FileTreeToolbar.tsx
@@ -73,10 +73,7 @@ const domContainer = document.getElementById("fileTreeToolbar");
 // biome-ignore lint/style/noNonNullAssertion: initial biome migration
 const root = createRoot(domContainer!);
 root.render(
-  // `content()` above resolves its text via `i18n.t()` directly rather than
-  // `useTranslation`, so it never re-renders once the namespace arrives —
-  // `I18nRoot` must gate FileTreeToolbar's whole first render, not just its
-  // presentational output, or the toolbar freezes with raw i18n keys.
+  // content() uses i18n.t() directly, not the hook, so I18nRoot must gate this whole render or labels freeze as raw keys.
   <I18nRoot namespaces={["common"]} fallback={<Skeleton variant="rectangular" height={64} />}>
     <FileTreeToolbar />
   </I18nRoot>,

--- a/src/main/webapp/ui/src/Toolbar/FileTreeToolbar.tsx
+++ b/src/main/webapp/ui/src/Toolbar/FileTreeToolbar.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
 import { ThemeProvider } from "@mui/material/styles";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import { createRoot } from "react-dom/client";
@@ -72,7 +73,11 @@ const domContainer = document.getElementById("fileTreeToolbar");
 // biome-ignore lint/style/noNonNullAssertion: initial biome migration
 const root = createRoot(domContainer!);
 root.render(
-  <I18nRoot namespaces={["common"]}>
+  // `content()` above resolves its text via `i18n.t()` directly rather than
+  // `useTranslation`, so it never re-renders once the namespace arrives —
+  // `I18nRoot` must gate FileTreeToolbar's whole first render, not just its
+  // presentational output, or the toolbar freezes with raw i18n keys.
+  <I18nRoot namespaces={["common"]} fallback={<Skeleton variant="rectangular" height={64} />}>
     <FileTreeToolbar />
   </I18nRoot>,
 );

--- a/src/main/webapp/ui/src/Toolbar/Notebook/Toolbar.tsx
+++ b/src/main/webapp/ui/src/Toolbar/Notebook/Toolbar.tsx
@@ -204,10 +204,7 @@ window.renderToolbar = (newProps: any) => {
     },
   };
   rootNode.render(
-    // `content()` above resolves its text via `i18n.t()` directly rather than
-    // `useTranslation`, so it never re-renders once the namespace arrives —
-    // `I18nRoot` must gate NotebookToolbar's whole first render, not just its
-    // presentational output, or the toolbar freezes with raw i18n keys.
+    // content() uses i18n.t() directly, not the hook, so I18nRoot must gate this whole render or labels freeze as raw keys.
     <I18nRoot namespaces={["common"]} fallback={<Skeleton variant="rectangular" height={64} />}>
       <NotebookToolbar domContainer={domContainer} {...prevProps} />
     </I18nRoot>,

--- a/src/main/webapp/ui/src/Toolbar/Notebook/Toolbar.tsx
+++ b/src/main/webapp/ui/src/Toolbar/Notebook/Toolbar.tsx
@@ -9,6 +9,7 @@ import { faTrashAlt } from "@fortawesome/free-solid-svg-icons/faTrashAlt";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
+import Skeleton from "@mui/material/Skeleton";
 import { ThemeProvider } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
@@ -203,7 +204,11 @@ window.renderToolbar = (newProps: any) => {
     },
   };
   rootNode.render(
-    <I18nRoot namespaces={["common"]}>
+    // `content()` above resolves its text via `i18n.t()` directly rather than
+    // `useTranslation`, so it never re-renders once the namespace arrives —
+    // `I18nRoot` must gate NotebookToolbar's whole first render, not just its
+    // presentational output, or the toolbar freezes with raw i18n keys.
+    <I18nRoot namespaces={["common"]} fallback={<Skeleton variant="rectangular" height={64} />}>
       <NotebookToolbar domContainer={domContainer} {...prevProps} />
     </I18nRoot>,
   );

--- a/src/main/webapp/ui/src/Toolbar/StructuredDocument/Toolbar.tsx
+++ b/src/main/webapp/ui/src/Toolbar/StructuredDocument/Toolbar.tsx
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
+import Skeleton from "@mui/material/Skeleton";
 import { ThemeProvider } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
@@ -305,7 +306,11 @@ window.renderToolbar = (newProps: any) => {
     canSign: newProps?.canSign ?? prevProps.canSign,
   };
   rootNode.render(
-    <I18nRoot namespaces={["common"]}>
+    // `content()` above resolves its text via `i18n.t()` directly rather than
+    // `useTranslation`, so it never re-renders once the namespace arrives —
+    // `I18nRoot` must gate StructuredDocumentToolbar's whole first render, not
+    // just its presentational output, or the toolbar freezes with raw i18n keys.
+    <I18nRoot namespaces={["common"]} fallback={<Skeleton variant="rectangular" height={64} />}>
       <StructuredDocumentToolbar domContainer={domContainer} {...prevProps} canSign={prevProps.canSign} />
     </I18nRoot>,
   );

--- a/src/main/webapp/ui/src/Toolbar/StructuredDocument/Toolbar.tsx
+++ b/src/main/webapp/ui/src/Toolbar/StructuredDocument/Toolbar.tsx
@@ -306,10 +306,7 @@ window.renderToolbar = (newProps: any) => {
     canSign: newProps?.canSign ?? prevProps.canSign,
   };
   rootNode.render(
-    // `content()` above resolves its text via `i18n.t()` directly rather than
-    // `useTranslation`, so it never re-renders once the namespace arrives —
-    // `I18nRoot` must gate StructuredDocumentToolbar's whole first render, not
-    // just its presentational output, or the toolbar freezes with raw i18n keys.
+    // content() uses i18n.t() directly, not the hook, so I18nRoot must gate this whole render or labels freeze as raw keys.
     <I18nRoot namespaces={["common"]} fallback={<Skeleton variant="rectangular" height={64} />}>
       <StructuredDocumentToolbar domContainer={domContainer} {...prevProps} canSign={prevProps.canSign} />
     </I18nRoot>,

--- a/src/main/webapp/ui/src/Toolbar/Workspace/Toolbar.tsx
+++ b/src/main/webapp/ui/src/Toolbar/Workspace/Toolbar.tsx
@@ -13,6 +13,7 @@ import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
+import Skeleton from "@mui/material/Skeleton";
 import { ThemeProvider } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
@@ -568,7 +569,11 @@ window.renderToolbar = (newProps) => {
     },
   };
   rootNode.render(
-    <I18nRoot namespaces={["workspace", "common"]}>
+    // `content()` above resolves its text via `i18n.t()` directly rather than
+    // `useTranslation`, so it never re-renders once the namespace arrives —
+    // `I18nRoot` must gate WorkspaceToolbar's whole first render, not just its
+    // presentational output, or the toolbar freezes with raw i18n keys.
+    <I18nRoot namespaces={["workspace", "common"]} fallback={<Skeleton variant="rectangular" height={64} />}>
       <WorkspaceToolbar domContainer={domContainer} {...prevProps} />
     </I18nRoot>,
   );

--- a/src/main/webapp/ui/src/Toolbar/Workspace/Toolbar.tsx
+++ b/src/main/webapp/ui/src/Toolbar/Workspace/Toolbar.tsx
@@ -569,10 +569,7 @@ window.renderToolbar = (newProps) => {
     },
   };
   rootNode.render(
-    // `content()` above resolves its text via `i18n.t()` directly rather than
-    // `useTranslation`, so it never re-renders once the namespace arrives —
-    // `I18nRoot` must gate WorkspaceToolbar's whole first render, not just its
-    // presentational output, or the toolbar freezes with raw i18n keys.
+    // content() uses i18n.t() directly, not the hook, so I18nRoot must gate this whole render or labels freeze as raw keys.
     <I18nRoot namespaces={["workspace", "common"]} fallback={<Skeleton variant="rectangular" height={64} />}>
       <WorkspaceToolbar domContainer={domContainer} {...prevProps} />
     </I18nRoot>,

--- a/src/main/webapp/ui/src/components/AppBar/index.test.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/index.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import "@/__tests__/__mocks__/matchMedia";
 import "@/__tests__/__mocks__/useOauthToken";
 import "@/__tests__/__mocks__/useWhoAmI";
@@ -202,6 +202,19 @@ describe("App Bar", () => {
        * can disable for all users, so if it has not been enabled then the
        * menuitem should not be shown.
        */
+    });
+
+    test("When published documents are opened, the new tab cannot access this page", async () => {
+      const user = userEvent.setup();
+      const open = vi.spyOn(window, "open").mockImplementation(() => null);
+      stubEndpoints({ published: true });
+      render(<SimplePageWithAppBar variant="page" />);
+      await waitForLoaded();
+      await user.click(screen.getByRole("button", { name: "common:appBar.accountMenu" }));
+
+      await user.click(await screen.findByRole("menuitem", { name: "common:appBar.published" }));
+
+      expect(open).toHaveBeenCalledWith("/public/publishedView/publishedDocuments", "_blank", "noopener,noreferrer");
     });
   });
 

--- a/src/main/webapp/ui/src/components/AppBar/index.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/index.tsx
@@ -27,6 +27,7 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import { menuClasses } from "@mui/material/Menu";
 import Popover from "@mui/material/Popover";
+import Skeleton from "@mui/material/Skeleton";
 import Stack from "@mui/material/Stack";
 import SvgIcon from "@mui/material/SvgIcon";
 import { darken, lighten, useTheme } from "@mui/material/styles";
@@ -977,7 +978,13 @@ function GalleryAppBar({
     </AppBar>
   );
 
-  return ambientI18n ? appBar : <I18nRoot namespaces={["common", "about"]}>{appBar}</I18nRoot>;
+  return ambientI18n ? (
+    appBar
+  ) : (
+    <I18nRoot namespaces={["common", "about"]} fallback={<Skeleton variant="rectangular" height={48} />}>
+      {appBar}
+    </I18nRoot>
+  );
 }
 
 export default observer(GalleryAppBar);

--- a/src/main/webapp/ui/src/components/AppBar/index.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/index.tsx
@@ -339,16 +339,7 @@ type GalleryAppBarArgs = {
     title: string;
   };
 
-  /**
-   * Full-page SPAs (Gallery, Apps, Inventory) already wrap their whole tree in
-   * an `I18nRoot` that preloads "common" and "about" alongside the page's own
-   * namespace. In that context, pass `true` so the AppBar renders directly
-   * against that ambient `I18nRoot` instead of mounting a second, nested one.
-   * Nesting would gate the whole toolbar's render on its own "about" fetch,
-   * causing it to blank out again even after the page has already appeared.
-   * Leave this `false` (the default) for standalone islands and dialogs, which
-   * have no ambient `I18nRoot` above them and so need AppBar to provide one.
-   */
+  /** Pass `true` inside a full-page SPA that already provides an ambient `I18nRoot`, to avoid nesting a second one. */
   ambientI18n?: boolean;
 };
 function GalleryAppBar({

--- a/src/main/webapp/ui/src/components/AppBar/index.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/index.tsx
@@ -841,7 +841,7 @@ function GalleryAppBar({
                       onClick={(e) => {
                         e.preventDefault();
                         setAccountMenuAnchorEl(null);
-                        window.open("/public/publishedView/publishedDocuments", "_target");
+                        window.open("/public/publishedView/publishedDocuments", "_blank", "noopener,noreferrer");
                       }}
                       component="a"
                       href="/public/publishedView/publishedDocuments"

--- a/src/main/webapp/ui/src/components/AppBar/index.tsx
+++ b/src/main/webapp/ui/src/components/AppBar/index.tsx
@@ -337,6 +337,18 @@ type GalleryAppBarArgs = {
     docLink: URL;
     title: string;
   };
+
+  /**
+   * Full-page SPAs (Gallery, Apps, Inventory) already wrap their whole tree in
+   * an `I18nRoot` that preloads "common" and "about" alongside the page's own
+   * namespace. In that context, pass `true` so the AppBar renders directly
+   * against that ambient `I18nRoot` instead of mounting a second, nested one.
+   * Nesting would gate the whole toolbar's render on its own "about" fetch,
+   * causing it to blank out again even after the page has already appeared.
+   * Leave this `false` (the default) for standalone islands and dialogs, which
+   * have no ambient `I18nRoot` above them and so need AppBar to provide one.
+   */
+  ambientI18n?: boolean;
 };
 function GalleryAppBar({
   variant,
@@ -344,6 +356,7 @@ function GalleryAppBar({
   sidebarToggle,
   accessibilityTips,
   helpPage,
+  ambientI18n = false,
 }: GalleryAppBarArgs): React.ReactNode {
   const { t } = useTranslation("common");
   const theme = useTheme();
@@ -388,585 +401,583 @@ function GalleryAppBar({
 
   const displayPage = (page: string): string => (isTabKey(page) ? sectionLabels[page].title : page);
 
-  return (
-    <I18nRoot namespaces={["common", "about"]}>
-      <AppBar position="relative" aria-label={variant === "page" ? t("appBar.pageHeader") : t("appBar.dialogHeader")}>
-        <Toolbar variant="dense">
-          {variant === "page" && !isViewportSmall && (
-            <>
-              <Box
-                sx={{
-                  height: "40px",
-                  backgroundColor: "white",
-                  width: "4px",
-                  clipPath: `url(#${leftClipId})`,
-                  marginLeft: "4px",
-                  marginRight: "-1px",
-                }}
-              ></Box>
-              {/** biome-ignore lint/a11y/noSvgWithoutTitle: initial biome migration */}
-              <svg width="0" height="0" viewBox="0 0 3.9 40">
-                <defs>
-                  <clipPath id={leftClipId}>
-                    <path d="M3.9,40C1.7,40,0,38.3,0,36.1V3.9C0,1.7,1.7,0,3.9,0v40Z" fill="#000000" />
-                  </clipPath>
-                </defs>
-              </svg>
-            </>
-          )}
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              backgroundColor: variant === "page" && !isViewportSmall ? "white" : "unset",
-              height: "40px",
-              px: 0.5,
-              gap: 0.5,
-            }}
-          >
-            {sidebarToggle}
-            {variant === "page" && !isViewportSmall && (
-              <Box
-                sx={{
-                  height: "36px",
-                  ml: 0.5,
-                  py: 0.25,
-                  position: "relative",
-                }}
-              >
-                {Result.fromNullable(brandingHref, new Error("branding not cached"))
-                  .orElseTry(() =>
-                    FetchingData.getSuccessValue(uiNavigationData).map(({ bannerImgSrc }) => bannerImgSrc),
-                  )
-                  .map((href) => (
-                    <img
-                      key="branding small"
-                      src={href}
-                      alt={t("appBar.brandingAlt")}
-                      style={{
-                        height: "100%",
-                      }}
-                    />
-                  ))
-                  .orElse(null)}
-              </Box>
-            )}
-          </Box>
-          {variant === "page" && !isViewportSmall && (
-            <>
-              <Box
-                sx={{
-                  height: "40px",
-                  backgroundColor: "white",
-                  width: "12px",
-                  clipPath: `url(#${rightClipId})`,
-                  marginLeft: "-1px",
-                }}
-              ></Box>
-              {/** biome-ignore lint/a11y/noSvgWithoutTitle: initial biome migration */}
-              <svg width="0" height="0">
-                <defs>
-                  <clipPath id={rightClipId}>
-                    <path d="M0,0c2.1,0,4.2,1.7,4.6,3.9l5.7,32.2c.4,2.1-1.1,3.9-3.2,3.9H0V0Z" fill="#000000" />
-                  </clipPath>
-                </defs>
-              </svg>
-            </>
-          )}
-          {variant === "page" && isTabbedPage && (
-            <VisuallyHiddenHeading variant="h1">{displayPage(currentPage)}</VisuallyHiddenHeading>
-          )}
-          {variant === "dialog" && (
+  const appBar = (
+    <AppBar position="relative" aria-label={variant === "page" ? t("appBar.pageHeader") : t("appBar.dialogHeader")}>
+      <Toolbar variant="dense">
+        {variant === "page" && !isViewportSmall && (
+          <>
             <Box
               sx={{
+                height: "40px",
+                backgroundColor: "white",
+                width: "4px",
+                clipPath: `url(#${leftClipId})`,
+                marginLeft: "4px",
+                marginRight: "-1px",
+              }}
+            ></Box>
+            {/** biome-ignore lint/a11y/noSvgWithoutTitle: initial biome migration */}
+            <svg width="0" height="0" viewBox="0 0 3.9 40">
+              <defs>
+                <clipPath id={leftClipId}>
+                  <path d="M3.9,40C1.7,40,0,38.3,0,36.1V3.9C0,1.7,1.7,0,3.9,0v40Z" fill="#000000" />
+                </clipPath>
+              </defs>
+            </svg>
+          </>
+        )}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            backgroundColor: variant === "page" && !isViewportSmall ? "white" : "unset",
+            height: "40px",
+            px: 0.5,
+            gap: 0.5,
+          }}
+        >
+          {sidebarToggle}
+          {variant === "page" && !isViewportSmall && (
+            <Box
+              sx={{
+                height: "36px",
                 ml: 0.5,
+                py: 0.25,
+                position: "relative",
               }}
             >
-              <Typography variant="h6" noWrap component="h2">
-                {displayPage(currentPage)}
-              </Typography>
+              {Result.fromNullable(brandingHref, new Error("branding not cached"))
+                .orElseTry(() => FetchingData.getSuccessValue(uiNavigationData).map(({ bannerImgSrc }) => bannerImgSrc))
+                .map((href) => (
+                  <img
+                    key="branding small"
+                    src={href}
+                    alt={t("appBar.brandingAlt")}
+                    style={{
+                      height: "100%",
+                    }}
+                  />
+                ))
+                .orElse(null)}
             </Box>
           )}
-          {!isViewportSmall && variant === "page" && (
-            <Stack
-              direction="row"
-              spacing={2}
+        </Box>
+        {variant === "page" && !isViewportSmall && (
+          <>
+            <Box
               sx={{
-                mx: 1,
+                height: "40px",
+                backgroundColor: "white",
+                width: "12px",
+                clipPath: `url(#${rightClipId})`,
+                marginLeft: "-1px",
               }}
-              component="nav"
-              aria-label={t("appBar.mainLinks")}
+            ></Box>
+            {/** biome-ignore lint/a11y/noSvgWithoutTitle: initial biome migration */}
+            <svg width="0" height="0">
+              <defs>
+                <clipPath id={rightClipId}>
+                  <path d="M0,0c2.1,0,4.2,1.7,4.6,3.9l5.7,32.2c.4,2.1-1.1,3.9-3.2,3.9H0V0Z" fill="#000000" />
+                </clipPath>
+              </defs>
+            </svg>
+          </>
+        )}
+        {variant === "page" && isTabbedPage && (
+          <VisuallyHiddenHeading variant="h1">{displayPage(currentPage)}</VisuallyHiddenHeading>
+        )}
+        {variant === "dialog" && (
+          <Box
+            sx={{
+              ml: 0.5,
+            }}
+          >
+            <Typography variant="h6" noWrap component="h2">
+              {displayPage(currentPage)}
+            </Typography>
+          </Box>
+        )}
+        {!isViewportSmall && variant === "page" && (
+          <Stack
+            direction="row"
+            spacing={2}
+            sx={{
+              mx: 1,
+            }}
+            component="nav"
+            aria-label={t("appBar.mainLinks")}
+          >
+            <Link target="_self" aria-current={currentPage === "workspace" ? "page" : false} href="/workspace">
+              {sectionLabels.workspace.title}
+            </Link>
+            <Link target="_self" aria-current={currentPage === "gallery" ? "page" : false} href="/gallery">
+              {sectionLabels.gallery.title}
+            </Link>
+            {showInventory && (
+              <Link target="_self" aria-current={currentPage === "inventory" ? "page" : false} href="/inventory">
+                {sectionLabels.inventory.title}
+              </Link>
+            )}
+            <Link
+              target="_self"
+              aria-current={currentPage === "myRSpace" ? "page" : false}
+              href={showMyLabGroups ? "/groups/viewPIGroup" : "/userform"}
             >
-              <Link target="_self" aria-current={currentPage === "workspace" ? "page" : false} href="/workspace">
-                {sectionLabels.workspace.title}
+              {sectionLabels.myRSpace.title}
+            </Link>
+            {showSystem && (
+              <Link target="_self" aria-current={currentPage === "system" ? "page" : false} href="/system">
+                {sectionLabels.system.title}
               </Link>
-              <Link target="_self" aria-current={currentPage === "gallery" ? "page" : false} href="/gallery">
-                {sectionLabels.gallery.title}
-              </Link>
-              {showInventory && (
-                <Link target="_self" aria-current={currentPage === "inventory" ? "page" : false} href="/inventory">
-                  {sectionLabels.inventory.title}
-                </Link>
-              )}
-              <Link
-                target="_self"
-                aria-current={currentPage === "myRSpace" ? "page" : false}
-                href={showMyLabGroups ? "/groups/viewPIGroup" : "/userform"}
-              >
-                {sectionLabels.myRSpace.title}
-              </Link>
-              {showSystem && (
-                <Link target="_self" aria-current={currentPage === "system" ? "page" : false} href="/system">
-                  {sectionLabels.system.title}
-                </Link>
-              )}
-            </Stack>
-          )}
-          {isViewportSmall && variant === "page" && (
-            <>
-              <List
-                component="nav"
-                aria-label={t("appBar.mainNavigation")}
-                disablePadding
-                sx={{
-                  ml: 1,
+            )}
+          </Stack>
+        )}
+        {isViewportSmall && variant === "page" && (
+          <>
+            <List
+              component="nav"
+              aria-label={t("appBar.mainNavigation")}
+              disablePadding
+              sx={{
+                ml: 1,
+              }}
+            >
+              <ListItemButton
+                dense
+                id="app-menu-button"
+                aria-haspopup="menu"
+                aria-controls="app-menu"
+                {...(appMenuAnchorEl
+                  ? {
+                      "aria-expanded": "true",
+                    }
+                  : {})}
+                onClick={(event) => {
+                  setAppMenuAnchorEl(event.currentTarget);
                 }}
               >
-                <ListItemButton
-                  dense
-                  id="app-menu-button"
-                  aria-haspopup="menu"
-                  aria-controls="app-menu"
-                  {...(appMenuAnchorEl
-                    ? {
-                        "aria-expanded": "true",
-                      }
-                    : {})}
-                  onClick={(event) => {
-                    setAppMenuAnchorEl(event.currentTarget);
+                <ListItemText primary={isTabbedPage ? displayPage(currentPage) : t("appBar.goTo")} />
+                <ListItemIcon>
+                  <ArrowDropDownIcon />
+                </ListItemIcon>
+              </ListItemButton>
+            </List>
+            <Menu
+              id="app-menu"
+              anchorEl={appMenuAnchorEl}
+              open={Boolean(appMenuAnchorEl)}
+              onClose={handleAppMenuClose}
+              anchorOrigin={{
+                vertical: "bottom",
+                horizontal: "left",
+              }}
+              transformOrigin={{
+                vertical: "top",
+                horizontal: "left",
+              }}
+              sx={{
+                [`.${menuClasses.paper}`]: {
+                  /*
+                   * Generally we don't add box shadows to menus, but we do add
+                   * box shadows to popups opened from the app bar to make them
+                   * hover over the page's content.
+                   */
+                  boxShadow:
+                    "3px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+                },
+              }}
+              slotProps={{
+                list: {
+                  "aria-labelledby": "app-menu-button",
+                  disablePadding: true,
+                },
+              }}
+            >
+              <AccentMenuItem
+                title={sectionLabels.workspace.title}
+                avatar={<NotebookIcon />}
+                subheader={sectionLabels.workspace.subheader}
+                foregroundColor={WORKSPACE_COLOR.contrastText}
+                backgroundColor={WORKSPACE_COLOR.main}
+                onClick={() => {
+                  window.location.href = "/workspace";
+                  handleAppMenuClose();
+                }}
+                current={currentPage === "workspace" ? "page" : false}
+              />
+              <AccentMenuItem
+                title={sectionLabels.gallery.title}
+                avatar={<FileIcon />}
+                subheader={sectionLabels.gallery.subheader}
+                foregroundColor={GALLERY_COLOR.contrastText}
+                backgroundColor={GALLERY_COLOR.main}
+                onClick={() => {
+                  window.location.href = "/gallery";
+                  handleAppMenuClose();
+                }}
+                current={currentPage === "gallery" ? "page" : false}
+              />
+              {showInventory && (
+                <AccentMenuItem
+                  title={sectionLabels.inventory.title}
+                  avatar={<FlaskIcon />}
+                  subheader={sectionLabels.inventory.subheader}
+                  foregroundColor={INVENTORY_COLOR.contrastText}
+                  backgroundColor={INVENTORY_COLOR.main}
+                  onClick={() => {
+                    window.location.href = "/inventory";
+                    handleAppMenuClose();
                   }}
-                >
-                  <ListItemText primary={isTabbedPage ? displayPage(currentPage) : t("appBar.goTo")} />
-                  <ListItemIcon>
-                    <ArrowDropDownIcon />
-                  </ListItemIcon>
-                </ListItemButton>
-              </List>
+                  current={currentPage === "inventory" ? "page" : false}
+                />
+              )}
+              <AccentMenuItem
+                title={sectionLabels.myRSpace.title}
+                avatar={<ProfileIcon />}
+                subheader={sectionLabels.myRSpace.subheader}
+                foregroundColor={OTHER_COLOR.contrastText}
+                backgroundColor={OTHER_COLOR.main}
+                onClick={() => {
+                  window.location.href = showMyLabGroups ? "/groups/viewPIGroup" : "/userform";
+                  setAccountMenuAnchorEl(null);
+                }}
+                current={currentPage === "myRSpace" ? "page" : false}
+              />
+              {showSystem && (
+                <AccentMenuItem
+                  title={sectionLabels.system.title}
+                  avatar={<SystemIcon />}
+                  subheader={sectionLabels.system.subheader}
+                  foregroundColor={SYSADMIN_COLOR.contrastText}
+                  backgroundColor={SYSADMIN_COLOR.main}
+                  onClick={() => {
+                    window.location.href = "/system";
+                    handleAppMenuClose();
+                  }}
+                  current={currentPage === "system" ? "page" : false}
+                />
+              )}
+            </Menu>
+          </>
+        )}
+        <Box
+          sx={{
+            flexGrow: 1,
+          }}
+        ></Box>
+        {FetchingData.getSuccessValue(uiNavigationData)
+          .map(({ nextMaintenance }) => nextMaintenance)
+          .flatMap(Parsers.isNotNull)
+          .map(({ startDate }) => <IncomingMaintenancePopup key="maintenance" startDate={startDate} />)
+          .orElse(null)}
+        {variant === "page" && (
+          <>
+            {FetchingData.getSuccessValue(fetchedCurrentUser)
+              .map((currentUser) => <NotificationCounter key="notification counter" currentUser={currentUser} />)
+              .orElse(null)}
+            <Box
+              sx={{
+                ml: 1,
+              }}
+            >
+              <IconButtonWithTooltip
+                size="small"
+                disabled={FetchingData.isLoading(uiNavigationData)}
+                onClick={(event) => {
+                  setAccountMenuAnchorEl(event.currentTarget);
+                }}
+                icon={<DynamicAvatar uiNavigationData={uiNavigationData} size="small" />}
+                title={t("appBar.accountMenu")}
+                id="account-menu-button"
+                aria-haspopup="menu"
+                aria-controls="account-menu"
+                {...(accountMenuAnchorEl
+                  ? {
+                      "aria-expanded": "true",
+                    }
+                  : {})}
+              />
               <Menu
-                id="app-menu"
-                anchorEl={appMenuAnchorEl}
-                open={Boolean(appMenuAnchorEl)}
-                onClose={handleAppMenuClose}
+                id="account-menu"
+                anchorEl={accountMenuAnchorEl}
+                open={Boolean(accountMenuAnchorEl)}
+                onClose={() => {
+                  setAccountMenuAnchorEl(null);
+                }}
                 anchorOrigin={{
                   vertical: "bottom",
-                  horizontal: "left",
+                  horizontal: "right",
                 }}
                 transformOrigin={{
                   vertical: "top",
-                  horizontal: "left",
+                  horizontal: "right",
                 }}
                 sx={{
                   [`.${menuClasses.paper}`]: {
-                    /*
-                     * Generally we don't add box shadows to menus, but we do add
-                     * box shadows to popups opened from the app bar to make them
-                     * hover over the page's content.
-                     */
                     boxShadow:
                       "3px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
                   },
                 }}
                 slotProps={{
                   list: {
-                    "aria-labelledby": "app-menu-button",
+                    "aria-labelledby": "account-menu-button",
                     disablePadding: true,
+                    sx: {
+                      pt: 0.5,
+                    },
                   },
                 }}
               >
+                {FetchingData.match(uiNavigationData, {
+                  loading: () => null,
+                  error: (errorMsg) => (
+                    <ListItem>
+                      <ListItemText primary={t("appBar.errorLoadingDetails")} secondary={errorMsg} />
+                    </ListItem>
+                  ),
+                  success: ({ userDetails }) => (
+                    <ListItem
+                      key="user details"
+                      sx={{
+                        py: 0,
+                      }}
+                    >
+                      <ListItemIcon
+                        sx={{
+                          alignSelf: "flex-start",
+                          mt: 1,
+                        }}
+                      >
+                        <DynamicAvatar uiNavigationData={uiNavigationData} />
+                      </ListItemIcon>
+                      <Stack>
+                        <ListItemText
+                          sx={{
+                            mt: 0.5,
+                            ml: 1.6,
+                          }}
+                          primary={
+                            <>
+                              {FetchingData.getSuccessValue(uiNavigationData)
+                                .map(({ operatedAs }) => operatedAs)
+                                .flatMap(Parsers.isTrue)
+                                .map(() => (
+                                  <>
+                                    <strong>{t("appBar.operatingAs")}</strong>
+                                    <br />
+                                  </>
+                                ))
+                                .orElse(null)}
+                              {`${userDetails.fullName} (${userDetails.username})`}
+                            </>
+                          }
+                          secondary={userDetails.email}
+                        />
+                        {userDetails.orcidAvailable && (
+                          <ListItemText
+                            /*
+                             * The styling of this component is dictated by the ORCID display guidelines
+                             * https://info.orcid.org/documentation/integration-guide/orcid-id-display-guidelines/#Compact_ORCID_iD
+                             */
+                            sx={{
+                              mt: -0.5,
+                            }}
+                            primary={
+                              userDetails.orcidId === null ? (
+                                <TransRichText i18nKey="common:appBar.orcidAdd" />
+                              ) : (
+                                <Stack
+                                  direction="row"
+                                  spacing={0.5}
+                                  sx={{
+                                    alignItems: "center",
+                                  }}
+                                >
+                                  <SvgIcon>
+                                    <OrcidIcon />
+                                  </SvgIcon>
+                                  <span>{userDetails.orcidId}</span>
+                                </Stack>
+                              )
+                            }
+                            slotProps={{
+                              primary: {
+                                sx: {
+                                  fontFamily: userDetails.orcidId === null ? "inherit" : "monospace",
+                                  lineHeight: userDetails.orcidId === null ? "unset" : "1em",
+                                  fontSize: "0.8em",
+                                  alignItems: "center",
+                                  textDecoration: userDetails.orcidId === null ? "none" : "underline",
+                                },
+                              },
+                            }}
+                          />
+                        )}
+                      </Stack>
+                    </ListItem>
+                  ),
+                })}
                 <AccentMenuItem
-                  title={sectionLabels.workspace.title}
-                  avatar={<NotebookIcon />}
-                  subheader={sectionLabels.workspace.subheader}
-                  foregroundColor={WORKSPACE_COLOR.contrastText}
-                  backgroundColor={WORKSPACE_COLOR.main}
+                  title={t("appBar.messaging")}
+                  avatar={<MessageIcon />}
+                  compact
                   onClick={() => {
-                    window.location.href = "/workspace";
-                    handleAppMenuClose();
-                  }}
-                  current={currentPage === "workspace" ? "page" : false}
-                />
-                <AccentMenuItem
-                  title={sectionLabels.gallery.title}
-                  avatar={<FileIcon />}
-                  subheader={sectionLabels.gallery.subheader}
-                  foregroundColor={GALLERY_COLOR.contrastText}
-                  backgroundColor={GALLERY_COLOR.main}
-                  onClick={() => {
-                    window.location.href = "/gallery";
-                    handleAppMenuClose();
-                  }}
-                  current={currentPage === "gallery" ? "page" : false}
-                />
-                {showInventory && (
-                  <AccentMenuItem
-                    title={sectionLabels.inventory.title}
-                    avatar={<FlaskIcon />}
-                    subheader={sectionLabels.inventory.subheader}
-                    foregroundColor={INVENTORY_COLOR.contrastText}
-                    backgroundColor={INVENTORY_COLOR.main}
-                    onClick={() => {
-                      window.location.href = "/inventory";
-                      handleAppMenuClose();
-                    }}
-                    current={currentPage === "inventory" ? "page" : false}
-                  />
-                )}
-                <AccentMenuItem
-                  title={sectionLabels.myRSpace.title}
-                  avatar={<ProfileIcon />}
-                  subheader={sectionLabels.myRSpace.subheader}
-                  foregroundColor={OTHER_COLOR.contrastText}
-                  backgroundColor={OTHER_COLOR.main}
-                  onClick={() => {
-                    window.location.href = showMyLabGroups ? "/groups/viewPIGroup" : "/userform";
                     setAccountMenuAnchorEl(null);
                   }}
-                  current={currentPage === "myRSpace" ? "page" : false}
+                  component="a"
+                  href="/dashboard"
                 />
-                {showSystem && (
-                  <AccentMenuItem
-                    title={sectionLabels.system.title}
-                    avatar={<SystemIcon />}
-                    subheader={sectionLabels.system.subheader}
-                    foregroundColor={SYSADMIN_COLOR.contrastText}
-                    backgroundColor={SYSADMIN_COLOR.main}
-                    onClick={() => {
-                      window.location.href = "/system";
-                      handleAppMenuClose();
-                    }}
-                    current={currentPage === "system" ? "page" : false}
-                  />
-                )}
-              </Menu>
-            </>
-          )}
-          <Box
-            sx={{
-              flexGrow: 1,
-            }}
-          ></Box>
-          {FetchingData.getSuccessValue(uiNavigationData)
-            .map(({ nextMaintenance }) => nextMaintenance)
-            .flatMap(Parsers.isNotNull)
-            .map(({ startDate }) => <IncomingMaintenancePopup key="maintenance" startDate={startDate} />)
-            .orElse(null)}
-          {variant === "page" && (
-            <>
-              {FetchingData.getSuccessValue(fetchedCurrentUser)
-                .map((currentUser) => <NotificationCounter key="notification counter" currentUser={currentUser} />)
-                .orElse(null)}
-              <Box
-                sx={{
-                  ml: 1,
-                }}
-              >
-                <IconButtonWithTooltip
-                  size="small"
-                  disabled={FetchingData.isLoading(uiNavigationData)}
-                  onClick={(event) => {
-                    setAccountMenuAnchorEl(event.currentTarget);
+                <AccentMenuItem
+                  title={t("appBar.apps")}
+                  avatar={<AppsIcon />}
+                  compact
+                  onClick={() => {
+                    setAccountMenuAnchorEl(null);
                   }}
-                  icon={<DynamicAvatar uiNavigationData={uiNavigationData} size="small" />}
-                  title={t("appBar.accountMenu")}
-                  id="account-menu-button"
-                  aria-haspopup="menu"
-                  aria-controls="account-menu"
-                  {...(accountMenuAnchorEl
-                    ? {
-                        "aria-expanded": "true",
-                      }
-                    : {})}
+                  component="a"
+                  href="/apps"
                 />
-                <Menu
-                  id="account-menu"
-                  anchorEl={accountMenuAnchorEl}
-                  open={Boolean(accountMenuAnchorEl)}
+                {FetchingData.getSuccessValue(uiNavigationData)
+                  .map(({ visibleTabs: { published } }) => published)
+                  .flatMap(Parsers.isTrue)
+                  .map(() => (
+                    <AccentMenuItem
+                      key="published"
+                      title={t("appBar.published")}
+                      avatar={<PublicIcon />}
+                      compact
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setAccountMenuAnchorEl(null);
+                        window.open("/public/publishedView/publishedDocuments", "_target");
+                      }}
+                      component="a"
+                      href="/public/publishedView/publishedDocuments"
+                    />
+                  ))
+                  .orElse(null)}
+                <AccessibilityTipsMenuItem
+                  {...(accessibilityTips ?? {})}
                   onClose={() => {
                     setAccountMenuAnchorEl(null);
                   }}
-                  anchorOrigin={{
-                    vertical: "bottom",
-                    horizontal: "right",
+                />
+                <AccentMenuItem
+                  title={t("appBar.aboutRSpace")}
+                  avatar={<InfoIcon />}
+                  compact
+                  onClick={() => {
+                    setAccountMenuAnchorEl(null);
+                    setAboutDialogOpen(true);
                   }}
-                  transformOrigin={{
-                    vertical: "top",
-                    horizontal: "right",
-                  }}
-                  sx={{
-                    [`.${menuClasses.paper}`]: {
-                      boxShadow:
-                        "3px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
-                    },
-                  }}
-                  slotProps={{
-                    list: {
-                      "aria-labelledby": "account-menu-button",
-                      disablePadding: true,
-                      sx: {
-                        pt: 0.5,
-                      },
-                    },
-                  }}
-                >
-                  {FetchingData.match(uiNavigationData, {
-                    loading: () => null,
-                    error: (errorMsg) => (
-                      <ListItem>
-                        <ListItemText primary={t("appBar.errorLoadingDetails")} secondary={errorMsg} />
-                      </ListItem>
-                    ),
-                    success: ({ userDetails }) => (
-                      <ListItem
-                        key="user details"
-                        sx={{
-                          py: 0,
-                        }}
-                      >
-                        <ListItemIcon
-                          sx={{
-                            alignSelf: "flex-start",
-                            mt: 1,
-                          }}
-                        >
-                          <DynamicAvatar uiNavigationData={uiNavigationData} />
-                        </ListItemIcon>
-                        <Stack>
-                          <ListItemText
-                            sx={{
-                              mt: 0.5,
-                              ml: 1.6,
-                            }}
-                            primary={
-                              <>
-                                {FetchingData.getSuccessValue(uiNavigationData)
-                                  .map(({ operatedAs }) => operatedAs)
-                                  .flatMap(Parsers.isTrue)
-                                  .map(() => (
-                                    <>
-                                      <strong>{t("appBar.operatingAs")}</strong>
-                                      <br />
-                                    </>
-                                  ))
-                                  .orElse(null)}
-                                {`${userDetails.fullName} (${userDetails.username})`}
-                              </>
-                            }
-                            secondary={userDetails.email}
-                          />
-                          {userDetails.orcidAvailable && (
-                            <ListItemText
-                              /*
-                               * The styling of this component is dictated by the ORCID display guidelines
-                               * https://info.orcid.org/documentation/integration-guide/orcid-id-display-guidelines/#Compact_ORCID_iD
-                               */
-                              sx={{
-                                mt: -0.5,
-                              }}
-                              primary={
-                                userDetails.orcidId === null ? (
-                                  <TransRichText i18nKey="common:appBar.orcidAdd" />
-                                ) : (
-                                  <Stack
-                                    direction="row"
-                                    spacing={0.5}
-                                    sx={{
-                                      alignItems: "center",
-                                    }}
-                                  >
-                                    <SvgIcon>
-                                      <OrcidIcon />
-                                    </SvgIcon>
-                                    <span>{userDetails.orcidId}</span>
-                                  </Stack>
-                                )
-                              }
-                              slotProps={{
-                                primary: {
-                                  sx: {
-                                    fontFamily: userDetails.orcidId === null ? "inherit" : "monospace",
-                                    lineHeight: userDetails.orcidId === null ? "unset" : "1em",
-                                    fontSize: "0.8em",
-                                    alignItems: "center",
-                                    textDecoration: userDetails.orcidId === null ? "none" : "underline",
-                                  },
-                                },
-                              }}
-                            />
-                          )}
-                        </Stack>
-                      </ListItem>
-                    ),
-                  })}
-                  <AccentMenuItem
-                    title={t("appBar.messaging")}
-                    avatar={<MessageIcon />}
-                    compact
-                    onClick={() => {
-                      setAccountMenuAnchorEl(null);
-                    }}
-                    component="a"
-                    href="/dashboard"
-                  />
-                  <AccentMenuItem
-                    title={t("appBar.apps")}
-                    avatar={<AppsIcon />}
-                    compact
-                    onClick={() => {
-                      setAccountMenuAnchorEl(null);
-                    }}
-                    component="a"
-                    href="/apps"
-                  />
-                  {FetchingData.getSuccessValue(uiNavigationData)
-                    .map(({ visibleTabs: { published } }) => published)
-                    .flatMap(Parsers.isTrue)
-                    .map(() => (
-                      <AccentMenuItem
-                        key="published"
-                        title={t("appBar.published")}
-                        avatar={<PublicIcon />}
-                        compact
-                        onClick={(e) => {
-                          e.preventDefault();
-                          setAccountMenuAnchorEl(null);
-                          window.open("/public/publishedView/publishedDocuments", "_target");
-                        }}
-                        component="a"
-                        href="/public/publishedView/publishedDocuments"
-                      />
-                    ))
-                    .orElse(null)}
-                  <AccessibilityTipsMenuItem
-                    {...(accessibilityTips ?? {})}
-                    onClose={() => {
-                      setAccountMenuAnchorEl(null);
-                    }}
-                  />
-                  <AccentMenuItem
-                    title={t("appBar.aboutRSpace")}
-                    avatar={<InfoIcon />}
-                    compact
-                    onClick={() => {
-                      setAccountMenuAnchorEl(null);
-                      setAboutDialogOpen(true);
-                    }}
-                  />
-                  {FetchingData.getSuccessValue(uiNavigationData)
-                    .map(({ operatedAs }) => operatedAs)
-                    .flatMap(Parsers.isTrue)
-                    .map(() => (
-                      <AccentMenuItem
-                        key="release"
-                        title={t("appBar.release")}
-                        avatar={<LogoutIcon />}
-                        backgroundColor={lighten(theme.palette.error.light, 0.5)}
-                        foregroundColor={darken(theme.palette.error.dark, 0.3)}
-                        compact
-                        onClick={() => {
-                          JwtService.destroyToken();
-                          setAccountMenuAnchorEl(null);
-                          window.location.href = "/logout/runAsRelease";
-                        }}
-                      />
-                    ))
-                    .orElse(
-                      <AccentMenuItem
-                        title={t("appBar.logOut")}
-                        avatar={<LogoutIcon />}
-                        backgroundColor={lighten(theme.palette.error.light, 0.5)}
-                        foregroundColor={darken(theme.palette.error.dark, 0.3)}
-                        compact
-                        onClick={() => {
-                          JwtService.destroyToken();
+                />
+                {FetchingData.getSuccessValue(uiNavigationData)
+                  .map(({ operatedAs }) => operatedAs)
+                  .flatMap(Parsers.isTrue)
+                  .map(() => (
+                    <AccentMenuItem
+                      key="release"
+                      title={t("appBar.release")}
+                      avatar={<LogoutIcon />}
+                      backgroundColor={lighten(theme.palette.error.light, 0.5)}
+                      foregroundColor={darken(theme.palette.error.dark, 0.3)}
+                      compact
+                      onClick={() => {
+                        JwtService.destroyToken();
+                        setAccountMenuAnchorEl(null);
+                        window.location.href = "/logout/runAsRelease";
+                      }}
+                    />
+                  ))
+                  .orElse(
+                    <AccentMenuItem
+                      title={t("appBar.logOut")}
+                      avatar={<LogoutIcon />}
+                      backgroundColor={lighten(theme.palette.error.light, 0.5)}
+                      foregroundColor={darken(theme.palette.error.dark, 0.3)}
+                      compact
+                      onClick={() => {
+                        JwtService.destroyToken();
 
-                          /*
-                           * On some servers the user can login with the Google
-                           * Login workflow. On those servers, `gapi` will be
-                           * defined globally by header.jsp
-                           */
-                          if (typeof window.gapi !== "undefined" && window.gapi.auth2) {
-                            const auth2 = window.gapi.auth2.getAuthInstance();
-                            if (auth2) {
-                              void auth2.signOut().then(() => {
-                                console.log("User signed out.");
-                              });
-                            } else {
-                              console.log("No GAPI authinstance defined");
-                            }
+                        /*
+                         * On some servers the user can login with the Google
+                         * Login workflow. On those servers, `gapi` will be
+                         * defined globally by header.jsp
+                         */
+                        if (typeof window.gapi !== "undefined" && window.gapi.auth2) {
+                          const auth2 = window.gapi.auth2.getAuthInstance();
+                          if (auth2) {
+                            void auth2.signOut().then(() => {
+                              console.log("User signed out.");
+                            });
                           } else {
-                            console.log("No GAPI defined");
+                            console.log("No GAPI authinstance defined");
                           }
-                          setAccountMenuAnchorEl(null);
-                          window.location.href = "/logout";
+                        } else {
+                          console.log("No GAPI defined");
+                        }
+                        setAccountMenuAnchorEl(null);
+                        window.location.href = "/logout";
+                      }}
+                    />,
+                  )}
+                {FetchingData.getSuccessValue(uiNavigationData)
+                  .map(({ bannerImgSrc }) => (
+                    <ListItem
+                      key="branding large"
+                      sx={{
+                        py: 0,
+                        mb: 1,
+                        justifyContent: "flex-end",
+                      }}
+                    >
+                      <img
+                        src={bannerImgSrc}
+                        alt={t("appBar.brandingAlt")}
+                        style={{
+                          maxWidth: "120px",
+                          display: "block",
                         }}
-                      />,
-                    )}
-                  {FetchingData.getSuccessValue(uiNavigationData)
-                    .map(({ bannerImgSrc }) => (
-                      <ListItem
-                        key="branding large"
-                        sx={{
-                          py: 0,
-                          mb: 1,
-                          justifyContent: "flex-end",
-                        }}
-                      >
-                        <img
-                          src={bannerImgSrc}
-                          alt={t("appBar.brandingAlt")}
-                          style={{
-                            maxWidth: "120px",
-                            display: "block",
-                          }}
-                        />
-                      </ListItem>
-                    ))
-                    .orElse(null)}
-                </Menu>
-                <AboutRSpaceDialog open={aboutDialogOpen} onClose={() => setAboutDialogOpen(false)} />
-              </Box>
-            </>
-          )}
-          {variant === "dialog" && (
-            <Box
-              sx={{
-                ml: 1,
-              }}
-            >
-              <AccessibilityTipsIconButton {...(accessibilityTips ?? {})} />
+                      />
+                    </ListItem>
+                  ))
+                  .orElse(null)}
+              </Menu>
+              <AboutRSpaceDialog open={aboutDialogOpen} onClose={() => setAboutDialogOpen(false)} />
             </Box>
-          )}
+          </>
+        )}
+        {variant === "dialog" && (
           <Box
             sx={{
               ml: 1,
             }}
           >
-            {helpPage ? (
-              <Box
-                sx={{
-                  transform: "translateY(2px)",
-                }}
-              >
-                <HelpLinkIcon title={helpPage.title} link={helpPage.docLink} />
-              </Box>
-            ) : (
-              <HelpDocs />
-            )}
+            <AccessibilityTipsIconButton {...(accessibilityTips ?? {})} />
           </Box>
-        </Toolbar>
-      </AppBar>
-    </I18nRoot>
+        )}
+        <Box
+          sx={{
+            ml: 1,
+          }}
+        >
+          {helpPage ? (
+            <Box
+              sx={{
+                transform: "translateY(2px)",
+              }}
+            >
+              <HelpLinkIcon title={helpPage.title} link={helpPage.docLink} />
+            </Box>
+          ) : (
+            <HelpDocs />
+          )}
+        </Box>
+      </Toolbar>
+    </AppBar>
   );
+
+  return ambientI18n ? appBar : <I18nRoot namespaces={["common", "about"]}>{appBar}</I18nRoot>;
 }
 
 export default observer(GalleryAppBar);

--- a/src/main/webapp/ui/src/components/BaseSearch.tsx
+++ b/src/main/webapp/ui/src/components/BaseSearch.tsx
@@ -80,12 +80,7 @@ function BaseSearch(props: {
   );
 }
 
-/**
- * Suspense fallback shown while the "common" namespace loads. Mirrors
- * `BaseSearch`'s markup with its known placeholder text and a disabled,
- * non-interactive input so the search bar's footprint doesn't shift once the
- * real component mounts.
- */
+/** I18nRoot fallback: a disabled lookalike so the search bar's footprint doesn't shift once it mounts. */
 function BaseSearchFallback({ placeholder, variant }: { placeholder: string; variant?: "elevation" | "outlined" }) {
   return (
     <Paper sx={{ boxShadow: "none" }} variant={variant} data-test-id="base-search-content">

--- a/src/main/webapp/ui/src/components/BaseSearch.tsx
+++ b/src/main/webapp/ui/src/components/BaseSearch.tsx
@@ -80,6 +80,32 @@ function BaseSearch(props: {
   );
 }
 
+/**
+ * Suspense fallback shown while the "common" namespace loads. Mirrors
+ * `BaseSearch`'s markup with its known placeholder text and a disabled,
+ * non-interactive input so the search bar's footprint doesn't shift once the
+ * real component mounts.
+ */
+function BaseSearchFallback({ placeholder, variant }: { placeholder: string; variant?: "elevation" | "outlined" }) {
+  return (
+    <Paper sx={{ boxShadow: "none" }} variant={variant} data-test-id="base-search-content">
+      <Box
+        sx={{
+          display: "flex",
+          width: "100%",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <InputBase placeholder={placeholder} disabled sx={{ pl: 1, flexGrow: 1 }} />
+        <IconButton disabled>
+          <SearchIcon />
+        </IconButton>
+      </Box>
+    </Paper>
+  );
+}
+
 /*
  * This is necessary because as of MUI v5 useStyles cannot be used in the same
  * component as the root MuiThemeProvider
@@ -88,7 +114,12 @@ export default function WrappedBaseSearch(props: React.ComponentProps<typeof Bas
   return (
     <StyledEngineProvider injectFirst enableCssLayer>
       <ThemeProvider theme={materialTheme}>
-        <BaseSearch {...props} />
+        <I18nRoot
+          namespaces={["common"]}
+          fallback={<BaseSearchFallback placeholder={props.placeholder} variant={props.variant} />}
+        >
+          <BaseSearch {...props} />
+        </I18nRoot>
       </ThemeProvider>
     </StyledEngineProvider>
   );
@@ -104,14 +135,12 @@ function renderElements() {
         const variant = dataset.variant === "outlined" || dataset.variant === "elevation" ? dataset.variant : undefined;
         const root = createRoot(container);
         root.render(
-          <I18nRoot namespaces={["common"]}>
-            <WrappedBaseSearch
-              placeholder={dataset.placeholder ?? ""}
-              onSubmit={dataset.onsubmit}
-              elId={dataset.elid ?? "base-search"}
-              variant={variant}
-            />
-          </I18nRoot>,
+          <WrappedBaseSearch
+            placeholder={dataset.placeholder ?? ""}
+            onSubmit={dataset.onsubmit}
+            elId={dataset.elid ?? "base-search"}
+            variant={variant}
+          />,
         );
       });
     }

--- a/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.tsx
+++ b/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.tsx
@@ -31,6 +31,7 @@ import { type ReactElement, type ReactNode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { useTranslation } from "react-i18next";
 import axios from "@/common/axios";
+import LoaderCircular from "@/components/LoadingCircular";
 import { MuiCssLayerProvider } from "@/components/MuiCssLayerProvider";
 import I18nRoot from "@/modules/common/i18n/I18nRoot";
 import { formatList } from "@/modules/common/i18n/listFormat";
@@ -754,7 +755,7 @@ window.addEventListener("load", (_e) => {
     const root = createRoot(domContainer);
     root.render(
       <MuiCssLayerProvider>
-        <I18nRoot namespaces={["public"]} fullPage>
+        <I18nRoot namespaces={["public"]} fallback={<LoaderCircular />}>
           <IdentifierPublicPage publicId={rsPublicId} />
         </I18nRoot>
       </MuiCssLayerProvider>,

--- a/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.tsx
+++ b/src/main/webapp/ui/src/components/PublicPages/IdentifierPublicPage.tsx
@@ -754,7 +754,7 @@ window.addEventListener("load", (_e) => {
     const root = createRoot(domContainer);
     root.render(
       <MuiCssLayerProvider>
-        <I18nRoot namespaces={["public"]}>
+        <I18nRoot namespaces={["public"]} fullPage>
           <IdentifierPublicPage publicId={rsPublicId} />
         </I18nRoot>
       </MuiCssLayerProvider>,

--- a/src/main/webapp/ui/src/components/UserDetailsEntrypoint.tsx
+++ b/src/main/webapp/ui/src/components/UserDetailsEntrypoint.tsx
@@ -1,3 +1,4 @@
+import Chip from "@mui/material/Chip";
 import { ThemeProvider } from "@mui/material/styles";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
 import { createRoot, type Root } from "react-dom/client";
@@ -108,9 +109,19 @@ function mountUserDetails(domContainer: Element): void {
   const root = createRoot(domContainer);
   mountedRoots.set(domContainer, root);
   root.render(
-    <I18nRoot namespaces={["common"]}>
-      <StyledEngineProvider injectFirst enableCssLayer>
-        <ThemeProvider theme={materialTheme}>
+    <StyledEngineProvider injectFirst enableCssLayer>
+      <ThemeProvider theme={materialTheme}>
+        <I18nRoot
+          namespaces={["common"]}
+          fallback={
+            <Chip
+              component="div"
+              variant="outlined"
+              label={label}
+              sx={(theme) => ({ mt: 0.5, mb: 0.5, height: theme.spacing(3), cursor: "default" })}
+            />
+          }
+        >
           <UserDetails
             userId={userId}
             fullName={fullName}
@@ -122,9 +133,9 @@ function mountUserDetails(domContainer: Element): void {
               window.RS?.trackEvent?.("user:open:user_details_popover");
             }}
           />
-        </ThemeProvider>
-      </StyledEngineProvider>
-    </I18nRoot>,
+        </I18nRoot>
+      </ThemeProvider>
+    </StyledEngineProvider>,
   );
 }
 

--- a/src/main/webapp/ui/src/eln/about/index.tsx
+++ b/src/main/webapp/ui/src/eln/about/index.tsx
@@ -66,7 +66,7 @@ window.addEventListener("load", () => {
             <ErrorBoundary>
               <CssBaseline />
               <ThemeProvider theme={createAccentedTheme(OTHER_COLOR)}>
-                <I18nRoot namespaces={["about"]}>
+                <I18nRoot namespaces={["about"]} fullPage>
                   <Box sx={{ fontSize: "1rem", lineHeight: "1.5" }}>
                     <DialogBoundary>
                       <Container maxWidth="sm">

--- a/src/main/webapp/ui/src/eln/about/index.tsx
+++ b/src/main/webapp/ui/src/eln/about/index.tsx
@@ -16,6 +16,7 @@ import Analytics from "../../components/Analytics";
 import { AboutRSpaceContent } from "../../components/AppBar/AboutRSpaceDialog";
 import { DialogBoundary } from "../../components/DialogBoundary";
 import ErrorBoundary from "../../components/ErrorBoundary";
+import LoaderCircular from "../../components/LoadingCircular";
 
 const queryClient = new QueryClient();
 
@@ -66,7 +67,7 @@ window.addEventListener("load", () => {
             <ErrorBoundary>
               <CssBaseline />
               <ThemeProvider theme={createAccentedTheme(OTHER_COLOR)}>
-                <I18nRoot namespaces={["about"]} fullPage>
+                <I18nRoot namespaces={["about"]} fallback={<LoaderCircular />}>
                   <Box sx={{ fontSize: "1rem", lineHeight: "1.5" }}>
                     <DialogBoundary>
                       <Container maxWidth="sm">

--- a/src/main/webapp/ui/src/eln/apps/App.tsx
+++ b/src/main/webapp/ui/src/eln/apps/App.tsx
@@ -165,6 +165,7 @@ function App(): React.ReactNode {
             <AppBar
               variant="page"
               currentPage="Apps"
+              ambientI18n
               accessibilityTips={{
                 supportsHighContrastMode: true,
                 supportsReducedMotion: true,

--- a/src/main/webapp/ui/src/eln/apps/index.tsx
+++ b/src/main/webapp/ui/src/eln/apps/index.tsx
@@ -61,7 +61,7 @@ window.addEventListener("load", () => {
             <QueryClientProvider client={queryClient}>
               <Analytics>
                 <ErrorBoundary>
-                  <I18nRoot namespaces={["apps", "common"]}>
+                  <I18nRoot namespaces={["apps", "common"]} fullPage>
                     <Alerts>
                       <App />
                     </Alerts>

--- a/src/main/webapp/ui/src/eln/apps/index.tsx
+++ b/src/main/webapp/ui/src/eln/apps/index.tsx
@@ -61,7 +61,7 @@ window.addEventListener("load", () => {
             <QueryClientProvider client={queryClient}>
               <Analytics>
                 <ErrorBoundary>
-                  <I18nRoot namespaces={["apps", "common"]} fullPage>
+                  <I18nRoot namespaces={["apps", "common", "about"]} fullPage>
                     <Alerts>
                       <App />
                     </Alerts>

--- a/src/main/webapp/ui/src/eln/apps/index.tsx
+++ b/src/main/webapp/ui/src/eln/apps/index.tsx
@@ -7,6 +7,7 @@ import { createRoot } from "react-dom/client";
 import Alerts from "../../components/Alerts/Alerts";
 import Analytics from "../../components/Analytics";
 import ErrorBoundary from "../../components/ErrorBoundary";
+import LoaderCircular from "../../components/LoadingCircular";
 import I18nRoot from "../../modules/common/i18n/I18nRoot";
 import materialTheme, { COLORS } from "../../theme";
 import { hslToHex } from "../../util/colors";
@@ -61,7 +62,7 @@ window.addEventListener("load", () => {
             <QueryClientProvider client={queryClient}>
               <Analytics>
                 <ErrorBoundary>
-                  <I18nRoot namespaces={["apps", "common", "about"]} fullPage>
+                  <I18nRoot namespaces={["apps", "common", "about"]} fallback={<LoaderCircular />}>
                     <Alerts>
                       <App />
                     </Alerts>

--- a/src/main/webapp/ui/src/eln/gallery/index.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/index.tsx
@@ -486,7 +486,7 @@ window.addEventListener("load", () => {
     const root = createRoot(domContainer);
     root.render(
       <React.StrictMode>
-        <I18nRoot namespaces={["gallery", "common"]}>
+        <I18nRoot namespaces={["gallery", "common"]} fullPage>
           <BrowserRouter>
             <Gallery />
           </BrowserRouter>

--- a/src/main/webapp/ui/src/eln/gallery/index.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/index.tsx
@@ -19,6 +19,7 @@ import SidebarToggle from "../../components/AppBar/SidebarToggle";
 import ErrorBoundary from "../../components/ErrorBoundary";
 import GoogleLoginProvider from "../../components/GoogleLoginProvider";
 import { LandmarksProvider } from "../../components/LandmarksContext";
+import LoaderCircular from "../../components/LoadingCircular";
 import SkipToContentMenu from "../../components/SkipToContentMenu";
 import { useDeploymentProperty } from "../../hooks/api/useDeploymentProperty";
 import useUiPreference, { PREFERENCES, UiPreferences } from "../../hooks/api/useUiPreference";
@@ -487,7 +488,7 @@ window.addEventListener("load", () => {
     const root = createRoot(domContainer);
     root.render(
       <React.StrictMode>
-        <I18nRoot namespaces={["gallery", "common", "about"]} fullPage>
+        <I18nRoot namespaces={["gallery", "common", "about"]} fallback={<LoaderCircular />}>
           <BrowserRouter>
             <Gallery />
           </BrowserRouter>

--- a/src/main/webapp/ui/src/eln/gallery/index.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/index.tsx
@@ -190,6 +190,7 @@ const WholePage = ({
                     <AppBar
                       variant="page"
                       currentPage="gallery"
+                      ambientI18n
                       sidebarToggle={
                         <SidebarToggle setSidebarOpen={setDrawerOpen} sidebarOpen={drawerOpen} sidebarId={sidebarId} />
                       }
@@ -486,7 +487,7 @@ window.addEventListener("load", () => {
     const root = createRoot(domContainer);
     root.render(
       <React.StrictMode>
-        <I18nRoot namespaces={["gallery", "common"]} fullPage>
+        <I18nRoot namespaces={["gallery", "common", "about"]} fullPage>
           <BrowserRouter>
             <Gallery />
           </BrowserRouter>

--- a/src/main/webapp/ui/src/eln/sysadmin/users/index.tsx
+++ b/src/main/webapp/ui/src/eln/sysadmin/users/index.tsx
@@ -75,6 +75,7 @@ import CustomTooltip from "../../../components/CustomTooltip";
 import ErrorBoundary from "../../../components/ErrorBoundary";
 import ExportMenuItem from "../../../components/ExportMenuItem";
 import IconButtonWithTooltip from "../../../components/IconButtonWithTooltip";
+import LoaderCircular from "../../../components/LoadingCircular";
 import SubmitSpinnerButton from "../../../components/SubmitSpinnerButton";
 import ExportDialog from "../../../Export/ExportDialog";
 import useCheckVerificationPasswordNeeded from "../../../hooks/api/useCheckVerificationPasswordNeeded";
@@ -1977,7 +1978,7 @@ const wrapperDiv = document.getElementById("sysadminUsers");
 if (wrapperDiv) {
   const root = createRoot(wrapperDiv);
   root.render(
-    <I18nRoot namespaces={["system", "common"]}>
+    <I18nRoot namespaces={["system", "common"]} fallback={<LoaderCircular />}>
       <QueryClientProvider client={queryClient}>
         <StyledEngineProvider injectFirst enableCssLayer>
           <ThemeProvider theme={createAccentedTheme(ACCENT_COLOR)}>

--- a/src/main/webapp/ui/src/modules/api/ApiDocsEntrypoint.tsx
+++ b/src/main/webapp/ui/src/modules/api/ApiDocsEntrypoint.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import LoaderCircular from "@/components/LoadingCircular";
 import I18nRoot from "@/modules/common/i18n/I18nRoot";
 import ApiDocsPage from "./components/ApiDocsPage";
 
@@ -19,7 +20,7 @@ window.addEventListener("load", () => {
   createRoot(domContainer).render(
     <React.StrictMode>
       <ErrorBoundary>
-        <I18nRoot>
+        <I18nRoot fallback={<LoaderCircular />}>
           <ApiDocsPage />
         </I18nRoot>
       </ErrorBoundary>

--- a/src/main/webapp/ui/src/modules/common/i18n/I18nRoot.tsx
+++ b/src/main/webapp/ui/src/modules/common/i18n/I18nRoot.tsx
@@ -29,14 +29,7 @@ export default function I18nRoot({
   children: React.ReactNode;
   namespaces?: readonly FlatNamespace[];
   componentMap?: RichTextComponents;
-  /**
-   * Shown while namespaces load. Defaults to nothing, which is correct for
-   * islands hidden until a user action (dialogs, toasts, menus). Callers that
-   * mount into visible, in-flow page space should pass something that
-   * occupies the same footprint (a `LoaderCircular` for full-page apps, a
-   * `Skeleton` or static lookalike for islands) so nothing reflows once the
-   * namespaces resolve.
-   */
+  /** Shown while namespaces load; defaults to nothing, right for hidden-until-triggered islands. */
   fallback?: React.ReactNode;
 }): React.ReactNode {
   return (

--- a/src/main/webapp/ui/src/modules/common/i18n/I18nRoot.tsx
+++ b/src/main/webapp/ui/src/modules/common/i18n/I18nRoot.tsx
@@ -25,15 +25,18 @@ export default function I18nRoot({
   children,
   namespaces,
   componentMap = muiRichTextComponents,
+  fullPage = false,
 }: {
   children: React.ReactNode;
   namespaces?: readonly FlatNamespace[];
   componentMap?: RichTextComponents;
+  /** Full-page apps show a loading spinner while namespaces load; islands render nothing. */
+  fullPage?: boolean;
 }): React.ReactNode {
   return (
     <I18nextProvider i18n={i18n}>
       <RichTextComponentsContext.Provider value={componentMap}>
-        <Suspense fallback={<LoaderCircular />}>
+        <Suspense fallback={fullPage ? <LoaderCircular /> : null}>
           <NamespacePreloader namespaces={namespaces}>{children}</NamespacePreloader>
         </Suspense>
       </RichTextComponentsContext.Provider>

--- a/src/main/webapp/ui/src/modules/common/i18n/I18nRoot.tsx
+++ b/src/main/webapp/ui/src/modules/common/i18n/I18nRoot.tsx
@@ -2,7 +2,6 @@ import type { FlatNamespace } from "i18next";
 import type React from "react";
 import { Suspense } from "react";
 import { I18nextProvider, useTranslation } from "react-i18next";
-import LoaderCircular from "@/components/LoadingCircular";
 import i18n from "@/modules/common/i18n";
 import {
   muiRichTextComponents,
@@ -25,18 +24,25 @@ export default function I18nRoot({
   children,
   namespaces,
   componentMap = muiRichTextComponents,
-  fullPage = false,
+  fallback = null,
 }: {
   children: React.ReactNode;
   namespaces?: readonly FlatNamespace[];
   componentMap?: RichTextComponents;
-  /** Full-page apps show a loading spinner while namespaces load; islands render nothing. */
-  fullPage?: boolean;
+  /**
+   * Shown while namespaces load. Defaults to nothing, which is correct for
+   * islands hidden until a user action (dialogs, toasts, menus). Callers that
+   * mount into visible, in-flow page space should pass something that
+   * occupies the same footprint (a `LoaderCircular` for full-page apps, a
+   * `Skeleton` or static lookalike for islands) so nothing reflows once the
+   * namespaces resolve.
+   */
+  fallback?: React.ReactNode;
 }): React.ReactNode {
   return (
     <I18nextProvider i18n={i18n}>
       <RichTextComponentsContext.Provider value={componentMap}>
-        <Suspense fallback={fullPage ? <LoaderCircular /> : null}>
+        <Suspense fallback={fallback}>
           <NamespacePreloader namespaces={namespaces}>{children}</NamespacePreloader>
         </Suspense>
       </RichTextComponentsContext.Provider>

--- a/src/main/webapp/ui/src/system-groups/NewLabGroup.tsx
+++ b/src/main/webapp/ui/src/system-groups/NewLabGroup.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { useTranslation } from "react-i18next";
 import axios from "@/common/axios";
+import LoaderCircular from "@/components/LoadingCircular";
 import I18nRoot from "@/modules/common/i18n/I18nRoot";
 import materialTheme from "../theme";
 import UserSelect from "./UserBox";
@@ -261,7 +262,7 @@ export default function NewLabGroup() {
 const domContainer = document.getElementById("newLabGroup");
 const root = createRoot(domContainer as HTMLElement);
 root.render(
-  <I18nRoot namespaces={["groups"]}>
+  <I18nRoot namespaces={["groups"]} fallback={<LoaderCircular />}>
     <NewLabGroup />
   </I18nRoot>,
 );

--- a/src/main/webapp/ui/src/system-ror/RoRIntegration.tsx
+++ b/src/main/webapp/ui/src/system-ror/RoRIntegration.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { useTranslation } from "react-i18next";
 import axios from "@/common/axios";
+import LoaderCircular from "@/components/LoadingCircular";
 import I18nRoot from "@/modules/common/i18n/I18nRoot";
 import TransRichText from "@/modules/common/i18n/TransRichText";
 import GenericsearchBar from "../components/GenericsearchBar";
@@ -321,7 +322,7 @@ function mountRoRIntegration(event?: Event) {
   const root = createRoot(domContainer);
   mainArea.rorRoot = root;
   root.render(
-    <I18nRoot namespaces={["system"]}>
+    <I18nRoot namespaces={["system"]} fallback={<LoaderCircular />}>
       <RoRIntegration />
     </I18nRoot>,
   );

--- a/src/main/webapp/ui/src/tinyMCE/PreviewInfo.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/PreviewInfo.tsx
@@ -1,6 +1,7 @@
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import CssBaseline from "@mui/material/CssBaseline";
+import Skeleton from "@mui/material/Skeleton";
 import Stack from "@mui/material/Stack";
 import { ThemeProvider } from "@mui/material/styles";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
@@ -161,6 +162,23 @@ function PreviewInfoFrame({ children, isTableOnly = false }: { children: React.R
   );
 }
 
+/**
+ * Suspense fallback shown while the "apps"/"common"/"workspace" namespaces
+ * load. Reuses `PreviewInfoFrame`'s chrome (border, radius, its own theme)
+ * so the eventual real content doesn't shift the surrounding document text:
+ * only the height, derived from the replaced img's own `height` attribute
+ * where known, needs to match.
+ */
+function PreviewInfoFallback({ isTableOnly, height }: { isTableOnly?: boolean; height: number }) {
+  return (
+    <PreviewInfoFrame isTableOnly={isTableOnly}>
+      <Box sx={{ p: 1 }}>
+        <Skeleton variant="rectangular" height={height} />
+      </Box>
+    </PreviewInfoFrame>
+  );
+}
+
 export default function PreviewInfo({ item }: { item: PreviewInfoItem }) {
   const stoichiometryReference = getStoichiometryReference(item["data-stoichiometry-table"]);
   const isTableOnly = item[STOICHIOMETRY_TABLE_ONLY_ATTRIBUTE] === "true";
@@ -220,8 +238,12 @@ export default function PreviewInfo({ item }: { item: PreviewInfoItem }) {
 
 function render(attributes: PreviewInfoItem, element: Element) {
   const root = getPreviewInfoRoot(element);
+  const isTableOnly = attributes[STOICHIOMETRY_TABLE_ONLY_ATTRIBUTE] === "true";
   root.render(
-    <I18nRoot namespaces={["apps", "common", "workspace"]}>
+    <I18nRoot
+      namespaces={["apps", "common", "workspace"]}
+      fallback={<PreviewInfoFallback isTableOnly={isTableOnly} height={Number(attributes.height) || 200} />}
+    >
       <PreviewInfo item={{ ...attributes }} />
     </I18nRoot>,
   );
@@ -241,7 +263,10 @@ function renderChemPreview(domContainer: HTMLImageElement) {
 
   const root = getPreviewInfoRoot(parent);
   root.render(
-    <I18nRoot namespaces={["apps", "common", "workspace"]}>
+    <I18nRoot
+      namespaces={["apps", "common", "workspace"]}
+      fallback={<PreviewInfoFallback height={Number(attributes.height) || 200} />}
+    >
       <PreviewInfo item={{ ...attributes }} />
     </I18nRoot>,
   );

--- a/src/main/webapp/ui/src/tinyMCE/PreviewInfo.tsx
+++ b/src/main/webapp/ui/src/tinyMCE/PreviewInfo.tsx
@@ -162,13 +162,7 @@ function PreviewInfoFrame({ children, isTableOnly = false }: { children: React.R
   );
 }
 
-/**
- * Suspense fallback shown while the "apps"/"common"/"workspace" namespaces
- * load. Reuses `PreviewInfoFrame`'s chrome (border, radius, its own theme)
- * so the eventual real content doesn't shift the surrounding document text:
- * only the height, derived from the replaced img's own `height` attribute
- * where known, needs to match.
- */
+/** I18nRoot fallback: reuses PreviewInfoFrame's chrome sized to the source img's height, so document text doesn't shift. */
 function PreviewInfoFallback({ isTableOnly, height }: { isTableOnly?: boolean; height: number }) {
   return (
     <PreviewInfoFrame isTableOnly={isTableOnly}>


### PR DESCRIPTION
## Description ##
Don't show loading spinner for React Islands when loading i18n, to avoid multiple spinners showing up on legacy pages.