### PR TITLE
RSDEV-1219: Release new PIDINST instrument template

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,9 +35,7 @@ resolved during design. This file is a glossary only — no implementation detai
   stamped onto every record created from that template (for the PIDINST template:
   Owner, Manufacturer, etc.).
 - **Extra field** — an ad-hoc field (text, number or link) a user attaches to an
-  individual record after creation, outside any template definition. On the
-  instrument side these are meaningful only for concrete Instruments, not
-  templates (ADR 0002, proposed); sample templates retain them.
+  individual record after creation, outside any template definition.
 
 ## Internationalization (i18n)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,6 +3,42 @@
 The shared, canonical vocabulary for this project. Terms are added as they are
 resolved during design. This file is a glossary only — no implementation details.
 
+## Inventory templates
+
+- **Instrument template** — a reusable definition (name + custom fields) from which
+  a user creates concrete Instruments. Persisted in the single-table
+  `InstrumentEntity` hierarchy under `DTYPE='InstrumentTemplate'`; its sibling
+  discriminator is the concrete `Instrument`.
+- **Sample template** — the analogous reusable definition for Samples, in the
+  `Sample`/`SampleTemplate` hierarchy. The instrument side is being brought to
+  behavioural parity with it, not merged into it.
+- **Default (system) template** — a template shipped by RSpace itself and made
+  readable and duplicable by every user on every deployment, while remaining
+  read-only to non-owners. The first such instrument template is named
+  `Instrument (PIDINST 1.0)`: its fields map 1-to-1 to the PIDINST/B2INST payload.
+  For samples the equivalents are the seeded standard templates (Antibody,
+  Bacteria, etc.).
+- **Default templates owner** — the single account that owns the default templates.
+  All users may read (and therefore duplicate) any template owned by this account.
+  For samples this account is resolved as the owner of the oldest template row,
+  which is safe only because samples are seeded before any user can create one.
+  For instruments the account is resolved explicitly as the sysadmin, because
+  user-created instrument templates may already predate the default one.
+- **Locked template** — a default template that cannot be edited, deleted, or
+  transferred by anyone, enforced by a persisted `isEditable=false` flag rather
+  than by ownership alone. Editability is a property of templates only: a
+  concrete Instrument is never locked, and one created from a locked template is
+  an ordinary, fully mutable instrument. Distinct from ordinary non-owner
+  read-only access, which merely prevents *other* users from mutating a template
+  they do not own.
+- **Custom field** — a typed field that is part of a template's definition and is
+  stamped onto every record created from that template (for the PIDINST template:
+  Owner, Manufacturer, etc.).
+- **Extra field** — an ad-hoc field (text, number or link) a user attaches to an
+  individual record after creation, outside any template definition. On the
+  instrument side these are meaningful only for concrete Instruments, not
+  templates (ADR 0002, proposed); sample templates retain them.
+
 ## Internationalization (i18n)
 
 - **Canonical translation catalog** — i18next JSON. The runtime and

--- a/pom.xml
+++ b/pom.xml
@@ -1465,7 +1465,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>RSDEV-1219-model-SNAPSHOT</version>
+      <version>2.31.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
           <include>velocityTemplates/**</include>
           <include>archiveResources/**</include>
           <include>StartUpData/**</include>
+          <include>inventory/**</include>
           <!-- see Spring application-resources.xml which uses this variable as
             well for deployment-dependent property files. -->
           <include>deployments/${deployment}/**</include>
@@ -1464,7 +1465,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>2.30.0</version>
+      <version>RSDEV-1219-model-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>
@@ -2414,6 +2415,7 @@
               <include>bundles/**</include>
               <include>velocityTemplates/**</include>
               <include>StartUpData/**</include>
+              <include>inventory/**</include>
               <!-- see Spring application-resources.xml which uses this variable
                 as well for deployment-dependent property files. -->
               <include>deployments/defaultDeployment.properties</include>

--- a/src/main/java/com/axiope/search/InventorySearchConfig.java
+++ b/src/main/java/com/axiope/search/InventorySearchConfig.java
@@ -6,7 +6,9 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.dtos.WorkspaceFilters;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.record.BaseRecord;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -38,7 +40,7 @@ public class InventorySearchConfig extends SearchConfig {
 
   private List<String> limitResultsToGlobalIds;
 
-  private String defaultTemplatesOwner;
+  private Set<String> defaultTemplatesOwners = new HashSet<>();
 
   private GlobalIdentifier parentOid;
 

--- a/src/main/java/com/researchspace/api/v1/controller/InstrumentTemplatesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/InstrumentTemplatesApiController.java
@@ -214,7 +214,7 @@ public class InstrumentTemplatesApiController extends BaseApiInventoryController
       throws BindException, IOException {
 
     InstrumentTemplate template =
-        instrumentApiMgr.assertUserCanReadInstrumentTemplate(templateId, user);
+        instrumentApiMgr.assertUserCanEditInstrumentTemplate(templateId, user);
     Optional<BufferedImage> img =
         getBufferedImageFromUploadedFile(new SpringMultipartFileAdapter(file));
     if (!img.isPresent()) {

--- a/src/main/java/com/researchspace/api/v1/controller/SampleTemplatesApiController.java
+++ b/src/main/java/com/researchspace/api/v1/controller/SampleTemplatesApiController.java
@@ -205,7 +205,7 @@ public class SampleTemplatesApiController extends BaseApiInventoryController
       @PathVariable Long templateId, MultipartFile file, @RequestAttribute(name = "user") User user)
       throws BindException, IOException {
 
-    SampleEntity template = sampleApiMgr.assertUserCanReadSampleTemplate(templateId, user);
+    SampleEntity template = sampleApiMgr.assertUserCanEditSampleTemplate(templateId, user);
     Optional<BufferedImage> img =
         getBufferedImageFromUploadedFile(new SpringMultipartFileAdapter(file));
     if (!img.isPresent()) {

--- a/src/main/java/com/researchspace/dao/InstrumentTemplateDao.java
+++ b/src/main/java/com/researchspace/dao/InstrumentTemplateDao.java
@@ -23,6 +23,14 @@ public interface InstrumentTemplateDao extends InstrumentEntityDao<InstrumentTem
       String searchTerm,
       User user);
 
+  /**
+   * @return username of the user who owns the locked default instrument template (the oldest
+   *     template whose {@code isEditable} flag is {@code false}), or {@code null} if no default
+   *     template has been seeded yet. Every user may read (and duplicate) templates owned by this
+   *     account.
+   */
+  String getDefaultTemplatesOwner();
+
   /** Returns all instrument templates with the given name owned by the given user. */
   List<InstrumentTemplate> findInstrumentTemplatesByName(String name, User user);
 

--- a/src/main/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219.java
+++ b/src/main/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219.java
@@ -1,0 +1,109 @@
+package com.researchspace.dao.customliquibaseupdates;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
+import com.researchspace.auth.GlobalInitSysadminAuthenticationToken;
+import com.researchspace.dao.InstrumentTemplateDao;
+import com.researchspace.dao.UserDao;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import com.researchspace.service.inventory.InstrumentEntityApiManager;
+import java.io.IOException;
+import java.io.InputStream;
+import liquibase.database.Database;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.util.ThreadContext;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Creates the locked default (system) instrument template "Instrument (PIDINST 1.0)" owned by the
+ * sysadmin, so that every RSpace deployment ships it and every user can read and duplicate it while
+ * nobody can edit, delete or transfer it (RSDEV-1219). Modelled on {@link
+ * UpdatingOwnerIdColumnOnDigitalObjectIdentifier_RSDEV607}: it runs once per database from the
+ * Liquibase customUpdates changelog, after all schema changes have been applied.
+ */
+@Slf4j
+public class CreateDefaultInstrumentTemplate_RSDEV1219 extends AbstractCustomLiquibaseUpdater {
+
+  static final String TEMPLATE_NAME = "Instrument (PIDINST 1.0)";
+  private static final String TEMPLATE_JSON =
+      "inventory/defaultInstrumentTemplate-PIDINST-1.0.json";
+
+  private InstrumentEntityApiManager instrumentApiMgr;
+  private UserDao userDao;
+  private InstrumentTemplateDao instrumentTemplateDao;
+  private String resultMessage = "Default instrument template already present; no changes made";
+
+  @Override
+  protected void addBeans() {
+    instrumentApiMgr = context.getBean(InstrumentEntityApiManager.class);
+    userDao = context.getBean(UserDao.class);
+    instrumentTemplateDao = context.getBean(InstrumentTemplateDao.class);
+  }
+
+  @Override
+  public String getConfirmationMessage() {
+    return resultMessage;
+  }
+
+  @Override
+  protected void doExecute(Database database) {
+    GlobalInitSysadminAuthenticationToken sysadminToken =
+        new GlobalInitSysadminAuthenticationToken();
+    User sysadmin = userDao.getUserByUsername(sysadminToken.getPrincipal().toString());
+    if (sysadmin == null) {
+      log.warn("No sysadmin account found; skipping default instrument template creation");
+      return;
+    }
+    // Idempotency: custom changes run once per DB via DATABASECHANGELOG, but guard anyway for
+    // re-baselined / restored databases.
+    if (!instrumentTemplateDao.findInstrumentTemplatesByName(TEMPLATE_NAME, sysadmin).isEmpty()) {
+      log.info("Default instrument template '{}' already exists; nothing to do", TEMPLATE_NAME);
+      return;
+    }
+
+    // The create path resolves modifiedBy via IActiveUserStrategy.CHECK_OPERATE_AS, which calls
+    // SecurityUtils.getSubject().isRunAs(). During the Liquibase migration phase Shiro's
+    // SecurityManager is not bound yet (GlobalInitManagerImpl binds it later, on
+    // ContextRefreshedEvent), so bind a minimal one to this thread for the duration of the create
+    // and clean it up afterwards. createInstrumentTemplate otherwise resolves owner/createdBy/
+    // modifiedBy purely from the passed user, and the audit listener uses the event's user.
+    SecurityManager previousSecurityManager = ThreadContext.getSecurityManager();
+    if (previousSecurityManager == null) {
+      ThreadContext.bind(new DefaultSecurityManager());
+    }
+    try {
+      ApiInstrumentTemplatePost post = readTemplatePost();
+      ApiInstrumentTemplate created = instrumentApiMgr.createInstrumentTemplate(post, sysadmin);
+
+      // the create path sets isEditable=true by default; the seeder is the only writer of false
+      InstrumentTemplate template = instrumentTemplateDao.get(created.getId());
+      template.setEditable(false);
+      instrumentTemplateDao.save(template);
+      instrumentTemplateDao.resetDefaultTemplateOwner();
+
+      resultMessage = "Created locked default instrument template '" + TEMPLATE_NAME + "'";
+      log.info(resultMessage);
+    } finally {
+      if (previousSecurityManager == null) {
+        ThreadContext.unbindSecurityManager();
+        ThreadContext.unbindSubject();
+      }
+    }
+  }
+
+  private ApiInstrumentTemplatePost readTemplatePost() {
+    ObjectMapper objectMapper =
+        new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    try (InputStream in = new ClassPathResource(TEMPLATE_JSON).getInputStream()) {
+      return objectMapper.readValue(in, ApiInstrumentTemplatePost.class);
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Could not read default instrument template resource: " + TEMPLATE_JSON, e);
+    }
+  }
+}

