### PR TITLE
Remove request-timing debug hack from LocaleFilter

### DIFF
--- a/src/main/java/com/researchspace/webapp/filter/LocaleFilter.java
+++ b/src/main/java/com/researchspace/webapp/filter/LocaleFilter.java
@@ -10,12 +10,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.servlet.jsp.jstl.core.Config;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /** Filter to wrap request with a request including user preferred locale. */
-@Slf4j
 public class LocaleFilter extends OncePerRequestFilter {
 
   /**
@@ -33,7 +31,6 @@ public class LocaleFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain chain)
       throws IOException, ServletException {
 
-    long tStart = System.currentTimeMillis();
     String locale = request.getParameter("locale");
     Locale preferredLocale = null;
 
@@ -74,17 +71,5 @@ public class LocaleFilter extends OncePerRequestFilter {
 
     // Reset thread-bound LocaleContext.
     LocaleContextHolder.setLocaleContext(null);
-
-    /* RSDEV-760: LocaleFilter is the first of RSpace filters configured in web.xml, and measuring
-    the request processing time here, rather than e.g. in PerformanceLoggingInterceptor, may
-    sometimes give a better picture. To enable logging just uncomment the line in log4j2.xml */
-    if (log.isDebugEnabled()) {
-      long tEnd = System.currentTimeMillis();
-      String requestUrl = request.getRequestURI();
-      log.debug(
-          "It took [{}] ms to complete request to {} (as measured by LocaleFilter)",
-          tEnd - tStart,
-          requestUrl);
-    }
   }
 }

--- a/src/main/resources/log4j2-dev.xml
+++ b/src/main/resources/log4j2-dev.xml
@@ -85,9 +85,6 @@
       <AppenderRef ref="SlowRequestsLogAppender"/>
     </Logger>
 
-    <!-- for debugging some performance issues, will log request time on filter level (RSDEV-760) -->
-    <!--<Logger name="com.researchspace.webapp.filter.LocaleFilter" level="DEBUG"/>-->
-
     <Logger name="com.researchspace.service.impl.FailedEmailLogger" level="INFO">
       <AppenderRef ref="FailedEmailLogAppender"/>
     </Logger>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -140,9 +140,6 @@
       <AppenderRef ref="SlowRequestsLogAppender"/>
     </Logger>
 
-    <!-- for debugging some performance issues, will log request time on filter level (RSDEV-760) -->
-    <!--<Logger name="com.researchspace.webapp.filter.LocaleFilter" level="DEBUG"/>-->
-
 
     <!-- all appenders need to be registered here so that they can get the root logging
      folder set in at application startup -->


### PR DESCRIPTION
## Description ##
The RSDEV-760 stopwatch measured whole-request time at filter level as a stopgap for cases PerformanceLoggingInterceptor (handler-slice only) could not see. OpenTelemetry is being introduced and its servlet auto-instrumentation covers the full filter chain, so the hack and its commented-out log4j2 toggles can go. Interim coverage remains via the JavaMelody monitoring filter and the slow-request interceptor log.