### PR TITLE
RSDEV-1171: Version/Revision history for Instruments and Instrument Templates

### DIFF
--- a/src/main/java/com/researchspace/api/v1/InstrumentTemplatesApi.java
+++ b/src/main/java/com/researchspace/api/v1/InstrumentTemplatesApi.java
@@ -11,6 +11,7 @@ import com.researchspace.api.v1.model.ApiInstrumentTemplate;
 import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
 import com.researchspace.api.v1.model.ApiInstrumentTemplateSearchResult;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult;
+import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.model.User;
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
@@ -44,6 +45,9 @@ public interface InstrumentTemplatesApi {
 
   @GetMapping(path = "/{id}/versions/{version}")
   ApiInstrumentTemplate getInstrumentTemplateVersionById(Long id, Long version, User user);
+
+  @GetMapping(value = "/{id}/revisions")
+  ApiInventoryRecordRevisionList getInstrumentTemplateAllRevisions(Long id, User user);
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/researchspace/api/v1/controller/InstrumentTemplatesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InstrumentTemplatesApiController.java
@@ -14,12 +14,14 @@ import com.researchspace.api.v1.model.ApiInventoryBulkOperationPost.BulkApiOpera
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult.InventoryBulkOperationStatus;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
+import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.api.v1.service.impl.SpringMultipartFileAdapter;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.record.IconEntity;
 import com.researchspace.service.IconImageManager;
+import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.impl.InventoryBulkOperationHandler;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -46,6 +48,7 @@ public class InstrumentTemplatesApiController extends BaseApiInventoryController
   private @Autowired InventoryBulkOperationHandler bulkOperationHandler;
   private @Autowired InstrumentTemplatePostValidator postValidator;
   private @Autowired InstrumentTemplatePutValidator putValidator;
+  private @Autowired InventoryAuditApiManager inventoryAuditMgr;
 
   @Override
   public ApiInstrumentTemplateSearchResult getTemplatesForUser(
@@ -91,10 +94,24 @@ public class InstrumentTemplatesApiController extends BaseApiInventoryController
       @RequestAttribute(name = "user") User user) {
     ApiInstrumentTemplate template =
         instrumentApiMgr.getApiInstrumentTemplateVersion(id, version, user);
-    if (template != null) {
-      buildAndAddInventoryRecordLinks(template);
+    if (template == null) {
+      throw new NotFoundException(createNotFoundMessage("Instrument template version", version));
     }
+    buildAndAddInventoryRecordLinks(template);
     return template;
+  }
+
+  @Override
+  public ApiInventoryRecordRevisionList getInstrumentTemplateAllRevisions(
+      @PathVariable Long id, @RequestAttribute(name = "user") User user) {
+    InstrumentTemplate dbTemplate = instrumentApiMgr.assertUserCanReadInstrumentTemplate(id, user);
+    ApiInventoryRecordRevisionList revisions =
+        inventoryAuditMgr.getInventoryRecordRevisions(dbTemplate);
+    for (ApiInventoryRecordRevisionList.ApiInventoryRecordRevision templateRev :
+        revisions.getRevisions()) {
+      buildAndAddInventoryRecordLinks(templateRev.getRecord());
+    }
+    return revisions;
   }
 
   @Override

--- a/src/main/java/com/researchspace/webapp/controller/GlobalLookupController.java
+++ b/src/main/java/com/researchspace/webapp/controller/GlobalLookupController.java
@@ -31,7 +31,8 @@ public class GlobalLookupController extends BaseController {
    *       <li>StructuredDocuments
    *       <li>Folders
    *       <li>Groups
-   *       <li>Inventory: Samples, Subsamples, Templates, Containers
+   *       <li>Inventory: Samples, Subsamples, Templates, Containers, Instruments, Instrument
+   *           Templates
    *     </ul>
    */
   @GetMapping("/{oid}")
@@ -70,7 +71,13 @@ public class GlobalLookupController extends BaseController {
 
   /** Inventory record types whose version-suffixed global IDs open the versioned viewer. */
   private static final Set<GlobalIdPrefix> VERSIONED_INVENTORY_PREFIXES =
-      EnumSet.of(GlobalIdPrefix.SA, GlobalIdPrefix.SS, GlobalIdPrefix.IC, GlobalIdPrefix.IT);
+      EnumSet.of(
+          GlobalIdPrefix.SA,
+          GlobalIdPrefix.SS,
+          GlobalIdPrefix.IC,
+          GlobalIdPrefix.IT,
+          GlobalIdPrefix.IN,
+          GlobalIdPrefix.NT);
 
   private String getRedirect(GlobalIdentifier oid) {
     GlobalIdPrefix prefix = oid.getPrefix();

--- a/src/main/webapp/resources/rspace_api_inventory_specs_2_24_0.yaml
+++ b/src/main/webapp/resources/rspace_api_inventory_specs_2_24_0.yaml
@@ -538,6 +538,20 @@ paths:
                 $ref: "#/components/schemas/InstrumentTemplate"
         "404":
           $ref: "#/components/responses/NotFound"
+  "/instrumentTemplates/{instrumentTemplateId}/revisions":
+    get:
+      summary: Gets historical revisions of the Instrument Template
+      description: Returns list of historical revisions saved for the Instrument Template,
+        starting from the earliest revision.
+      tags:
+        - Instrument Templates
+      parameters:
+        - $ref: "#/components/parameters/instrumentTemplateIdParam"
+      responses:
+        "200":
+          description: A list of revision information objects.
+        "404":
+          $ref: "#/components/responses/NotFound"
   "/instrumentTemplates/{instrumentTemplateId}/image/{timestamp}":
     get:
       summary: Get the full image attached to the Instrument Template

--- a/src/main/webapp/ui/src/Inventory/Instrument/Form.tsx
+++ b/src/main/webapp/ui/src/Inventory/Instrument/Form.tsx
@@ -14,6 +14,7 @@ import LocationField from "../components/Fields/Location";
 import NameField from "../components/Fields/Name";
 import OwnerField from "../components/Fields/Owner";
 import TagsField from "../components/Fields/Tags";
+import HistoricalVersionAlert from "../components/HistoricalVersionAlert";
 import LimitedAccessAlert from "../components/LimitedAccessAlert";
 import Stepper from "../components/Stepper/Stepper";
 import StepperPanel from "../components/Stepper/StepperPanel";
@@ -129,7 +130,12 @@ function InstrumentForm(): ReactNode {
   const owner: Person = activeResult.owner;
 
   return (
-    <Stepper titleText={activeResult.name} resetScrollPosition={activeResult} factory={activeResult.factory}>
+    <Stepper
+      stickyAlert={activeResult.historicalVersion ? <HistoricalVersionAlert record={activeResult} /> : null}
+      titleText={activeResult.name}
+      resetScrollPosition={activeResult}
+      factory={activeResult.factory}
+    >
       <LimitedAccessAlert
         readAccessLevel={activeResult.readAccessLevel}
         whatLabel={t("recordTypes.instrument.lower")}

--- a/src/main/webapp/ui/src/Inventory/InstrumentTemplate/Fields/InstrumentsList.tsx
+++ b/src/main/webapp/ui/src/Inventory/InstrumentTemplate/Fields/InstrumentsList.tsx
@@ -24,7 +24,7 @@ function InstrumentsList(): React.ReactNode {
   const handleSearch = (query: string) => {
     void instrumentsSearch().fetcher.performInitialSearch({
       query,
-      parentGlobalId: activeResult.globalId,
+      parentGlobalId: activeResult.globalIdOfLatest,
     });
   };
 

--- a/src/main/webapp/ui/src/Inventory/InstrumentTemplate/Form.tsx
+++ b/src/main/webapp/ui/src/Inventory/InstrumentTemplate/Form.tsx
@@ -12,6 +12,7 @@ import ImageField from "../components/Fields/Image";
 import NameField from "../components/Fields/Name";
 import OwnerField from "../components/Fields/Owner";
 import TagsField from "../components/Fields/Tags";
+import HistoricalVersionAlert from "../components/HistoricalVersionAlert";
 import LimitedAccessAlert from "../components/LimitedAccessAlert";
 import Stepper from "../components/Stepper/Stepper";
 import StepperPanel from "../components/Stepper/StepperPanel";
@@ -116,7 +117,12 @@ function InstrumentTemplateForm(): ReactNode {
   const owner: Person = activeResult.owner;
 
   return (
-    <Stepper titleText={activeResult.name} resetScrollPosition={activeResult} factory={activeResult.factory}>
+    <Stepper
+      stickyAlert={activeResult.historicalVersion ? <HistoricalVersionAlert record={activeResult} /> : null}
+      titleText={activeResult.name}
+      resetScrollPosition={activeResult}
+      factory={activeResult.factory}
+    >
       <LimitedAccessAlert
         readAccessLevel={activeResult.readAccessLevel}
         whatLabel={t("recordTypes.instrumentTemplate.lower")}

--- a/src/main/webapp/ui/src/Inventory/__tests__/PermalinkRouter.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/__tests__/PermalinkRouter.test.tsx
@@ -25,7 +25,7 @@ function LocationDisplay() {
   );
 }
 
-function renderAt(initialUrl: string, type: "sample" | "subsample") {
+function renderAt(initialUrl: string, type: "sample" | "subsample" | "instrument" | "instrumenttemplate") {
   return render(
     <MemoryRouter initialEntries={[initialUrl]}>
       <NavigateContext.Provider
@@ -57,6 +57,22 @@ describe("PermalinkRouter", () => {
     expect(screen.getByTestId("location-pathname")).toHaveTextContent("/inventory/subsample/4");
     expect(screen.getByTestId("location-search")).toHaveTextContent("version=1");
     // and the redirected route resolves to the versioned permalink search
+    expect(screen.getByTestId("search-router")).toHaveTextContent('"version":1');
+  });
+
+  test("a versioned instrument Global Id redirects with the version as a search param", () => {
+    renderAt("/inventory/instrument/IN4v1", "instrument");
+
+    expect(screen.getByTestId("location-pathname")).toHaveTextContent("/inventory/instrument/4");
+    expect(screen.getByTestId("location-search")).toHaveTextContent("version=1");
+    expect(screen.getByTestId("search-router")).toHaveTextContent('"version":1');
+  });
+
+  test("a versioned instrument template Global Id redirects with the version as a search param", () => {
+    renderAt("/inventory/instrumenttemplate/NT4v1", "instrumenttemplate");
+
+    expect(screen.getByTestId("location-pathname")).toHaveTextContent("/inventory/instrumenttemplate/4");
+    expect(screen.getByTestId("location-search")).toHaveTextContent("version=1");
     expect(screen.getByTestId("search-router")).toHaveTextContent('"version":1');
   });
 

--- a/src/main/webapp/ui/src/Inventory/__tests__/historicalVersionForm.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/__tests__/historicalVersionForm.test.tsx
@@ -8,15 +8,20 @@ import "@/__tests__/__mocks__/matchMedia";
 import { cleanup, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { ThemeProvider } from "@mui/material/styles";
+import type { ReactNode } from "react";
 import { IsValid } from "../../components/ValidatingSubmitButton";
 import type { InventoryRecord } from "../../stores/definitions/InventoryRecord";
 import { makeMockContainer } from "../../stores/models/__tests__/ContainerModel/mocking";
+import { makeMockInstrument } from "../../stores/models/__tests__/InstrumentModel/mocking";
+import { makeMockInstrumentTemplate } from "../../stores/models/__tests__/InstrumentTemplateModel/mocking";
 import { personAttrs } from "../../stores/models/__tests__/PersonModel/mocking";
 import { makeMockRootStore } from "../../stores/stores/__tests__/RootStore/mocking";
 import { storesContext } from "../../stores/stores-context";
 import materialTheme from "../../theme";
 import ContainerForm from "../Container/Form";
 import SynchroniseFormSections from "../components/Stepper/SynchroniseFormSections";
+import InstrumentForm from "../Instrument/Form";
+import InstrumentTemplateForm from "../InstrumentTemplate/Form";
 
 class ResizeObserver {
   observe(): void {}
@@ -34,6 +39,18 @@ vi.mock("../components/Fields/ExtraFields/ExtraFields", () => ({
   default: vi.fn(() => <div></div>),
 }));
 vi.mock("../components/ContextMenu/ContextMenu", () => ({
+  default: vi.fn(() => <div></div>),
+}));
+vi.mock("../Instrument/Fields/InstrumentTemplateField", () => ({
+  default: vi.fn(() => <div></div>),
+}));
+vi.mock("../Instrument/Fields/TemplateFields", () => ({
+  default: vi.fn(() => <div></div>),
+}));
+vi.mock("../InstrumentTemplate/Fields/CustomFields", () => ({
+  default: vi.fn(() => <div></div>),
+}));
+vi.mock("../InstrumentTemplate/Fields/InstrumentsList", () => ({
   default: vi.fn(() => <div></div>),
 }));
 vi.mock("../../common/InvApiService", () => ({
@@ -97,6 +114,95 @@ function renderContainerForm(activeResult: InventoryRecord) {
     </ThemeProvider>,
   );
 }
+
+function renderForm(FormComponent: () => ReactNode, activeResult: InventoryRecord) {
+  const rootStore = makeMockRootStore({
+    searchStore: {
+      activeResult,
+      fetcher: {
+        generateNewQuery: () => "foo",
+      },
+      search: {
+        activeResult,
+        processingContextActions: false,
+        fetcher: {
+          basketSearch: false,
+        },
+        batchEditableInstance: { loading: false, submittable: IsValid() },
+      },
+    },
+    unitStore: {
+      getUnit: () => ({
+        id: 1,
+        label: "items",
+        category: "dimensionless",
+        description: "",
+      }),
+      unitsOfCategory: () => [],
+    },
+  });
+  render(
+    <ThemeProvider theme={materialTheme}>
+      <storesContext.Provider value={rootStore}>
+        <SynchroniseFormSections>
+          <FormComponent />
+        </SynchroniseFormSections>
+      </storesContext.Provider>
+    </ThemeProvider>,
+  );
+}
+
+describe("Instrument Form and historical versions", () => {
+  window.ResizeObserver = ResizeObserver;
+  window.scrollTo = vi.fn();
+
+  afterEach(cleanup);
+
+  test("the HistoricalVersionAlert is shown for a historical instrument", () => {
+    renderForm(
+      InstrumentForm,
+      makeMockInstrument({
+        owner: personAttrs(),
+        version: 1,
+        historicalVersion: true,
+      }),
+    );
+
+    expect(screen.getByText("inventory:historicalVersion.title")).toBeInTheDocument();
+  });
+
+  test("the HistoricalVersionAlert is not shown for a live instrument", () => {
+    renderForm(InstrumentForm, makeMockInstrument({ owner: personAttrs() }));
+
+    expect(screen.queryByText("inventory:historicalVersion.title")).not.toBeInTheDocument();
+  });
+});
+
+describe("Instrument Template Form and historical versions", () => {
+  window.ResizeObserver = ResizeObserver;
+  window.scrollTo = vi.fn();
+
+  afterEach(cleanup);
+
+  test("the HistoricalVersionAlert is shown for a historical instrument template", () => {
+    renderForm(
+      InstrumentTemplateForm,
+      makeMockInstrumentTemplate({
+        owner: personAttrs(),
+        version: 1,
+        historicalVersion: true,
+      }),
+    );
+
+    expect(screen.getByText("inventory:historicalVersion.title")).toBeInTheDocument();
+  });
+
+  test("the HistoricalVersionAlert is not shown for a live instrument template", () => {
+    renderForm(InstrumentTemplateForm, makeMockInstrumentTemplate({ owner: personAttrs() }));
+
+    expect(screen.queryByText("inventory:historicalVersion.title")).not.toBeInTheDocument();
+  });
+});
 
 describe("Container Form and historical versions", () => {
   window.ResizeObserver = ResizeObserver;

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/VersionHistory.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/VersionHistory.tsx
@@ -146,7 +146,9 @@ function VersionHistory({ record }: VersionHistoryArgs): React.ReactNode {
   const [state, setState] = useState<State>({ state: "init" });
 
   const supported =
-    ["sample", "subSample", "container", "sampleTemplate"].includes(record.recordType) && record.id !== null;
+    ["sample", "subSample", "container", "sampleTemplate", "instrument", "instrumentTemplate"].includes(
+      record.recordType,
+    ) && record.id !== null;
 
   useEffect(() => {
     if (open && supported) {

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/VersionHistory.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/VersionHistory.test.tsx
@@ -7,6 +7,8 @@ import { renderWithRealI18n, wrapWithRealI18n } from "@/__tests__/helpers/realI1
 import commonEn from "@/modules/common/i18n/locales/en-US/common.json";
 import inventoryEn from "@/modules/common/i18n/locales/en-US/inventory.json";
 import InvApiService from "../../../../common/InvApiService";
+import { makeMockInstrument } from "../../../../stores/models/__tests__/InstrumentModel/mocking";
+import { makeMockInstrumentTemplate } from "../../../../stores/models/__tests__/InstrumentTemplateModel/mocking";
 import { makeMockSample } from "../../../../stores/models/__tests__/SampleModel/mocking";
 import { makeMockSubSample } from "../../../../stores/models/__tests__/SubSampleModel/mocking";
 import { makeMockTemplate } from "../../../../stores/models/__tests__/TemplateModel/mocking";
@@ -169,6 +171,58 @@ describe("VersionHistory", () => {
     await screen.findByRole("table");
     const link = screen.getByRole("link", { name: "Version 1" });
     expect(link).toHaveAttribute("href", "/inventory/sampletemplate/1?version=1");
+  });
+
+  test("shows the version history of an instrument", async () => {
+    const spy = vi
+      .spyOn(InvApiService, "get")
+      .mockImplementation(() => Promise.resolve(revisionsResponse([{ revisionId: 100, version: 1 }])));
+    const instrument = makeMockInstrument({ version: 2 });
+    await renderVersionHistory(instrument);
+
+    expect(screen.getByText("2")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "View version history" }));
+    expect(await screen.findByRole("table")).toBeVisible();
+    expect(spy).toHaveBeenCalledWith("instruments/1/revisions");
+  });
+
+  test("an instrument version row links to the versioned viewer URL", async () => {
+    vi.spyOn(InvApiService, "get").mockImplementation(() =>
+      Promise.resolve(revisionsResponse([{ revisionId: 100, version: 1 }])),
+    );
+    const instrument = makeMockInstrument({ version: 2 });
+    await renderVersionHistory(instrument);
+    fireEvent.click(screen.getByRole("button", { name: "View version history" }));
+
+    await screen.findByRole("table");
+    const link = screen.getByRole("link", { name: "Version 1" });
+    expect(link).toHaveAttribute("href", "/inventory/instrument/1?version=1");
+  });
+
+  test("shows the version history of an instrument template", async () => {
+    const spy = vi
+      .spyOn(InvApiService, "get")
+      .mockImplementation(() => Promise.resolve(revisionsResponse([{ revisionId: 100, version: 1 }])));
+    const instrumentTemplate = makeMockInstrumentTemplate({ version: 2 });
+    await renderVersionHistory(instrumentTemplate);
+
+    expect(screen.getByText("2")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "View version history" }));
+    expect(await screen.findByRole("table")).toBeVisible();
+    expect(spy).toHaveBeenCalledWith("instrumentTemplates/1/revisions");
+  });
+
+  test("an instrument template version row links to the versioned viewer URL", async () => {
+    vi.spyOn(InvApiService, "get").mockImplementation(() =>
+      Promise.resolve(revisionsResponse([{ revisionId: 100, version: 1 }])),
+    );
+    const instrumentTemplate = makeMockInstrumentTemplate({ version: 2 });
+    await renderVersionHistory(instrumentTemplate);
+    fireEvent.click(screen.getByRole("button", { name: "View version history" }));
+
+    await screen.findByRole("table");
+    const link = screen.getByRole("link", { name: "Version 1" });
+    expect(link).toHaveAttribute("href", "/inventory/instrumenttemplate/1?version=1");
   });
 
   test("shows an informational message when there is no history yet", async () => {

--- a/src/main/webapp/ui/src/stores/definitions/BaseRecord.ts
+++ b/src/main/webapp/ui/src/stores/definitions/BaseRecord.ts
@@ -35,8 +35,9 @@ export type GlobalIdPrefix = "SA" | "SS" | "IC" | "IT" | "BE" | "BA" | "IF" | "S
  * fall out of sync with its own Global ID format.
  */
 export const globalIdDefinitions = {
-  // samples, subsamples, containers, and templates support an optional
-  // version suffix (e.g. SS4v1), identifying a historical version
+  // samples, subsamples, containers, instruments, and templates (sample and
+  // instrument) support an optional version suffix (e.g. SS4v1), identifying
+  // a historical version
   sample: { pattern: /^sa\d+(v\d+)?$/i, prefix: "SA" },
   subsample: { pattern: /^ss\d+(v\d+)?$/i, prefix: "SS" },
   container: { pattern: /^ic\d+(v\d+)?$/i, prefix: "IC" },
@@ -47,7 +48,7 @@ export const globalIdDefinitions = {
   field: { pattern: /^sf\d+$/i, prefix: "SF" },
   document: { pattern: /^sd\d+$/i, prefix: "SD" },
   group: { pattern: /^gp\d+$/i, prefix: "GP" },
-  instrument: { pattern: /^in\d+$/i, prefix: "IN" },
+  instrument: { pattern: /^in\d+(v\d+)?$/i, prefix: "IN" },
   instrumentTemplate: { pattern: /^nt\d+(v\d+)?$/i, prefix: "NT" },
 } satisfies Record<string, { pattern: RegExp; prefix: GlobalIdPrefix }>;
 

--- a/src/main/webapp/ui/src/stores/models/Factory/__tests__/AlwaysNewFactory.test.ts
+++ b/src/main/webapp/ui/src/stores/models/Factory/__tests__/AlwaysNewFactory.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
 import type { GlobalId } from "../../../definitions/BaseRecord";
 import { containerAttrs } from "../../__tests__/ContainerModel/mocking";
+import { instrumentAttrs } from "../../__tests__/InstrumentModel/mocking";
+import { instrumentTemplateAttrs } from "../../__tests__/InstrumentTemplateModel/mocking";
 import { personAttrs } from "../../__tests__/PersonModel/mocking";
 import { makeMockSample, sampleAttrs } from "../../__tests__/SampleModel/mocking";
 import { subsampleAttrs } from "../../__tests__/SubSampleModel/mocking";
@@ -61,6 +63,26 @@ describe("AlwaysNewFactory", () => {
         },
       );
       expect(container.recordType).toBe("container");
+    });
+
+    test("instantiate an instrument from e.g. IN4v1.", () => {
+      const factory = new AlwaysNewFactory();
+      const instrument = factory.newRecord(
+        instrumentAttrs({ globalId: "IN4v1" }) as Record<string, unknown> & {
+          globalId: GlobalId;
+        },
+      );
+      expect(instrument.recordType).toBe("instrument");
+    });
+
+    test("instantiate an instrument template from e.g. NT7v2.", () => {
+      const factory = new AlwaysNewFactory();
+      const instrumentTemplate = factory.newRecord(
+        instrumentTemplateAttrs({ globalId: "NT7v2" }) as Record<string, unknown> & {
+          globalId: GlobalId;
+        },
+      );
+      expect(instrumentTemplate.recordType).toBe("instrumentTemplate");
     });
   });
 

--- a/src/main/webapp/ui/src/stores/models/InstrumentModel.tsx
+++ b/src/main/webapp/ui/src/stores/models/InstrumentModel.tsx
@@ -3,7 +3,6 @@ import type React from "react";
 import i18n from "@/modules/common/i18n";
 import type { _LINK } from "@/util/types";
 import InstrumentHeader from "../../assets/graphics/RecordTypeGraphics/HeaderIllustrations/InstrumentHeader";
-import ApiService from "../../common/InvApiService";
 import RsSet from "../../util/set";
 import type { BarcodeAttrs } from "../definitions/Barcode";
 import { type GlobalId, type Id, inventoryRecordTypeLabels } from "../definitions/BaseRecord";
@@ -26,7 +25,7 @@ import type { ContainerAttrs } from "./ContainerModel";
 import ExtraFieldModel from "./ExtraFieldModel";
 import FieldModel, { type FieldModelAttrs } from "./FieldModel";
 import { HasLocationMixin } from "./HasLocation";
-import InstrumentTemplateModel, { type InstrumentTemplateAttrs } from "./InstrumentTemplateModel";
+import type InstrumentTemplateModel from "./InstrumentTemplateModel";
 import InventoryBaseRecord, {
   defaultVisibleResultFields,
   type InventoryBaseRecordEditableFields,
@@ -65,6 +64,8 @@ export type InstrumentAttrs = {
   extraFields?: Array<ExtraFieldAttrs>;
   fields?: Array<FieldModelAttrs>;
   templateVersion?: number | null;
+  version?: number | null;
+  historicalVersion?: boolean;
   _links: Array<_LINK>;
 } & Record<string, unknown>;
 
@@ -241,9 +242,13 @@ export default class InstrumentModel
     await super.fetchAdditionalInfo(silent);
     if (this.templateId) {
       const templateId = this.templateId;
-      const { data } = await ApiService.get<InstrumentTemplateAttrs>("instrumentTemplates", String(templateId));
+      const template = await getRootStore().searchStore.getInstrumentTemplate(
+        templateId,
+        this.templateVersion,
+        this.factory.newFactory(),
+      );
       runInAction(() => {
-        this.template = new InstrumentTemplateModel(this.factory.newFactory(), data);
+        this.template = template;
       });
     }
     getRootStore().trackingStore.trackEvent("InventoryRecordAccessed", {

--- a/src/main/webapp/ui/src/stores/models/InstrumentTemplateModel.tsx
+++ b/src/main/webapp/ui/src/stores/models/InstrumentTemplateModel.tsx
@@ -1,4 +1,4 @@
-import { action, makeObservable, observable, override } from "mobx";
+import { action, computed, makeObservable, observable, override } from "mobx";
 import type React from "react";
 import i18n from "@/modules/common/i18n";
 import TransRichText, { helpDocsArticleUrl } from "@/modules/common/i18n/TransRichText";
@@ -47,6 +47,7 @@ export type InstrumentTemplateAttrs = {
   permittedActions: Array<Action>;
   tags: string | null;
   version?: number;
+  historicalVersion?: boolean;
   iconId?: string;
   newBase64Image?: string;
   image?: string;
@@ -101,13 +102,14 @@ export default class InstrumentTemplateModel
       supportsBatchEditing: override,
       showNewlyCreatedRecordSearchParams: override,
       fieldNamesInUse: override,
+      globalIdOfLatest: computed,
     });
 
     if (this.recordType === "instrumentTemplate") this.populateFromJson(factory, params, {});
 
     this.search = new Search({
       fetcherParams: {
-        parentGlobalId: this.globalId,
+        parentGlobalId: this.globalIdOfLatest,
         resultType: "INSTRUMENT",
       },
       uiConfig: {
@@ -125,6 +127,11 @@ export default class InstrumentTemplateModel
 
   get cardTypeLabel(): string {
     return inventoryRecordTypeLabels.instrumentTemplate;
+  }
+
+  get globalIdOfLatest(): GlobalId | null {
+    if (!this.id) return null;
+    return `NT${this.id}`;
   }
 
   get recordTypeLabel(): string {
@@ -253,7 +260,7 @@ export default class InstrumentTemplateModel
   private async setActiveResultToLatest(): Promise<InstrumentTemplateModel> {
     const id = this.id;
     if (!id) throw new Error("id is required.");
-    const latest = await getRootStore().searchStore.getInstrumentTemplate(id, this.factory.newFactory());
+    const latest = await getRootStore().searchStore.getInstrumentTemplate(id, null, this.factory.newFactory());
     await mainSearch().setActiveResult(latest);
     mainSearch().replaceResult(latest);
     return latest;

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/fetchAdditionalInfo.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/fetchAdditionalInfo.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import InvApiService from "../../../../common/InvApiService";
-import { instrumentTemplateAttrs } from "../InstrumentTemplateModel/mocking";
+import { makeMockInstrumentTemplate } from "../InstrumentTemplateModel/mocking";
 import { instrumentAttrs, makeMockInstrument } from "./mocking";
 
 const mockRootStore = {
@@ -9,6 +9,9 @@ const mockRootStore = {
   },
   uiStore: {
     addAlert: vi.fn(),
+  },
+  searchStore: {
+    getInstrumentTemplate: vi.fn(),
   },
 };
 
@@ -42,7 +45,7 @@ describe("InstrumentModel.fetchAdditionalInfo", () => {
 
   test("fetches and sets the template when templateId is present", async () => {
     const instrument = makeMockInstrument({ id: 1, templateId: 10 });
-    const templateData = instrumentTemplateAttrs({ id: 10, globalId: "NT10" });
+    const template = makeMockInstrumentTemplate({ id: 10, globalId: "NT10" });
 
     vi.spyOn(InvApiService, "query").mockResolvedValue({
       data: instrumentAttrs({ templateId: 10 }),
@@ -52,18 +55,49 @@ describe("InstrumentModel.fetchAdditionalInfo", () => {
       // biome-ignore lint/suspicious/noExplicitAny: test setup
       config: {} as any,
     });
-    vi.spyOn(InvApiService, "get").mockResolvedValue({
-      data: templateData,
+    mockRootStore.searchStore.getInstrumentTemplate.mockResolvedValue(template);
+
+    await instrument.fetchAdditionalInfo();
+    expect(instrument.template).not.toBeNull();
+    expect(instrument.template?.id).toBe(10);
+  });
+
+  test("pins the template fetch to templateVersion when set", async () => {
+    const instrument = makeMockInstrument({ id: 1, templateId: 10, templateVersion: 3 });
+    const template = makeMockInstrumentTemplate({ id: 10, globalId: "NT10" });
+
+    vi.spyOn(InvApiService, "query").mockResolvedValue({
+      data: instrumentAttrs({ templateId: 10, templateVersion: 3 }),
       status: 200,
       statusText: "OK",
       headers: {},
       // biome-ignore lint/suspicious/noExplicitAny: test setup
       config: {} as any,
     });
+    mockRootStore.searchStore.getInstrumentTemplate.mockResolvedValue(template);
 
     await instrument.fetchAdditionalInfo();
-    expect(instrument.template).not.toBeNull();
-    expect(instrument.template?.id).toBe(10);
+
+    expect(mockRootStore.searchStore.getInstrumentTemplate).toHaveBeenCalledWith(10, 3, expect.anything());
+  });
+
+  test("fetches the live template when templateVersion is null", async () => {
+    const instrument = makeMockInstrument({ id: 1, templateId: 10, templateVersion: null });
+    const template = makeMockInstrumentTemplate({ id: 10, globalId: "NT10" });
+
+    vi.spyOn(InvApiService, "query").mockResolvedValue({
+      data: instrumentAttrs({ templateId: 10, templateVersion: null }),
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      // biome-ignore lint/suspicious/noExplicitAny: test setup
+      config: {} as any,
+    });
+    mockRootStore.searchStore.getInstrumentTemplate.mockResolvedValue(template);
+
+    await instrument.fetchAdditionalInfo();
+
+    expect(mockRootStore.searchStore.getInstrumentTemplate).toHaveBeenCalledWith(10, null, expect.anything());
   });
 
   test("tracks an inventory access event", async () => {

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/historicalVersion.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/historicalVersion.test.ts
@@ -1,0 +1,100 @@
+import type { MockInstance } from "@vitest/spy";
+import { describe, expect, test, vi } from "vitest";
+import InvApiService from "../../../../common/InvApiService";
+import { GeneratedBarcode } from "../../Barcode";
+import { instrumentAttrs, makeMockInstrument } from "./mocking";
+
+vi.mock("../../../../common/InvApiService", () => ({
+  default: {
+    query: vi.fn(() => ({})),
+    get: vi.fn(() => ({})),
+  },
+}));
+vi.mock("../../../../stores/stores/getRootStore", () => ({
+  default: () => ({
+    uiStore: {
+      addAlert: () => {},
+      setPageNavigationConfirmation: () => {},
+      setDirty: () => {},
+    },
+    trackingStore: {
+      trackEvent: () => {},
+    },
+    unitStore: {
+      getUnit: () => ({ label: "ml" }),
+    },
+  }),
+}));
+
+describe("InstrumentModel historical version handling", () => {
+  test("populateFromJson reads version and historicalVersion", () => {
+    const instrument = makeMockInstrument({
+      version: 2,
+      historicalVersion: true,
+    });
+    expect(instrument.version).toBe(2);
+    expect(instrument.historicalVersion).toBe(true);
+  });
+
+  test("records default to non-historical", () => {
+    const instrument = makeMockInstrument();
+    expect(instrument.historicalVersion).toBe(false);
+  });
+
+  test("fetchAdditionalInfo fetches the versioned snapshot for a historical record", async () => {
+    const instrument = makeMockInstrument({
+      version: 2,
+      historicalVersion: true,
+      templateId: null,
+    });
+    const querySpy = (vi.spyOn(InvApiService, "query") as MockInstance).mockImplementation(() =>
+      Promise.resolve({
+        data: instrumentAttrs({ version: 2, historicalVersion: true, templateId: null }),
+      } as never),
+    );
+
+    await instrument.fetchAdditionalInfo();
+
+    expect(querySpy).toHaveBeenCalledWith("instruments/1/versions/2", expect.anything());
+  });
+
+  test("fetchAdditionalInfo fetches the live record when not historical", async () => {
+    const instrument = makeMockInstrument({ templateId: null });
+    const querySpy = (vi.spyOn(InvApiService, "query") as MockInstance).mockImplementation(() =>
+      Promise.resolve({
+        data: instrumentAttrs({ templateId: null }),
+      } as never),
+    );
+
+    await instrument.fetchAdditionalInfo();
+
+    expect(querySpy).toHaveBeenCalledWith("instruments/1", expect.anything());
+  });
+
+  test("setEditing(true) is refused for a historical record", async () => {
+    const instrument = makeMockInstrument({
+      version: 2,
+      historicalVersion: true,
+    });
+    const checkLockSpy = vi.spyOn(instrument, "checkLock");
+
+    expect(await instrument.setEditing(true)).toBe("CANNOT_LOCK");
+
+    expect(checkLockSpy).not.toHaveBeenCalled();
+    expect(instrument.editing).toBe(false);
+  });
+
+  test("generated barcode always encodes the live record, never a version", () => {
+    const instrument = makeMockInstrument({
+      version: 2,
+      historicalVersion: true,
+    });
+
+    const generated = instrument.barcodes[0];
+    if (!(generated instanceof GeneratedBarcode)) throw new Error("expected a generated barcode");
+
+    expect(generated.data).toMatch(/\/inventory\/instrument\/1$/);
+    expect(generated.data).not.toContain("version=");
+    expect(instrument.permalinkURL).toBe("/inventory/instrument/1?version=2");
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/permalinkURL.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/permalinkURL.test.ts
@@ -19,4 +19,17 @@ describe("InstrumentModel.permalinkURL", () => {
     const instrument = makeMockInstrument({ id: 1, globalId: "IN1" });
     expect(instrument.permalinkURL).not.toBeNull();
   });
+
+  test("carries the version for a historical record", () => {
+    const instrument = makeMockInstrument({
+      version: 2,
+      historicalVersion: true,
+    });
+    expect(instrument.permalinkURL).toBe("/inventory/instrument/1?version=2");
+  });
+
+  test("is unversioned for a live record", () => {
+    const instrument = makeMockInstrument({ version: 3 });
+    expect(instrument.permalinkURL).toBe("/inventory/instrument/1");
+  });
 });

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentTemplateModel/globalIdOfLatest.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentTemplateModel/globalIdOfLatest.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { makeMockInstrumentTemplate } from "./mocking";
+
+describe("InstrumentTemplateModel.globalIdOfLatest", () => {
+  test("returns the unversioned global id even when globalId carries a version", () => {
+    const template = makeMockInstrumentTemplate({ id: 7, globalId: "NT7v2" });
+    expect(template.globalIdOfLatest).toBe("NT7");
+  });
+
+  test("is null when the template has not yet been saved", () => {
+    const template = makeMockInstrumentTemplate({ id: null, globalId: null });
+    expect(template.globalIdOfLatest).toBeNull();
+  });
+
+  test("the nested instruments search uses the unversioned parentGlobalId on a historical instance", () => {
+    const template = makeMockInstrumentTemplate({
+      id: 7,
+      globalId: "NT7v2",
+      version: 2,
+      historicalVersion: true,
+    });
+    expect(template.search.staticFetcher.parentGlobalId).toBe("NT7");
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentTemplateModel/historicalVersion.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentTemplateModel/historicalVersion.test.ts
@@ -1,0 +1,99 @@
+import type { MockInstance } from "@vitest/spy";
+import { describe, expect, test, vi } from "vitest";
+import InvApiService from "../../../../common/InvApiService";
+import { GeneratedBarcode } from "../../Barcode";
+import { instrumentTemplateAttrs, makeMockInstrumentTemplate } from "./mocking";
+
+vi.mock("../../../../common/InvApiService", () => ({
+  default: {
+    query: vi.fn(() => ({})),
+    get: vi.fn(() => ({})),
+  },
+}));
+vi.mock("../../../../stores/stores/getRootStore", () => ({
+  default: () => ({
+    uiStore: {
+      addAlert: () => {},
+      setPageNavigationConfirmation: () => {},
+      setDirty: () => {},
+    },
+    trackingStore: {
+      trackEvent: () => {},
+    },
+    unitStore: {
+      getUnit: () => ({ label: "ml" }),
+    },
+  }),
+}));
+
+describe("InstrumentTemplateModel historical version handling", () => {
+  test("populateFromJson reads version and historicalVersion", () => {
+    const template = makeMockInstrumentTemplate({
+      version: 2,
+      historicalVersion: true,
+    });
+    expect(template.version).toBe(2);
+    expect(template.historicalVersion).toBe(true);
+  });
+
+  test("records default to non-historical", () => {
+    const template = makeMockInstrumentTemplate();
+    expect(template.historicalVersion).toBe(false);
+  });
+
+  test("fetchAdditionalInfo fetches the versioned snapshot for a historical record", async () => {
+    const template = makeMockInstrumentTemplate({
+      version: 2,
+      historicalVersion: true,
+    });
+    const querySpy = (vi.spyOn(InvApiService, "query") as MockInstance).mockImplementation(() =>
+      Promise.resolve({
+        data: instrumentTemplateAttrs({ version: 2, historicalVersion: true }),
+      } as never),
+    );
+
+    await template.fetchAdditionalInfo();
+
+    expect(querySpy).toHaveBeenCalledWith("instrumentTemplates/1/versions/2", expect.anything());
+  });
+
+  test("fetchAdditionalInfo fetches the live record when not historical", async () => {
+    const template = makeMockInstrumentTemplate();
+    const querySpy = (vi.spyOn(InvApiService, "query") as MockInstance).mockImplementation(() =>
+      Promise.resolve({
+        data: instrumentTemplateAttrs(),
+      } as never),
+    );
+
+    await template.fetchAdditionalInfo();
+
+    expect(querySpy).toHaveBeenCalledWith("instrumentTemplates/1", expect.anything());
+  });
+
+  test("setEditing(true) is refused for a historical record", async () => {
+    const template = makeMockInstrumentTemplate({
+      version: 2,
+      historicalVersion: true,
+    });
+    const checkLockSpy = vi.spyOn(template, "checkLock");
+
+    expect(await template.setEditing(true)).toBe("CANNOT_LOCK");
+
+    expect(checkLockSpy).not.toHaveBeenCalled();
+    expect(template.editing).toBe(false);
+  });
+
+  test("generated barcode always encodes the live record, never a version", () => {
+    const template = makeMockInstrumentTemplate({
+      version: 2,
+      historicalVersion: true,
+    });
+
+    const generated = template.barcodes[0];
+    if (!(generated instanceof GeneratedBarcode)) throw new Error("expected a generated barcode");
+
+    expect(generated.data).toMatch(/\/inventory\/instrumenttemplate\/1$/);
+    expect(generated.data).not.toContain("version=");
+    expect(template.permalinkURL).toBe("/inventory/instrumenttemplate/1?version=2");
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentTemplateModel/permalinkURL.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentTemplateModel/permalinkURL.test.ts
@@ -19,4 +19,17 @@ describe("InstrumentTemplateModel.permalinkURL", () => {
     const template = makeMockInstrumentTemplate({ id: 1, globalId: "NT1" });
     expect(template.permalinkURL).not.toBeNull();
   });
+
+  test("carries the version for a historical record", () => {
+    const template = makeMockInstrumentTemplate({
+      version: 2,
+      historicalVersion: true,
+    });
+    expect(template.permalinkURL).toBe("/inventory/instrumenttemplate/1?version=2");
+  });
+
+  test("is unversioned for a live record", () => {
+    const template = makeMockInstrumentTemplate({ version: 3 });
+    expect(template.permalinkURL).toBe("/inventory/instrumenttemplate/1");
+  });
 });

--- a/src/main/webapp/ui/src/stores/stores/SearchStore.tsx
+++ b/src/main/webapp/ui/src/stores/stores/SearchStore.tsx
@@ -443,8 +443,15 @@ export default class SearchStore {
     return new TemplateModel(factory, data);
   }
 
-  async getInstrumentTemplate(id: number, factory: Factory): Promise<InstrumentTemplateModel> {
-    const { data } = await ApiService.get<InstrumentTemplateAttrs>("instrumentTemplates", `${id}`);
+  async getInstrumentTemplate(
+    id: number,
+    version: number | null | undefined,
+    factory: Factory,
+  ): Promise<InstrumentTemplateModel> {
+    const { data } = await ApiService.get<InstrumentTemplateAttrs>(
+      "instrumentTemplates",
+      typeof version === "number" ? `${id}/versions/${version}` : `${id}`,
+    );
     return new InstrumentTemplateModel(factory, data);
   }
 

--- a/src/main/webapp/ui/src/stores/stores/__tests__/SearchStore/getInstrumentTemplate.test.ts
+++ b/src/main/webapp/ui/src/stores/stores/__tests__/SearchStore/getInstrumentTemplate.test.ts
@@ -1,0 +1,40 @@
+import "@/stores/stores/RootStore";
+import { describe, expect, test, vi } from "vitest";
+import ApiService from "../../../../common/InvApiService";
+import { instrumentTemplateAttrs } from "../../../models/__tests__/InstrumentTemplateModel/mocking";
+import AlwaysNewFactory from "../../../models/Factory/AlwaysNewFactory";
+import getRootStore from "../../getRootStore";
+
+describe("method: getInstrumentTemplate", () => {
+  test("fetches the plain endpoint when no version is given", async () => {
+    const { searchStore } = getRootStore();
+    const spy = vi.spyOn(ApiService, "get").mockResolvedValue({
+      data: instrumentTemplateAttrs({ id: 10 }),
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      // biome-ignore lint/suspicious/noExplicitAny: test setup
+      config: {} as any,
+    });
+
+    await searchStore.getInstrumentTemplate(10, null, new AlwaysNewFactory());
+
+    expect(spy).toHaveBeenCalledWith("instrumentTemplates", "10");
+  });
+
+  test("fetches the versioned endpoint when a version is given", async () => {
+    const { searchStore } = getRootStore();
+    const spy = vi.spyOn(ApiService, "get").mockResolvedValue({
+      data: instrumentTemplateAttrs({ id: 10, version: 3, historicalVersion: true }),
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      // biome-ignore lint/suspicious/noExplicitAny: test setup
+      config: {} as any,
+    });
+
+    await searchStore.getInstrumentTemplate(10, 3, new AlwaysNewFactory());
+
+    expect(spy).toHaveBeenCalledWith("instrumentTemplates", "10/versions/3");
+  });
+});

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatesRevisionsEndpointTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatesRevisionsEndpointTest.java
@@ -1,0 +1,66 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import com.researchspace.service.MessageSourceUtils;
+import com.researchspace.service.inventory.InstrumentEntityApiManager;
+import com.researchspace.service.inventory.InventoryAuditApiManager;
+import com.researchspace.testutils.TestFactory;
+import javax.ws.rs.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Fast unit tests for the contract of the instrument template revisions listing endpoint. Populated
+ * revision lists (with links) are covered by the MVC ITs.
+ */
+public class InstrumentTemplatesRevisionsEndpointTest {
+
+  private final InventoryAuditApiManager auditMgr = mock(InventoryAuditApiManager.class);
+  private final InstrumentEntityApiManager instrumentMgr = mock(InstrumentEntityApiManager.class);
+  private final MessageSourceUtils messages = mock(MessageSourceUtils.class);
+
+  private final User user = TestFactory.createAnyUser("templateRevisionsUser");
+
+  private InstrumentTemplatesApiController controller;
+
+  @BeforeEach
+  public void setUp() {
+    controller = new InstrumentTemplatesApiController();
+    ReflectionTestUtils.setField(controller, "instrumentApiMgr", instrumentMgr);
+    ReflectionTestUtils.setField(controller, "inventoryAuditMgr", auditMgr);
+    ReflectionTestUtils.setField(controller, "messages", messages);
+    lenient()
+        .when(messages.getResourceNotFoundMessage(anyString(), anyLong()))
+        .thenReturn("not found");
+  }
+
+  @Test
+  public void templateRevisionsEndpointReturnsRevisionListForTemplate() {
+    InstrumentTemplate template = new InstrumentTemplate();
+    when(instrumentMgr.assertUserCanReadInstrumentTemplate(1L, user)).thenReturn(template);
+    ApiInventoryRecordRevisionList revisions = new ApiInventoryRecordRevisionList();
+    when(auditMgr.getInventoryRecordRevisions(template)).thenReturn(revisions);
+
+    assertSame(revisions, controller.getInstrumentTemplateAllRevisions(1L, user));
+  }
+
+  @Test
+  public void templateRevisionsEndpointThrows404ForNonTemplateId() {
+    when(instrumentMgr.assertUserCanReadInstrumentTemplate(1L, user))
+        .thenThrow(new NotFoundException("No instrument template with id: 1"));
+
+    assertThrows(
+        NotFoundException.class, () -> controller.getInstrumentTemplateAllRevisions(1L, user));
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryVersionEndpointsNotFoundTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryVersionEndpointsNotFoundTest.java
@@ -144,6 +144,15 @@ public class InventoryVersionEndpointsNotFoundTest {
         NotFoundException.class, () -> controller.getSampleTemplateVersionById(1L, 9L, user));
   }
 
+  @Test
+  public void instrumentTemplateVersionEndpointThrows404ForMissingVersion() {
+    InstrumentTemplatesApiController controller = wireBase(new InstrumentTemplatesApiController());
+    when(instrumentMgr.getApiInstrumentTemplateVersion(1L, 9L, user)).thenReturn(null);
+
+    assertThrows(
+        NotFoundException.class, () -> controller.getInstrumentTemplateVersionById(1L, 9L, user));
+  }
+
   private InstrumentsApiController wiredInstrumentsController() {
     return wire(new InstrumentsApiController());
   }

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryVersionsApiMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryVersionsApiMVCIT.java
@@ -7,7 +7,10 @@ import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.researchspace.api.v1.model.ApiContainer;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
 import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.api.v1.model.ApiLinkItem;
@@ -513,6 +516,66 @@ public class InventoryVersionsApiMVCIT extends API_MVC_InventoryTestBase {
                 API_VERSION.ONE,
                 apiKey,
                 "/sampleTemplates/" + plainSample.getId() + "/revisions",
+                anyUser))
+        .andExpect(status().isNotFound())
+        .andReturn();
+  }
+
+  @Test
+  public void instrumentTemplateRevisionsListing() throws Exception {
+    User anyUser = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(anyUser);
+
+    // create an instrument template, then update it to bump it to version 2
+    ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
+    templatePost.setName("instrument template version one");
+    templatePost.getFields().add(createBasicApiSampleField("F1", ApiFieldType.TEXT, "default"));
+    MvcResult result =
+        this.mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(
+                    apiKey, "/instrumentTemplates", anyUser, templatePost))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn();
+    ApiInstrumentTemplate template = getFromJsonResponseBody(result, ApiInstrumentTemplate.class);
+
+    this.mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(
+                apiKey,
+                "/instrumentTemplates/" + template.getId(),
+                anyUser,
+                "{ \"name\": \"instrument template version two\" }"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // both versions appear in the revisions history, oldest first
+    result =
+        this.mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE,
+                    apiKey,
+                    "/instrumentTemplates/" + template.getId() + "/revisions",
+                    anyUser))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiInventoryRecordRevisionList history =
+        getFromJsonResponseBody(result, ApiInventoryRecordRevisionList.class);
+    assertEquals(2, history.getRevisions().size());
+    assertEquals(
+        "instrument template version one", history.getRevisions().get(0).getRecord().getName());
+    assertEquals(
+        "instrument template version two", history.getRevisions().get(1).getRecord().getName());
+
+    // a plain sample id is not addressable through the instrument template revisions endpoint
+    ApiSampleWithFullSubSamples plainSample = createBasicSampleForUser(anyUser, "not a template");
+    this.mockMvc
+        .perform(
+            createBuilderForGet(
+                API_VERSION.ONE,
+                apiKey,
+                "/instrumentTemplates/" + plainSample.getId() + "/revisions",
                 anyUser))
         .andExpect(status().isNotFound())
         .andReturn();

--- a/src/test/java/com/researchspace/webapp/controller/GlobalLookupControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/GlobalLookupControllerMVCIT.java
@@ -76,6 +76,12 @@ public class GlobalLookupControllerMVCIT extends MVCTestBase {
     GlobalIdentifier conGid = new GlobalIdentifier(GlobalIdPrefix.IC, 12345L);
     assertRedirect(conGid, "/inventory/container");
 
+    GlobalIdentifier inGid = new GlobalIdentifier(GlobalIdPrefix.IN, 12345L);
+    assertRedirect(inGid, "/inventory/instrument");
+
+    GlobalIdentifier ntGid = new GlobalIdentifier(GlobalIdPrefix.NT, 12345L);
+    assertRedirect(ntGid, "/inventory/instrumenttemplate");
+
     // version-suffixed inventory global ids open the read-only versioned viewer (RSDEV-1141)
     GlobalIdentifier saVersionGid = new GlobalIdentifier(GlobalIdPrefix.SA, 12345L, 2L);
     assertRedirect(saVersionGid, "/inventory/sample/12345?version=2");
@@ -88,6 +94,13 @@ public class GlobalLookupControllerMVCIT extends MVCTestBase {
 
     GlobalIdentifier icVersionGid = new GlobalIdentifier(GlobalIdPrefix.IC, 12345L, 1L);
     assertRedirect(icVersionGid, "/inventory/container/12345?version=1");
+
+    // version-suffixed instrument/instrument-template global ids (RSDEV-1171)
+    GlobalIdentifier inVersionGid = new GlobalIdentifier(GlobalIdPrefix.IN, 12345L, 1L);
+    assertRedirect(inVersionGid, "/inventory/instrument/12345?version=1");
+
+    GlobalIdentifier ntVersionGid = new GlobalIdentifier(GlobalIdPrefix.NT, 12345L, 2L);
+    assertRedirect(ntVersionGid, "/inventory/instrumenttemplate/12345?version=2");
 
     GlobalIdentifier groupId = new GlobalIdentifier(GlobalIdPrefix.GP, 12345L);
     assertRedirect(groupId, "/groups/view");

--- a/src/test/java/com/researchspace/webapp/controller/GlobalLookupControllerRedirectTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/GlobalLookupControllerRedirectTest.java
@@ -1,7 +1,6 @@
 package com.researchspace.webapp.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,8 +49,14 @@ public class GlobalLookupControllerRedirectTest {
   }
 
   @Test
-  public void versionedInstrumentRemainsUnsupported() {
-    assertThrows(UnsupportedOperationException.class, () -> controller.globalIdLookUp("IN7v1"));
+  public void versionedInstrumentRedirectsToVersionedViewer() {
+    assertEquals("redirect:/inventory/instrument/7?version=1", controller.globalIdLookUp("IN7v1"));
+  }
+
+  @Test
+  public void versionedInstrumentTemplateRedirectsToVersionedViewer() {
+    assertEquals(
+        "redirect:/inventory/instrumenttemplate/7?version=2", controller.globalIdLookUp("NT7v2"));
   }
 
   @Test


### PR DESCRIPTION
## Description ##

Adds version/revision history for Inventory **Instruments** (global-ID prefix `IN`)
and **Instrument Templates** (prefix `NT`), closing the parity gap left by
RSDEV-1141 (#831), which gave samples, subsamples, containers, and sample templates
a "View version history" dialog in the MoreInfoSidebar plus a read-only
versioned-permalink viewer. Instruments and instrument templates were excluded then
only because they had no React Inventory UI yet; that UI has since shipped.

User-visible changes:
- Both record types now offer "View version history" in the MoreInfoSidebar; each
  row links to the read-only versioned viewer.
- Version-suffixed global IDs (`IN42v2`, `NT7v2`) now open the versioned viewer via
  `/globalId/...` instead of throwing `UnsupportedOperationException` (instruments)
  or crashing the model factory (versioned API payloads carried `IN4v1`-style IDs
  that matched no pattern).
- Viewing a historical version shows the sticky historical-version alert, refuses
  editing, and keeps barcodes encoding the live record URL, all consistent with the
  RSDEV-1141 behaviour.

Note on the branch name: the work is on `RSDEV-1189-link-instruments` because
RSDEV-1171 is a sub-task of RSDEV-1240 and blocks RSDEV-1189, which continues on
this branch.

### Backend changes ###
- New `GET /api/inventory/v1/instrumentTemplates/{id}/revisions` endpoint
  (`InstrumentTemplatesApi` + controller), mirroring the sample-templates one. It
  reuses the generic `InventoryAuditApiManager.getInventoryRecordRevisions()`, so
  there are no service, DAO, or DTO changes. The instrument endpoints
  (`/revisions`, `/revisions/{revisionId}`, `/versions/{version}`) already existed.
- Contract fix: `GET /instrumentTemplates/{id}/versions/{version}` now returns 404
  for a missing version instead of HTTP 200 with a null body.
- `GlobalLookupController`: `IN` and `NT` added to the versioned-prefix set, so
  `/globalId/IN42v2` redirects to `/inventory/instrument/42?version=2` (and
  `NT7v2` to `/inventory/instrumenttemplate/7?version=2`).

### Swagger changes ###
- `rspace_api_inventory_specs_2_24_0.yaml`: documents the new
  `/instrumentTemplates/{instrumentTemplateId}/revisions` path.

### Frontend changes ###
- `MoreInfoSidebar/VersionHistory.tsx` treats `instrument` and
  `instrumentTemplate` as supported record types.
- `globalIdDefinitions.instrument` now accepts an optional version suffix
  (`IN4v1`), so the model factory can instantiate versioned API responses
  (`instrumentTemplate` already accepted one).
- `Instrument/Form.tsx` and `InstrumentTemplate/Form.tsx` render the sticky
  `HistoricalVersionAlert` when showing a historical version.
- `InstrumentModel` / `InstrumentTemplateModel` read `version` and
  `historicalVersion` from the API payload; the versioned fetch
  (`/{type}s/{id}/versions/{v}`), edit refusal, versioned `permalinkURL`, and
  live-URL barcodes are inherited from `InventoryBaseRecord`.
- New `InstrumentTemplateModel.globalIdOfLatest` computed (`NT{id}` without the
  version suffix). The nested instruments search and the template's
  `InstrumentsList` use it as `parentGlobalId`, so a historical template still
  lists the instruments of the live template.
- `SearchStore.getInstrumentTemplate(id, version, factory)` hits the versioned
  endpoint when a version is given; `InstrumentModel.fetchAdditionalInfo()` pins
  the template fetch to the instrument's `templateVersion`.

## Jira ticket ##
https://researchspace.atlassian.net/browse/RSDEV-1171

## Design decisions ##
- Mirror the RSDEV-1141 patterns exactly rather than inventing new ones: the
  revisions endpoint copies the sample-templates controller shape, and the
  frontend reuses the versioned-viewer machinery inherited from
  `InventoryBaseRecord`, keeping the diff small.
- No audit-layer changes: `InventoryAuditApiManager.getInventoryRecordRevisions()`
  is generic over the runtime class and already handles `InstrumentTemplate`.
- A historical template's nested instruments search deliberately targets the live
  template (`NT7`, not `NT7v2`): the instrument-to-template link is not versioned,
  and the parent-global-id search does not understand versioned IDs.
- Barcodes always encode the live record URL, never a versioned one, matching the
  RSDEV-1141 decision that a physical label should not pin a snapshot.

## Testing notes ##

### Automatic tests  ###

- No database changes (no Liquibase changesets).
- Backend fast unit tests:
  `mvn test -Dfast=true -Dtest=InstrumentTemplatesRevisionsEndpointTest,GlobalLookupControllerRedirectTest,InventoryVersionEndpointsNotFoundTest`.
- MVC/IT coverage added (`InventoryVersionsApiMVCIT#instrumentTemplateRevisionsListing`,
  `GlobalLookupControllerMVCIT` redirects for `IN`/`NT`, versioned and plain);
  runs under `mvn verify -Denvironment=drop-recreate-db`.
- Frontend: `pnpm run tsc`, `pnpm run lint`, and targeted Vitest files:
  - `src/Inventory/components/MoreInfoSidebar/__tests__/VersionHistory.test.tsx`
  - `src/Inventory/__tests__/historicalVersionForm.test.tsx`
  - `src/Inventory/__tests__/PermalinkRouter.test.tsx`
  - `src/stores/models/__tests__/InstrumentModel/*.test.ts`
  - `src/stores/models/__tests__/InstrumentTemplateModel/*.test.ts`
  - `src/stores/stores/__tests__/SearchStore/getInstrumentTemplate.test.ts`
  - `src/stores/models/Factory/__tests__/AlwaysNewFactory.test.ts`

### Manual test scenario (Inventory UI) ###
**AWS instance**: https://rsdev-1189-link-instruments-4d430bb1-2.researchspace.com

- Create an Instrument or Instrument Template
- Edit the name and save
- Click on the INFO button at the top/left of the inventory item

VERIFY THAT
- A vertical side bar is shown, displaying the version number together with the
  "View version history" button
- Clicking "View version history" opens the dialog and both versions are present