--- a/src/main/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219.java
+++ b/src/main/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219.java
@@ -12,6 +12,7 @@ import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.service.inventory.InstrumentEntityApiManager;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import liquibase.database.Database;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.mgt.DefaultSecurityManager;
@@ -56,13 +57,24 @@ public class CreateDefaultInstrumentTemplate_RSDEV1219 extends AbstractCustomLiq
         new GlobalInitSysadminAuthenticationToken();
     User sysadmin = userDao.getUserByUsername(sysadminToken.getPrincipal().toString());
     if (sysadmin == null) {
-      log.warn("No sysadmin account found; skipping default instrument template creation");
-      return;
+      // Fail the migration rather than return: a silent skip would be recorded as applied in
+      // DATABASECHANGELOG and never retried, permanently leaving the deployment without the
+      // required default template. The sysadmin account is seeded before customUpdates runs, so a
+      // null here is a genuine, unexpected error state.
+      throw new IllegalStateException(
+          "No sysadmin account found; cannot create the default instrument template '"
+              + TEMPLATE_NAME
+              + "'");
     }
     // Idempotency: custom changes run once per DB via DATABASECHANGELOG, but guard anyway for
-    // re-baselined / restored databases.
-    if (!instrumentTemplateDao.findInstrumentTemplatesByName(TEMPLATE_NAME, sysadmin).isEmpty()) {
-      log.info("Default instrument template '{}' already exists; nothing to do", TEMPLATE_NAME);
+    // re-baselined / restored databases. Only a *locked* template counts as already seeded; an
+    // editable same-named template (e.g. from a prior run interrupted before the lock step) must be
+    // locked rather than treated as done, or the deployment would keep an unlocked default.
+    List<InstrumentTemplate> existing =
+        instrumentTemplateDao.findInstrumentTemplatesByName(TEMPLATE_NAME, sysadmin);
+    if (existing.stream().anyMatch(template -> !template.isEditable())) {
+      log.info(
+          "Locked default instrument template '{}' already exists; nothing to do", TEMPLATE_NAME);
       return;
     }
 
@@ -77,11 +89,18 @@ public class CreateDefaultInstrumentTemplate_RSDEV1219 extends AbstractCustomLiq
       ThreadContext.bind(new DefaultSecurityManager());
     }
     try {
-      ApiInstrumentTemplatePost post = readTemplatePost();
-      ApiInstrumentTemplate created = instrumentApiMgr.createInstrumentTemplate(post, sysadmin);
-
-      // the create path sets isEditable=true by default; the seeder is the only writer of false
-      InstrumentTemplate template = instrumentTemplateDao.get(created.getId());
+      InstrumentTemplate template;
+      if (existing.isEmpty()) {
+        ApiInstrumentTemplate created =
+            instrumentApiMgr.createInstrumentTemplate(readTemplatePost(), sysadmin);
+        // the create path sets isEditable=true by default; the seeder is the only writer of false
+        template = instrumentTemplateDao.get(created.getId());
+      } else {
+        // a prior run created the template but did not lock it; finish the job by locking the
+        // existing one rather than creating a duplicate
+        template = existing.get(0);
+        log.info("Found an unlocked default instrument template '{}'; locking it", TEMPLATE_NAME);
+      }
       template.setEditable(false);
       instrumentTemplateDao.save(template);
       instrumentTemplateDao.resetDefaultTemplateOwner();

--- a/src/main/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219.java
+++ b/src/main/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219.java
@@ -67,9 +67,10 @@ public class CreateDefaultInstrumentTemplate_RSDEV1219 extends AbstractCustomLiq
               + "'");
     }
     // Idempotency: custom changes run once per DB via DATABASECHANGELOG, but guard anyway for
-    // re-baselined / restored databases. Only a *locked* template counts as already seeded; an
-    // editable same-named template (e.g. from a prior run interrupted before the lock step) must be
-    // locked rather than treated as done, or the deployment would keep an unlocked default.
+    // re-baselined / restored databases. Only a *locked* template counts as already seeded.
+    // An editable same-named template does NOT suppress seeding and is left untouched: it may
+    // be a sysadmin template that does not match the PIDINST 1.0 fields, so we always create
+    // the canonical locked template below rather than locking a template we did not create.
     List<InstrumentTemplate> existing =
         instrumentTemplateDao.findInstrumentTemplatesByName(TEMPLATE_NAME, sysadmin);
     if (existing.stream().anyMatch(template -> !template.isEditable())) {
@@ -89,18 +90,10 @@ public class CreateDefaultInstrumentTemplate_RSDEV1219 extends AbstractCustomLiq
       ThreadContext.bind(new DefaultSecurityManager());
     }
     try {
-      InstrumentTemplate template;
-      if (existing.isEmpty()) {
-        ApiInstrumentTemplate created =
-            instrumentApiMgr.createInstrumentTemplate(readTemplatePost(), sysadmin);
-        // the create path sets isEditable=true by default; the seeder is the only writer of false
-        template = instrumentTemplateDao.get(created.getId());
-      } else {
-        // a prior run created the template but did not lock it; finish the job by locking the
-        // existing one rather than creating a duplicate
-        template = existing.get(0);
-        log.info("Found an unlocked default instrument template '{}'; locking it", TEMPLATE_NAME);
-      }
+      ApiInstrumentTemplate created =
+          instrumentApiMgr.createInstrumentTemplate(readTemplatePost(), sysadmin);
+      // the create path sets isEditable=true by default; the seeder is the only writer of false
+      InstrumentTemplate template = instrumentTemplateDao.get(created.getId());
       template.setEditable(false);
       instrumentTemplateDao.save(template);
       instrumentTemplateDao.resetDefaultTemplateOwner();

--- a/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
@@ -369,21 +369,27 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
   public ISearchResults<InventoryRecord> getSearchedInventoryRecords(
       InventorySearchConfig srchConfigInput) {
     LuceneSrchCfg srchConfig = new LuceneSrchCfg(srchConfigInput, termListFactory);
-    List<InventoryRecord> luceneHits = getLuceneInventoryQueryList(srchConfig);
-    List<InventoryRecord> dbHits =
-        findInvRecordsWithGlobalIdOrBarcodeMatchingSearchQuery(srchConfigInput);
-    List<InventoryRecord> finalHits =
-        Stream.concat(luceneHits.stream(), dbHits.stream())
-            .distinct()
-            // Apply the default-owner and read-permission filters to BOTH Lucene and direct
-            // (global-id / barcode) hits, so a direct lookup cannot bypass them (RSDEV-1219): a
-            // restricted user must not receive a default owner's ordinary records, nor any record
-            // they lack read permission on, merely by searching its global id or barcode.
+    // The default-owner and read-permission filters apply to LUCENE hits only. Direct global-id /
+    // barcode hits are deliberately exempt: by design they may return records the user cannot
+    // fully read, which the API layer then strips down to public-view fields
+    // (ApiInventoryRecordInfo.clearPropertiesForPublicView; contract pinned by
+    // SearchManagerTest.inventorySearchForLimitedAndPublicView). The default-owner post-filter
+    // exists only to compensate for the default owners being added to the Lucene username filter
+    // (RSDEV-1219 E2), so it has no role on the direct-lookup path either: a default owner's
+    // ordinary record found by exact id/barcode is public-view sanitised like anyone else's.
+    List<InventoryRecord> luceneHits =
+        getLuceneInventoryQueryList(srchConfig).stream()
             .filter(
                 rec ->
                     isNotOwnedByDefaultTemplatesOwnerOrTemplate(
                         rec, srchConfigInput.getDefaultTemplatesOwners()))
             .filter(rec -> canCurrentUserReadInvRec(rec, srchConfigInput.getAuthenticatedUser()))
+            .collect(Collectors.toList());
+    List<InventoryRecord> dbHits =
+        findInvRecordsWithGlobalIdOrBarcodeMatchingSearchQuery(srchConfigInput);
+    List<InventoryRecord> finalHits =
+        Stream.concat(luceneHits.stream(), dbHits.stream())
+            .distinct()
             .filter(rec -> isMatchingDeletedItemsOption(rec, srchConfigInput.getDeletedOption()))
             .filter(this::isNotSubSampleOfTemplate)
             .filter(this::isNotWorkbench)

--- a/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
@@ -369,19 +369,21 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
   public ISearchResults<InventoryRecord> getSearchedInventoryRecords(
       InventorySearchConfig srchConfigInput) {
     LuceneSrchCfg srchConfig = new LuceneSrchCfg(srchConfigInput, termListFactory);
-    List<InventoryRecord> luceneHits =
-        getLuceneInventoryQueryList(srchConfig).stream()
-            .filter(
-                rec ->
-                    isNotOwnedByDefaultTemplatesOwnerOrTemplate(
-                        rec, srchConfigInput.getDefaultTemplatesOwners()))
-            .filter(rec -> canCurrentUserReadInvRec(rec, srchConfigInput.getAuthenticatedUser()))
-            .collect(Collectors.toList());
+    List<InventoryRecord> luceneHits = getLuceneInventoryQueryList(srchConfig);
     List<InventoryRecord> dbHits =
         findInvRecordsWithGlobalIdOrBarcodeMatchingSearchQuery(srchConfigInput);
     List<InventoryRecord> finalHits =
         Stream.concat(luceneHits.stream(), dbHits.stream())
             .distinct()
+            // Apply the default-owner and read-permission filters to BOTH Lucene and direct
+            // (global-id / barcode) hits, so a direct lookup cannot bypass them (RSDEV-1219): a
+            // restricted user must not receive a default owner's ordinary records, nor any record
+            // they lack read permission on, merely by searching its global id or barcode.
+            .filter(
+                rec ->
+                    isNotOwnedByDefaultTemplatesOwnerOrTemplate(
+                        rec, srchConfigInput.getDefaultTemplatesOwners()))
+            .filter(rec -> canCurrentUserReadInvRec(rec, srchConfigInput.getAuthenticatedUser()))
             .filter(rec -> isMatchingDeletedItemsOption(rec, srchConfigInput.getDeletedOption()))
             .filter(this::isNotSubSampleOfTemplate)
             .filter(this::isNotWorkbench)

--- a/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
@@ -374,7 +374,7 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
             .filter(
                 rec ->
                     isNotOwnedByDefaultTemplatesOwnerOrTemplate(
-                        rec, srchConfigInput.getDefaultTemplatesOwner()))
+                        rec, srchConfigInput.getDefaultTemplatesOwners()))
             .filter(rec -> canCurrentUserReadInvRec(rec, srchConfigInput.getAuthenticatedUser()))
             .collect(Collectors.toList());
     List<InventoryRecord> dbHits =
@@ -502,14 +502,15 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
     return isTemplate || searchType != InventorySearchType.SAMPLE_TEMPLATE;
   }
 
