### PR TITLE
RSDEV-1244: make sure that when publish to B2INST, the error is returned to UI

### DIFF
--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
@@ -584,8 +584,9 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
       result = b2instConnector.publishDoi(doi.getIdentifier());
     } catch (B2instConnectionException b2instException) {
       throw new B2instConnectionException(
-          "Error when publishing the instrument PID in B2INST. "
-              + "If the problem persists, please contact your System Admin",
+          messages.getMessage(
+              "errors.inventory.identifier.b2inst.publish.failed",
+              new Object[] {b2instException.getMessage()}),
           b2instException);
     }
     ApiInventoryDOI publishDoi = new ApiInventoryDOI();

--- a/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImpl.java
+++ b/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImpl.java
@@ -5,6 +5,7 @@ import com.researchspace.b2inst.model.request.B2instReviewReceiver;
 import com.researchspace.b2inst.model.request.B2instReviewRequest;
 import com.researchspace.b2inst.model.response.B2instDraftRecord;
 import com.researchspace.b2inst.model.response.B2instRequestResponse;
+import com.researchspace.core.util.JacksonUtil;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.SystemPropertyManager;
 import com.researchspace.service.SystemPropertyName;
@@ -19,6 +20,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -81,7 +83,8 @@ public class B2instConnectorImpl implements B2instConnector {
       return restTemplate.postForObject(
           apiBase() + "/records", new HttpEntity<>(doi), B2instDraftRecord.class);
     } catch (RestClientException e) {
-      throw new B2instConnectionException("Error creating B2INST draft record", e);
+      throw new B2instConnectionException(
+          "Error creating B2INST draft record: " + describeFailure(e), e);
     }
   }
 
@@ -91,7 +94,8 @@ public class B2instConnectorImpl implements B2instConnector {
       restTemplate.delete(apiBase() + "/records/" + rid + "/draft");
       return true;
     } catch (RestClientException e) {
-      throw new B2instConnectionException("Error deleting B2INST draft record " + rid, e);
+      throw new B2instConnectionException(
+          "Error deleting B2INST draft record " + rid + ": " + describeFailure(e), e);
     }
   }
 
@@ -120,7 +124,8 @@ public class B2instConnectorImpl implements B2instConnector {
       return restTemplate.postForObject(submitUrl, HttpEntity.EMPTY, B2instRequestResponse.class);
     } catch (RestClientException e) {
       throw new B2instConnectionException(
-          "Error submitting B2INST record " + rid + " for community review", e);
+          "Error submitting B2INST record " + rid + " for community review: " + describeFailure(e),
+          e);
     }
   }
 
@@ -140,6 +145,31 @@ public class B2instConnectorImpl implements B2instConnector {
       log.warn("B2INST connection test failed: {}", e.getMessage());
       return false;
     }
+  }
+
+  /**
+   * Builds a human-readable reason for a failed B2INST call. When the server replied, prefers the
+   * parsed field-validation errors, then the payload's top-level message, then the HTTP status;
+   * without a response (transport error) falls back to the client exception message.
+   */
+  private String describeFailure(RestClientException e) {
+    if (e instanceof RestClientResponseException restError) {
+      String body = restError.getResponseBodyAsString();
+      String parsedDescription =
+          JacksonUtil.fromJsonOpt(body, B2instErrorResponse.class)
+              .map(B2instErrorResponse::describe)
+              .orElse(null);
+      if (parsedDescription != null) {
+        return parsedDescription;
+      }
+      log.warn(
+          "Unparseable B2INST error response (HTTP {}): {}", restError.getRawStatusCode(), body);
+      return "B2INST returned HTTP "
+          + restError.getRawStatusCode()
+          + " "
+          + restError.getStatusText();
+    }
+    return e.getMessage();
   }
 
   private String submitUrlOf(B2instRequestResponse created) {

--- a/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImpl.java
+++ b/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImpl.java
@@ -163,7 +163,9 @@ public class B2instConnectorImpl implements B2instConnector {
         return parsedDescription;
       }
       log.warn(
-          "Unparseable B2INST error response (HTTP {}): {}", restError.getRawStatusCode(), body);
+          "No usable failure reason in B2INST error response (HTTP {}): {}",
+          restError.getRawStatusCode(),
+          StringUtils.abbreviate(body, 500));
       return "B2INST returned HTTP "
           + restError.getRawStatusCode()
           + " "

