### PR TITLE
RSDEV-1189 RSDEV-1190: Extend Inventory Links to work with `Instruments` and `Instrument Templates`

### DIFF
--- a/src/main/java/com/researchspace/service/inventory/InventoryLinkValidator.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryLinkValidator.java
@@ -11,9 +11,9 @@ import org.springframework.validation.Errors;
 /**
  * Validates an incoming {@link ApiInventoryLink} payload independent of database state. Checks
  * relationType against the DataCite vocabulary, syntactic GlobalID parse, that the target prefix is
- * a supported link target (Inventory items including sample templates, or ELN documents, notebooks
- * and gallery files), and forbids self-links. Existence and read-permission checks live in the
- * manager layer, where the acting user is available.
+ * a supported link target (Inventory items including sample and instrument templates, or ELN
+ * documents, notebooks and gallery files), and forbids self-links. Existence and read-permission
+ * checks live in the manager layer, where the acting user is available.
  */
 public class InventoryLinkValidator {
 
@@ -45,6 +45,7 @@ public class InventoryLinkValidator {
           GlobalIdPrefix.IC,
           GlobalIdPrefix.IN,
           GlobalIdPrefix.IT,
+          GlobalIdPrefix.NT,
           GlobalIdPrefix.SD,
           GlobalIdPrefix.NB,
           GlobalIdPrefix.GL);

--- a/src/main/java/com/researchspace/service/inventory/impl/LinkTargetResolverImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/LinkTargetResolverImpl.java
@@ -34,7 +34,8 @@ public class LinkTargetResolverImpl implements LinkTargetResolver {
           GlobalIdPrefix.SS,
           GlobalIdPrefix.IC,
           GlobalIdPrefix.IN,
-          GlobalIdPrefix.IT);
+          GlobalIdPrefix.IT,
+          GlobalIdPrefix.NT);
 
   private static final Set<GlobalIdPrefix> ELN_BASE_RECORD_PREFIXES =
       EnumSet.of(GlobalIdPrefix.SD, GlobalIdPrefix.NB, GlobalIdPrefix.GL);

--- a/src/main/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImpl.java
@@ -8,6 +8,7 @@ import com.researchspace.model.core.GlobalIdPrefix;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleTemplate;
@@ -121,7 +122,8 @@ public class LinkTargetSnapshotResolverImpl implements LinkTargetSnapshotResolve
         || prefix == GlobalIdPrefix.SS
         || prefix == GlobalIdPrefix.IC
         || prefix == GlobalIdPrefix.IN
