### PR TITLE
Extract drive-by cleanups from the backend i18n branch

### DIFF
--- a/src/main/java/com/researchspace/api/v1/controller/SysadminApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SysadminApiController.java
@@ -510,7 +510,7 @@ public class SysadminApiController extends BaseApiController implements Sysadmin
 
   private String combineUsersByRole(List<UserGroupPost> users, RoleInGroup role) {
     return users.stream()
-        .filter(user -> user.roleInGroup.equals(role.name()))
+        .filter(user -> user.getRoleInGroup().equals(role.name()))
         .map(UserGroupPost::getUsername)
         .collect(Collectors.joining(","));
   }

--- a/src/main/java/com/researchspace/api/v1/controller/SysadminApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SysadminApiController.java
@@ -510,7 +510,7 @@ public class SysadminApiController extends BaseApiController implements Sysadmin
 
   private String combineUsersByRole(List<UserGroupPost> users, RoleInGroup role) {
     return users.stream()
-        .filter(user -> user.getRoleInGroup().equals(role.name()))
+        .filter(user -> role.name().equals(user.getRoleInGroup()))
         .map(UserGroupPost::getUsername)
         .collect(Collectors.joining(","));
   }

--- a/src/main/java/com/researchspace/export/pdf/CommentAppendix.java
+++ b/src/main/java/com/researchspace/export/pdf/CommentAppendix.java
@@ -34,18 +34,6 @@ public class CommentAppendix {
     return itemContents.get(idx);
   }
 
-  public void setItemName(String lst) {
-    itemNames.add(lst);
-  }
-
-  public void setItemDate(String lst) {
-    itemDates.add(lst);
-  }
-
-  public void setItemContent(String lst) {
-    itemContents.add(lst);
-  }
-
   public int getSize() {
     return itemNames.size();
   }

--- a/src/main/webapp/WEB-INF/pages/admin/admin.jsp
+++ b/src/main/webapp/WEB-INF/pages/admin/admin.jsp
@@ -127,7 +127,7 @@
         <c:if test="${fn:startsWith(pageContext.request.servletPath, '/WEB-INF/pages/groups/sharing') && !publishedLinks_for_user_to_see && !publishedLinks_for_sysadmin_to_manage}"> currentPanel</c:if>">
         <a id="sharedDocumentsLink" href="/record/share/manage">
           <fmt:message key="menu.admin.listrecordsharing"/><br>
-          <img src="/images/icons/manageShared.png" class="menuInnerPanelIcon" style="max-height: 80px">
+          <img src="/images/icons/manageShared.png" class="menuInnerPanelIcon">
         </a>
       </li>
       <shiro:hasAnyRoles name="ROLE_PI,ROLE_USER">

--- a/src/main/webapp/WEB-INF/pages/admin/admin.jsp
+++ b/src/main/webapp/WEB-INF/pages/admin/admin.jsp
@@ -127,7 +127,7 @@
         <c:if test="${fn:startsWith(pageContext.request.servletPath, '/WEB-INF/pages/groups/sharing') && !publishedLinks_for_user_to_see && !publishedLinks_for_sysadmin_to_manage}"> currentPanel</c:if>">
         <a id="sharedDocumentsLink" href="/record/share/manage">
           <fmt:message key="menu.admin.listrecordsharing"/><br>
-          <img src="/images/icons/manageShared.png" class="menuInnerPanelIcon">
+          <img src="/images/icons/manageShared.png" class="menuInnerPanelIcon" style="max-height: 80px">
         </a>
       </li>
       <shiro:hasAnyRoles name="ROLE_PI,ROLE_USER">

--- a/src/main/webapp/styles/admin.css
+++ b/src/main/webapp/styles/admin.css
@@ -16,6 +16,9 @@
   width: 100%;
   object-fit: contain; }
 
+#sharedDocumentsLink .menuInnerPanelIcon {
+  max-height: 80px; }
+
 .menuInnerPanelIconNew {
   display: block;
   margin: 4px auto 0;

--- a/src/test/java/com/researchspace/webapp/controller/UserProfileControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/UserProfileControllerMVCIT.java
@@ -280,11 +280,10 @@ public class UserProfileControllerMVCIT extends MVCTestBase {
             .andExpect(status().isOk())
             .andReturn();
 
+    String result2Response = result2.getResponse().getContentAsString();
     assertTrue(
-        result2
-            .getResponse()
-            .getContentAsString()
-            .contains(getMsgFromResourceBundler("errors.invalidpwd").substring(0, 10)));
+        "unexpected: " + result2Response,
+        result2Response.contains(getMsgFromResourceBundler("errors.invalidpwd").substring(0, 10)));
 
     String newPassword3 = RandomStringUtils.randomAlphanumeric(10);
     MvcResult result3 =


### PR DESCRIPTION
## Description ##
Non-i18n tidy-ups that had accumulated inside the backend phrases branch, moved here so that branch stays scoped to localization:

- SysadminApiController: use the Lombok getter instead of direct field access in combineUsersByRole, matching the adjacent call sites
- admin.jsp: cap the manageShared menu icon height at 80px
- CommentAppendix: remove three unused single-element setters
- UserProfileControllerMVCIT: extract a local for the response body and add an assertion failure message