--- a/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImpl.java
+++ b/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImpl.java
@@ -150,7 +150,8 @@ public class B2instConnectorImpl implements B2instConnector {
   /**
    * Builds a human-readable reason for a failed B2INST call. When the server replied, prefers the
    * parsed field-validation errors, then the payload's top-level message, then the HTTP status;
-   * without a response (transport error) falls back to the client exception message.
+   * without a response (transport error) falls back to the client exception message, or the
+   * exception type when even that is blank.
    */
   private String describeFailure(RestClientException e) {
     if (e instanceof RestClientResponseException restError) {
@@ -165,13 +166,18 @@ public class B2instConnectorImpl implements B2instConnector {
       log.warn(
           "No usable failure reason in B2INST error response (HTTP {}): {}",
           restError.getRawStatusCode(),
-          StringUtils.abbreviate(body, 500));
+          StringUtils.abbreviate(redactToken(body), 500));
       return "B2INST returned HTTP "
           + restError.getRawStatusCode()
           + " "
           + restError.getStatusText();
     }
-    return e.getMessage();
+    return StringUtils.defaultIfBlank(e.getMessage(), e.getClass().getSimpleName());
+  }
+
+  /** The bearer token is the one secret we hold that a proxy error page could echo back. */
+  private String redactToken(String body) {
+    return StringUtils.isBlank(token) ? body : body.replace(token, "***");
   }
 
   private String submitUrlOf(B2instRequestResponse created) {

--- a/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponse.java
+++ b/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponse.java
@@ -30,8 +30,9 @@ public record B2instErrorResponse(int status, String message, List<FieldError> e
   public record FieldError(String field, List<String> messages) {}
 
   /**
-   * One-line human-readable summary: field errors joined as {@code field: message}, else the
-   * top-level message, else {@code null} when the payload carries nothing usable.
+   * One-line human-readable summary: field errors joined as {@code field: message} (message-only
+   * when the payload omits the field name), else the top-level message, else {@code null} when the
+   * payload carries nothing usable.
    */
   public String describe() {
     String fieldSummary =
@@ -40,11 +41,18 @@ public record B2instErrorResponse(int status, String message, List<FieldError> e
             : errors.stream()
                 .filter(Objects::nonNull)
                 .filter(error -> error.messages() != null && !error.messages().isEmpty())
-                .map(error -> error.field() + ": " + String.join(" ", error.messages()))
+                .map(B2instErrorResponse::describeEntry)
                 .collect(Collectors.joining("; "));
     if (!fieldSummary.isBlank()) {
       return fieldSummary;
     }
     return (message == null || message.isBlank()) ? null : message;
+  }
+
+  private static String describeEntry(FieldError error) {
+    String joinedMessages = String.join(" ", error.messages());
+    return (error.field() == null || error.field().isBlank())
+        ? joinedMessages
+        : error.field() + ": " + joinedMessages;
   }
 }

--- a/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponse.java
+++ b/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponse.java
@@ -2,6 +2,7 @@ package com.researchspace.webapp.integrations.b2inst;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -37,6 +38,7 @@ public record B2instErrorResponse(int status, String message, List<FieldError> e
         errors == null
             ? ""
             : errors.stream()
+                .filter(Objects::nonNull)
                 .filter(error -> error.messages() != null && !error.messages().isEmpty())
                 .map(error -> error.field() + ": " + String.join(" ", error.messages()))
                 .collect(Collectors.joining("; "));

--- a/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponse.java
+++ b/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponse.java
@@ -1,0 +1,48 @@
+package com.researchspace.webapp.integrations.b2inst;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Error payload returned by B2INST (InvenioRDM) when a request fails, e.g. when a draft record
+ * fails community validation on submission for review.
+ *
+ * <p>Example: {@code {"status": 400, "message": "A validation error occurred.", "errors":
+ * [{"field": "instrument_type", "messages": ["Missing data for required field."]}]}}. The {@code
+ * errors} array is absent on non-validation failures such as permission errors.
+ *
+ * @param status HTTP status code reported in the payload (e.g. 400).
+ * @param message Human-readable summary of the failure.
+ * @param errors Per-field validation failures; may be null.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record B2instErrorResponse(int status, String message, List<FieldError> errors) {
+
+  /**
+   * A single field-level validation failure.
+   *
+   * @param field Dot-path to the offending field (e.g. {@code instrument_type}).
+   * @param messages One or more messages describing why the field failed.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record FieldError(String field, List<String> messages) {}
+
+  /**
+   * One-line human-readable summary: field errors joined as {@code field: message}, else the
+   * top-level message, else {@code null} when the payload carries nothing usable.
+   */
+  public String describe() {
+    String fieldSummary =
+        errors == null
+            ? ""
+            : errors.stream()
+                .filter(error -> error.messages() != null && !error.messages().isEmpty())
+                .map(error -> error.field() + ": " + String.join(" ", error.messages()))
+                .collect(Collectors.joining("; "));
+    if (!fieldSummary.isBlank()) {
+      return fieldSummary;
+    }
+    return (message == null || message.isBlank()) ? null : message;
+  }
+}

--- a/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponse.java
+++ b/src/main/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponse.java
@@ -40,8 +40,9 @@ public record B2instErrorResponse(int status, String message, List<FieldError> e
             ? ""
             : errors.stream()
                 .filter(Objects::nonNull)
-                .filter(error -> error.messages() != null && !error.messages().isEmpty())
+                .filter(error -> error.messages() != null)
                 .map(B2instErrorResponse::describeEntry)
+                .filter(entrySummary -> !entrySummary.isEmpty())
                 .collect(Collectors.joining("; "));
     if (!fieldSummary.isBlank()) {
       return fieldSummary;
@@ -50,7 +51,15 @@ public record B2instErrorResponse(int status, String message, List<FieldError> e
   }
 
   private static String describeEntry(FieldError error) {
-    String joinedMessages = String.join(" ", error.messages());
+    String joinedMessages =
+        error.messages().stream()
+            .filter(Objects::nonNull)
+            .map(String::strip)
+            .filter(message -> !message.isEmpty())
+            .collect(Collectors.joining(" "));
+    if (joinedMessages.isEmpty()) {
+      return "";
+    }
     return (error.field() == null || error.field().isBlank())
         ? joinedMessages
         : error.field() + ": " + joinedMessages;

--- a/src/main/resources/bundles/inventory/inventory.properties
+++ b/src/main/resources/bundles/inventory/inventory.properties
@@ -69,4 +69,5 @@ errors.inventory.identifier.minting.unsupported.type=unsupported type for mintin
 errors.inventory.identifier.delete.not.owner=You can only delete an identifier that you own.
 errors.inventory.identifier.bulk.positive.required=not a valid number of IGSNs to allocate: "{0}". The number must be greater than 0
 errors.inventory.identifier.bulk.max.exceeded=cannot allocate more than {0} IGSNs in a single request
+errors.inventory.identifier.b2inst.publish.failed=Could not publish the instrument PID in B2INST. {0}
 errors.inventory.settings.provider.required=A 'provider' must be specified to identify which identifier settings to update (one of IGSN_DATACITE, PIDINST_DATACITE, PIDINST_B2INST).

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImplUnitTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImplUnitTest.java
@@ -1,9 +1,12 @@
 package com.researchspace.service.inventory.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -13,6 +16,8 @@ import com.researchspace.api.v1.model.ApiInventoryDOI;
 import com.researchspace.api.v1.model.ApiInventorySystemSettings.InventorySettingType;
 import com.researchspace.b2inst.model.request.B2instDoi;
 import com.researchspace.b2inst.model.response.B2instDraftRecord;
+import com.researchspace.b2inst.model.response.B2instRequestResponse;
+import com.researchspace.core.util.JacksonUtil;
 import com.researchspace.dao.DigitalObjectIdentifierDao;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.DigitalObjectIdentifier;
@@ -21,8 +26,10 @@ import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.inventory.RspaceToExternalProviderAdapter;
+import com.researchspace.webapp.integrations.b2inst.B2instConnectionException;
 import com.researchspace.webapp.integrations.b2inst.B2instConnector;
 import com.researchspace.webapp.integrations.datacite.DataCiteConnector;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -89,6 +96,68 @@ class InventoryIdentifierApiManagerImplUnitTest {
     assertEquals("draft", result.getState());
     assertEquals(IdentifierType.PIDINST_B2INST.name(), result.getDoiType());
     assertEquals("Instrument", result.getResourceType());
+  }
+
+  @Test
+  void publishB2instSurfacesConnectorFailureReason() throws Exception {
+    InventoryIdentifierApiManagerImpl mgr = new InventoryIdentifierApiManagerImpl();
+    B2instConnector b2instConnector = mock(B2instConnector.class);
+    MessageSourceUtils messages = mock(MessageSourceUtils.class);
+    ReflectionTestUtils.setField(mgr, "b2instConnector", b2instConnector);
+    ReflectionTestUtils.setField(mgr, "messages", messages);
+
+    DigitalObjectIdentifier doi = mock(DigitalObjectIdentifier.class);
+    when(doi.getIdentifier()).thenReturn("k2j9p-7yh21");
+    B2instConnectionException original =
+        new B2instConnectionException(
+            "Error submitting B2INST record k2j9p-7yh21 for community review: "
+                + "instrument_type: Missing data for required field.");
+    when(b2instConnector.publishDoi("k2j9p-7yh21")).thenThrow(original);
+    when(messages.getMessage(
+            eq("errors.inventory.identifier.b2inst.publish.failed"), any(Object[].class)))
+        .thenAnswer(
+            invocation ->
+                "Could not publish the instrument PID in B2INST. "
+                    + ((Object[]) invocation.getArgument(1))[0]);
+
+    Method publish =
+        InventoryIdentifierApiManagerImpl.class.getDeclaredMethod(
+            "createUpdateWithPublishedB2instDoi", DigitalObjectIdentifier.class);
+    publish.setAccessible(true);
+    InvocationTargetException wrapped =
+        assertThrows(InvocationTargetException.class, () -> publish.invoke(mgr, doi));
+
+    Throwable thrown = wrapped.getCause();
+    assertTrue(thrown instanceof B2instConnectionException);
+    assertEquals(
+        "Could not publish the instrument PID in B2INST. Error submitting B2INST record"
+            + " k2j9p-7yh21 for community review: instrument_type: Missing data for required"
+            + " field.",
+        thrown.getMessage());
+    assertSame(original, thrown.getCause());
+  }
+
+  @Test
+  void publishB2instMapsSubmissionStatusOntoDoi() throws Exception {
+    InventoryIdentifierApiManagerImpl mgr = new InventoryIdentifierApiManagerImpl();
+    B2instConnector b2instConnector = mock(B2instConnector.class);
+    ReflectionTestUtils.setField(mgr, "b2instConnector", b2instConnector);
+
+    DigitalObjectIdentifier doi = mock(DigitalObjectIdentifier.class);
+    when(doi.getIdentifier()).thenReturn("k2j9p-7yh21");
+    when(doi.getId()).thenReturn(7L);
+    B2instRequestResponse submitted =
+        JacksonUtil.fromJson("{\"status\":\"submitted\"}", B2instRequestResponse.class);
+    when(b2instConnector.publishDoi("k2j9p-7yh21")).thenReturn(submitted);
+
+    Method publish =
+        InventoryIdentifierApiManagerImpl.class.getDeclaredMethod(
+            "createUpdateWithPublishedB2instDoi", DigitalObjectIdentifier.class);
+    publish.setAccessible(true);
+    ApiInventoryDOI result = (ApiInventoryDOI) publish.invoke(mgr, doi);
+
+    assertEquals(7L, result.getId());
+    assertEquals("submitted", result.getState());
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImplTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImplTest.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -19,6 +21,7 @@ import com.researchspace.b2inst.model.response.B2instDraftRecord;
 import com.researchspace.model.system.SystemProperty;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.SystemPropertyManager;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -175,6 +178,7 @@ class B2instConnectorImplTest {
     server
         .expect(requestTo(submitUrl))
         .andExpect(method(HttpMethod.POST))
+        .andExpect(content().string(""))
         .andRespond(withSuccess("{\"status\":\"submitted\"}", MediaType.APPLICATION_JSON));
 
     assertEquals("submitted", connector.publishDoi("k2j9p-7yh21").getStatus());
@@ -187,6 +191,116 @@ class B2instConnectorImplTest {
     connector.reloadClient();
 
     assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));
+  }
+
+  @Test
+  void publishDoiSurfacesFieldValidationErrorsFromB2inst() {
+    connector.reloadClient();
+    MockRestServiceServer server =
+        MockRestServiceServer.bindTo(connector.getRestTemplate()).build();
+    String validationError =
+        "{\"status\":400,\"message\":\"A validation error"
+            + " occurred.\",\"errors\":[{\"field\":\"instrument_type\",\"messages\":[\"Missing data"
+            + " for required field.\"]},{\"field\":\"owners\",\"messages\":[\"Shorter than minimum"
+            + " length 1.\"]}]}";
+    server
+        .expect(requestTo("https://b2inst-test.gwdg.de/api/records/k2j9p-7yh21/draft/review"))
+        .andRespond(
+            withStatus(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(validationError));
+
+    B2instConnectionException ex =
+        assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));
+
+    assertEquals(
+        "Error submitting B2INST record k2j9p-7yh21 for community review: "
+            + "instrument_type: Missing data for required field.; "
+            + "owners: Shorter than minimum length 1.",
+        ex.getMessage());
+  }
+
+  @Test
+  void publishDoiSurfacesTopLevelMessageWhenNoFieldErrors() {
+    connector.reloadClient();
+    MockRestServiceServer server =
+        MockRestServiceServer.bindTo(connector.getRestTemplate()).build();
+    server
+        .expect(requestTo("https://b2inst-test.gwdg.de/api/records/k2j9p-7yh21/draft/review"))
+        .andRespond(
+            withStatus(HttpStatus.FORBIDDEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"status\":403,\"message\":\"Permission denied.\"}"));
+
+    B2instConnectionException ex =
+        assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));
+
+    assertEquals(
+        "Error submitting B2INST record k2j9p-7yh21 for community review: Permission denied.",
+        ex.getMessage());
+  }
+
+  @Test
+  void publishDoiFallsBackToHttpStatusWhenBodyIsNotJson() {
+    connector.reloadClient();
+    MockRestServiceServer server =
+        MockRestServiceServer.bindTo(connector.getRestTemplate()).build();
+    server
+        .expect(requestTo("https://b2inst-test.gwdg.de/api/records/k2j9p-7yh21/draft/review"))
+        .andRespond(
+            withStatus(HttpStatus.BAD_GATEWAY)
+                .contentType(MediaType.TEXT_HTML)
+                .body("<html>Bad Gateway</html>"));
+
+    B2instConnectionException ex =
+        assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));
+
+    assertEquals(
+        "Error submitting B2INST record k2j9p-7yh21 for community review: "
+            + "B2INST returned HTTP 502 Bad Gateway",
+        ex.getMessage());
+  }
+
+  @Test
+  void publishDoiKeepsTransportErrorMessageWhenNoResponse() {
+    connector.reloadClient();
+    MockRestServiceServer server =
+        MockRestServiceServer.bindTo(connector.getRestTemplate()).build();
+    server
+        .expect(requestTo("https://b2inst-test.gwdg.de/api/records/k2j9p-7yh21/draft/review"))
+        .andRespond(withException(new IOException("connect timed out")));
+
+    B2instConnectionException ex =
+        assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));
+
+    assertTrue(
+        ex.getMessage()
+            .startsWith("Error submitting B2INST record k2j9p-7yh21 for community review: "));
+    assertTrue(ex.getMessage().contains("connect timed out"));
+  }
+
+  @Test
+  void registerDoiSurfacesFieldValidationErrors() {
+    connector.reloadClient();
+    MockRestServiceServer server =
+        MockRestServiceServer.bindTo(connector.getRestTemplate()).build();
+    server
+        .expect(requestTo("https://b2inst-test.gwdg.de/api/records"))
+        .andRespond(
+            withStatus(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(
+                    "{\"status\":400,\"message\":\"A validation error occurred.\",\"errors\":"
+                        + "[{\"field\":\"community\",\"messages\":[\"Missing data for required"
+                        + " field.\"]}]}"));
+
+    B2instConnectionException ex =
+        assertThrows(
+            B2instConnectionException.class, () -> connector.registerDoi(draftWithName("X")));
+
+    assertEquals(
+        "Error creating B2INST draft record: community: Missing data for required field.",
+        ex.getMessage());
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImplTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImplTest.java
@@ -22,6 +22,7 @@ import com.researchspace.model.system.SystemProperty;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.SystemPropertyManager;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +41,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClientException;
 
 @ExtendWith(MockitoExtension.class)
 class B2instConnectorImplTest {
@@ -224,6 +226,7 @@ class B2instConnectorImplTest {
             + "instrument_type: Missing data for required field.; "
             + "owners: Shorter than minimum length 1.",
         ex.getMessage());
+    server.verify();
   }
 
   @Test
@@ -244,6 +247,7 @@ class B2instConnectorImplTest {
     assertEquals(
         "Error submitting B2INST record k2j9p-7yh21 for community review: Permission denied.",
         ex.getMessage());
+    server.verify();
   }
 
   @Test
@@ -265,6 +269,7 @@ class B2instConnectorImplTest {
         "Error submitting B2INST record k2j9p-7yh21 for community review: "
             + "B2INST returned HTTP 502 Bad Gateway",
         ex.getMessage());
+    server.verify();
   }
 
   @Test
@@ -296,6 +301,7 @@ class B2instConnectorImplTest {
       coreLogger.removeAppender(capture);
       capture.stop();
     }
+    server.verify();
 
     String warning =
         warnings.stream()
@@ -326,6 +332,7 @@ class B2instConnectorImplTest {
         "Error submitting B2INST record k2j9p-7yh21 for community review: "
             + "B2INST returned HTTP 502 Bad Gateway",
         ex.getMessage());
+    server.verify();
   }
 
   @Test