-        || prefix == GlobalIdPrefix.IT;
+        || prefix == GlobalIdPrefix.IT
+        || prefix == GlobalIdPrefix.NT;
   }
 
   private Class<?> entityClassFor(GlobalIdPrefix prefix) {
@@ -139,6 +141,11 @@ public class LinkTargetSnapshotResolverImpl implements LinkTargetSnapshotResolve
         // concrete class so Envers resolves the template revision (Sample.class would filter to
         // DTYPE='Sample' and miss it).
         return SampleTemplate.class;
+      case NT:
+        // like IT: a distinct single-table subtype (DTYPE='InstrumentTemplate'); query the
+        // concrete class so Envers resolves the template revision (Instrument.class would filter
+        // to DTYPE='Instrument' and miss it).
+        return InstrumentTemplate.class;
       case SD:
         return StructuredDocument.class;
       case NB:
@@ -167,6 +174,8 @@ public class LinkTargetSnapshotResolverImpl implements LinkTargetSnapshotResolve
         return "INSTRUMENT";
       case IT:
         return "SAMPLE";
+      case NT:
+        return "INSTRUMENT_TEMPLATE";
       case SD:
         return "DOCUMENT";
       case NB:

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkField.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkField.tsx
@@ -28,6 +28,7 @@ const INVENTORY_PREFIX_TO_ROUTE: Record<string, string> = {
   SS: "subsample",
   IC: "container",
   IN: "instrument",
+  NT: "instrumenttemplate",
 };
 
 /**

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkTargetBrowser.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkTargetBrowser.tsx
@@ -34,7 +34,15 @@ function LinkTargetBrowser(props: LinkTargetBrowserProps): React.ReactElement {
         },
         uiConfig: {
           allowedSearchModules: new Set(["TYPE", "OWNER", "SAVEDSEARCHES", "TAG"]),
-          allowedTypeFilters: new Set(["ALL", "SAMPLE", "SUBSAMPLE", "CONTAINER", "SAMPLE_TEMPLATE"]),
+          allowedTypeFilters: new Set([
+            "ALL",
+            "SAMPLE",
+            "SUBSAMPLE",
+            "CONTAINER",
+            "SAMPLE_TEMPLATE",
+            "INSTRUMENT",
+            "INSTRUMENT_TEMPLATE",
+          ]),
           selectionMode: "SINGLE",
           // mirror Browse ELN: clicking a result only selects it, and the
           // picker's Choose button (enabled once a row is selected) confirms

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkField.test.tsx
@@ -238,6 +238,30 @@ describe("LinkField", () => {
     expect(openLink).toHaveAttribute("target", "_blank");
   });
 
+  it("links Open to the versioned viewer for a pinned instrument target", () => {
+    renderField({
+      link: { ...baseLink, targetGlobalId: "IN42", versionPin: 3 },
+    });
+
+    // exercises INVENTORY_PREFIX_TO_ROUTE.IN: a pinned instrument link opens the
+    // read-only versioned instrument viewer, not the live record.
+    const openLink = screen.getByRole("link", { name: "inventory:fields.link.linkField.openLabel" });
+    expect(openLink).toHaveAttribute("href", "/inventory/instrument/42?version=3");
+    expect(openLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("links Open to the versioned viewer for a pinned instrument-template target", () => {
+    renderField({
+      link: { ...baseLink, targetGlobalId: "NT42", versionPin: 3 },
+    });
+
+    // exercises INVENTORY_PREFIX_TO_ROUTE.NT: a pinned instrument-template link
+    // opens the read-only versioned template viewer, not the live template.
+    const openLink = screen.getByRole("link", { name: "inventory:fields.link.linkField.openLabel" });
+    expect(openLink).toHaveAttribute("href", "/inventory/instrumenttemplate/42?version=3");
+    expect(openLink).toHaveAttribute("target", "_blank");
+  });
+
   it("keeps Open enabled when no versionPin is set", () => {
     renderField({ link: { ...baseLink, versionPin: null } });
     expect(screen.getByRole("link", { name: "inventory:fields.link.linkField.openLabel" })).toHaveAttribute(

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkTargetBrowser.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkTargetBrowser.test.tsx
@@ -70,6 +70,24 @@ describe("LinkTargetBrowser", () => {
     expect([...args.uiConfig.allowedTypeFilters]).toContain("SAMPLE_TEMPLATE");
   });
 
+  it("lets instruments be browsed as link targets", () => {
+    render(<LinkTargetBrowser open onPick={() => {}} onCancel={() => {}} />);
+
+    const args = searchConstructorArgs.at(-1) as {
+      uiConfig: { allowedTypeFilters: Set<string> };
+    };
+    expect([...args.uiConfig.allowedTypeFilters]).toContain("INSTRUMENT");
+  });
+
+  it("lets instrument templates be browsed as link targets", () => {
+    render(<LinkTargetBrowser open onPick={() => {}} onCancel={() => {}} />);
+
+    const args = searchConstructorArgs.at(-1) as {
+      uiConfig: { allowedTypeFilters: Set<string> };
+    };
+    expect([...args.uiConfig.allowedTypeFilters]).toContain("INSTRUMENT_TEMPLATE");
+  });
+
   it("requires an explicit Choose click instead of confirming on row click", () => {
     // mirrors Browse ELN: clicking a result only selects it; the picker's
     // Choose button (enabled once something is selected) confirms the pick.

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/VersionLockDialog.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/VersionLockDialog.test.tsx
@@ -180,6 +180,17 @@ describe("VersionLockDialog", () => {
     expect(vi.mocked(apiGet)).toHaveBeenCalledWith("samples/42/revisions");
   });
 
+  it("fetches instrument revisions for an instrument link target", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
+    const apiGet = InvApiService.get;
+    vi.mocked(apiGet).mockResolvedValue(revisionsResponse);
+    renderDialog({ globalId: "IN42" });
+    await waitFor(() => {
+      expect(getVersionRadio("1")).toBeInTheDocument();
+    });
+    expect(vi.mocked(apiGet)).toHaveBeenCalledWith("instruments/42/revisions");
+  });
+
   it("calls onConfirm with the chosen user-facing version, not the audit revisionId", async () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method -- mock setup
     const apiGet = InvApiService.get;

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/iconForGlobalId.test.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/iconForGlobalId.test.ts
@@ -23,7 +23,7 @@ describe("iconForInventoryGlobalId", () => {
       recordTypeLabel: "inventory:recordTypes.container.singular",
     });
     expect(iconForInventoryGlobalId("IN7")).toEqual({
-      iconName: "container",
+      iconName: "instrument",
       recordTypeLabel: "inventory:recordTypes.instrument.singular",
     });
   });
@@ -33,6 +33,15 @@ describe("iconForInventoryGlobalId", () => {
       iconName: "template",
       recordTypeLabel: "inventory:recordTypes.sampleTemplate.singular",
     });
+  });
+
+  test("maps instrument templates to the instrumentTemplate icon", () => {
+    expect(iconForInventoryGlobalId("NT3")).toEqual({
+      iconName: "instrumentTemplate",
+      recordTypeLabel: "inventory:recordTypes.instrumentTemplate.singular",
+    });
+    expect(isInventoryGlobalId("NT3")).toBe(true);
+    expect(supportsVersionPin("NT3")).toBe(true);
   });
 
   test("returns null for ELN and unknown prefixes and malformed ids", () => {

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/linkTarget.test.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/linkTarget.test.ts
@@ -14,6 +14,14 @@ describe("validateTarget", () => {
     }
   });
 
+  test("accepts an instrument template target", () => {
+    expect(validateTarget("NT7", "SA42").ok).toBe(true);
+  });
+
+  test("rejects an instrument template self link", () => {
+    expect(validateTarget("NT7", "NT7").ok).toBe(false);
+  });
+
   test("rejects unsupported prefixes", () => {
     const { ok, reason } = validateTarget("GF9", "SA1");
     expect(ok).toBe(false);

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/iconForGlobalId.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/iconForGlobalId.ts
@@ -23,7 +23,7 @@ export const INVENTORY_PREFIX_ICON_DATA: Record<string, RecordIconData> = {
     },
   },
   IN: {
-    iconName: "container",
+    iconName: "instrument",
     get recordTypeLabel() {
       return i18n.t("inventory:recordTypes.instrument.singular");
     },
@@ -32,6 +32,12 @@ export const INVENTORY_PREFIX_ICON_DATA: Record<string, RecordIconData> = {
     iconName: "template",
     get recordTypeLabel() {
       return i18n.t("inventory:recordTypes.sampleTemplate.singular");
+    },
+  },
+  NT: {
+    iconName: "instrumentTemplate",
+    get recordTypeLabel() {
+      return i18n.t("inventory:recordTypes.instrumentTemplate.singular");
     },
   },
 };
@@ -85,7 +91,10 @@ export function iconForGlobalId(globalId: string): RecordIconData | null {
   return INVENTORY_PREFIX_ICON_DATA[prefix] ?? ELN_PREFIX_ICON_DATA[prefix] ?? null;
 }
 
-/** True when the Global ID is an Inventory item (sample, subsample, container, instrument). */
+/**
+ * True when the Global ID is an Inventory item (sample, subsample, container, instrument,
+ * sample/instrument template).
+ */
 export function isInventoryGlobalId(globalId: string): boolean {
   const prefix = prefixOf(globalId);
   return prefix != null && prefix in INVENTORY_PREFIX_ICON_DATA;

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/linkTarget.ts
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/linkTarget.ts
@@ -8,9 +8,19 @@ import i18n from "@/modules/common/i18n";
  * round-trip and live in checkLinkTargetExists.
  */
 
-// Inventory items (SA/SS/IC/IN, plus IT sample templates) and ELN documents (SD),
-// notebooks (NB) and gallery files (GL).
-export const ALLOWED_TARGET_PREFIXES: ReadonlySet<string> = new Set(["SA", "SS", "IC", "IN", "IT", "SD", "NB", "GL"]);
+// Inventory items (SA/SS/IC/IN, plus IT sample templates and NT instrument templates)
+// and ELN documents (SD), notebooks (NB) and gallery files (GL).
+export const ALLOWED_TARGET_PREFIXES: ReadonlySet<string> = new Set([
+  "SA",
+  "SS",
+  "IC",
+  "IN",
+  "IT",
+  "NT",
+  "SD",
+  "NB",
+  "GL",
+]);
 
 export const GLOBAL_ID_PATTERN = /^([A-Z]{2})(\d+)(?:v(\d+))?$/;
 
@@ -25,6 +35,7 @@ export const INVENTORY_PREFIX_TO_API_PATH: Record<string, string> = {
   IC: "containers",
   IN: "instruments",
   IT: "sampleTemplates",
+  NT: "instrumentTemplates",
 };
 
 /** True when target points at the same item as source, ignoring any version suffix. */

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/LinkedDocuments.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/LinkedDocuments.tsx
@@ -53,9 +53,9 @@ import { GLOBAL_ID_PATTERN, INVENTORY_PREFIX_TO_API_PATH } from "@/Inventory/com
 function referencingItemsEndpoint(globalId: string): string | null {
   const match = GLOBAL_ID_PATTERN.exec(globalId);
   if (!match) return null;
-  // sample templates have no typed referencingItems endpoint; use the
-  // generic by-Global-ID route instead
-  if (match[1] === "IT") return `referencingItems/${globalId}`;
+  // sample and instrument templates have no typed referencingItems endpoint;
+  // use the generic by-Global-ID route instead
+  if (match[1] === "IT" || match[1] === "NT") return `referencingItems/${globalId}`;
   const segment = INVENTORY_PREFIX_TO_API_PATH[match[1]];
   if (segment) return `${segment}/${match[2]}/referencingItems`;
   return null;

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/SidebarBody.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/SidebarBody.tsx
@@ -47,9 +47,8 @@ function SidebarBody({ record, factory }: SidebarBodyArgs): React.ReactNode {
       {/* templates cannot appear in a List of Materials, but they are valid
           link targets, so the linked-documents dialog (which also lists the
           inventory items linking here) applies to them like every other type */}
-      {(record.usableInLoM || record.recordType === "sampleTemplate") && record.globalId && (
-        <LinkedDocuments globalId={record.globalId} factory={factory} />
-      )}
+      {(record.usableInLoM || record.recordType === "sampleTemplate" || record.recordType === "instrumentTemplate") &&
+        record.globalId && <LinkedDocuments globalId={record.globalId} factory={factory} />}
     </Stack>
   );
 }

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/MoreInfoLinkedDocuments.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/MoreInfoLinkedDocuments.test.tsx
@@ -54,6 +54,41 @@ describe("LinkedDocuments", () => {
     expect(spy).toHaveBeenCalledWith("referencingItems/IT5");
   });
 
+  test("fetches instrument-template back-references via the generic referencingItems route", async () => {
+    // NT has an entry in INVENTORY_PREFIX_TO_API_PATH, but the typed
+    // instrumentTemplates/{id}/referencingItems endpoint does not exist on the
+    // backend; like IT sample templates, instrument templates must use the
+    // generic /referencingItems/{globalId} route
+    const spy = vi.spyOn(InvApiService, "get").mockImplementation((url) => {
+      if (String(url).startsWith("referencingItems/")) {
+        return Promise.resolve({
+          data: {
+            referencingItems: [
+              {
+                sourceGlobalId: "SA1",
+                sourceName: "A sample",
+                sourceType: "SAMPLE",
+                relationType: "References",
+                versionPin: null,
+              },
+            ],
+          },
+        } as AxiosResponse);
+      }
+      return Promise.resolve({ data: [] } as AxiosResponse);
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkedDocuments factory={mockFactory()} globalId="NT5" />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+
+    expect(await screen.findByText("A sample")).toBeVisible();
+    expect(spy).toHaveBeenCalledWith("listOfMaterials/forInventoryItem/NT5");
+    expect(spy).toHaveBeenCalledWith("referencingItems/NT5");
+  });
+
   test("Assert that correct API endpoint is called with Global ID", async () => {
     const spy = vi.spyOn(InvApiService, "get").mockImplementation(() => Promise.reject(new Error("An error")));
     render(<LinkedDocuments factory={mockFactory()} globalId="IC1" />);

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/SidebarBody.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/SidebarBody.test.tsx
@@ -112,6 +112,26 @@ describe("SidebarBody", () => {
     expect(screen.getByTestId("linked-documents")).toHaveAttribute("data-globalid", "IT5");
   });
 
+  it("includes LinkedDocuments for an instrument template", () => {
+    // like sample templates: not usable in a List of Materials, but a valid
+    // link target, so the back-reference panel must render
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <SidebarBody
+          record={
+            makeRecord({
+              globalId: "NT42",
+              usableInLoM: false,
+              recordType: "instrumentTemplate",
+            }) as never
+          }
+          factory={null}
+        />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("linked-documents")).toHaveAttribute("data-globalid", "NT42");
+  });
+
   it("omits LinkedDocuments when the record has no Global ID yet", () => {
     render(
       <ThemeProvider theme={materialTheme}>

--- a/src/main/webapp/ui/src/stores/models/LinkableRecordFromGlobalId.ts
+++ b/src/main/webapp/ui/src/stores/models/LinkableRecordFromGlobalId.ts
@@ -31,6 +31,8 @@ export default class LinkableRecordFromGlobalId implements LinkableRecord {
       SA: "sample",
       SS: "subsample",
       IT: "template",
+      IN: "instrument",
+      NT: "instrumentTemplate",
     }).orElseGet(() => {
       throw new Error("Not an Inventory Record Type");
     });

--- a/src/main/webapp/ui/src/stores/models/__tests__/LinkableRecordFromGlobalId.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/LinkableRecordFromGlobalId.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import LinkableRecordFromGlobalId from "../LinkableRecordFromGlobalId";
+
+describe("LinkableRecordFromGlobalId", () => {
+  it("maps instrument global ids to the instrument icon instead of throwing", () => {
+    const record = new LinkableRecordFromGlobalId("IN7");
+    expect(record.iconName).toBe("instrument");
+    expect(record.id).toBe(7);
+    expect(record.permalinkURL).toBe("/globalId/IN7");
+  });
+
+  it("still maps the pre-existing inventory prefixes", () => {
+    expect(new LinkableRecordFromGlobalId("IC3").iconName).toBe("container");
+    expect(new LinkableRecordFromGlobalId("SA3").iconName).toBe("sample");
+    expect(new LinkableRecordFromGlobalId("SS3").iconName).toBe("subsample");
+    expect(new LinkableRecordFromGlobalId("IT3").iconName).toBe("template");
+  });
+
+  it("maps instrument template global ids to the instrumentTemplate icon", () => {
+    expect(new LinkableRecordFromGlobalId("NT7").iconName).toBe("instrumentTemplate");
+  });
+});

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryLinkInstrumentTemplateTargetMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryLinkInstrumentTemplateTargetMVCIT.java
@@ -1,0 +1,87 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiExtraField;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage for linking to an instrument template (RSDEV-1190): an NT Global ID is a
+ * valid link target, accepted by validation, round-tripping through the API, and surfaced by the
+ * generic referencingItems endpoint.
+ *
+ * <p>Authored alongside the feature; not run automatically (extends a real-transaction MVC base).
+ */
+public class InventoryLinkInstrumentTemplateTargetMVCIT extends API_MVC_InventoryTestBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void createsExtraFieldLinkTargetingAnInstrumentTemplateAndListsBackReference()
+      throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    MvcResult created =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(
+                    apiKey,
+                    "/instrumentTemplates",
+                    user,
+                    "{ \"name\": \"linkable instrument template\" }"))
+            .andExpect(status().isCreated())
+            .andReturn();
+    ApiInstrumentTemplate template = getFromJsonResponseBody(created, ApiInstrumentTemplate.class);
+
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+    String updateJson =
+        "{\"extraFields\":[{"
+            + "\"name\":\"Uses template\","
+            + "\"type\":\"link\","
+            + "\"newFieldRequest\":true,"
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + template.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    MvcResult updated =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/samples/" + source.getId(), user, updateJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleWithFullSubSamples sourceAfter =
+        getFromJsonResponseBody(updated, ApiSampleWithFullSubSamples.class);
+    ApiExtraField linkField =
+        sourceAfter.getExtraFields().stream()
+            .filter(ef -> ef.getLink() != null)
+            .findFirst()
+            .orElse(null);
+    assertNotNull(linkField);
+    assertEquals(template.getGlobalId(), linkField.getLink().getTargetGlobalId());
+
+    MvcResult refs =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE, apiKey, "/referencingItems/" + template.getGlobalId(), user))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(refs, ApiInventoryReferencingItems.class);
+    assertEquals(1, body.getReferencingItems().size());
+    assertEquals(source.getGlobalId(), body.getReferencingItems().get(0).getSourceGlobalId());
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryReferencingItemsApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryReferencingItemsApiControllerMVCIT.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.researchspace.api.v1.model.ApiInstrument;
 import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.model.User;
@@ -65,6 +66,46 @@ public class InventoryReferencingItemsApiControllerMVCIT extends API_MVC_Invento
                     API_VERSION.ONE,
                     apiKey,
                     "/samples/{id}/referencingItems",
+                    user,
+                    target.getId()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(1, body.getReferencingItems().size());
+    assertEquals("IsCalibratedBy", body.getReferencingItems().get(0).getRelationType());
+    assertEquals(source.getGlobalId(), body.getReferencingItems().get(0).getSourceGlobalId());
+  }
+
+  @Test
+  public void instrumentReferencingItemsSurfacesSourcesLinkingToInstrument() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    String apiKey = createNewApiKeyForUser(user);
+
+    MvcResult created =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(
+                    apiKey, "/instruments", user, "{ \"name\": \"link target instrument\" }"))
+            .andExpect(status().isCreated())
+            .andReturn();
+    ApiInstrument target = getFromJsonResponseBody(created, ApiInstrument.class);
+
+    ApiSampleWithFullSubSamples source = createBasicSampleForUser(user);
+    String updateJson = buildLinkExtraFieldUpdate(target.getGlobalId(), "IsCalibratedBy");
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(apiKey, "/samples/" + source.getId(), user, updateJson))
+        .andExpect(status().isOk());
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE,
+                    apiKey,
+                    "/instruments/{id}/referencingItems",
                     user,
                     target.getId()))
             .andExpect(status().isOk())

