### PR TITLE
Constructor-inject EmailBroadcastImpl dependencies; rename from EmailBroadcastImp

### DIFF
--- a/DevDocs/public/ExampleStartupLog.txt
+++ b/DevDocs/public/ExampleStartupLog.txt
@@ -69,7 +69,7 @@ INFO 24 Mar 2022 02:10:55,203 - MarkerIgnoringBase.info | Change set classpath:s
           where ug.roleInGroup = 1 and u.id != u2.id and g.groupType = 0]
 INFO 24 Mar 2022 02:10:55,208 - MarkerIgnoringBase.info | Successfully released change log lock
 INFO 24 Mar 2022 02:10:55,334 - LdapConfig.contextSource | creating production LdapContextSource and connecting to ldaps://kudu.researchspace.com - dc=test,dc=kudu,dc=axiope,dc=com
-INFO 24 Mar 2022 02:10:55,539 - EmailBroadcastImp.<init> | Email sender will rate limit to 5 mails per seconds
+INFO 24 Mar 2022 02:10:55,539 - EmailBroadcastImpl.<init> | Email sender will rate limit to 5 mails per seconds
 INFO 24 Mar 2022 02:10:55,770 - ProductionConfig.figshareRepository | Setting figshare categories and licenses from static files, Categories: [${figshare.categories.path}]  Licenses: ${figshare.licenses.path}
 ERROR 24 Mar 2022 02:10:55,771 - ProductionConfig.figshareRepository | Error setting categories and subjects from JSON file: ${figshare.licenses.path}
 INFO 24 Mar 2022 02:10:55,771 - ProductionConfig.figshareRepository | Setting in repository implementation com.researchspace.figshare.rspaceadapter.FigshareRSpaceRepository@193476a8

--- a/src/main/java/com/axiope/service/cfg/BaseConfig.java
+++ b/src/main/java/com/axiope/service/cfg/BaseConfig.java
@@ -181,7 +181,7 @@ import com.researchspace.service.impl.DetailedRecordInformationProviderImpl;
 import com.researchspace.service.impl.DevBroadCaster;
 import com.researchspace.service.impl.DevEmailSenderImpl;
 import com.researchspace.service.impl.DocumentHTMLPreviewHandlerImpl;
-import com.researchspace.service.impl.EmailBroadcastImp;
+import com.researchspace.service.impl.EmailBroadcastImpl;
 import com.researchspace.service.impl.ExampleContentAction;
 import com.researchspace.service.impl.ExportImportImpl;
 import com.researchspace.service.impl.ExportUtils;