@@ -344,6 +351,7 @@ class B2instConnectorImplTest {
         ex.getMessage()
             .startsWith("Error submitting B2INST record k2j9p-7yh21 for community review: "));
     assertTrue(ex.getMessage().contains("connect timed out"));
+    server.verify();
   }
 
   @Test
@@ -368,6 +376,60 @@ class B2instConnectorImplTest {
     assertEquals(
         "Error creating B2INST draft record: community: Missing data for required field.",
         ex.getMessage());
+    server.verify();
+  }
+
+  @Test
+  void publishDoiRedactsConfiguredTokenFromWarnLog() {
+    connector.reloadClient();
+    MockRestServiceServer server =
+        MockRestServiceServer.bindTo(connector.getRestTemplate()).build();
+    server
+        .expect(requestTo("https://b2inst-test.gwdg.de/api/records/k2j9p-7yh21/draft/review"))
+        .andRespond(
+            withStatus(HttpStatus.BAD_GATEWAY)
+                .contentType(MediaType.TEXT_HTML)
+                .body("<html>debug echo: Authorization Bearer TOK123</html>"));
+
+    List<String> warnings = new ArrayList<>();
+    AbstractAppender capture =
+        new AbstractAppender("b2instRedactCapture", null, null, true, Property.EMPTY_ARRAY) {
+          @Override
+          public void append(LogEvent event) {
+            warnings.add(event.getMessage().getFormattedMessage());
+          }
+        };
+    capture.start();
+    org.apache.logging.log4j.core.Logger coreLogger =
+        (org.apache.logging.log4j.core.Logger) LogManager.getLogger(B2instConnectorImpl.class);
+    coreLogger.addAppender(capture);
+    try {
+      assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));
+    } finally {
+      coreLogger.removeAppender(capture);
+      capture.stop();
+    }
+    server.verify();
+
+    String warning =
+        warnings.stream()
+            .filter(message -> message.contains("B2INST error response"))
+            .findFirst()
+            .orElseThrow();
+    assertFalse(warning.contains("TOK123"));
+    assertTrue(warning.contains("***"));
+  }
+
+  @Test
+  void describeFailureFallsBackToExceptionTypeWhenMessageMissing() throws Exception {
+    connector.reloadClient();
+    Method describeFailure =
+        B2instConnectorImpl.class.getDeclaredMethod("describeFailure", RestClientException.class);
+    describeFailure.setAccessible(true);
+
+    Object description = describeFailure.invoke(connector, new RestClientException((String) null));
+
+    assertEquals("RestClientException", description);
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImplTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instConnectorImplTest.java
@@ -22,8 +22,14 @@ import com.researchspace.model.system.SystemProperty;
 import com.researchspace.model.system.SystemPropertyValue;
 import com.researchspace.service.SystemPropertyManager;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -251,6 +257,67 @@ class B2instConnectorImplTest {
             withStatus(HttpStatus.BAD_GATEWAY)
                 .contentType(MediaType.TEXT_HTML)
                 .body("<html>Bad Gateway</html>"));
+
+    B2instConnectionException ex =
+        assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));
+
+    assertEquals(
+        "Error submitting B2INST record k2j9p-7yh21 for community review: "
+            + "B2INST returned HTTP 502 Bad Gateway",
+        ex.getMessage());
+  }
+
+  @Test
+  void publishDoiLogsClarifiedAndAbbreviatedWarningWhenNoUsableReason() {
+    connector.reloadClient();
+    MockRestServiceServer server =
+        MockRestServiceServer.bindTo(connector.getRestTemplate()).build();
+    String longHtmlBody = "<html>" + "x".repeat(2000) + "</html>";
+    server
+        .expect(requestTo("https://b2inst-test.gwdg.de/api/records/k2j9p-7yh21/draft/review"))
+        .andRespond(
+            withStatus(HttpStatus.BAD_GATEWAY).contentType(MediaType.TEXT_HTML).body(longHtmlBody));
+
+    List<String> warnings = new ArrayList<>();
+    AbstractAppender capture =
+        new AbstractAppender("b2instWarnCapture", null, null, true, Property.EMPTY_ARRAY) {
+          @Override
+          public void append(LogEvent event) {
+            warnings.add(event.getMessage().getFormattedMessage());
+          }
+        };
+    capture.start();
+    org.apache.logging.log4j.core.Logger coreLogger =
+        (org.apache.logging.log4j.core.Logger) LogManager.getLogger(B2instConnectorImpl.class);
+    coreLogger.addAppender(capture);
+    try {
+      assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));
+    } finally {
+      coreLogger.removeAppender(capture);
+      capture.stop();
+    }
+
+    String warning =
+        warnings.stream()
+            .filter(message -> message.contains("B2INST error response"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(warning.contains("No usable failure reason"));
+    assertTrue(warning.contains("..."));
+    assertTrue(warning.length() < 700);
+  }
+
+  @Test
+  void publishDoiFallsBackToHttpStatusWhenJsonCarriesNothingUsable() {
+    connector.reloadClient();
+    MockRestServiceServer server =
+        MockRestServiceServer.bindTo(connector.getRestTemplate()).build();
+    server
+        .expect(requestTo("https://b2inst-test.gwdg.de/api/records/k2j9p-7yh21/draft/review"))
+        .andRespond(
+            withStatus(HttpStatus.BAD_GATEWAY)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"status\":502}"));
 
     B2instConnectionException ex =
         assertThrows(B2instConnectionException.class, () -> connector.publishDoi("k2j9p-7yh21"));

--- a/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponseTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponseTest.java
@@ -88,6 +88,29 @@ class B2instErrorResponseTest {
   }
 
   @Test
+  void describeSkipsNullAndBlankMessageEntries() {
+    String json =
+        "{\"status\":400,\"message\":\"A validation error occurred.\",\"errors\":"
+            + "[{\"field\":\"instrument_type\",\"messages\":[null,\" \",\"Missing data for"
+            + " required field.\"]}]}";
+
+    B2instErrorResponse parsed = JacksonUtil.fromJson(json, B2instErrorResponse.class);
+
+    assertEquals("instrument_type: Missing data for required field.", parsed.describe());
+  }
+
+  @Test
+  void describeFallsBackToMessageWhenAllMessagesAreNullOrBlank() {
+    String json =
+        "{\"status\":400,\"message\":\"A validation error occurred.\",\"errors\":"
+            + "[{\"field\":\"instrument_type\",\"messages\":[null,\" \"]}]}";
+
+    B2instErrorResponse parsed = JacksonUtil.fromJson(json, B2instErrorResponse.class);
+
+    assertEquals("A validation error occurred.", parsed.describe());
+  }
+
+  @Test
   void describeFallsBackToTopLevelMessage() {
     assertEquals(
         "Permission denied.", new B2instErrorResponse(403, "Permission denied.", null).describe());

--- a/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponseTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponseTest.java
@@ -1,0 +1,52 @@
+package com.researchspace.webapp.integrations.b2inst;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.researchspace.core.util.JacksonUtil;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class B2instErrorResponseTest {
+
+  @Test
+  void deserialisesInvenioValidationPayloadIgnoringUnknownFields() {
+    String json =
+        "{\"status\":400,\"message\":\"A validation error occurred.\",\"unknown\":true,"
+            + "\"errors\":[{\"field\":\"instrument_type\","
+            + "\"messages\":[\"Missing data for required field.\"],\"extra\":1}]}";
+
+    B2instErrorResponse parsed = JacksonUtil.fromJson(json, B2instErrorResponse.class);
+
+    assertEquals("instrument_type: Missing data for required field.", parsed.describe());
+  }
+
+  @Test
+  void describeJoinsMultipleFieldErrors() {
+    B2instErrorResponse response =
+        new B2instErrorResponse(
+            400,
+            "A validation error occurred.",
+            List.of(
+                new B2instErrorResponse.FieldError(
+                    "instrument_type", List.of("Missing data for required field.")),
+                new B2instErrorResponse.FieldError(
+                    "owners", List.of("Shorter than minimum length 1."))));
+
+    assertEquals(
+        "instrument_type: Missing data for required field.; owners: Shorter than minimum"
+            + " length 1.",
+        response.describe());
+  }
+
+  @Test
+  void describeFallsBackToTopLevelMessage() {
+    assertEquals(
+        "Permission denied.", new B2instErrorResponse(403, "Permission denied.", null).describe());
+  }
+
+  @Test
+  void describeReturnsNullWhenNothingUsable() {
+    assertNull(new B2instErrorResponse(500, " ", List.of()).describe());
+  }
+}

--- a/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponseTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponseTest.java
@@ -40,6 +40,27 @@ class B2instErrorResponseTest {
   }
 
   @Test
+  void describeToleratesNullErrorEntries() {
+    String json =
+        "{\"status\":400,\"message\":\"A validation error occurred.\",\"errors\":"
+            + "[null,{\"field\":\"instrument_type\",\"messages\":[\"Missing data for required"
+            + " field.\"]}]}";
+
+    B2instErrorResponse parsed = JacksonUtil.fromJson(json, B2instErrorResponse.class);
+
+    assertEquals("instrument_type: Missing data for required field.", parsed.describe());
+  }
+
+  @Test
+  void describeFallsBackToMessageWhenAllErrorEntriesAreNull() {
+    String json = "{\"status\":400,\"message\":\"A validation error occurred.\",\"errors\":[null]}";
+
+    B2instErrorResponse parsed = JacksonUtil.fromJson(json, B2instErrorResponse.class);
+
+    assertEquals("A validation error occurred.", parsed.describe());
+  }
+
+  @Test
   void describeFallsBackToTopLevelMessage() {
     assertEquals(
         "Permission denied.", new B2instErrorResponse(403, "Permission denied.", null).describe());

--- a/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponseTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/b2inst/B2instErrorResponseTest.java
@@ -61,6 +61,33 @@ class B2instErrorResponseTest {
   }
 
   @Test
+  void describeRendersFieldlessErrorMessagesWithoutPrefix() {
+    String json =
+        "{\"status\":400,\"message\":\"A validation error occurred.\",\"errors\":"
+            + "[{\"messages\":[\"Record has validation errors.\"]}]}";
+
+    B2instErrorResponse parsed = JacksonUtil.fromJson(json, B2instErrorResponse.class);
+
+    assertEquals("Record has validation errors.", parsed.describe());
+  }
+
+  @Test
+  void describeRendersBlankFieldErrorMessagesWithoutPrefix() {
+    B2instErrorResponse response =
+        new B2instErrorResponse(
+            400,
+            "A validation error occurred.",
+            List.of(
+                new B2instErrorResponse.FieldError(" ", List.of("Record has validation errors.")),
+                new B2instErrorResponse.FieldError(
+                    "instrument_type", List.of("Missing data for required field."))));
+
+    assertEquals(
+        "Record has validation errors.; instrument_type: Missing data for required field.",
+        response.describe());
+  }
+
+  @Test
   void describeFallsBackToTopLevelMessage() {
     assertEquals(
         "Permission denied.", new B2instErrorResponse(403, "Permission denied.", null).describe());


### PR DESCRIPTION
## Description ##
We have noticed that the "publish" operation for B2INST was not going successfull.
After investigating, the error is actually genuine, so this PR is actually making sure that the error returned from the "publish" is actually returned to the user

### Root cause ###
"Publish for review" submits the B2INST draft record to the configured community, and B2INST (InvenioRDM) validates the record at that point. When the record is incomplete for the community (for example a required field is missing), B2INST rejects the submission with a structured validation payload:

```json
{"status": 400, "message": "A validation error occurred.", "errors": [{"field": "instrument_type", "messages": ["Missing data for required field."]}]}
```

RSpace swallowed that payload and replaced it with a generic "Error when publishing the instrument PID in B2INST. If the problem persists, please contact your System Admin", so the user had no way to know the failure was theirs to fix (and no admin could help). The delivery pipeline itself already works: an unhandled `B2instConnectionException` reaches the UI via `RestControllerAdvice.handleAll` (which puts `ex.getLocalizedMessage()` into `ApiError.message`) and the error alert in `IdentifierModel.publish()`, so the fix is to put the real rejection reason into the exception message. No frontend change is needed.

After this PR a failed publish shows, for example:

> Could not publish the instrument PID in B2INST. Error submitting B2INST record k2j9p-7yh21 for community review: instrument_type: Missing data for required field.; owners: Shorter than minimum length 1.

### Backend changes ###
- **`B2instErrorResponse` (new)**: typed model of B2INST's error payload (`status` / `message` / `errors[field, messages]`), living next to the connector. Its `describe()` renders a one-line summary: field errors joined as `field: message`, else the top-level message. Unknown JSON properties are ignored.
- **`B2instConnectorImpl`**: the three `RestClientException` catch blocks (register / delete / publish) now build their message through a new `describeFailure()` helper. When the server replied (`RestClientResponseException`) it parses the raw response body via `JacksonUtil.fromJsonOpt`; if the body is not parseable JSON it logs it at WARN and falls back to `B2INST returned HTTP <code> <text>`; without a response (transport error) it keeps the client exception message. The delete message also gains the record id.
- **`InventoryIdentifierApiManagerImpl`**: the publish path no longer replaces the connector message with the generic advice; it rethrows wrapped in a bundle-resolved lead sentence, keeping the original exception as the cause. Register and delete keep their existing generic UI message (their server logs still improve through the connector change).
- **`bundles/inventory/inventory.properties`**: new key `errors.inventory.identifier.b2inst.publish.failed=Could not publish the instrument PID in B2INST. {0}`.

## Jira tickets ##
- https://researchspace.atlassian.net/browse/RSDEV-1244

## Design decisions ##
- **Parse the response body at the connector, not the exception message.** Spring rewrites bodies embedded in `RestClientResponseException.getMessage()` (quote wrapping, newline replacement), and message-string surgery breaks on every non-HTTP failure (timeouts, misconfiguration). `getResponseBodyAsString()` provides the raw untruncated body, and `DSWController` already uses this same `JacksonUtil`-on-body pattern.
- **Graceful degradation, never a worse error.** The fallback chain is: field errors, then top-level message, then HTTP status, then transport message. A malformed or non-JSON body can no longer surface a raw parsing exception to the user.
- **Model placed next to the connector.** The payload is B2INST's contract, not RSpace's public API model, so it lives in `webapp.integrations.b2inst` rather than `api.v1.model`, and not in `rspace-core-model` (no cross-repo release for a web-tier concern).
- **User-facing text is bundle-resolved** at the manager seam, with the dynamic detail interpolated as `{0}`.
- **The submit-action POST keeps its empty body.** During investigation we confirmed real B2INST does not require the review payload on the submit call; the existing publish test now pins the empty body with a `content().string("")` assertion so it cannot change silently.

## Testing notes
Publish with B2INST in the AWS instance https://rsdev-1244-bug-message-publish-0afd5172-9.researchspace.com and check if the specific error arrives to UI

### Automated coverage (fast unit tests, `mvn test -Dfast=true`) ###
- **`B2instErrorResponseTest` (new, 4 tests)**: deserialises the InvenioRDM payload ignoring unknown fields, joins multiple field errors, falls back to the top-level message, returns null when the payload carries nothing usable.
- **`B2instConnectorImplTest` (+5, 16 total)**: publish surfaces field validation errors and message-only payloads; an HTML (non-JSON) error body falls back to the HTTP status; a transport error keeps its "connect timed out" detail; register surfaces validation errors too; the existing publish test now also asserts the empty submit body.
- **`InventoryIdentifierApiManagerImplUnitTest` (+2, 8 total)**: the publish failure path rethrows a `B2instConnectionException` carrying the bundle wrapper plus the connector detail with the original exception as cause; the success path still maps the submission status onto the DOI state.

`mvn spotless:check` is clean.