--- a/src/test/java/com/researchspace/service/inventory/InventoryLinkValidatorTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryLinkValidatorTest.java
@@ -111,6 +111,36 @@ class InventoryLinkValidatorTest {
   }
 
   @Test
+  void acceptsInstrumentTarget() {
+    ApiInventoryLink link = buildLink("References", "IN7");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertFalse(errors.hasErrors());
+  }
+
+  @Test
+  void acceptsInstrumentTemplateTarget() {
+    ApiInventoryLink link = buildLink("References", "NT7");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "SA42", errors);
+
+    assertFalse(errors.hasErrors());
+  }
+
+  @Test
+  void rejectsInstrumentSelfLinkIgnoringVersionSuffix() {
+    ApiInventoryLink link = buildLink("References", "IN42v2");
+    Errors errors = errorsFor(link);
+    validator.validate(link, "IN42", errors);
+
+    assertTrue(errors.hasFieldErrors("targetGlobalId"));
+    assertEquals(
+        "errors.inventory.field.link.selfLinkForbidden",
+        errors.getFieldError("targetGlobalId").getCode());
+  }
+
+  @Test
   void acceptsElnTargetPrefixes() {
     for (String prefix : new String[] {"SD", "NB", "GL"}) {
       ApiInventoryLink link = buildLink("References", prefix + "1");

--- a/src/test/java/com/researchspace/service/inventory/impl/LinkTargetResolverImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/LinkTargetResolverImplTest.java
@@ -84,6 +84,26 @@ class LinkTargetResolverImplTest {
   }
 
   @Test
+  void instrumentTargetResolvesThroughInventoryReadabilityCheck() {
+    when(inventoryPermissionUtils.canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user)))
+        .thenReturn(true);
+
+    assertTrue(resolver.targetExistsAndIsReadable(new GlobalIdentifier("IN42"), user));
+
+    ArgumentCaptor<GlobalIdentifier> gid = ArgumentCaptor.forClass(GlobalIdentifier.class);
+    verify(inventoryPermissionUtils).canUserReadInventoryRecord(gid.capture(), eq(user));
+    assertEquals(GlobalIdPrefix.IN, gid.getValue().getPrefix());
+  }
+
+  @Test
+  void instrumentTemplateTargetResolvesThroughInventoryReadabilityCheck() {
+    when(inventoryPermissionUtils.canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user)))
+        .thenReturn(true);
+
+    assertTrue(resolver.targetExistsAndIsReadable(new GlobalIdentifier("NT42"), user));
+  }
+
+  @Test
   void inventoryTargetNotReadableResolvesFalse() {
     when(inventoryPermissionUtils.canUserReadInventoryRecord(any(GlobalIdentifier.class), eq(user)))
         .thenReturn(false);

--- a/src/test/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/LinkTargetSnapshotResolverImplTest.java
@@ -15,6 +15,8 @@ import com.researchspace.api.v1.model.ApiInventoryLinkTargetSummary;
 import com.researchspace.model.User;
 import com.researchspace.model.audit.AuditedEntity;
 import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.record.Folder;
@@ -96,6 +98,38 @@ class LinkTargetSnapshotResolverImplTest {
     Long rev = resolver.resolveRevisionForVersion(GlobalIdPrefix.IT, 20L, 2L);
 
     assertEquals(Long.valueOf(33), rev);
+  }
+
+  @Test
+  void resolvesRevisionForPinnedInstrumentVersionViaInstrumentClass() {
+    when(auditManager.getRevisionNumberForInventoryRecordVersion(Instrument.class, 15L, 2L))
+        .thenReturn(88);
+
+    Long rev = resolver.resolveRevisionForVersion(GlobalIdPrefix.IN, 15L, 2L);
+
+    assertEquals(Long.valueOf(88), rev);
+  }
+
+  @Test
+  void summaryForInstrumentDegradesToGlobalIdOnlyWhenNoAuditSnapshotExists() {
+    when(auditManager.getNewestRevisionForEntity(Instrument.class, 15L)).thenReturn(null);
+
+    ApiInventoryLinkTargetSummary summary =
+        resolver.resolveSummary(GlobalIdPrefix.IN, 15L, null, null, user);
+
+    assertEquals("IN15", summary.getGlobalId());
+  }
+
+  @Test
+  void resolvesRevisionForInstrumentTemplateViaInstrumentTemplateClass() {
+    // instrument templates are a distinct single-table subtype (DTYPE='InstrumentTemplate');
+    // querying Instrument.class would filter them out, mirroring the IT/SampleTemplate case
+    when(auditManager.getRevisionNumberForInventoryRecordVersion(InstrumentTemplate.class, 20L, 2L))
+        .thenReturn(44);
+
+    Long rev = resolver.resolveRevisionForVersion(GlobalIdPrefix.NT, 20L, 2L);
+
+    assertEquals(Long.valueOf(44), rev);
   }
 
   @Test


### PR DESCRIPTION
## Description ##

The rspace-web implementation of **RSDEV-1189** (link to `Instruments`) and **RSDEV-1190** (link to `Instrument Templates`), both sub-tasks of the RSDEV-1131 Related Items / structured Link fields story.

RSDEV-1131 shipped the Link-field feature with instrument (`IN`) support already plumbed through the backend and most of the frontend, then left it dormant because Instruments had no GUI (every instrument row in its manual test plan was marked "deferred - Instrument UI"). Now that the instrument GUI (RSDEV-1064), version history (RSDEV-1171), and the instrument-template view/create screens (RSDEV-1097 / RSDEV-1164) have landed, this PR lights up the remaining gaps so that both **Instruments (`IN`)** and **Instrument Templates (`NT`)** are first-class Inventory link targets, and it replaces the placeholder instrument icon.

Two different starting points:
- **`IN` (instrument)** was almost entirely pre-wired by RSDEV-1131 (validator, resolver, snapshot/version resolution, the `referencingItems` endpoint, the API-path map, version-pin support). It needed only the last-mile frontend pieces: a picker filter, a real icon, and a fix so it stops throwing when rendered as a linkable record.
- **`NT` (instrument template)** was in no link prefix set at all. It is added here end to end, mirroring how sample templates (`IT`) already work.

### Scope note ###
This is instrument / instrument-template as a link **TARGET**. RSDEV-1190's "Facet 2" (instrument templates HOSTING Link fields with an allowed-relation-type whitelist, and propagation to instruments-created-from-template) is **already delivered** by RSDEV-1200, which reuses the sample-template field components and the backend mirrors (`InstrumentTemplateFieldValidator`, whitelist sync, update-to-latest-version). No new work was required for it, so it is not in this PR.

### Backend changes ###
All three additions add the `NT` prefix alongside the `IN` prefix that RSDEV-1131 already handled:
- **`InventoryLinkValidator`**: `GlobalIdPrefix.NT` added to the allowed link-target prefixes, so an `NT` target passes payload validation (and self-link rejection applies to it).
- **`LinkTargetResolverImpl`**: `NT` added to `INVENTORY_PREFIXES`, routing an instrument-template target through the same existence + full-READ-permission check as every other inventory item.
- **`LinkTargetSnapshotResolverImpl`**: `NT` recognised as an inventory prefix; `entityClassFor(NT)` maps to `InstrumentTemplate.class` and `typeFor(NT)` returns `INSTRUMENT_TEMPLATE`. Like `IT`, `NT` is a distinct single-table subtype (`DTYPE='InstrumentTemplate'`), so the concrete class is queried and Envers resolves the template revision (querying `Instrument.class` would filter to `DTYPE='Instrument'` and miss it).

### Frontend changes ###
- **`linkTarget.ts`**: `NT` added to `ALLOWED_TARGET_PREFIXES` and to `INVENTORY_PREFIX_TO_API_PATH` (`NT` to `instrumentTemplates`). This transitively makes `isInventoryGlobalId` and `supportsVersionPin` true for `NT`.
- **`iconForGlobalId.ts`**: `IN` now uses the dedicated `instrument` glyph instead of borrowing `container` as a placeholder, and an `NT` entry is added (`instrumentTemplate` glyph, "Instrument template" label).
- **`LinkTargetBrowser.tsx`**: `INSTRUMENT` and `INSTRUMENT_TEMPLATE` added to the Browse Inventory picker's `allowedTypeFilters`, so both can be selected as targets (previously only a hand-typed Global ID worked, and neither could be obtained through the UI).
- **`LinkField.tsx`**: `NT` to `instrumenttemplate` added to `INVENTORY_PREFIX_TO_ROUTE` (`IN` was already mapped), so a version-pinned instrument-template link's Open points at the RSDEV-1141 read-only versioned viewer route (`/inventory/{type}/{id}?version=N`).
- **`LinkedDocuments.tsx`**: `referencingItemsEndpoint` routes `NT` (alongside `IT`) through the generic `/referencingItems/{globalId}` endpoint, because instrument templates have no typed `referencingItems` route.
- **`SidebarBody.tsx`**: the LinkedDocuments back-reference panel now also renders for `instrumentTemplate` records. Templates cannot appear in a List of Materials but are valid link targets, so they get the same "items linking here" panel as sample templates.
- **`LinkableRecordFromGlobalId.ts`**: `IN` to `instrument` and `NT` to `instrumentTemplate` added to the icon-name map, which previously threw "Not an Inventory Record Type" for both (reachable when an IGSN table row renders one of these as a linkable record).

### API / Swagger ###
No API contract change. Link targets are validated by Global ID prefix, the `referencingItems` endpoints and settings shapes are unchanged, and the inventory Swagger spec does not enumerate the allowed link-target kinds, so no spec edit was required.

## Related work ##
- Parent story: RSDEV-1131 (Related Items / structured Link fields), whose sample-template (`IT`) handling this mirrors for `NT`.
- Builds on already-merged prerequisites: RSDEV-1064 (instrument GUI + viewer + MoreInfo, #884), RSDEV-1171 (instrument / instrument-template version history, #945), RSDEV-1097 / RSDEV-1164 (instrument-template view / create), and RSDEV-1200 (instrument-template field editor + backend mirrors, #941).
- No `core-model` change and no unreleased dependency: unlike RSDEV-1176 (#887), this needs no `pom.xml` bump.

## Jira tickets ##
- https://researchspace.atlassian.net/browse/RSDEV-1189
- https://researchspace.atlassian.net/browse/RSDEV-1190

## Design decisions ##
- **Mirror `IT`, do not invent a new path.** `NT` reuses the sample-template code path at every layer (validator prefix set, resolver, snapshot/Envers resolution, generic `referencingItems` route, icon-data shape, sidebar back-ref panel) rather than adding a bespoke instrument-template branch.
- **`entityClassFor(NT)` = `InstrumentTemplate.class`**, not the underlying instrument row. Instrument templates are a distinct single-table subtype, so Envers revision resolution needs the concrete class, exactly as `IT` resolves to `SampleTemplate.class`.
- **No dedicated `/instrumentTemplates/{id}/referencingItems` endpoint.** Instrument templates get their back-references through the generic `/referencingItems/{globalId}` route, the same way sample templates do; a typed endpoint would add symmetry, not capability.
- **Facet 2 deliberately excluded** (see Scope note): instrument-template Link-field hosting already shipped in RSDEV-1200.
- **Instrument icon promoted from placeholder.** `IN` had been borrowing the container glyph; it now has its own, and `NT` gets the template variant.

## Testing notes ##
- **Frontend**: `pnpm run test`, `pnpm run tsc`, `pnpm run lint`. New/updated specs cover the `INSTRUMENT` / `INSTRUMENT_TEMPLATE` picker filters, the `IN`/`NT` icon mapping, the `NT` target + self-link validation, the pinned `IN`/`NT` versioned-viewer route, the `NT` back-reference generic route, the instrument-template LinkedDocuments panel, and the `LinkableRecordFromGlobalId` `IN`/`NT` mapping.
- **Backend (fast unit)**: `mvn test -Dfast=true` covers the validator (`IN`/`NT` accepted, instrument self-link rejected), the resolver (`IN`/`NT` readability), and the snapshot resolver (`IN` revision + degrade-to-Global-ID, `NT` revision via `InstrumentTemplate.class`).
- **Backend (MVCIT, real DB commits, run under `mvn verify -Denvironment=drop-recreate-db`)**: `InventoryReferencingItemsApiControllerMVCIT` gains an instrument back-reference case, and the new `InventoryLinkInstrumentTemplateTargetMVCIT` links a sample to an `NT` target and asserts the generic `referencingItems` endpoint lists it.

### Manual test scenario (Inventory UI) ###

**AWS Instance**: https://rsdev-1189-1190-links-instr-d36cbf4a-7.researchspace.com/

1. Open a instrument / subsample / container and edit (or add) a Link extra-field.
2. In the Browse Inventory picker, confirm the type filter now offers **Instrument** and **Instrument template**, and that both can be picked as a target.
3. Confirm the resulting link chip shows the dedicated instrument / instrument-template icon (not the old container glyph) with the correct type label, and that Open resolves the target.
4. On an instrument's and an instrument template's MoreInfo sidebar, confirm the "Show Linked Documents" / back-reference panel lists the items linking to it.
5. (Where version history exists for the target) pin a version and confirm the info dialog shows the pinned snapshot.