@@ -1130,7 +1130,8 @@ public abstract class BaseConfig {
   @Bean
   public EmailBroadcast emailBroadcast() {
     if (Boolean.parseBoolean(emailEnabled)) {
-      return new EmailBroadcastImp(getMaxEmailsPerSecond(), getEmailAddressChunkSize());
+      return new EmailBroadcastImpl(
+          getMaxEmailsPerSecond(), getEmailAddressChunkSize(), strictEmailContentGenerator());
     }
     return new DevEmailSenderImpl();
   }
@@ -1138,7 +1139,8 @@ public abstract class BaseConfig {
   @Bean
   public Broadcaster broadcaster() {
     if (Boolean.parseBoolean(emailEnabled)) {
-      return new EmailBroadcastImp(getMaxEmailsPerSecond(), getEmailAddressChunkSize());
+      return new EmailBroadcastImpl(
+          getMaxEmailsPerSecond(), getEmailAddressChunkSize(), strictEmailContentGenerator());
     } else {
       return new DevBroadCaster();
     }

--- a/src/main/java/com/axiope/userimport/NotifyUserPostUserCreate.java
+++ b/src/main/java/com/axiope/userimport/NotifyUserPostUserCreate.java
@@ -2,7 +2,7 @@ package com.axiope.userimport;
 
 import com.researchspace.model.User;
 import com.researchspace.service.EmailBroadcast;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/com/researchspace/service/EmailBroadcast.java
+++ b/src/main/java/com/researchspace/service/EmailBroadcast.java
@@ -1,7 +1,7 @@
 package com.researchspace.service;
 
 import com.researchspace.model.comms.Communication;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import java.util.List;
 import org.springframework.scheduling.annotation.Async;
 

--- a/src/main/java/com/researchspace/service/cloud/impl/CloudNotificationManagerImpl.java
+++ b/src/main/java/com/researchspace/service/cloud/impl/CloudNotificationManagerImpl.java
@@ -19,7 +19,7 @@ import com.researchspace.service.EmailBroadcast;
 import com.researchspace.service.MessageOrRequestCreatorManager;
 import com.researchspace.service.UserManager;
 import com.researchspace.service.cloud.CloudNotificationManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/com/researchspace/service/cloud/impl/CloudUserManagerImpl.java
+++ b/src/main/java/com/researchspace/service/cloud/impl/CloudUserManagerImpl.java
@@ -12,7 +12,7 @@ import com.researchspace.service.EmailBroadcast;
 import com.researchspace.service.RoleManager;
 import com.researchspace.service.UserManager;
 import com.researchspace.service.cloud.CommunityUserManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/com/researchspace/service/cloud/impl/CommunityPostSignupVerification.java
+++ b/src/main/java/com/researchspace/service/cloud/impl/CommunityPostSignupVerification.java
@@ -8,7 +8,7 @@ import com.researchspace.model.User;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.EmailBroadcast;
 import com.researchspace.service.UserManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/com/researchspace/service/impl/DevEmailSenderImpl.java
+++ b/src/main/java/com/researchspace/service/impl/DevEmailSenderImpl.java
@@ -2,7 +2,7 @@ package com.researchspace.service.impl;
 
 import com.researchspace.model.comms.Communication;
 import com.researchspace.service.EmailBroadcast;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;

--- a/src/main/java/com/researchspace/service/impl/EmailBroadcastImpl.java
+++ b/src/main/java/com/researchspace/service/impl/EmailBroadcastImpl.java
@@ -51,7 +51,6 @@ import org.apache.velocity.tools.generic.DateTool;
 import org.jsoup.helper.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 /**
@@ -71,17 +70,13 @@ import org.springframework.beans.factory.annotation.Value;
  *       <p><b> Implementation notes </b>
  *       <p>TODO this class has too many responsibilities; needs refactoring into separate classes
  */
-public class EmailBroadcastImp implements EmailBroadcast, Broadcaster {
+public class EmailBroadcastImpl implements EmailBroadcast, Broadcaster {
 
   public static final String TEXT_ONLY_EMAIL_DEFAULT = "This email can only be viewed in HTML";
 
-  private @Autowired StrictEmailContentGenerator strictEmailContentGenerator;
+  private final StrictEmailContentGenerator strictEmailContentGenerator;
 
   private int retryDelayMillis = 1000;
-
-  void setStrictEmailContentGenerator(StrictEmailContentGenerator strictEmailContentGenerator) {
-    this.strictEmailContentGenerator = strictEmailContentGenerator;
-  }
 
   void setRetryDelayMillis(int retryDelayMillis) {
     this.retryDelayMillis = retryDelayMillis;
@@ -203,13 +198,17 @@ public class EmailBroadcastImp implements EmailBroadcast, Broadcaster {
     this.addressChunkSize = addressChunkSize;
   }
 
-  public EmailBroadcastImp() {
-    this(5, 25);
+  public EmailBroadcastImpl(StrictEmailContentGenerator strictEmailContentGenerator) {
+    this(5, 25, strictEmailContentGenerator);
   }
 
-  public EmailBroadcastImp(Integer maxEmailsPerSecond, Integer addressChunkSize) {
+  public EmailBroadcastImpl(
+      Integer maxEmailsPerSecond,
+      Integer addressChunkSize,
+      StrictEmailContentGenerator strictEmailContentGenerator) {
     this.maxEmailsPerSecond = maxEmailsPerSecond;
     this.addressChunkSize = addressChunkSize;
+    this.strictEmailContentGenerator = strictEmailContentGenerator;
     log.info("Email sender will rate limit to {} mails per seconds", maxEmailsPerSecond);
   }
 

--- a/src/main/java/com/researchspace/service/impl/StrictEmailContentGenerator.java
+++ b/src/main/java/com/researchspace/service/impl/StrictEmailContentGenerator.java
@@ -2,7 +2,7 @@ package com.researchspace.service.impl;
 
 import static org.apache.commons.lang3.StringUtils.replace;
 
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.velocity.app.VelocityEngine;

--- a/src/main/java/com/researchspace/service/impl/SysadminUserCreationHandlerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SysadminUserCreationHandlerImpl.java
@@ -28,7 +28,7 @@ import com.researchspace.service.IGroupCreationStrategy;
 import com.researchspace.service.SysadminUserCreationHandler;
 import com.researchspace.service.UserExistsException;
 import com.researchspace.service.UserManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.webapp.controller.AjaxReturnObject;
 import com.researchspace.webapp.controller.SysAdminCreateUser;
 import com.researchspace.webapp.filter.RemoteUserRetrievalPolicy;

--- a/src/main/java/com/researchspace/service/impl/UserEnablementUtilsImpl.java
+++ b/src/main/java/com/researchspace/service/impl/UserEnablementUtilsImpl.java
@@ -15,7 +15,7 @@ import com.researchspace.service.LicenseService;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.UserEnablementUtils;
 import com.researchspace.service.UserManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Setter;

--- a/src/main/java/com/researchspace/webapp/controller/PasswordResetByEmailHandlerBase.java
+++ b/src/main/java/com/researchspace/webapp/controller/PasswordResetByEmailHandlerBase.java
@@ -12,7 +12,7 @@ import com.researchspace.model.permissions.SecurityLogger;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.EmailBroadcast;
 import com.researchspace.service.UserManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminController.java
@@ -61,7 +61,7 @@ import com.researchspace.service.UserExistsException;
 import com.researchspace.service.UserRoleHandler;
 import com.researchspace.service.UserStatisticsManager;
 import com.researchspace.service.UserTagManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import com.researchspace.webapp.filter.IUserAccountLockoutPolicy;
 import java.net.URI;

--- a/src/main/java/com/researchspace/webapp/controller/SysAdminSupportController.java
+++ b/src/main/java/com/researchspace/webapp/controller/SysAdminSupportController.java
@@ -7,7 +7,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.field.ErrorList;
 import com.researchspace.service.EmailBroadcast;
 import com.researchspace.service.SystemPropertyPermissionManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import java.io.IOException;
 import java.util.Date;

--- a/src/main/java/com/researchspace/webapp/controller/UserRoleHandlerImpl.java
+++ b/src/main/java/com/researchspace/webapp/controller/UserRoleHandlerImpl.java
@@ -21,7 +21,7 @@ import com.researchspace.service.IGroupCreationStrategy;
 import com.researchspace.service.RoleManager;
 import com.researchspace.service.UserManager;
 import com.researchspace.service.UserRoleHandler;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/researchspace/webapp/controller/UsernameReminderByEmailHandler.java
+++ b/src/main/java/com/researchspace/webapp/controller/UsernameReminderByEmailHandler.java
@@ -7,7 +7,7 @@ import com.researchspace.model.permissions.SecurityLogger;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.EmailBroadcast;
 import com.researchspace.service.UserManager;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;

--- a/src/test/java/com/axiope/service/cfg/EmailBroadcasterConfigTest.java
+++ b/src/test/java/com/axiope/service/cfg/EmailBroadcasterConfigTest.java
@@ -2,7 +2,7 @@ package com.axiope.service.cfg;
 
 import static org.junit.Assert.assertEquals;
 
-import com.researchspace.service.impl.EmailBroadcastImp;
+import com.researchspace.service.impl.EmailBroadcastImpl;
 import com.researchspace.service.impl.StrictEmailContentGenerator;
 import org.apache.velocity.spring.VelocityEngineFactoryBean;
 import org.junit.Test;
@@ -42,10 +42,11 @@ public class EmailBroadcasterConfigTest {
     public EmailConfig() {}
 
     @Bean
-    EmailBroadcastImp emailBroadcastImp() {
+    EmailBroadcastImpl emailBroadcastImpl() {
       Integer millis = env.getProperty("mail.maxEmailsPerSecond", Integer.class);
       Integer addressChunkSize = env.getProperty("mail.addressChunkSize", Integer.class);
-      EmailBroadcastImp rc = new EmailBroadcastImp(millis, addressChunkSize);
+      EmailBroadcastImpl rc =
+          new EmailBroadcastImpl(millis, addressChunkSize, new StrictEmailContentGenerator());
       return rc;
     }
 
@@ -69,7 +70,7 @@ public class EmailBroadcasterConfigTest {
   @ActiveProfiles(profiles = {"emailConfig"})
   @TestPropertySource(properties = {"mail.maxEmailsPerSecond=23", "mail.addressChunkSize=21"})
   public static class TestBase extends AbstractJUnit4SpringContextTests {
-    private @Autowired EmailBroadcastImp emailImpl;
+    private @Autowired EmailBroadcastImpl emailImpl;
 
     @Test
     public void testEmbeddedConfig() {

--- a/src/test/java/com/axiope/service/cfg/EmailBroadcasterConfigTest.java
+++ b/src/test/java/com/axiope/service/cfg/EmailBroadcasterConfigTest.java
@@ -42,12 +42,10 @@ public class EmailBroadcasterConfigTest {
     public EmailConfig() {}
 
     @Bean
-    EmailBroadcastImpl emailBroadcastImpl() {
+    EmailBroadcastImpl emailBroadcastImpl(StrictEmailContentGenerator strictEmailContentGenerator) {
       Integer millis = env.getProperty("mail.maxEmailsPerSecond", Integer.class);
       Integer addressChunkSize = env.getProperty("mail.addressChunkSize", Integer.class);
-      EmailBroadcastImpl rc =
-          new EmailBroadcastImpl(millis, addressChunkSize, new StrictEmailContentGenerator());
-      return rc;
+      return new EmailBroadcastImpl(millis, addressChunkSize, strictEmailContentGenerator);
     }
 
     @Bean(name = "velocityEngine")

--- a/src/test/java/com/researchspace/service/impl/EmailBroadcastTest.java
+++ b/src/test/java/com/researchspace/service/impl/EmailBroadcastTest.java
@@ -18,7 +18,7 @@ import com.researchspace.model.comms.NotificationType;
 import com.researchspace.model.record.Notebook;
 import com.researchspace.model.record.Record;
 import com.researchspace.service.EmailBroadcast;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.testutils.SpringTransactionalTest;
 import com.researchspace.testutils.TestFactory;
 import io.github.resilience4j.ratelimiter.RateLimiter;
@@ -50,7 +50,11 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
   private static final String BASEURL = "http://localhost:8080/";
 
   // Removes retries (which aren't tested in this class) from stubs to avoid waiting during tests
-  abstract static class NoRetryBroadcasterStub extends EmailBroadcastImp {
+  abstract static class NoRetryBroadcasterStub extends EmailBroadcastImpl {
+    NoRetryBroadcasterStub(StrictEmailContentGenerator strictEmailContentGenerator) {
+      super(strictEmailContentGenerator);
+    }
+
     @Override
     RetryConfig buildRetryConfig() {
       return RetryConfig.custom().maxAttempts(1).build();
@@ -58,6 +62,10 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
   }
 
   static class AuthFailureBroadcasterStub extends NoRetryBroadcasterStub {
+    AuthFailureBroadcasterStub(StrictEmailContentGenerator strictEmailContentGenerator) {
+      super(strictEmailContentGenerator);
+    }
+
     @Override
     protected void sendMailToAddresses(EmailConfig config) throws MessagingException {
       throw new AuthenticationFailedException("test auth failure");
@@ -65,6 +73,10 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
   }
 
   static class SendFailureBroadcasterStub extends NoRetryBroadcasterStub {
+    SendFailureBroadcasterStub(StrictEmailContentGenerator strictEmailContentGenerator) {
+      super(strictEmailContentGenerator);
+    }
+
     @Override
     protected void sendMailToAddresses(EmailConfig config) throws MessagingException {
       throw new SendFailedException("test send failure");
@@ -72,13 +84,21 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
   }
 
   static class IllegalWriteFailureBroadcasterStub extends NoRetryBroadcasterStub {
+    IllegalWriteFailureBroadcasterStub(StrictEmailContentGenerator strictEmailContentGenerator) {
+      super(strictEmailContentGenerator);
+    }
+
     @Override
     protected void sendMailToAddresses(EmailConfig config) throws MessagingException {
       throw new IllegalWriteException("test send failure");
     }
   }
 
-  static class EmailSenderStub extends EmailBroadcastImp {
+  static class EmailSenderStub extends EmailBroadcastImpl {
+
+    EmailSenderStub(StrictEmailContentGenerator strictEmailContentGenerator) {
+      super(strictEmailContentGenerator);
+    }
 
     int messageCount = 0;
 
@@ -95,15 +115,13 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
 
   private @Autowired StrictEmailContentGenerator strictEmailContentGenerator;
 
-  private EmailBroadcastImp broadcast = new EmailBroadcastImp();
-  EmailBroadcast api = broadcast;
+  private EmailBroadcastImpl broadcast;
 
   @Before
   public void setUp() throws Exception {
     // we need to explicitly create this, as it is only created by Spring in 'prod' profile
     // and these tests run in dev profile.
-    broadcast = new EmailBroadcastImp();
-    broadcast.setStrictEmailContentGenerator(strictEmailContentGenerator);
+    broadcast = new EmailBroadcastImpl(strictEmailContentGenerator);
     broadcast.setHtmlDomainPrefix(BASEURL);
     broadcast.init();
   }
@@ -211,31 +229,34 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
     StringAppenderForTestLogging testStringAppender =
         CoreTestUtils.configureStringLogger(LogManager.getLogger(FailedEmailLogger.class));
 
-    AuthFailureBroadcasterStub broadcast = new AuthFailureBroadcasterStub();
+    AuthFailureBroadcasterStub broadcast =
+        new AuthFailureBroadcasterStub(strictEmailContentGenerator);
     broadcast.init();
     broadcast.sendHtmlEmail("any", anyHtmlBody(), Collections.emptyList(), null);
     String firstMessage = testStringAppender.logContents;
     assertTrue(
         "unexpected content: " + firstMessage,
-        firstMessage.startsWith(EmailBroadcastImp.AUTHENTICATION_FAILURE_PREFIX));
+        firstMessage.startsWith(EmailBroadcastImpl.AUTHENTICATION_FAILURE_PREFIX));
 
     testStringAppender.clearLog();
-    SendFailureBroadcasterStub broadcast2 = new SendFailureBroadcasterStub();
+    SendFailureBroadcasterStub broadcast2 =
+        new SendFailureBroadcasterStub(strictEmailContentGenerator);
     broadcast2.init();
     broadcast2.sendHtmlEmail("any", anyHtmlBody(), Collections.emptyList(), null);
     firstMessage = testStringAppender.logContents;
     assertTrue(
         "unexpected content: " + firstMessage,
-        firstMessage.startsWith(EmailBroadcastImp.SEND_FAILURE_PREFIX));
+        firstMessage.startsWith(EmailBroadcastImpl.SEND_FAILURE_PREFIX));
 
     testStringAppender.clearLog();
-    IllegalWriteFailureBroadcasterStub broadcast3 = new IllegalWriteFailureBroadcasterStub();
+    IllegalWriteFailureBroadcasterStub broadcast3 =
+        new IllegalWriteFailureBroadcasterStub(strictEmailContentGenerator);
     broadcast3.init();
     broadcast3.sendHtmlEmail("any", anyHtmlBody(), Collections.emptyList(), null);
     firstMessage = testStringAppender.logContents;
     assertTrue(
         "unexpected content: " + firstMessage,
-        firstMessage.startsWith(EmailBroadcastImp.GENERAL_FAILURE_PREFIX));
+        firstMessage.startsWith(EmailBroadcastImpl.GENERAL_FAILURE_PREFIX));
   }
 
   @Test
@@ -248,7 +269,7 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
   @Test
   public void partitionEmailsByAddressLimit() {
     // send in batches of 3, count how many distinct emails are made
-    EmailSenderStub senderTss = new EmailSenderStub();
+    EmailSenderStub senderTss = new EmailSenderStub(strictEmailContentGenerator);
     senderTss.init();
     senderTss.setAddressChunkSize(3);
 
@@ -276,7 +297,7 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
    */
   @Test
   public void rateLimiterTestFailure() throws Exception {
-    EmailSenderStub senderTss = new EmailSenderStub();
+    EmailSenderStub senderTss = new EmailSenderStub(strictEmailContentGenerator);
     senderTss.init();
     senderTss.setAddressChunkSize(3);
 
@@ -298,7 +319,7 @@ public class EmailBroadcastTest extends SpringTransactionalTest {
   // in this test, we allow a timeout duration long enough to allow tokens to refresh
   @Test
   public void rateLimiterTestSuccess() throws Exception {
-    EmailSenderStub senderTss = new EmailSenderStub();
+    EmailSenderStub senderTss = new EmailSenderStub(strictEmailContentGenerator);
     senderTss.init();
     senderTss.setAddressChunkSize(3);
 

--- a/src/test/java/com/researchspace/service/impl/EmailBroadcastVanillaJunit.java
+++ b/src/test/java/com/researchspace/service/impl/EmailBroadcastVanillaJunit.java
@@ -1,13 +1,13 @@
 package com.researchspace.service.impl;
 
-import static com.researchspace.service.impl.EmailBroadcastImp.TEXT_ONLY_EMAIL_DEFAULT;
+import static com.researchspace.service.impl.EmailBroadcastImpl.TEXT_ONLY_EMAIL_DEFAULT;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.researchspace.model.User;
 import com.researchspace.model.comms.CommunicationTarget;
 import com.researchspace.model.comms.MessageOrRequest;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import com.researchspace.testutils.TestFactory;
 import java.io.IOException;
 import java.text.ParseException;
@@ -30,7 +30,8 @@ public class EmailBroadcastVanillaJunit {
   // this oracle comes from the library class whose function we are testing.
   // a little circular but will detect regressions.
   static final FastDateFormat EMAIL_DATE_FORMAT = DateFormatUtils.SMTP_DATETIME_FORMAT;
-  EmailBroadcastImp emailerBroadcastImp = new EmailBroadcastImp();
+  EmailBroadcastImpl emailerBroadcastImpl =
+      new EmailBroadcastImpl(new StrictEmailContentGenerator());
 
   @Test
   public void calculateRecipients() {
@@ -47,7 +48,7 @@ public class EmailBroadcastVanillaJunit {
     mf.addRecipient(ct1);
     mf.addRecipient(ct2);
     List<String> addresses = new ArrayList<>();
-    emailerBroadcastImp.addRecipients(mf, addresses, mf.getRecipients());
+    emailerBroadcastImpl.addRecipients(mf, addresses, mf.getRecipients());
 
     assertEquals(1, addresses.size());
     assertTrue(addresses.get(0).equals(enabledUser.getEmail()));
@@ -58,7 +59,7 @@ public class EmailBroadcastVanillaJunit {
     Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
 
     MimeMessage message = createMimeMessage();
-    emailerBroadcastImp.setDateHeader(message, now);
+    emailerBroadcastImpl.setDateHeader(message, now);
     // parse date
     Date parsedHeader = EMAIL_DATE_FORMAT.parse(message.getHeader("Date")[0]);
     // ignore nanos as these get discarded in email Header
@@ -67,8 +68,8 @@ public class EmailBroadcastVanillaJunit {
 
   @Test
   public void createMessagePart() throws MessagingException, ParseException, IOException {
-    EmailBroadcastImp.EmailConfig plainTextConfig = createHtmlAndPlainTextEmailContent();
-    Multipart multi = emailerBroadcastImp.generateMultipartContent(plainTextConfig);
+    EmailBroadcastImpl.EmailConfig plainTextConfig = createHtmlAndPlainTextEmailContent();
+    Multipart multi = emailerBroadcastImpl.generateMultipartContent(plainTextConfig);
     assertEquals("text/plain", multi.getBodyPart(0).getContentType());
     assertEquals("text/html", multi.getBodyPart(1).getContentType());
     assertTrue(multi.getBodyPart(0).getContent().toString().equals("hello"));
@@ -77,14 +78,14 @@ public class EmailBroadcastVanillaJunit {
   @Test
   public void createMessagePartShowsDefaultTextIfNotSet()
       throws MessagingException, ParseException, IOException {
-    EmailBroadcastImp.EmailConfig plainTextConfig = createHtmlOnlyEmailContent();
-    Multipart multi = emailerBroadcastImp.generateMultipartContent(plainTextConfig);
+    EmailBroadcastImpl.EmailConfig plainTextConfig = createHtmlOnlyEmailContent();
+    Multipart multi = emailerBroadcastImpl.generateMultipartContent(plainTextConfig);
     assertTrue(multi.getBodyPart(0).getContent().toString().equals(TEXT_ONLY_EMAIL_DEFAULT));
   }
 
-  private EmailBroadcastImp.EmailConfig createHtmlOnlyEmailContent() {
-    EmailBroadcastImp.EmailConfig plainTextConfig =
-        new EmailBroadcastImp.EmailConfig(
+  private EmailBroadcastImpl.EmailConfig createHtmlOnlyEmailContent() {
+    EmailBroadcastImpl.EmailConfig plainTextConfig =
+        new EmailBroadcastImpl.EmailConfig(
             Collections.emptyList(),
             "subject",
             EmailContent.builder().htmlContent("<html>hello</html").build(),
@@ -93,9 +94,9 @@ public class EmailBroadcastVanillaJunit {
     return plainTextConfig;
   }
 
-  private EmailBroadcastImp.EmailConfig createHtmlAndPlainTextEmailContent() {
-    EmailBroadcastImp.EmailConfig plainTextConfig =
-        new EmailBroadcastImp.EmailConfig(
+  private EmailBroadcastImpl.EmailConfig createHtmlAndPlainTextEmailContent() {
+    EmailBroadcastImpl.EmailConfig plainTextConfig =
+        new EmailBroadcastImpl.EmailConfig(
             Collections.emptyList(),
             "subject",
             EmailContent.builder()

--- a/src/test/java/com/researchspace/service/impl/EmailSenderTest.java
+++ b/src/test/java/com/researchspace/service/impl/EmailSenderTest.java
@@ -4,7 +4,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.researchspace.model.comms.MessageOrRequest;
-import com.researchspace.service.impl.EmailBroadcastImp.EmailContent;
+import com.researchspace.service.impl.EmailBroadcastImpl.EmailContent;
 import java.util.Collections;
 import javax.mail.AuthenticationFailedException;
 import javax.mail.MessagingException;
@@ -27,7 +27,7 @@ public class EmailSenderTest {
 
   @Test
   public void whenSendFailsRetryUntilMaxAttempts() {
-    EmailBroadcastImp emailSender = new SendFailureStub();
+    EmailBroadcastImpl emailSender = new SendFailureStub();
     emailSender.setErrorLog(logger);
     emailSender.setRetryDelayMillis(RETRY_MILLIS);
     emailSender.init();
@@ -41,7 +41,7 @@ public class EmailSenderTest {
 
   @Test
   public void whenAuthFailsDontRetry() {
-    EmailBroadcastImp emailSender = new AuthFailureStub();
+    EmailBroadcastImpl emailSender = new AuthFailureStub();
     emailSender.setErrorLog(logger);
     emailSender.setRetryDelayMillis(RETRY_MILLIS);
     emailSender.init();
@@ -52,14 +52,22 @@ public class EmailSenderTest {
         .error(Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any());
   }
 
-  static class SendFailureStub extends EmailBroadcastImp {
+  static class SendFailureStub extends EmailBroadcastImpl {
+    SendFailureStub() {
+      super(new StrictEmailContentGenerator());
+    }
+
     @Override
     protected void sendMailToAddresses(EmailConfig config) throws MessagingException {
       throw new SendFailedException("test send failure");
     }
   }
 
-  static class AuthFailureStub extends EmailBroadcastImp {
+  static class AuthFailureStub extends EmailBroadcastImpl {
+    AuthFailureStub() {
+      super(new StrictEmailContentGenerator());
+    }
+
     @Override
     protected void sendMailToAddresses(EmailConfig config) throws MessagingException {
       throw new AuthenticationFailedException("test auth failure");


### PR DESCRIPTION
## Description ##
Renames EmailBroadcastImp to EmailBroadcastImpl (matching the *Impl convention used everywhere else) and converts its one autowired collaborator, StrictEmailContentGenerator, to a final constructor parameter. The class is built directly in BaseConfig @Bean methods, so the generator bean is now passed explicitly there.

This removes the package-private test-seam setter for the generator: tests construct the class with its dependency instead of mutating it afterwards, and future collaborators (e.g. the i18n branch's MessageSourceUtils and UserLocaleService) can join the constructor rather than growing new setters.