-  private boolean isNotOwnedByDefaultTemplatesOwnerOrTemplate(
-      InventoryRecord rec, String defaultTemplatesOwner) {
-    if (defaultTemplatesOwner == null) {
-      return true; // we were not adding default templates owner to search filter
+  // package-private + static for unit testing: a pure predicate over (record, default owners).
+  static boolean isNotOwnedByDefaultTemplatesOwnerOrTemplate(
+      InventoryRecord rec, Set<String> defaultTemplatesOwners) {
+    if (defaultTemplatesOwners == null || defaultTemplatesOwners.isEmpty()) {
+      return true; // we were not adding any default templates owner to the search filter
     }
     boolean notOwnedByDefaultTemplateOwner =
-        !defaultTemplatesOwner.equals(rec.getOwner().getUsername());
-    // keep the default owner's templates (sample and instrument) but exclude their other records
+        !defaultTemplatesOwners.contains(rec.getOwner().getUsername());
+    // keep every default owner's templates (sample and instrument) but exclude their other records
     return notOwnedByDefaultTemplateOwner || rec.isSampleTemplate() || rec.isInstrumentTemplate();
   }
 

--- a/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FullTextSearcherImpl.java
@@ -509,7 +509,8 @@ public class FullTextSearcherImpl implements IFullTextSearcher {
     }
     boolean notOwnedByDefaultTemplateOwner =
         !defaultTemplatesOwner.equals(rec.getOwner().getUsername());
-    return notOwnedByDefaultTemplateOwner || rec.isSampleTemplate();
+    // keep the default owner's templates (sample and instrument) but exclude their other records
+    return notOwnedByDefaultTemplateOwner || rec.isSampleTemplate() || rec.isInstrumentTemplate();
   }
 
   private boolean canCurrentUserReadInvRec(InventoryRecord rec, User authenticatedUser) {

--- a/src/main/java/com/researchspace/dao/hibernate/InstrumentTemplateDaoHibernateImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/InstrumentTemplateDaoHibernateImpl.java
@@ -47,6 +47,12 @@ public class InstrumentTemplateDaoHibernateImpl
     List<String> userGroupsUniqueNames =
         user.getGroups().stream().map(Group::getUniqueName).collect(Collectors.toList());
     List<String> visibleOwners = invPermissionUtils.getOwnersVisibleWithUserRole(user);
+    // every user can also see templates owned by the default-templates owner (the seeded locked
+    // template). Guarded because, unlike samples, a default instrument template may not exist yet.
+    String defaultOwner = getDefaultTemplatesOwner();
+    if (defaultOwner != null) {
+      visibleOwners.add(defaultOwner);
+    }
     String permittedFragment =
         getOwnedByAndPermittedItemsSqlQueryFragment(
             ownedBy, user, userGroupMembers, userGroupsUniqueNames, visibleOwners);
@@ -101,6 +107,27 @@ public class InstrumentTemplateDaoHibernateImpl
     }
     List<InstrumentTemplate> page = pageQueryWithParams.list();
     return new SearchResultsImpl<>(page, pgCrit, totalCount);
+  }
+
+  @Override
+  public String getDefaultTemplatesOwner() {
+    if (defaultTemplateOwner == null) {
+      // The default owner is bound to the actual seeded locked template rather than the "oldest
+      // row" heuristic used for samples: instrument templates are already live on customer
+      // instances, so the oldest row may belong to an ordinary user. `editable` is the JavaBeans
+      // property name for the `isEditable` column. uniqueResult() (not getSingleResult()) keeps
+      // this null-safe before the default template has been seeded.
+      defaultTemplateOwner =
+          sessionFactory
+              .getCurrentSession()
+              .createQuery(
+                  "select t.owner.username from InstrumentTemplate t"
+                      + " where t.editable = false order by t.id asc",
+                  String.class)
+              .setMaxResults(1)
+              .uniqueResult();
+    }
+    return defaultTemplateOwner;
   }
 
   @Override

--- a/src/main/java/com/researchspace/service/impl/SearchManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SearchManagerImpl.java
@@ -21,6 +21,7 @@ import com.axiope.search.WorkspaceSearchInputValidator;
 import com.researchspace.Constants;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
 import com.researchspace.core.util.ISearchResults;
+import com.researchspace.dao.InstrumentTemplateDao;
 import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.dao.TextSearchDao;
 import com.researchspace.model.Group;
