### PR TITLE
Apps config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,17 +143,22 @@ jobs:
       # Start the app in the background first so its ~2.5 min boot overlaps the
       # pnpm/Playwright install below instead of stacking after it.
       - name: Start RSpace (prebuilt WAR)
+        env:
+          PYRAT_SERVER_TOKEN: ${{ inputs.mode == 'real' && secrets.PYRAT_SERVER_TOKEN || '' }}
         run: |
           set -euo pipefail
-          MOCK_ARGS=()
           if [ "${{ inputs.mode }}" = "mock" ]; then
-            MOCK_ARGS=(
+            INTEGRATION_ARGS=(
               "-Dpubchem.base.url=http://localhost:$E2E_MOCK_PORT"
               "-Dfieldmark.api.url=http://localhost:$E2E_MOCK_PORT"
               "-Dzenodo.url=http://localhost:$E2E_MOCK_PORT"
               "-Dgalaxy.server.config=[{\"alias\":\"mock\",\"url\":\"http://localhost:$E2E_MOCK_PORT\"}]"
               "-Dpyrat.server.config={\"mock\":{\"url\":\"http://localhost:$E2E_MOCK_PORT\",\"token\":\"mock-server-token\"}}"
               "-Domero.api.url=http://localhost:$E2E_MOCK_PORT"
+            )
+          else
+            INTEGRATION_ARGS=(
+              "-Dpyrat.server.config={\"default-server\":{\"url\":\"https://demo.pyrat.cloud/rspace511/api/v3/\",\"token\":\"$PYRAT_SERVER_TOKEN\"}}"
             )
           fi
           nohup ./mvnw jetty:run-war \
@@ -169,7 +174,7 @@ jobs:
             -Djdbc.db.maven=rspace \
             -DRS_FILE_BASE="$RS_FILE_BASE" \
             -DRS.devlogLevel=INFO \
-            "${MOCK_ARGS[@]}" \
+            "${INTEGRATION_ARGS[@]}" \
             > /tmp/jetty.log 2>&1 &
 
       - run: pnpm install --frozen-lockfile

--- a/docker/dev/.env.example
+++ b/docker/dev/.env.example
@@ -43,6 +43,8 @@ VITE_USE_POLLING=true
 # NODE_IMAGE=node:24-bookworm-slim
 # CHEMISTRY_IMAGE=rspaceops/oss-chemistry:latest
 # MAVEN_OPTS=-Xmx2g
+# PyRAT real mode needs a server-level secret:
+# MAVEN_OPTS=-Xmx2g -Dpyrat.server.config={"default-server":{"url":"...","token":"..."}}
 # RSPACE_DEBUG=false        # disable the JDWP remote-debug agent (on by default)
 # RSPACE_DEBUG_SUSPEND=y    # pause JVM startup until a debugger attaches
 # RSPACE_HOTSWAP=false      # disable JBR enhanced redefinition + HotswapAgent

--- a/src/main/webapp/ui/src/__tests__/e2e/docs/e2e-mocking.md
+++ b/src/main/webapp/ui/src/__tests__/e2e/docs/e2e-mocking.md
@@ -154,7 +154,7 @@ credentials in `.env`:
 | `DATAVERSE_NAME` | Dataverse real-mode spec | Alias of an **existing** collection on that server — an arbitrary/made-up alias 404s (see below) |
 | `DSW_API_KEY` | DSW real-mode spec | Target DSW/FAIR Wizard instance → account settings → API Token |
 | `DSW_SERVER_URL` | DSW real-mode spec | The instance's base URL, e.g. `https://your-dsw-instance.example` |
-| `PYRAT_API_KEY` | PyRAT (real mode not currently runnable — see below) | Target PyRAT instance → Administration → API → Request access |
+| `PYRAT_API_KEY` | PyRAT real-mode spec (per-user key) | Target PyRAT instance → Apps page → PyRAT → Add server → generate a user API key |
 | `OMERO_USERNAME` | OMERO real-mode spec | An OMERO account username (e.g. via `demo.openmicroscopy.org` self-service signup) |
 | `OMERO_PASSWORD` | OMERO real-mode spec | That account's password |
 | `IGSN_ACCOUNT_ID` | IGSN real-mode specs | DataCite Repository Account ID |
@@ -162,8 +162,7 @@ credentials in `.env`:
 | `IGSN_REPO_PREFIX` | IGSN real-mode specs | Prefix assigned to that DataCite repository account |
 | `IGSN_SERVER_URL` | IGSN real-mode specs | DataCite API URL; defaults to `https://api.test.datacite.org` |
 
-Missing a key causes that spec's real-mode run to `test.skip` with an
-actionable message rather than fail — mock mode is unaffected either way.
+Missing a key skips with an actionable message for most specs.
 
 **Fieldmark tokens expire** (observed: about two weeks from generation — check
 Fieldmark's own docs for their exact policy, it isn't published anywhere we

--- a/src/main/webapp/ui/src/modules/fieldmark/__tests__/fieldmark.e2e.ts
+++ b/src/main/webapp/ui/src/modules/fieldmark/__tests__/fieldmark.e2e.ts
@@ -9,13 +9,10 @@ const EXPECTED = {
 };
 
 const INTEGRATION_MODE = env.integrationMode;
-const FIELDMARK_API_KEY = INTEGRATION_MODE === "real" ? env.fieldmarkApiKey : "mock-fieldmark-token";
+const FIELDMARK_API_KEY = "mock-fieldmark-token";
 
 test.describe(`Fieldmark integration [${INTEGRATION_MODE}]`, { tag: tags.APPS }, () => {
-  test.skip(
-    INTEGRATION_MODE === "real" && !FIELDMARK_API_KEY,
-    "real mode needs FIELDMARK_API_KEY (a Fieldmark long-lived token) in .env / CI secrets",
-  );
+  test.skip(INTEGRATION_MODE === "real", "real mode is broken");
 
   test.beforeEach(async ({ flowSysadminConfig }) => {
     await flowSysadminConfig.ensureSetting("fieldmark.available", "ALLOWED");

--- a/src/main/webapp/ui/src/modules/omero/__tests__/omero.e2e.ts
+++ b/src/main/webapp/ui/src/modules/omero/__tests__/omero.e2e.ts
@@ -10,10 +10,11 @@ const OMERO_USERNAME = INTEGRATION_MODE === "real" ? env.omeroUsername : "mock-o
 const OMERO_PASSWORD = INTEGRATION_MODE === "real" ? env.omeroPassword : "mock-omero-password";
 
 test.describe(`OMERO integration [${INTEGRATION_MODE}]`, { tag: tags.APPS }, () => {
-  test.skip(
-    INTEGRATION_MODE === "real" && !(OMERO_USERNAME && OMERO_PASSWORD),
-    "real mode needs OMERO_USERNAME and OMERO_PASSWORD in .env / CI secrets",
-  );
+  test.beforeAll(async () => {
+    if (INTEGRATION_MODE === "real" && !(OMERO_USERNAME && OMERO_PASSWORD)) {
+      throw new Error("OMERO_USERNAME and OMERO_PASSWORD must be set in .env / CI secrets for real mode");
+    }
+  });
 
   test.beforeEach(async ({ flowSysadminConfig }) => {
     await flowSysadminConfig.ensureSetting("omero.available", "ALLOWED");

--- a/src/main/webapp/ui/src/modules/omero/__tests__/pageObjects/OmeroDialogComponent.ts
+++ b/src/main/webapp/ui/src/modules/omero/__tests__/pageObjects/OmeroDialogComponent.ts
@@ -21,7 +21,7 @@ export class OmeroDialogComponent {
   }
 
   async selectFirstItem(): Promise<void> {
-    await this.resultsTable.getByRole("checkbox").first().click();
+    await this.resultsTable.locator('input[type="checkbox"][aria-labelledby]').first().click();
   }
 
   async clickInsert(): Promise<void> {

--- a/src/main/webapp/ui/src/modules/pyrat/__tests__/pageObjects/PyratDialogComponent.ts
+++ b/src/main/webapp/ui/src/modules/pyrat/__tests__/pageObjects/PyratDialogComponent.ts
@@ -16,13 +16,22 @@ export class PyratDialogComponent {
   async waitForOpen(): Promise<void> {
     await this.root.waitFor({ state: "visible" });
     const errorAlert = this.root.getByRole("alert");
-    await Promise.race([
-      this.resultsTable.waitFor({ state: "visible" }),
-      errorAlert.waitFor({ state: "visible" }).then(async () => {
-        const message = await errorAlert.textContent();
-        throw new Error(`PyRAT dialog showed an error instead of loading results: ${message}`);
-      }),
-    ]);
+
+    let resultsVisible = false;
+    const resultsPromise = this.resultsTable.waitFor({ state: "visible" }).then(() => {
+      resultsVisible = true;
+    });
+    const errorPromise = errorAlert.waitFor({ state: "visible" }).then(async () => {
+      if (resultsVisible) return;
+      const message = await errorAlert.textContent();
+      throw new Error(`PyRAT dialog showed an error instead of loading results: ${message}`);
+    });
+
+    try {
+      await Promise.race([resultsPromise, errorPromise]);
+    } finally {
+      void Promise.allSettled([resultsPromise, errorPromise]);
+    }
   }
 
   async selectAnimal(eartagOrId: string): Promise<void> {

--- a/src/main/webapp/ui/src/modules/pyrat/__tests__/pageObjects/PyratDialogComponent.ts
+++ b/src/main/webapp/ui/src/modules/pyrat/__tests__/pageObjects/PyratDialogComponent.ts
@@ -15,11 +15,27 @@ export class PyratDialogComponent {
 
   async waitForOpen(): Promise<void> {
     await this.root.waitFor({ state: "visible" });
-    await this.resultsTable.waitFor({ state: "visible" });
+    const errorAlert = this.root.getByRole("alert");
+    await Promise.race([
+      this.resultsTable.waitFor({ state: "visible" }),
+      errorAlert.waitFor({ state: "visible" }).then(async () => {
+        const message = await errorAlert.textContent();
+        throw new Error(`PyRAT dialog showed an error instead of loading results: ${message}`);
+      }),
+    ]);
   }
 
   async selectAnimal(eartagOrId: string): Promise<void> {
     await this.resultsTable.getByRole("cell", { name: eartagOrId, exact: true }).click();
+  }
+
+  async selectFirstAnimal(): Promise<string> {
+    const dataRowGroup = this.resultsTable.getByRole("rowgroup").nth(1);
+    const idCell = dataRowGroup.getByRole("cell").nth(1);
+    const eartagOrId = (await idCell.textContent())?.trim();
+    if (!eartagOrId) throw new Error("The first PyRAT animal's ID cell has no text.");
+    await idCell.click();
+    return eartagOrId;
   }
 
   async clickInsert(): Promise<void> {

--- a/src/main/webapp/ui/src/modules/pyrat/__tests__/pyrat.e2e.ts
+++ b/src/main/webapp/ui/src/modules/pyrat/__tests__/pyrat.e2e.ts
@@ -3,13 +3,19 @@ import { env } from "@/__tests__/e2e/env";
 import { dynamicUserTest as test } from "@/__tests__/e2e/fixtures/dynamicUser";
 import { tags } from "@/__tests__/e2e/tags";
 
-const EXPECTED = { eartagOrId: "MOCK-001" };
+const EXPECTED_MOCK_EARTAG = "MOCK-001";
 
 const INTEGRATION_MODE = env.integrationMode;
-const PYRAT_ALIAS = "mock";
+const PYRAT_ALIAS = INTEGRATION_MODE === "real" ? "default-server" : "mock";
 const PYRAT_API_KEY = INTEGRATION_MODE === "real" ? env.pyratApiKey : "mock-pyrat-token";
 
 test.describe(`PyRAT integration [${INTEGRATION_MODE}]`, { tag: tags.APPS }, () => {
+  test.beforeAll(async () => {
+    if (INTEGRATION_MODE === "real" && !PYRAT_API_KEY) {
+      throw new Error("PYRAT_API_KEY must be set in .env / CI secrets for real mode");
+    }
+  });
+
   test.beforeEach(async ({ flowSysadminConfig }) => {
     await flowSysadminConfig.ensureSetting("pyrat.available", "ALLOWED");
   });
@@ -26,10 +32,16 @@ test.describe(`PyRAT integration [${INTEGRATION_MODE}]`, { tag: tags.APPS }, () 
     const docEditor = await pageWorkspace.createBasicDocument();
     const dialog = await docEditor.openPyratDialog();
 
-    await dialog.selectAnimal(EXPECTED.eartagOrId);
+    let expectedEartagOrId: string;
+    if (INTEGRATION_MODE === "real") {
+      expectedEartagOrId = await dialog.selectFirstAnimal();
+    } else {
+      expectedEartagOrId = EXPECTED_MOCK_EARTAG;
+      await dialog.selectAnimal(expectedEartagOrId);
+    }
     await dialog.clickInsert();
 
     const field = await docEditor.getField("New List of Materials");
-    await expect.poll(() => field.getText()).toContain(EXPECTED.eartagOrId);
+    await expect.poll(() => field.getText()).toContain(expectedEartagOrId);
   });
 });


### PR DESCRIPTION
 - OMERO: fixed a flaky checkbox selector in the results table; missing credentials now hard-fail instead of
  silently skipping.
  - PyRAT: real-mode tests now work  surface API errors clearly, and pick whatever animal is actually on the server
  instead of a hardcoded mock ID.
  - Fieldmark: real mode is currently broken, so it's now explicitly skipped with a clear reason.
  - CI/docs: wired up the PyRAT secret in GitHub Actions so real mode can actually run there, and updated the docs
  to match.