@@ -65,6 +66,7 @@ public class SearchManagerImpl implements SearchManager {
   private @Autowired FolderManager folderMgr;
   private @Autowired SampleApiManager sampleApiManager;
   private @Autowired SampleTemplateDao sampleTemplateDao;
+  private @Autowired InstrumentTemplateDao instrumentTemplateDao;
   private @Autowired BasketApiManager basketApiManager;
   private @Autowired InventoryPermissionUtils invPermissionUtils;
   private @Autowired MessageSourceUtils messages;
@@ -305,6 +307,17 @@ public class SearchManagerImpl implements SearchManager {
         // let's also search templates of default templates owner
         ownersFilter.add(defaultTemplatesOwner);
         searchConfig.setDefaultTemplatesOwner(defaultTemplatesOwner);
+      }
+      // also include the default INSTRUMENT template owner so the locked default instrument
+      // template appears in restricted global search (RSDEV-1219 E2). Normally the same sysadmin
+      // owns both defaults, so guard against adding a duplicate owner to the filter.
+      String defaultInstrumentTemplatesOwner = instrumentTemplateDao.getDefaultTemplatesOwner();
+      if (defaultInstrumentTemplatesOwner != null
+          && !ownersFilter.contains(defaultInstrumentTemplatesOwner)
+          && !invPermissionUtils.isInventoryOwnerReadableByUser(
+              defaultInstrumentTemplatesOwner, user)) {
+        ownersFilter.add(defaultInstrumentTemplatesOwner);
+        searchConfig.setDefaultTemplatesOwner(defaultInstrumentTemplatesOwner);
       }
       searchConfig.setUsernameFilter(ownersFilter);
 

--- a/src/main/java/com/researchspace/service/impl/SearchManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/SearchManagerImpl.java
@@ -43,8 +43,10 @@ import com.researchspace.service.inventory.SampleApiManager;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.UrlValidator;
@@ -301,24 +303,26 @@ public class SearchManagerImpl implements SearchManager {
      * so default templates are included in search.
      */
     if (searchConfig.isRestrictByUser()) {
-      String defaultTemplatesOwner = sampleTemplateDao.getDefaultTemplatesOwner();
-      if (defaultTemplatesOwner != null
-          && !invPermissionUtils.isInventoryOwnerReadableByUser(defaultTemplatesOwner, user)) {
-        // let's also search templates of default templates owner
-        ownersFilter.add(defaultTemplatesOwner);
-        searchConfig.setDefaultTemplatesOwner(defaultTemplatesOwner);
+      // Include the default SAMPLE and INSTRUMENT template owners so their locked default templates
+      // appear in restricted global search (RSDEV-1219 E2). Track every such owner (not just the
+      // last one) so the full-text post-filter suppresses each owner's non-template records;
+      // otherwise, when the two defaults resolve to different owners, one owner's ordinary
+      // inventory could leak into another user's restricted search results.
+      Set<String> defaultTemplatesOwners = new HashSet<>();
+      for (String defaultOwner :
+          new String[] {
+            sampleTemplateDao.getDefaultTemplatesOwner(),
+            instrumentTemplateDao.getDefaultTemplatesOwner()
+          }) {
+        if (defaultOwner != null
+            && !invPermissionUtils.isInventoryOwnerReadableByUser(defaultOwner, user)) {
+          if (!ownersFilter.contains(defaultOwner)) {
+            ownersFilter.add(defaultOwner);
+          }
+          defaultTemplatesOwners.add(defaultOwner);
+        }
       }
-      // also include the default INSTRUMENT template owner so the locked default instrument
-      // template appears in restricted global search (RSDEV-1219 E2). Normally the same sysadmin
-      // owns both defaults, so guard against adding a duplicate owner to the filter.
-      String defaultInstrumentTemplatesOwner = instrumentTemplateDao.getDefaultTemplatesOwner();
-      if (defaultInstrumentTemplatesOwner != null
-          && !ownersFilter.contains(defaultInstrumentTemplatesOwner)
-          && !invPermissionUtils.isInventoryOwnerReadableByUser(
-              defaultInstrumentTemplatesOwner, user)) {
-        ownersFilter.add(defaultInstrumentTemplatesOwner);
-        searchConfig.setDefaultTemplatesOwner(defaultInstrumentTemplatesOwner);
-      }
+      searchConfig.setDefaultTemplatesOwners(defaultTemplatesOwners);
       searchConfig.setUsernameFilter(ownersFilter);
 
       List<String> userGroupUniqueNames =

--- a/src/main/java/com/researchspace/service/inventory/InventoryPermissionUtils.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryPermissionUtils.java
@@ -2,6 +2,7 @@ package com.researchspace.service.inventory;
 
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
+import com.researchspace.dao.InstrumentTemplateDao;
 import com.researchspace.dao.ListOfMaterialsDao;
 import com.researchspace.dao.SampleDao;
 import com.researchspace.dao.SampleTemplateDao;
@@ -14,6 +15,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.elninventory.ListOfMaterials;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.InventoryRecord.InventorySharingMode;
 import com.researchspace.model.inventory.MovableInventoryRecord;
@@ -36,6 +38,7 @@ public class InventoryPermissionUtils {
 
   private @Autowired SampleDao sampleDao;
   private @Autowired SampleTemplateDao sampleTemplateDao;
+  private @Autowired InstrumentTemplateDao instrumentTemplateDao;
   private @Autowired ListOfMaterialsDao lomDao;
 
   private @Autowired UserManager userMgr;
@@ -106,6 +109,7 @@ public class InventoryPermissionUtils {
         || canViewWithUserRole(record, user)
         || isContainerRelatedReadAccessAllowed(record, user)
         || isDefaultSampleTemplate(record)
+        || isDefaultInstrumentTemplate(record)
         || canAccessAsSystemOrCommunityAdmin(record.getOwner().getUsername(), user);
   }
 
@@ -189,6 +193,17 @@ public class InventoryPermissionUtils {
     return false;
   }
 
+  private boolean isDefaultInstrumentTemplate(InventoryRecord record) {
+    if (record.isInstrumentTemplate()) {
+      // null-safe: getDefaultTemplatesOwner() returns null before a default template is seeded
+      return record
+          .getOwner()
+          .getUsername()
+          .equals(instrumentTemplateDao.getDefaultTemplatesOwner());
+    }
+    return false;
+  }
+
   public void assertUserCanReadOrLimitedReadInventoryRecord(InventoryRecord invRec, User user) {
     boolean canRead = canUserReadOrLimitedReadInventoryRecord(invRec, user);
     if (!canRead) {
@@ -209,10 +224,20 @@ public class InventoryPermissionUtils {
   }
 
   public boolean canUserEditInventoryRecord(InventoryRecord record, User user) {
+    if (isLockedInstrumentTemplate(record)) {
+      // a locked (default/system) instrument template is read-only for everyone, including its
+      // owning sysadmin; this central check also drives the permittedActions in API responses
+      return false;
+    }
     if (isUserAnItemOwner(record, user)) {
       return true; // owner has full access
     }
     return canAccessDirectlyWithSharingPermission(record, user);
+  }
+
+  /** A default/system instrument template whose {@code isEditable} flag has been set to false. */
+  private boolean isLockedInstrumentTemplate(InventoryRecord invRec) {
+    return invRec instanceof InstrumentTemplate && !((InstrumentTemplate) invRec).isEditable();
   }
 
   private boolean isUserAnItemOwner(InventoryRecord item, User user) {
@@ -270,10 +295,13 @@ public class InventoryPermissionUtils {
     if (!canRead) {
       throwNotFoundException(record.getId());
     }
-    // can read, just can't transfer. we can show more useful message
+    // can read, just can't transfer. we can show more useful message. A locked (default/system)
+    // instrument template cannot be transferred by anyone (transfer does not consult
+    // canUserEditInventoryRecord, so the lock is enforced explicitly here too).
     String invRecOwner = record.getOwner().getUsername();
-    if (!user.getUsername().equals(invRecOwner)
-        && !isPiOrAdminOfRecordOwnerGroup(user, invRecOwner)) {
+    if (isLockedInstrumentTemplate(record)
+        || (!user.getUsername().equals(invRecOwner)
+            && !isPiOrAdminOfRecordOwnerGroup(user, invRecOwner))) {
       throw new IllegalArgumentException(
           record.getType()
               + " with id ["
@@ -311,9 +339,10 @@ public class InventoryPermissionUtils {
     } else if (canUserLimitedReadInventoryRecord(invRec, user)) {
       apiInvRec.addPermittedAction(ApiInventoryRecordPermittedAction.LIMITED_READ);
     }
-    if (user.getUsername().equals(invRecOwner)
-        || isPiOrAdminOfRecordOwnerGroup(user, invRecOwner)
-        || user.hasSysadminRole()) {
+    if (!isLockedInstrumentTemplate(invRec)
+        && (user.getUsername().equals(invRecOwner)
+            || isPiOrAdminOfRecordOwnerGroup(user, invRecOwner)
+            || user.hasSysadminRole())) {
       // FIXME community admin should also have TRANSFER permission
       apiInvRec.addPermittedAction(ApiInventoryRecordPermittedAction.CHANGE_OWNER);
     }

--- a/src/main/resources/inventory/defaultInstrumentTemplate-PIDINST-1.0.json
+++ b/src/main/resources/inventory/defaultInstrumentTemplate-PIDINST-1.0.json
@@ -1,0 +1,142 @@
+{
+  "id": null,
+  "globalId": null,
+  "name": "Instrument (PIDINST 1.0)",
+  "description": "<p>Instrument Template for PIDINST (version 1.0)</p>",
+  "extraFields": [],
+  "tags": [],
+  "newBase64Image": null,
+  "barcodes": [],
+  "identifiers": [],
+  "sharingMode": "OWNER_GROUPS",
+  "sharedWith": [],
+  "fields": [
+    {
+      "name": "Owner",
+      "type": "string",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": true,
+      "content": ""
+    },
+    {
+      "name": "Manufacturer",
+      "type": "string",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": true,
+      "content": ""
+    },
+    {
+      "name": "Model",
+      "type": "string",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "content": ""
+    },
+    {
+      "name": "Instrument type",
+      "type": "string",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "content": ""
+    },
+    {
+      "name": "Commissioned",
+      "type": "date",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "content": ""
+    },
+    {
+      "name": "Decommissioned",
+      "type": "date",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "content": ""
+    },
+    {
+      "name": "Measurement technique",
+      "type": "link",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "allowedRelationTypes": [
+        "IsDocumentedBy"
+      ],
+      "link": null
+    },
+    {
+      "name": "Measured quantity",
+      "type": "string",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "content": ""
+    },
+    {
+      "name": "Calibration",
+      "type": "link",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "allowedRelationTypes": [
+        "IsCalibratedBy",
+        "IsDescribedBy"
+      ],
+      "link": null
+    },
+    {
+      "name": "Last calibrated",
+      "type": "date",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "content": ""
+    },
+    {
+      "name": "Landing page",
+      "type": "uri",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "content": ""
+    },
+    {
+      "name": "Alternate Identifier",
+      "type": "string",
+      "definition": {},
+      "newFieldRequest": true,
+      "deleteFieldRequest": false,
+      "deleteFieldOnSampleUpdate": false,
+      "mandatory": false,
+      "content": ""
+    }
+  ]
+}

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1219.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1219.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <!--
+      RSDEV-1219: add the isEditable flag to InstrumentEntity (and its audit table).
+      A false value locks a default/system instrument template against edit, delete and transfer
+      for everyone (including the owning sysadmin); the lock is enforced centrally in
+      InventoryPermissionUtils. Existing rows default to editable (1); the audit column is nullable,
+      as audit-table columns generally are.
+  -->
+  <changeSet id="2026-07-21-instrumentEntity-isEditable" context="run" author="nico">
+    <comment>Add isEditable column to InstrumentEntity and InstrumentEntity_AUD</comment>
+    <addColumn tableName="InstrumentEntity">
+      <column name="isEditable" type="bit" defaultValueNumeric="1">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="InstrumentEntity_AUD">
+      <column name="isEditable" type="bit"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/sqlUpdates/changeLog-rsdev-1219.xml
+++ b/src/main/resources/sqlUpdates/changeLog-rsdev-1219.xml
@@ -9,8 +9,8 @@
       RSDEV-1219: add the isEditable flag to InstrumentEntity (and its audit table).
       A false value locks a default/system instrument template against edit, delete and transfer
       for everyone (including the owning sysadmin); the lock is enforced centrally in
-      InventoryPermissionUtils. Existing rows default to editable (1); the audit column is nullable,
-      as audit-table columns generally are.
+      InventoryPermissionUtils. Existing rows default to editable (1); the audit column defaults
+      to 1 as well but stays nullable, as audit-table columns generally are.
   -->
   <changeSet id="2026-07-21-instrumentEntity-isEditable" context="run" author="nico">
     <comment>Add isEditable column to InstrumentEntity and InstrumentEntity_AUD</comment>
@@ -20,7 +20,7 @@
       </column>
     </addColumn>
     <addColumn tableName="InstrumentEntity_AUD">
-      <column name="isEditable" type="bit"/>
+      <column name="isEditable" type="bit" defaultValueNumeric="1"/>
     </addColumn>
   </changeSet>
 

--- a/src/main/resources/sqlUpdates/customUpdates-changeLog.xml
+++ b/src/main/resources/sqlUpdates/customUpdates-changeLog.xml
@@ -8,5 +8,7 @@
     <include relativeToChangelogFile="true" file="rsdev-310-perform-hash-apiKeys.xml"/>
     <include relativeToChangelogFile="true" file="rsdev-292-custom.xml"/>
     <include relativeToChangelogFile="true" file="rsdev-607-perform-doi-bulk-update.xml"/>
+    <include relativeToChangelogFile="true"
+      file="rsdev-1219-create-default-instrument-template.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/sqlUpdates/liquibase-master.xml
+++ b/src/main/resources/sqlUpdates/liquibase-master.xml
@@ -62,6 +62,7 @@
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1175.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1065.xml"/>
     <include relativeToChangelogFile="true" file="changeLog-rsdev-1176.xml"/>
+    <include relativeToChangelogFile="true" file="changeLog-rsdev-1219.xml"/>
 
   <!-- These two run last: recurring-changeLog.xml (runAlways diagnostics / batch re-init) then
        customUpdates-changeLog.xml. customUpdates-changeLog.xml must ALWAYS be the final include

--- a/src/main/resources/sqlUpdates/rsdev-1219-create-default-instrument-template.xml
+++ b/src/main/resources/sqlUpdates/rsdev-1219-create-default-instrument-template.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <changeSet id="2026-07-21-create-default-instrument-template" context="run" author="nico">
+    <comment>RSDEV-1219: create the locked default instrument template "Instrument (PIDINST 1.0)"
+      owned by the sysadmin (readable/duplicable by all, editable by none). Runs after the
+      isEditable schema change (changeLog-rsdev-1219.xml) has been applied.</comment>
+    <customChange
+      class="com.researchspace.dao.customliquibaseupdates.CreateDefaultInstrumentTemplate_RSDEV1219"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatesApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatesApiControllerMVCIT.java
@@ -239,6 +239,28 @@ public class InstrumentTemplatesApiControllerMVCIT extends API_MVC_InventoryTest
   }
 
   @Test
+  public void iconUploadByReaderButNotEditorIsRefused() throws Exception {
+    // A sysadmin can READ any record via the admin override but is not the owner and has no
+    // sharing-based edit right, so it is a reader that is not an editor. Changing a template's
+    // icon is a mutation and must require EDIT, not just READ (RSDEV-1219 Part J). Before the fix
+    // the icon endpoint asserted only READ, so any non-editor reader could overwrite the icon.
+    ApiInstrumentTemplate created = postValidInstrumentTemplate(createValidPostWithOneField());
+
+    String sysadminApiKey = createNewApiKeyForUser(getSysAdminUser());
+    MockMultipartFile iconFile =
+        new MockMultipartFile(
+            "file", "Picture1.png", "image/png", getTestResourceFileStream("Picture1.png"));
+
+    mockMvc
+        .perform(
+            multipart(
+                    createUrl(API_VERSION.ONE, "/instrumentTemplates/" + created.getId() + "/icon"))
+                .file(iconFile)
+                .header("apiKey", sysadminApiKey))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
   public void imageAndThumbnailReturn404WhenNotSet() throws Exception {
     ApiInstrumentTemplate created = postValidInstrumentTemplate(createValidPostWithOneField());
 

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesApiControllerMVCIT.java
@@ -355,6 +355,27 @@ public class SampleTemplatesApiControllerMVCIT extends API_MVC_InventoryTestBase
   }
 
   @Test
+  public void iconUploadByReaderButNotEditorIsRefused() throws Exception {
+    // A sysadmin can READ any record via the admin override but is not the owner and has no
+    // sharing-based edit right, so it is a reader that is not an editor. Changing a template's
+    // icon is a mutation and must require EDIT, not just READ (RSDEV-1219 Part J). Before the fix
+    // the icon endpoint asserted only READ, so any non-editor reader could overwrite the icon.
+    ApiSampleTemplate created = postValidSampleTemplate(createValidSampleTemplatePostNoFields());
+
+    String sysadminApiKey = createNewApiKeyForUser(getSysAdminUser());
+    MockMultipartFile iconFile =
+        new MockMultipartFile(
+            "file", "Picture1.png", "image/png", getTestResourceFileStream("Picture1.png"));
+
+    mockMvc
+        .perform(
+            multipart(createUrl(API_VERSION.ONE, "/sampleTemplates/" + created.getId() + "/icon"))
+                .file(iconFile)
+                .header("apiKey", sysadminApiKey))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
   public void imageAndThumbnailReturn404WhenNotSet() throws Exception {
     ApiSampleTemplate created = postValidSampleTemplate(createValidSampleTemplatePostNoFields());
 

--- a/src/test/java/com/researchspace/dao/InstrumentTemplateDaoTest.java
+++ b/src/test/java/com/researchspace/dao/InstrumentTemplateDaoTest.java
@@ -1,0 +1,125 @@
+package com.researchspace.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.core.util.ISearchResults;
+import com.researchspace.model.PaginationCriteria;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import com.researchspace.testutils.SpringTransactionalTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class InstrumentTemplateDaoTest extends SpringTransactionalTest {
+
+  @Autowired private InstrumentTemplateDao instrumentTemplateDao;
+
+  @Before
+  public void setUp() {
+    // the owner cache lives on the singleton DAO bean; clear it so tests don't leak into each other
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+  }
+
+  /**
+   * Creates a template for the (currently logged-in) owner and marks it locked (isEditable=false).
+   */
+  private InstrumentTemplate persistLockedTemplateFor(User owner, String name) {
+    ApiInstrumentTemplate api = createBasicInstrumentTemplateForUser(owner, name);
+    InstrumentTemplate entity = instrumentTemplateDao.get(api.getId());
+    entity.setEditable(false);
+    return instrumentTemplateDao.save(entity);
+  }
+
+  private InstrumentTemplate persistEditableTemplateFor(User owner, String name) {
+    ApiInstrumentTemplate api = createBasicInstrumentTemplateForUser(owner, name);
+    return instrumentTemplateDao.get(api.getId());
+  }
+
+  @Test
+  public void getDefaultTemplatesOwnerReturnsOwnerOfOldestLockedTemplate() {
+    User owner = createInitAndLoginAnyUser();
+    persistLockedTemplateFor(owner, "locked default template");
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+
+    String defaultOwner = instrumentTemplateDao.getDefaultTemplatesOwner();
+    assertNotNull(defaultOwner);
+
+    // must equal the owner of the OLDEST locked (editable=false) template, not merely the oldest
+    // row
+    InstrumentTemplate oldestLocked =
+        sessionFactory
+            .getCurrentSession()
+            .createQuery(
+                "from InstrumentTemplate where editable = false order by id asc",
+                InstrumentTemplate.class)
+            .setMaxResults(1)
+            .getSingleResult();
+    assertEquals(oldestLocked.getOwner().getUsername(), defaultOwner);
+
+    // value is cached until reset
+    assertEquals(defaultOwner, instrumentTemplateDao.getDefaultTemplatesOwner());
+  }
+
+  @Test
+  public void getDefaultTemplatesOwnerIgnoresEditableTemplates() {
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+    String before = instrumentTemplateDao.getDefaultTemplatesOwner();
+
+    // a fresh user's EDITABLE template must not make them the default owner
+    User user = createInitAndLoginAnyUser();
+    persistEditableTemplateFor(user, "ordinary editable template");
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+
+    assertEquals(
+        before,
+        instrumentTemplateDao.getDefaultTemplatesOwner(),
+        "an editable template must not change the default templates owner");
+  }
+
+  @Test
+  public void getTemplatesForUserExposesDefaultOwnerTemplatesButNotOthers() {
+    // ensure a default (locked) template owner exists
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+    String defaultOwner = instrumentTemplateDao.getDefaultTemplatesOwner();
+    if (defaultOwner == null) {
+      User lockOwner = createInitAndLoginAnyUser();
+      persistLockedTemplateFor(lockOwner, "locked default template");
+      instrumentTemplateDao.resetDefaultTemplateOwner();
+      defaultOwner = instrumentTemplateDao.getDefaultTemplatesOwner();
+    }
+    assertNotNull(defaultOwner);
+
+    // a third user's private editable template (that user is not the default owner)
+    User thirdUser = createInitAndLoginAnyUser();
+    InstrumentTemplate privateTemplate =
+        persistEditableTemplateFor(thirdUser, "third user private");
+
+    // the observer: yet another independent user (no shared groups, not an admin)
+    User observer = createInitAndLoginAnyUser();
+    PaginationCriteria<InstrumentTemplate> pgCrit =
+        PaginationCriteria.createDefaultForClass(InstrumentTemplate.class);
+    pgCrit.setResultsPerPage(1000);
+    final String finalDefaultOwner = defaultOwner;
+    ISearchResults<InstrumentTemplate> results =
+        instrumentTemplateDao.getTemplatesForUser(pgCrit, null, null, null, observer);
+
+    assertTrue(
+        results.getResults().stream()
+            .anyMatch(t -> t.getOwner().getUsername().equals(finalDefaultOwner)),
+        "a non-owner must see the default owner's (locked) template");
+    assertTrue(
+        results.getResults().stream().noneMatch(t -> t.getId().equals(privateTemplate.getId())),
+        "a non-owner must not see a non-default-owner's private template");
+  }
+}

--- a/src/test/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219Test.java
+++ b/src/test/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219Test.java
@@ -1,5 +1,6 @@
 package com.researchspace.dao.customliquibaseupdates;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -85,25 +86,38 @@ class CreateDefaultInstrumentTemplate_RSDEV1219Test {
     verify(instrumentApiMgr, never()).createInstrumentTemplate(any(), any());
     verify(locked, never()).setEditable(anyBoolean());
     verify(instrumentTemplateDao, never()).save(any());
+    assertEquals(
+        "Default instrument template already present; no changes made",
+        seeder.getConfirmationMessage());
   }
 
   @Test
-  @DisplayName(
-      "An unlocked template from an interrupted prior run is locked, not skipped or duplicated")
-  void locksExistingUnlockedTemplateInsteadOfSkipping() {
+  @DisplayName("An editable same-named template does not suppress seeding and is left untouched")
+  void createsCanonicalTemplateWhenOnlyEditableSameNamedExists() {
     when(userDao.getUserByUsername(anyString())).thenReturn(sysadmin);
-    InstrumentTemplate editable = Mockito.mock(InstrumentTemplate.class);
-    when(editable.isEditable()).thenReturn(true);
+    InstrumentTemplate preExistingEditable = Mockito.mock(InstrumentTemplate.class);
+    when(preExistingEditable.isEditable()).thenReturn(true);
     when(instrumentTemplateDao.findInstrumentTemplatesByName(
             CreateDefaultInstrumentTemplate_RSDEV1219.TEMPLATE_NAME, sysadmin))
-        .thenReturn(List.of(editable));
+        .thenReturn(List.of(preExistingEditable));
+    ApiInstrumentTemplate created = Mockito.mock(ApiInstrumentTemplate.class);
+    when(created.getId()).thenReturn(42L);
+    when(instrumentApiMgr.createInstrumentTemplate(
+            any(ApiInstrumentTemplatePost.class), eq(sysadmin)))
+        .thenReturn(created);
+    InstrumentTemplate canonical = Mockito.mock(InstrumentTemplate.class);
+    when(instrumentTemplateDao.get(42L)).thenReturn(canonical);
 
     seeder.doExecute(null);
 
-    verify(instrumentApiMgr, never()).createInstrumentTemplate(any(), any());
-    verify(editable).setEditable(false);
-    verify(instrumentTemplateDao).save(editable);
-    verify(instrumentTemplateDao).resetDefaultTemplateOwner();
+    // the canonical template is created from JSON and locked; the sysadmin's own template is
+    // untouched
+    verify(instrumentApiMgr)
+        .createInstrumentTemplate(any(ApiInstrumentTemplatePost.class), eq(sysadmin));
+    verify(canonical).setEditable(false);
+    verify(instrumentTemplateDao).save(canonical);
+    verify(preExistingEditable, never()).setEditable(anyBoolean());
+    verify(instrumentTemplateDao, never()).save(preExistingEditable);
   }
 
   @Test
@@ -128,5 +142,10 @@ class CreateDefaultInstrumentTemplate_RSDEV1219Test {
     verify(saved).setEditable(false);
     verify(instrumentTemplateDao).save(saved);
     verify(instrumentTemplateDao).resetDefaultTemplateOwner();
+    assertEquals(
+        "Created locked default instrument template '"
+            + CreateDefaultInstrumentTemplate_RSDEV1219.TEMPLATE_NAME
+            + "'",
+        seeder.getConfirmationMessage());
   }
 }

--- a/src/test/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219Test.java
+++ b/src/test/java/com/researchspace/dao/customliquibaseupdates/CreateDefaultInstrumentTemplate_RSDEV1219Test.java
@@ -1,0 +1,132 @@
+package com.researchspace.dao.customliquibaseupdates;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
+import com.researchspace.dao.InstrumentTemplateDao;
+import com.researchspace.dao.UserDao;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import com.researchspace.service.inventory.InstrumentEntityApiManager;
+import java.util.List;
+import org.apache.shiro.util.ThreadContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Pure unit test for the default-instrument-template seeder, exercising the edge cases raised in
+ * review (RSDEV-1219): a missing sysadmin must fail loudly rather than silently skip, and a
+ * pre-existing but unlocked template must be locked rather than treated as already seeded.
+ */
+class CreateDefaultInstrumentTemplate_RSDEV1219Test {
+
+  private CreateDefaultInstrumentTemplate_RSDEV1219 seeder;
+  private InstrumentEntityApiManager instrumentApiMgr;
+  private UserDao userDao;
+  private InstrumentTemplateDao instrumentTemplateDao;
+  private User sysadmin;
+
+  @BeforeEach
+  void setUp() {
+    ThreadContext.remove();
+    instrumentApiMgr = Mockito.mock(InstrumentEntityApiManager.class);
+    userDao = Mockito.mock(UserDao.class);
+    instrumentTemplateDao = Mockito.mock(InstrumentTemplateDao.class);
+    sysadmin = Mockito.mock(User.class);
+
+    ApplicationContext context = Mockito.mock(ApplicationContext.class);
+    when(context.getBean(InstrumentEntityApiManager.class)).thenReturn(instrumentApiMgr);
+    when(context.getBean(UserDao.class)).thenReturn(userDao);
+    when(context.getBean(InstrumentTemplateDao.class)).thenReturn(instrumentTemplateDao);
+
+    seeder = new CreateDefaultInstrumentTemplate_RSDEV1219();
+    seeder.context = context; // protected field on AbstractCustomLiquibaseUpdater (same package)
+    seeder.addBeans();
+  }
+
+  @AfterEach
+  void tearDown() {
+    ThreadContext.remove();
+  }
+
+  @Test
+  @DisplayName("A missing sysadmin fails the migration instead of silently skipping the seed")
+  void throwsWhenNoSysadmin() {
+    when(userDao.getUserByUsername(anyString())).thenReturn(null);
+
+    assertThrows(IllegalStateException.class, () -> seeder.doExecute(null));
+    verify(instrumentApiMgr, never()).createInstrumentTemplate(any(), any());
+  }
+
+  @Test
+  @DisplayName("A locked template with the default name is treated as already seeded")
+  void skipsWhenLockedTemplateAlreadyExists() {
+    when(userDao.getUserByUsername(anyString())).thenReturn(sysadmin);
+    InstrumentTemplate locked = Mockito.mock(InstrumentTemplate.class);
+    when(locked.isEditable()).thenReturn(false);
+    when(instrumentTemplateDao.findInstrumentTemplatesByName(
+            CreateDefaultInstrumentTemplate_RSDEV1219.TEMPLATE_NAME, sysadmin))
+        .thenReturn(List.of(locked));
+
+    seeder.doExecute(null);
+
+    verify(instrumentApiMgr, never()).createInstrumentTemplate(any(), any());
+    verify(locked, never()).setEditable(anyBoolean());
+    verify(instrumentTemplateDao, never()).save(any());
+  }
+
+  @Test
+  @DisplayName(
+      "An unlocked template from an interrupted prior run is locked, not skipped or duplicated")
+  void locksExistingUnlockedTemplateInsteadOfSkipping() {
+    when(userDao.getUserByUsername(anyString())).thenReturn(sysadmin);
+    InstrumentTemplate editable = Mockito.mock(InstrumentTemplate.class);
+    when(editable.isEditable()).thenReturn(true);
+    when(instrumentTemplateDao.findInstrumentTemplatesByName(
+            CreateDefaultInstrumentTemplate_RSDEV1219.TEMPLATE_NAME, sysadmin))
+        .thenReturn(List.of(editable));
+
+    seeder.doExecute(null);
+
+    verify(instrumentApiMgr, never()).createInstrumentTemplate(any(), any());
+    verify(editable).setEditable(false);
+    verify(instrumentTemplateDao).save(editable);
+    verify(instrumentTemplateDao).resetDefaultTemplateOwner();
+  }
+
+  @Test
+  @DisplayName("When nothing exists the template is created and locked")
+  void createsAndLocksWhenNoneExists() {
+    when(userDao.getUserByUsername(anyString())).thenReturn(sysadmin);
+    when(instrumentTemplateDao.findInstrumentTemplatesByName(
+            CreateDefaultInstrumentTemplate_RSDEV1219.TEMPLATE_NAME, sysadmin))
+        .thenReturn(List.of());
+    ApiInstrumentTemplate created = Mockito.mock(ApiInstrumentTemplate.class);
+    when(created.getId()).thenReturn(42L);
+    when(instrumentApiMgr.createInstrumentTemplate(
+            any(ApiInstrumentTemplatePost.class), eq(sysadmin)))
+        .thenReturn(created);
+    InstrumentTemplate saved = Mockito.mock(InstrumentTemplate.class);
+    when(instrumentTemplateDao.get(42L)).thenReturn(saved);
+
+    seeder.doExecute(null);
+
+    verify(instrumentApiMgr)
+        .createInstrumentTemplate(any(ApiInstrumentTemplatePost.class), eq(sysadmin));
+    verify(saved).setEditable(false);
+    verify(instrumentTemplateDao).save(saved);
+    verify(instrumentTemplateDao).resetDefaultTemplateOwner();
+  }
+}

--- a/src/test/java/com/researchspace/dao/hibernate/FullTextSearcherDefaultOwnerFilterTest.java
+++ b/src/test/java/com/researchspace/dao/hibernate/FullTextSearcherDefaultOwnerFilterTest.java
@@ -1,0 +1,78 @@
+package com.researchspace.dao.hibernate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InventoryRecord;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit test for the restricted-search post-filter that keeps the default template owners' templates
+ * visible while hiding their ordinary records. Pins the RSDEV-1219 fix that tracks <em>every</em>
+ * default owner (sample and instrument), so that when the two defaults resolve to different owners
+ * neither owner's non-template inventory leaks into another user's restricted search results.
+ */
+class FullTextSearcherDefaultOwnerFilterTest {
+
+  private InventoryRecord recordOwnedBy(
+      String owner, boolean sampleTemplate, boolean instrumentTemplate) {
+    User user = Mockito.mock(User.class);
+    when(user.getUsername()).thenReturn(owner);
+    InventoryRecord rec = Mockito.mock(InventoryRecord.class);
+    when(rec.getOwner()).thenReturn(user);
+    when(rec.isSampleTemplate()).thenReturn(sampleTemplate);
+    when(rec.isInstrumentTemplate()).thenReturn(instrumentTemplate);
+    return rec;
+  }
+
+  @Test
+  @DisplayName("With no default owners nothing is filtered out")
+  void keepsEverythingWhenNoDefaultOwners() {
+    InventoryRecord rec = recordOwnedBy("someone", false, false);
+    assertTrue(FullTextSearcherImpl.isNotOwnedByDefaultTemplatesOwnerOrTemplate(rec, null));
+    assertTrue(FullTextSearcherImpl.isNotOwnedByDefaultTemplatesOwnerOrTemplate(rec, Set.of()));
+  }
+
+  @Test
+  @DisplayName("Records owned by a non-default user are kept")
+  void keepsRecordsOwnedByANonDefaultUser() {
+    InventoryRecord rec = recordOwnedBy("otherUser", false, false);
+    assertTrue(
+        FullTextSearcherImpl.isNotOwnedByDefaultTemplatesOwnerOrTemplate(
+            rec, Set.of("sampleOwner", "instrumentOwner")));
+  }
+
+  @Test
+  @DisplayName("Non-template records of every default owner are excluded, not just the last one")
+  void excludesNonTemplateRecordsForEveryDefaultOwner() {
+    Set<String> owners = Set.of("sampleOwner", "instrumentOwner");
+    InventoryRecord sampleOwnersRecord = recordOwnedBy("sampleOwner", false, false);
+    InventoryRecord instrumentOwnersRecord = recordOwnedBy("instrumentOwner", false, false);
+
+    assertFalse(
+        FullTextSearcherImpl.isNotOwnedByDefaultTemplatesOwnerOrTemplate(
+            sampleOwnersRecord, owners));
+    assertFalse(
+        FullTextSearcherImpl.isNotOwnedByDefaultTemplatesOwnerOrTemplate(
+            instrumentOwnersRecord, owners));
+  }
+
+  @Test
+  @DisplayName("Each default owner's own templates remain visible")
+  void keepsDefaultOwnersTemplates() {
+    Set<String> owners = Set.of("sampleOwner", "instrumentOwner");
+    InventoryRecord sampleTemplate = recordOwnedBy("sampleOwner", true, false);
+    InventoryRecord instrumentTemplate = recordOwnedBy("instrumentOwner", false, true);
+
+    assertTrue(
+        FullTextSearcherImpl.isNotOwnedByDefaultTemplatesOwnerOrTemplate(sampleTemplate, owners));
+    assertTrue(
+        FullTextSearcherImpl.isNotOwnedByDefaultTemplatesOwnerOrTemplate(
+            instrumentTemplate, owners));
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/DefaultInstrumentTemplatePermissionsTest.java
+++ b/src/test/java/com/researchspace/service/inventory/DefaultInstrumentTemplatePermissionsTest.java
@@ -1,0 +1,147 @@
+package com.researchspace.service.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiInventoryRecordPermittedAction;
+import com.researchspace.dao.InstrumentTemplateDao;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.InstrumentTemplate;
+import com.researchspace.testutils.SpringTransactionalTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Behaviour of the locked default (system) instrument template: readable and duplicable by every
+ * user, but not editable / deletable / transferable by anyone (RSDEV-1219 Parts E &amp; F).
+ *
+ * <p>The tests obtain the default template via {@link #getOrCreateDefaultLockedTemplate()} so they
+ * hold both on a DB where the Liquibase seeder has already created it (owned by the sysadmin) and
+ * on one where it has not (in which case the test creates its own locked template).
+ */
+public class DefaultInstrumentTemplatePermissionsTest extends SpringTransactionalTest {
+
+  @Autowired private InstrumentTemplateDao instrumentTemplateDao;
+
+  @Before
+  public void setUp() {
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+  }
+
+  /** Creates a template owned by (currently logged-in) owner and locks it (isEditable=false). */
+  private InstrumentTemplate persistLockedTemplateFor(User owner, String name) {
+    ApiInstrumentTemplate api = createBasicInstrumentTemplateForUser(owner, name);
+    InstrumentTemplate entity = instrumentTemplateDao.get(api.getId());
+    entity.setEditable(false);
+    InstrumentTemplate saved = instrumentTemplateDao.save(entity);
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+    return saved;
+  }
+
+  private InstrumentTemplate persistEditableTemplateFor(User owner, String name) {
+    ApiInstrumentTemplate api = createBasicInstrumentTemplateForUser(owner, name);
+    return instrumentTemplateDao.get(api.getId());
+  }
+
+  /**
+   * Returns the locked default template (the seeded one if present, otherwise a freshly created).
+   */
+  private InstrumentTemplate getOrCreateDefaultLockedTemplate() {
+    instrumentTemplateDao.resetDefaultTemplateOwner();
+    if (instrumentTemplateDao.getDefaultTemplatesOwner() == null) {
+      User owner = createInitAndLoginAnyUser();
+      return persistLockedTemplateFor(owner, "locked default template");
+    }
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery(
+            "from InstrumentTemplate where editable = false order by id asc",
+            InstrumentTemplate.class)
+        .setMaxResults(1)
+        .getSingleResult();
+  }
+
+  @Test
+  public void nonOwnerCanReadLockedDefaultInstrumentTemplate() {
+    InstrumentTemplate template = getOrCreateDefaultLockedTemplate();
+
+    User other = createInitAndLoginAnyUser();
+    assertTrue(
+        invPermissionUtils.canUserReadInventoryRecord(template, other),
+        "every user must be able to read the locked default instrument template");
+  }
+
+  @Test
+  public void lockedDefaultTemplateIsNotEditableByAnyoneIncludingOwner() {
+    InstrumentTemplate locked = getOrCreateDefaultLockedTemplate();
+    User owner = locked.getOwner();
+    User other = createInitAndLoginAnyUser();
+
+    assertFalse(
+        invPermissionUtils.canUserEditInventoryRecord(locked, owner),
+        "the owning sysadmin must not be able to edit the locked template");
+    assertFalse(
+        invPermissionUtils.canUserEditInventoryRecord(locked, other),
+        "a non-owner must not be able to edit the locked template");
+  }
+
+  @Test
+  public void ordinaryInstrumentTemplateRemainsEditableByOwner() {
+    User owner = createInitAndLoginAnyUser();
+    InstrumentTemplate editable = persistEditableTemplateFor(owner, "ordinary template");
+
+    assertTrue(
+        invPermissionUtils.canUserEditInventoryRecord(editable, owner),
+        "the lock guard must not over-block ordinary (editable) instrument templates");
+  }
+
+  @Test
+  public void lockedDefaultTemplateCannotBeTransferredEvenByOwner() {
+    InstrumentTemplate locked = getOrCreateDefaultLockedTemplate();
+    User owner = locked.getOwner();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> invPermissionUtils.assertUserCanTransferInventoryRecord(locked, owner));
+  }
+
+  @Test
+  public void lockedTemplatePermittedActionsAreReadOnlyForOwner() {
+    InstrumentTemplate locked = getOrCreateDefaultLockedTemplate();
+    User owner = locked.getOwner();
+
+    ApiInstrumentTemplate api = new ApiInstrumentTemplate(locked);
+    invPermissionUtils.setPermissionsInApiInventoryRecord(api, locked, owner);
+
+    assertTrue(api.getPermittedActions().contains(ApiInventoryRecordPermittedAction.READ));
+    assertFalse(
+        api.getPermittedActions().contains(ApiInventoryRecordPermittedAction.UPDATE),
+        "locked template must not expose UPDATE");
+    assertFalse(
+        api.getPermittedActions().contains(ApiInventoryRecordPermittedAction.CHANGE_OWNER),
+        "locked template must not expose CHANGE_OWNER");
+  }
+
+  @Test
+  public void duplicateOfLockedTemplateIsEditable() {
+    InstrumentTemplate locked = getOrCreateDefaultLockedTemplate();
+    User owner = locked.getOwner();
+
+    // duplication asserts READ only, so it stays allowed; the copy must be editable again
+    ApiInstrumentTemplate duplicate =
+        instrumentApiMgr.duplicateInstrumentTemplate(locked.getId(), owner);
+    InstrumentTemplate duplicateEntity = instrumentTemplateDao.get(duplicate.getId());
+
+    assertTrue(duplicateEntity.isEditable(), "a duplicate of a locked template must be editable");
+  }
+}


### PR DESCRIPTION
## Description ##

The rspace-web implementation of **RSDEV-1219** (PIDINST epic RSDEV-1030): every RSpace deployment now ships a locked default instrument template, **`Instrument (PIDINST 1.0)`**, whose 12 fields map 1-to-1 to the PIDINST/B2INST payload. Every user can **read** and **duplicate** it; **nobody** can edit, delete or transfer it, the owning sysadmin included. It pairs with rspace-core-model PR #82, which adds the persisted `isEditable` flag this PR builds on.

### Core model (companion PR) ###
- `InstrumentTemplate` gains a persisted `isEditable` flag (column `isEditable` on the single-table `InstrumentEntity` hierarchy), default `true`. Editability is a template-only concept: a concrete `Instrument` is never locked.
- Copies and instruments created from a template are fresh instances, so they stay editable; core-model unit tests pin that a future refactor cannot silently start propagating the flag.
- `pom.xml` currently pins the temporary `RSDEV-1219-model-SNAPSHOT`; to be bumped to the released core-model version once #82 merges.

### Schema (Liquibase) ###
- `changeLog-rsdev-1219.xml`: `isEditable` added to `InstrumentEntity` (`bit`, default `1`, not null; existing rows stay editable) and to `InstrumentEntity_AUD` (nullable, per audit-table convention). Included in `liquibase-master.xml` before the customUpdates changelog.

### Default-owner visibility (DAO, permissions, search) ###
- `InstrumentTemplateDao.getDefaultTemplatesOwner()` resolves the owner of the **oldest locked template** (cached, null-safe before seeding). This deliberately does not copy the sample-side "oldest row" heuristic; see Design decisions.
- `getTemplatesForUser` adds the default owner to the visible owners (guarded, since a default template may not exist yet), which is what makes the template appear in every user's template picker.
- `InventoryPermissionUtils.isDefaultInstrumentTemplate(record)` is OR-ed into `canUserReadInventoryRecord`, mirroring `isDefaultSampleTemplate`. World-readability is what makes Duplicate work for non-owners.
- Global search: `SearchManagerImpl` adds the instrument default owner to the restricted-search owner filter, and the `FullTextSearcherImpl` post-filter now lets the default owner's **instrument** templates through (previously sample templates only).

### The lock ###
- New central guard in `InventoryPermissionUtils.canUserEditInventoryRecord`: a locked template returns `false` for everyone, before the owner short-circuit. One check covers template update, delete/restore, field edits, file attach/remove and bulk operations, and it also drives the `permittedActions` in API responses, so the UI renders the template read-only (READ present; UPDATE and CHANGE_OWNER absent) for owner and non-owner alike.
- The transfer assertion gets the same explicit guard (transfer does not consult `canUserEditInventoryRecord`).
- `duplicateInstrumentTemplate` asserts READ only, and copies reset to editable, so duplicate-and-adapt keeps working.

### Security hardening: template icon uploads ###
- Both template icon-upload endpoints (`POST /instrumentTemplates/{id}/icon` and `POST /sampleTemplates/{id}/icon`) previously asserted only READ before mutating the record. They now assert EDIT. This closes a pre-existing hole (any reader could overwrite a template's icon) and is a prerequisite here: once the default template is world-readable, the old check would have let anyone on the instance change its icon.

### Seeder ###
- `CreateDefaultInstrumentTemplate_RSDEV1219`, a Liquibase `customChange` in the customUpdates changelog (runs after all schema changes, once per database): resolves the sysadmin, checks idempotency by template name, deserialises the classpath resource `inventory/defaultInstrumentTemplate-PIDINST-1.0.json` (supplied by product; Owner and Manufacturer mandatory), creates the template through the normal manager path, then flips `isEditable` to `false`. The seeder is the only writer of `false`.
- The create path resolves `modifiedBy` via `CHECK_OPERATE_AS`, which needs a Shiro Subject, and Liquibase runs before the app binds Shiro's SecurityManager; the custom change therefore binds a minimal SecurityManager to the ThreadContext for the duration of the create and unbinds it in `finally`.
- The pom resource includes gain `inventory/**` (main build and prodRelease profile) so the JSON ships on the classpath.

### Docs ###
- `CONTEXT.md` glossary entries for the domain language introduced here: default (system) template, default templates owner, locked template, and the custom-field vs extra-field distinction.

## Related PRs ##
https://github.com/rspace-os/rspace-core-model/pull/82

## Jira tickets ##
- https://researchspace.atlassian.net/browse/RSDEV-1219

## Design decisions ##
- **Explicit sysadmin as default owner, not the oldest row.** Samples resolve the default owner as the owner of the oldest template row, which is safe only because samples are seeded before any user can create one. Instrument templates are already live on customer instances, so the oldest row may belong to an ordinary user and would leak their templates to everyone. The instrument default owner is bound to the actual seeded locked template instead.
- **A persisted flag enforced at the central choke point, not ownership and not the template-specific asserts.** Ownership alone would still let the sysadmin delete the template, and the template-specific assert methods are bypassed by mutation routes such as file attach. Only the central `canUserEditInventoryRecord` check also flows into `permittedActions`, so the UI read-only rendering comes for free.
- **Seeding via a Liquibase custom change, not an app initialiser.** The release rides the migration path that already reaches every deployment and runs exactly once per database. The cost is the Shiro timing workaround described above (sample templates seed via an app initialiser instead, where Shiro is already up).
- **Accepted trade-off: owner-based visibility exposes all of the sysadmin's instrument templates**, not only the locked one, mirroring how sample default templates already behave. The sysadmin is a system account and should not keep personal templates.
- **Icon endpoints tightened from READ to EDIT** rather than special-casing the locked template, fixing the general looseness for all templates (sample and instrument).

## Testing notes ##
AWS instance: https://rsdev-1219-release-instrument-template-7d328093-12.researchspace.com

New backend coverage (TDD, failing-first):
- `InstrumentTemplateDaoTest`: default-owner resolution (oldest locked template, editable templates ignored, cache + reset), picker visibility for non-owners.
- `DefaultInstrumentTemplatePermissionsTest`: read-for-all, lock against owner and non-owner, transfer refusal, read-only `permittedActions`, duplicate-is-editable. Robust to the seeder having already created the template.
- `InstrumentTemplatesApiControllerMVCIT` / `SampleTemplatesApiControllerMVCIT`: `iconUploadByReaderButNotEditorIsRefused` (a reader that is not an editor gets 4xx; the pre-fix behaviour was 201), while the existing owner-run icon tests stay green.

Commands (need the local test DB; booting any Spring test context applies the migration and runs the seeder):
```
mvn test -Dtest=InstrumentTemplateDaoTest
mvn test -Dtest=DefaultInstrumentTemplatePermissionsTest
mvn test -Dtest=InstrumentTemplatesApiControllerMVCIT
mvn test -Dtest=SampleTemplatesApiControllerMVCIT
```

### Manual test scenario (Inventory UI) ###
1. As any ordinary user, open the instrument-template list/picker: `Instrument (PIDINST 1.0)` is listed and opens read-only (no edit, delete or transfer affordances).
2. Search for it in global inventory search (restricted search) and confirm it is found. Seeding happens during the migration phase, so index population relies on the startup reindex: worth confirming on the AWS instance.
3. Duplicate it: the copy is owned by the current user and fully editable.
4. Create an instrument from the template: the instrument is an ordinary, fully mutable record.
5. As the sysadmin (owner): edit, delete and transfer are refused, and the icon upload is refused too.
6. Ordinary user-created instrument templates behave exactly as before (owners can still edit them).
