### PR TITLE
Rsdev 173 Inventory Attachment Backlinks in Gallery

### DIFF
--- a/DevDocs/CONTEXT.md
+++ b/DevDocs/CONTEXT.md
@@ -29,3 +29,32 @@ useful: removed for deleted or inaccessible ELN targets (their routes produce
 error pages), kept for deleted Inventory targets (the trash viewer works) and
 for all readable targets.
 _Avoid_: view, go to
+
+## Related inventory items (Gallery info panel)
+
+**Referencing item**:
+An Inventory item that connects to a Gallery file the viewer is looking at, and
+so appears as a back-reference row in the Gallery info panel's "Related
+inventory items" section. The connection is one of two **relation kinds**:
+_Link_ or _Attachment_. The section shows both, one row per connection.
+_Avoid_: related item, back-link
+
+**Link (relation kind)**:
+An `InventoryLink` on the item pointing at the Gallery file by Global ID (RSDEV-1131).
+Carries a DataCite _relation type_ (IsPartOf, References, ...) shown in the
+Relation column. No file bytes are copied.
+_Avoid_: reference, pointer
+
+**Attachment (relation kind)**:
+An `InventoryFile` whose `mediaFile` is the Gallery file: an inventory item
+attached that Gallery file (its bytes were copied into the item). Reported
+against the **owning item** whether the file hangs off the record directly or
+off one of the item's attachment fields; the field is never the subject. Has no
+DataCite relation type, so its Relation column reads "Attachment". Distinct from
+a Link.
+_Avoid_: file link, attached link, embedded file, attachment field
+
+**Relation (column)**:
+The single grid column that names how each referencing item connects: a Link
+row shows its DataCite relation type; an Attachment row shows the literal
+"Attachment". One axis, one column.

--- a/DevDocs/adr/0002-link-target-state-non-disclosure.md
+++ b/DevDocs/adr/0002-link-target-state-non-disclosure.md
@@ -35,3 +35,9 @@ knowledge the viewer is not entitled to.
   Open could only produce an error page.
 * Inventory targets ignore `readable` in the UI: every logged-in user retains
   the limited-read view, so Open keeps working and no pill is shown.
+* The gallery "Related inventory items" attachments endpoint (RSDEV-173,
+  `GET /workspace/getAttachingInventoryItems/{globalId}`) applies the same
+  non-disclosure gate: an unreadable, nonexistent, or malformed target Global ID
+  all return one identical not-found, so it never reveals a gallery file exists
+  or which Inventory items attached it. This mirrors the links referencing-items
+  endpoint.

--- a/src/main/java/com/researchspace/dao/InventoryFileDao.java
+++ b/src/main/java/com/researchspace/dao/InventoryFileDao.java
@@ -20,9 +20,10 @@ public interface InventoryFileDao extends GenericDao<InventoryFile, Long> {
   List<InventoryFile> findByMediaFileId(Long mediaFileId);
 
   /**
-   * The sample/template attachment fields holding a live (non-deleted) attachment of the given
-   * Gallery media file. Used to resolve field-level attachments back to their owning item, which
-   * the attachment's own {@code getInventoryRecord()} cannot reach.
+   * The live (non-deleted) sample/template attachment fields holding a live (non-deleted)
+   * attachment of the given Gallery media file. Used to resolve field-level attachments back to
+   * their owning item, which the attachment's own {@code getInventoryRecord()} cannot reach. Both
+   * flags are checked because deleting a field does not soft-delete its {@code InventoryFile}.
    *
    * @param mediaFileId the db id of the Gallery {@code EcatMediaFile}
    */

--- a/src/main/java/com/researchspace/dao/InventoryFileDao.java
+++ b/src/main/java/com/researchspace/dao/InventoryFileDao.java
@@ -1,9 +1,30 @@
 package com.researchspace.dao;
 
 import com.researchspace.model.inventory.InventoryFile;
+import com.researchspace.model.inventory.field.InventoryAttachmentField;
+import java.util.List;
 
 /** For DAO operations on Inventory File. */
 public interface InventoryFileDao extends GenericDao<InventoryFile, Long> {
 
   InventoryFile getWithInitializedFields(Long id);
+
+  /**
+   * All live (non-deleted) inventory-file attachments of the given Gallery media file. Includes
+   * both record-level and field-level attachments; the caller resolves each attachment's owning
+   * inventory record (field-level attachments resolve to null here and are found via {@link
+   * #findAttachmentFieldsByMediaFileId}).
+   *
+   * @param mediaFileId the db id of the Gallery {@code EcatMediaFile}
+   */
+  List<InventoryFile> findByMediaFileId(Long mediaFileId);
+
+  /**
+   * The sample/template attachment fields holding a live (non-deleted) attachment of the given
+   * Gallery media file. Used to resolve field-level attachments back to their owning item, which
+   * the attachment's own {@code getInventoryRecord()} cannot reach.
+   *
+   * @param mediaFileId the db id of the Gallery {@code EcatMediaFile}
+   */
+  List<InventoryAttachmentField> findAttachmentFieldsByMediaFileId(Long mediaFileId);
 }

--- a/src/main/java/com/researchspace/dao/hibernate/InventoryFileDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/InventoryFileDaoHibernate.java
@@ -39,11 +39,15 @@ public class InventoryFileDaoHibernate extends GenericDaoHibernate<InventoryFile
 
   @Override
   public List<InventoryAttachmentField> findAttachmentFieldsByMediaFileId(Long mediaFileId) {
+    // both the attachment and its owning field must be live: deleting a field only flips the
+    // field's flag, leaving its InventoryFile non-deleted, so filtering the file alone would
+    // surface a stale back-reference. Mirrors the field-soft-delete filter the link queries use.
     return sessionFactory
         .getCurrentSession()
         .createQuery(
             "select af from InventoryAttachmentField af join af.files f"
-                + " where f.mediaFile.id = :mediaFileId and f.deleted = false",
+                + " where f.mediaFile.id = :mediaFileId and f.deleted = false"
+                + " and af.deleted = false",
             InventoryAttachmentField.class)
         .setParameter("mediaFileId", mediaFileId)
         .list();

--- a/src/main/java/com/researchspace/dao/hibernate/InventoryFileDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/InventoryFileDaoHibernate.java
@@ -3,6 +3,8 @@ package com.researchspace.dao.hibernate;
 import com.researchspace.dao.GenericDaoHibernate;
 import com.researchspace.dao.InventoryFileDao;
 import com.researchspace.model.inventory.InventoryFile;
+import com.researchspace.model.inventory.field.InventoryAttachmentField;
+import java.util.List;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,5 +24,28 @@ public class InventoryFileDaoHibernate extends GenericDaoHibernate<InventoryFile
     InventoryFile inventoryFile = get(id);
     inventoryFile.getFileProperty().getFileName(); // load fileProperty that is lazy-initialized
     return inventoryFile;
+  }
+
+  @Override
+  public List<InventoryFile> findByMediaFileId(Long mediaFileId) {
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery(
+            "from InventoryFile f where f.mediaFile.id = :mediaFileId and f.deleted = false",
+            InventoryFile.class)
+        .setParameter("mediaFileId", mediaFileId)
+        .list();
+  }
+
+  @Override
+  public List<InventoryAttachmentField> findAttachmentFieldsByMediaFileId(Long mediaFileId) {
+    return sessionFactory
+        .getCurrentSession()
+        .createQuery(
+            "select af from InventoryAttachmentField af join af.files f"
+                + " where f.mediaFile.id = :mediaFileId and f.deleted = false",
+            InventoryAttachmentField.class)
+        .setParameter("mediaFileId", mediaFileId)
+        .list();
   }
 }

--- a/src/main/java/com/researchspace/service/inventory/InventoryFileApiManager.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryFileApiManager.java
@@ -1,17 +1,32 @@
 package com.researchspace.service.inventory;
 
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
 import com.researchspace.model.FileProperty;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.InventoryFile;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 /** Handles API actions around Inventory File. */
 public interface InventoryFileApiManager {
 
   /** Checks if Inventory File with given id exists */
   boolean exists(long id);
+
+  /**
+   * The Inventory items that attach the given Gallery media file, for the "Related inventory items"
+   * back-reference panels. Covers both record-level and field-level attachments, each reported
+   * against its owning item. The caller must be able to READ the target Gallery file; an
+   * unreadable, missing, malformed, or non-Gallery Global ID all raise the same not-found error so
+   * the endpoint discloses nothing (mirrors {@link InventoryLinkManager#findReferencingItems} and
+   * ADR-0002). Source items the caller cannot read are filtered out.
+   *
+   * @param galleryFileGlobalId the Global ID of the Gallery file (GL...)
+   * @param actor the requesting user
+   */
+  List<ApiInventoryReferencingItem> findAttachingItems(String galleryFileGlobalId, User actor);
 
   /** Retrieve Inventory File with given id */
   InventoryFile getInventoryFileById(Long id, User user);

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImpl.java
@@ -1,5 +1,7 @@
 package com.researchspace.service.inventory.impl;
 
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
 import com.researchspace.core.util.MediaUtils;
 import com.researchspace.dao.InstrumentEntityDao;
 import com.researchspace.dao.InventoryEntityFieldDao;
@@ -15,6 +17,7 @@ import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.field.InventoryAttachmentField;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.record.IRecordFactory;
 import com.researchspace.service.BaseRecordManager;
@@ -28,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URLConnection;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.authz.AuthorizationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 @Service("inventoryFileApiManager")
@@ -64,6 +69,67 @@ public class InventoryFileApiManagerImpl implements InventoryFileApiManager {
   @Override
   public boolean exists(long id) {
     return inventoryFileDao.exists(id);
+  }
+
+  @Override
+  public List<ApiInventoryReferencingItem> findAttachingItems(
+      String galleryFileGlobalId, User actor) {
+    GlobalIdentifier target = parseGalleryTargetOrThrow(galleryFileGlobalId);
+    // read-gate: the caller must be able to READ the target Gallery file. Unreadable, missing,
+    // malformed and non-Gallery ids all raise the same not-found so the endpoint never discloses a
+    // file's existence or its inbound attachments (ADR-0002).
+    try {
+      baseRecordManager.retrieveMediaFile(actor, target.getDbId());
+    } catch (AuthorizationException | IllegalStateException | DataAccessException e) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.targetNotFound", galleryFileGlobalId);
+    }
+    List<ApiInventoryReferencingItem> rows = new ArrayList<>();
+    // record-level attachments: the attachment resolves its own owning record
+    for (InventoryFile file : inventoryFileDao.findByMediaFileId(target.getDbId())) {
+      addAttachmentRowIfReadable(rows, file.getInventoryRecord(), actor);
+    }
+    // field-level attachments: resolved through the owning attachment field, since the attachment
+    // itself cannot reach the record it hangs off a field on
+    for (InventoryAttachmentField field :
+        inventoryFileDao.findAttachmentFieldsByMediaFileId(target.getDbId())) {
+      addAttachmentRowIfReadable(rows, field.getInventoryRecord(), actor);
+    }
+    return rows;
+  }
+
+  private GlobalIdentifier parseGalleryTargetOrThrow(String galleryFileGlobalId) {
+    GlobalIdentifier gid;
+    try {
+      gid = new GlobalIdentifier(galleryFileGlobalId);
+    } catch (IllegalArgumentException | NullPointerException e) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.targetNotFound", galleryFileGlobalId);
+    }
+    // attachments only ever target a Gallery media file; any other kind is treated as not-found so
+    // a caller cannot probe non-Gallery ids through this endpoint
+    if (gid.getPrefix() != GlobalIdPrefix.GL) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.targetNotFound", galleryFileGlobalId);
+    }
+    return gid;
+  }
+
+  private void addAttachmentRowIfReadable(
+      List<ApiInventoryReferencingItem> rows, InventoryRecord owningRecord, User actor) {
+    if (owningRecord == null || owningRecord.isDeleted()) {
+      return;
+    }
+    if (!invPermissions.canUserReadInventoryRecord(owningRecord, actor)) {
+      return;
+    }
+    ApiInventoryReferencingItem row = new ApiInventoryReferencingItem();
+    row.setSourceGlobalId(owningRecord.getOid().toString());
+    row.setSourceName(owningRecord.getName());
+    row.setSourceType(owningRecord.getType().toString());
+    // relationType/versionPin/modifiedAt stay null: an attachment carries no DataCite relation; the
+    // client labels these rows "Attachment"
+    rows.add(row);
   }
 
   @Override

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImpl.java
@@ -27,6 +27,7 @@ import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.inventory.InventoryFileApiManager;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
 import com.researchspace.service.inventory.InventoryRecordRetriever;
+import com.researchspace.service.inventory.LinkTargetResolver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -40,7 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.authz.AuthorizationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 @Service("inventoryFileApiManager")
@@ -57,6 +57,7 @@ public class InventoryFileApiManagerImpl implements InventoryFileApiManager {
   private @Autowired MessageSourceUtils messages;
   private @Autowired IRecordFactory recordFactory;
   private @Autowired BaseRecordManager baseRecordManager;
+  private @Autowired LinkTargetResolver linkTargetResolver;
 
   @Autowired
   @Qualifier("compositeFileStore")
@@ -77,10 +78,11 @@ public class InventoryFileApiManagerImpl implements InventoryFileApiManager {
     GlobalIdentifier target = parseGalleryTargetOrThrow(galleryFileGlobalId);
     // read-gate: the caller must be able to READ the target Gallery file. Unreadable, missing,
     // malformed and non-Gallery ids all raise the same not-found so the endpoint never discloses a
-    // file's existence or its inbound attachments (ADR-0002).
-    try {
-      baseRecordManager.retrieveMediaFile(actor, target.getDbId());
-    } catch (AuthorizationException | IllegalStateException | DataAccessException e) {
+    // file's existence or its inbound attachments (ADR-0002). Resolve through the shared
+    // LinkTargetResolver (as the sibling links endpoint does): it is collision-safe for the GL/
+    // FL/SD id space and returns false rather than throwing when the id resolves to a non-media
+    // record, so a crafted GL<non-media-id> cannot become an existence oracle via a 500.
+    if (!linkTargetResolver.targetExistsAndIsReadable(target, actor)) {
       throw new ApiRuntimeException(
           "errors.inventory.field.link.targetNotFound", galleryFileGlobalId);
     }

--- a/src/main/java/com/researchspace/webapp/controller/ReferencingInventoryItemsController.java
+++ b/src/main/java/com/researchspace/webapp/controller/ReferencingInventoryItemsController.java
@@ -1,13 +1,17 @@
 package com.researchspace.webapp.controller;
 
 import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
 import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
 import com.researchspace.model.User;
 import com.researchspace.model.field.ErrorList;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.UserManager;
+import com.researchspace.service.inventory.InventoryFileApiManager;
 import com.researchspace.service.inventory.InventoryLinkManager;
 import java.security.Principal;
+import java.util.List;
+import java.util.function.Supplier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,18 +22,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
- * Session-authenticated lookup of the Inventory items that link to a given ELN record. Backs the
+ * Session-authenticated lookup of the Inventory items connected to a given ELN record. Backs the
  * ELN-side "Related inventory items" panels (the legacy record info panel for documents/notebooks
  * and the React gallery info panel). Those run in the browser session and do not present the API
- * key or OAuth bearer token that the {@code /api/inventory/v1} endpoints require, so they call this
- * {@code /workspace} endpoint instead. It delegates to the same permission-filtered manager method
- * as the API endpoint, so callers only ever see items they may read.
+ * key or OAuth bearer token that the {@code /api/inventory/v1} endpoints require, so they call
+ * these {@code /workspace} endpoints instead. Both delegate to the same permission-filtered
+ * managers as the API endpoints, so callers only ever see items they may read.
+ *
+ * <p>Two relation kinds are served separately, one endpoint each: <em>links</em> (an inventory Link
+ * field pointing at the record) and <em>attachments</em> (an inventory item that attached a Gallery
+ * file). The Gallery info panel calls both and merges them into one grid.
  */
 @Controller
 @RequestMapping("/workspace")
 public class ReferencingInventoryItemsController {
 
   @Autowired private InventoryLinkManager inventoryLinkManager;
+  @Autowired private InventoryFileApiManager inventoryFileApiManager;
   @Autowired private UserManager userManager;
   @Autowired private MessageSourceUtils messageSource;
 
@@ -38,16 +47,31 @@ public class ReferencingInventoryItemsController {
   public ResponseEntity<?> getReferencingInventoryItems(
       @PathVariable("globalId") String globalId, Principal principal) {
     User user = userManager.getUserByUsername(principal.getName());
+    return buildResponse(() -> inventoryLinkManager.findReferencingItems(globalId, user));
+  }
+
+  @ResponseBody
+  @GetMapping("/getAttachingInventoryItems/{globalId}")
+  public ResponseEntity<?> getAttachingInventoryItems(
+      @PathVariable("globalId") String globalId, Principal principal) {
+    User user = userManager.getUserByUsername(principal.getName());
+    return buildResponse(() -> inventoryFileApiManager.findAttachingItems(globalId, user));
+  }
+
+  /**
+   * Runs a referencing-items lookup and wraps the result, translating the manager's malformed- or
+   * unreadable-target {@link ApiRuntimeException} into a structured JSON 404. No
+   * {@code @ControllerAdvice} applies to this session {@code @Controller} and it does not extend
+   * {@code BaseController}, so without this the exception would escape to Spring's default
+   * dispatcher as an HTML 500. Translating it keeps this endpoint's contract JSON, matching the
+   * api.v1 referencing-items endpoint.
+   */
+  private ResponseEntity<?> buildResponse(Supplier<List<ApiInventoryReferencingItem>> lookup) {
     try {
       ApiInventoryReferencingItems result = new ApiInventoryReferencingItems();
-      result.setReferencingItems(inventoryLinkManager.findReferencingItems(globalId, user));
+      result.setReferencingItems(lookup.get());
       return ResponseEntity.ok(result);
     } catch (ApiRuntimeException e) {
-      // findReferencingItems throws this for a malformed globalId. No @ControllerAdvice applies to
-      // this session @Controller and it does not extend BaseController, so the exception would
-      // otherwise escape to Spring's default dispatcher as an HTML 500. Translate it to a
-      // structured JSON 404 so this endpoint's contract stays JSON, matching the api.v1
-      // referencing-items endpoint.
       return ResponseEntity.status(HttpStatus.NOT_FOUND)
           .body(ErrorList.of(messageSource.getMessage(e.getErrorCode(), e.getArgs())));
     }

--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useReferencingInventoryItems.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useReferencingInventoryItems.test.tsx
@@ -9,14 +9,30 @@ vi.mock("@/common/axios", () => ({
 
 import useReferencingInventoryItems from "../useReferencingInventoryItems";
 
+type Row = Record<string, unknown>;
+
+/**
+ * The hook fans out to two endpoints for a gallery file: the links (referencing) endpoint and the
+ * attachments endpoint. Route each mocked response by URL so a test can supply link rows and
+ * attachment rows independently.
+ */
+function mockEndpoints({ links = [], attachments = [] }: { links?: Array<Row>; attachments?: Array<Row> }) {
+  mockAxiosGet.mockImplementation((url: string) => {
+    if (url.includes("getAttachingInventoryItems")) {
+      return Promise.resolve({ data: { referencingItems: attachments } });
+    }
+    return Promise.resolve({ data: { referencingItems: links } });
+  });
+}
+
 describe("useReferencingInventoryItems", () => {
   beforeEach(() => {
     mockAxiosGet.mockReset();
   });
   afterEach(cleanup);
 
-  it("requests the generic referencingItems endpoint with the record's global id", async () => {
-    mockAxiosGet.mockResolvedValue({ data: { referencingItems: [] } });
+  it("requests the links endpoint with the record's global id", async () => {
+    mockEndpoints({});
 
     const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
 
@@ -24,11 +40,32 @@ describe("useReferencingInventoryItems", () => {
     expect(mockAxiosGet).toHaveBeenCalledWith("/workspace/getReferencingInventoryItems/GL5");
   });
 
+  it("also requests the attachments endpoint for a gallery-file target", async () => {
+    mockEndpoints({});
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockAxiosGet).toHaveBeenCalledWith("/workspace/getAttachingInventoryItems/GL5");
+  });
+
+  it("does not request the attachments endpoint for a non-gallery target", async () => {
+    // only gallery files can be attached; firing the attachments endpoint for an ELN/inventory
+    // target would 404
+    mockEndpoints({});
+
+    const { result } = renderHook(() => useReferencingInventoryItems("SD123"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockAxiosGet).toHaveBeenCalledWith("/workspace/getReferencingInventoryItems/SD123");
+    expect(mockAxiosGet).not.toHaveBeenCalledWith(expect.stringContaining("getAttachingInventoryItems"));
+  });
+
   it("url-encodes the global id in the request path", async () => {
     // a global id is normally path-safe, but encoding guards against any
     // future id format that introduces characters that would otherwise alter
     // the request path
-    mockAxiosGet.mockResolvedValue({ data: { referencingItems: [] } });
+    mockEndpoints({});
 
     const { result } = renderHook(() => useReferencingInventoryItems("SA1 2#3"));
 
@@ -36,20 +73,18 @@ describe("useReferencingInventoryItems", () => {
     expect(mockAxiosGet).toHaveBeenCalledWith("/workspace/getReferencingInventoryItems/SA1%202%233");
   });
 
-  it("maps referencing items into rows with a linkable inventory record", async () => {
-    mockAxiosGet.mockResolvedValue({
-      data: {
-        referencingItems: [
-          {
-            sourceGlobalId: "SA1",
-            sourceName: "My sample",
-            sourceType: "SAMPLE",
-            relationType: "IsPartOf",
-            versionPin: null,
-            modifiedAt: null,
-          },
-        ],
-      },
+  it("maps link items into rows with a linkable inventory record", async () => {
+    mockEndpoints({
+      links: [
+        {
+          sourceGlobalId: "SA1",
+          sourceName: "My sample",
+          sourceType: "SAMPLE",
+          relationType: "IsPartOf",
+          versionPin: null,
+          modifiedAt: null,
+        },
+      ],
     });
 
     const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
@@ -64,21 +99,66 @@ describe("useReferencingInventoryItems", () => {
     expect(row.linkableRecord.permalinkURL).toBe("/globalId/SA1");
   });
 
-  it("renders a row whose relationType is missing rather than dropping it", async () => {
+  it("merges attachment rows and labels them Attachment", async () => {
+    // attachments arrive from a different endpoint and carry no DataCite relation type; the hook
+    // marks their Relation column so they read distinctly from links in the shared grid
+    mockEndpoints({
+      links: [
+        {
+          sourceGlobalId: "SA1",
+          sourceName: "Linked sample",
+          sourceType: "SAMPLE",
+          relationType: "IsPartOf",
+        },
+      ],
+      attachments: [
+        {
+          sourceGlobalId: "IC7",
+          sourceName: "Box A",
+          sourceType: "CONTAINER",
+          relationType: null,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toHaveLength(2);
+    const attachmentRow = result.current.items.find((i) => i.globalId === "IC7");
+    expect(attachmentRow?.relationType).toContain("attachment");
+    const linkRow = result.current.items.find((i) => i.globalId === "SA1");
+    expect(linkRow?.relationType).toBe("IsPartOf");
+  });
+
+  it("keeps one row per attachment connection without dedup", async () => {
+    // the same item attaching the same gallery file twice yields two rows, matching the backend
+    mockEndpoints({
+      attachments: [
+        { sourceGlobalId: "SA1", sourceName: "My sample", sourceType: "SAMPLE", relationType: null },
+        { sourceGlobalId: "SA1", sourceName: "My sample", sourceType: "SAMPLE", relationType: null },
+      ],
+    });
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toHaveLength(2);
+  });
+
+  it("renders a link row whose relationType is missing rather than dropping it", async () => {
     // the relation column is nullable on the server; the legacy panel renders
     // such rows with a blank relation and this hook must agree
-    mockAxiosGet.mockResolvedValue({
-      data: {
-        referencingItems: [
-          {
-            sourceGlobalId: "SA2",
-            sourceName: "No relation",
-            sourceType: "SAMPLE",
-            versionPin: null,
-            modifiedAt: null,
-          },
-        ],
-      },
+    mockEndpoints({
+      links: [
+        {
+          sourceGlobalId: "SA2",
+          sourceName: "No relation",
+          sourceType: "SAMPLE",
+          versionPin: null,
+          modifiedAt: null,
+        },
+      ],
     });
 
     const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
@@ -97,7 +177,7 @@ describe("useReferencingInventoryItems", () => {
     expect(result.current.items).toHaveLength(0);
   });
 
-  it("surfaces an error message when the request fails", async () => {
+  it("surfaces an error message when a request fails", async () => {
     mockAxiosGet.mockRejectedValue(new Error("boom"));
 
     const { result } = renderHook(() => useReferencingInventoryItems("GL5"));

--- a/src/main/webapp/ui/src/eln/gallery/__tests__/useReferencingInventoryItems.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/__tests__/useReferencingInventoryItems.test.tsx
@@ -7,6 +7,7 @@ vi.mock("@/common/axios", () => ({
   default: { get: mockAxiosGet },
 }));
 
+import { silenceConsole } from "@/__tests__/helpers/silenceConsole";
 import useReferencingInventoryItems from "../useReferencingInventoryItems";
 
 type Row = Record<string, unknown>;
@@ -177,7 +178,8 @@ describe("useReferencingInventoryItems", () => {
     expect(result.current.items).toHaveLength(0);
   });
 
-  it("surfaces an error message when a request fails", async () => {
+  it("surfaces an error message when the links request fails", async () => {
+    const restoreConsole = silenceConsole(["error"], [/.*/]);
     mockAxiosGet.mockRejectedValue(new Error("boom"));
 
     const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
@@ -185,11 +187,86 @@ describe("useReferencingInventoryItems", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.errorMessage).toContain("gallery:referencingInventoryItems.loadFailed");
     expect(result.current.items).toHaveLength(0);
+    restoreConsole();
+  });
+
+  it("renders links when only the attachments endpoint fails", async () => {
+    // a failing attachments lookup is a supplementary back-reference; it must not blank the links
+    // that loaded fine, so the section degrades to links-only with no error
+    const restoreConsole = silenceConsole(["error"], [/.*/]);
+    mockAxiosGet.mockImplementation((url: string) => {
+      if (url.includes("getAttachingInventoryItems")) {
+        return Promise.reject(new Error("attachments 500"));
+      }
+      return Promise.resolve({
+        data: {
+          referencingItems: [
+            { sourceGlobalId: "SA1", sourceName: "Linked sample", sourceType: "SAMPLE", relationType: "IsPartOf" },
+          ],
+        },
+      });
+    });
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].globalId).toBe("SA1");
+    restoreConsole();
+  });
+
+  it("drops a row missing a required field rather than failing the whole payload", async () => {
+    // the two endpoints' payloads are merged; one malformed row must not blank the grid
+    mockEndpoints({
+      links: [
+        { sourceGlobalId: "SA1", sourceName: "Good row", sourceType: "SAMPLE", relationType: "IsPartOf" },
+        { sourceGlobalId: "SA2", sourceType: "SAMPLE", relationType: "IsPartOf" }, // missing sourceName
+      ],
+    });
+
+    const { result } = renderHook(() => useReferencingInventoryItems("GL5"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].globalId).toBe("SA1");
+  });
+
+  it("ignores a stale response after the global id changes", async () => {
+    // clicking between gallery files must not let an earlier in-flight response overwrite the
+    // current target's rows
+    const deferred: Array<(v: unknown) => void> = [];
+    mockAxiosGet.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          deferred.push(resolve);
+        }),
+    );
+
+    const initialProps: { id: string } = { id: "SD1" };
+    const { result, rerender } = renderHook(({ id }: { id: string }) => useReferencingInventoryItems(id), {
+      initialProps,
+    });
+    // SD1 and SD2 are non-gallery, so each fires exactly one (links) request
+    await waitFor(() => expect(deferred).toHaveLength(1));
+    rerender({ id: "SD2" });
+    await waitFor(() => expect(deferred).toHaveLength(2));
+
+    // resolve the current target (SD2) first, then the stale SD1 request
+    deferred[1]({
+      data: { referencingItems: [{ sourceGlobalId: "SA2", sourceName: "current", sourceType: "SAMPLE" }] },
+    });
+    deferred[0]({ data: { referencingItems: [{ sourceGlobalId: "SA1", sourceName: "stale", sourceType: "SAMPLE" }] } });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].globalId).toBe("SA2");
   });
 
   it("clears a stale error when the global id becomes null", async () => {
     // a failure for one record must not leave its error showing once the hook
     // is pointed at no record at all (the early-return path)
+    const restoreConsole = silenceConsole(["error"], [/.*/]);
     mockAxiosGet.mockRejectedValue(new Error("boom"));
 
     const initialProps: { id: string | null } = { id: "GL5" };
@@ -204,5 +281,6 @@ describe("useReferencingInventoryItems", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.errorMessage).toBeNull();
     expect(result.current.items).toHaveLength(0);
+    restoreConsole();
   });
 });

--- a/src/main/webapp/ui/src/eln/gallery/useReferencingInventoryItems.ts
+++ b/src/main/webapp/ui/src/eln/gallery/useReferencingInventoryItems.ts
@@ -41,50 +41,59 @@ export default function useReferencingInventoryItems(globalId: string | null): {
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const { t } = useTranslation(["gallery", "common", "inventory"]);
 
-  const fetchReferencingItems = React.useCallback(async (): Promise<void> => {
-    if (!globalId) {
-      setItems([]);
-      setErrorMessage(null);
-      setLoading(false);
-      return;
-    }
-    setItems([]);
-    setLoading(true);
-    setErrorMessage(null);
-    try {
-      const itemFallbackLabel = t("common:recordTypes.item.singular");
-      const isGalleryFile = globalId.startsWith(GALLERY_FILE_PREFIX);
-      const requests: Array<Promise<unknown>> = [
-        axios
-          .get<unknown>(`/workspace/getReferencingInventoryItems/${encodeURIComponent(globalId)}`)
-          .then((r) => r.data),
-      ];
-      if (isGalleryFile) {
-        requests.push(
-          axios
-            .get<unknown>(`/workspace/getAttachingInventoryItems/${encodeURIComponent(globalId)}`)
-            .then((r) => r.data),
-        );
-      }
-      const [linksBody, attachmentsBody] = await Promise.all(requests);
-      const rows = parseRows(linksBody, null, itemFallbackLabel);
-      if (isGalleryFile) {
-        // attachments carry no DataCite relation type, so their Relation column shows a fixed label
-        const attachmentLabel = t("inventory:fields.link.relatedInventoryItems.attachment");
-        rows.push(...parseRows(attachmentsBody, attachmentLabel, itemFallbackLabel));
-      }
-      setItems(rows);
-    } catch (e) {
-      console.error(e);
-      setErrorMessage(t("referencingInventoryItems.loadFailed"));
-    } finally {
-      setLoading(false);
-    }
-  }, [globalId, t]);
-
   React.useEffect(() => {
+    // guard against a stale in-flight response overwriting a newer target's rows, and against
+    // setState after unmount (matches the InfoPanel convention in this module)
+    let cancelled = false;
+    const fetchReferencingItems = async (): Promise<void> => {
+      if (!globalId) {
+        setItems([]);
+        setErrorMessage(null);
+        setLoading(false);
+        return;
+      }
+      setItems([]);
+      setLoading(true);
+      setErrorMessage(null);
+      try {
+        const itemFallbackLabel = t("common:recordTypes.item.singular");
+        const isGalleryFile = globalId.startsWith(GALLERY_FILE_PREFIX);
+        const linksBody = axios
+          .get<unknown>(`/workspace/getReferencingInventoryItems/${encodeURIComponent(globalId)}`)
+          .then((r) => r.data);
+        // a failed attachments lookup must not blank the links that loaded fine: degrade to
+        // links-only by resolving the attachments half to an empty payload on error
+        const attachmentsBody: Promise<unknown> = isGalleryFile
+          ? axios
+              .get<unknown>(`/workspace/getAttachingInventoryItems/${encodeURIComponent(globalId)}`)
+              .then((r) => r.data)
+              .catch((e: unknown) => {
+                console.error(e);
+                return { referencingItems: [] };
+              })
+          : Promise.resolve({ referencingItems: [] });
+        const [links, attachments] = await Promise.all([linksBody, attachmentsBody]);
+        if (cancelled) return;
+        const rows = parseRows(links, null, itemFallbackLabel);
+        if (isGalleryFile) {
+          // attachments carry no DataCite relation type, so their Relation column shows a fixed label
+          const attachmentLabel = t("inventory:fields.link.relatedInventoryItems.attachment");
+          rows.push(...parseRows(attachments, attachmentLabel, itemFallbackLabel));
+        }
+        setItems(rows);
+      } catch (e) {
+        if (cancelled) return;
+        console.error(e);
+        setErrorMessage(t("referencingInventoryItems.loadFailed"));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
     void fetchReferencingItems();
-  }, [fetchReferencingItems]);
+    return () => {
+      cancelled = true;
+    };
+  }, [globalId, t]);
 
   return { items, loading, errorMessage };
 }

--- a/src/main/webapp/ui/src/eln/gallery/useReferencingInventoryItems.ts
+++ b/src/main/webapp/ui/src/eln/gallery/useReferencingInventoryItems.ts
@@ -7,8 +7,10 @@ import * as Parsers from "../../util/parsers";
 import Result from "../../util/result";
 
 /**
- * An Inventory item that links to the current ELN record, to the extent the
- * Gallery info panel needs to render a back-reference row.
+ * An Inventory item that is related to the current ELN record, to the extent the Gallery info panel
+ * needs to render a back-reference row. The relation is either a Link (the item's Link field points
+ * at the record, carrying a DataCite {@link relationType}) or an Attachment (the item attached this
+ * Gallery file, in which case {@link relationType} holds the localised "Attachment" label).
  */
 export type ReferencingInventoryItem = {
   globalId: string;
@@ -19,11 +21,15 @@ export type ReferencingInventoryItem = {
   linkableRecord: LinkableRecord;
 };
 
+/** The Gallery media-file Global ID prefix; only these targets can be attached by Inventory items. */
+const GALLERY_FILE_PREFIX = "GL";
+
 /**
- * Given an ELN record's Global ID (e.g. a gallery file GLnnn), fetch the Inventory
- * items whose Link extra-field points at it. Backs the "Related inventory items"
- * section on the ELN side. The endpoint is permission-filtered server-side, so the
- * caller only ever receives items the user may read. Mirrors {@link useLinkedDocuments}.
+ * Given an ELN record's Global ID (e.g. a gallery file GLnnn), fetch the Inventory items related to
+ * it for the "Related inventory items" back-reference section. For a Gallery file this fans out to
+ * two permission-filtered endpoints and merges them into one list: the Link references and the
+ * Attachments. For any other target only Links are fetched, since only Gallery files can be
+ * attached. Both endpoints filter server-side, so the caller only ever receives items it may read.
  */
 export default function useReferencingInventoryItems(globalId: string | null): {
   items: ReadonlyArray<ReferencingInventoryItem>;
@@ -33,7 +39,7 @@ export default function useReferencingInventoryItems(globalId: string | null): {
   const [loading, setLoading] = React.useState(true);
   const [items, setItems] = React.useState<ReadonlyArray<ReferencingInventoryItem>>([]);
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
-  const { t } = useTranslation(["gallery", "common"]);
+  const { t } = useTranslation(["gallery", "common", "inventory"]);
 
   const fetchReferencingItems = React.useCallback(async (): Promise<void> => {
     if (!globalId) {
@@ -46,45 +52,27 @@ export default function useReferencingInventoryItems(globalId: string | null): {
     setLoading(true);
     setErrorMessage(null);
     try {
-      const { data } = await axios.get<unknown>(
-        `/workspace/getReferencingInventoryItems/${encodeURIComponent(globalId)}`,
-      );
-      const rows: Array<ReferencingInventoryItem> = [];
-      Parsers.objectPath(["referencingItems"], data)
-        .flatMap(Parsers.isArray)
-        .do((arr) => {
-          for (const item of arr) {
-            Parsers.isObject(item)
-              .flatMap(Parsers.isNotNull)
-              .flatMap((obj) => {
-                const sourceGlobalId = Parsers.getValueWithKey("sourceGlobalId")(obj).flatMap(Parsers.isString);
-                const name = Parsers.getValueWithKey("sourceName")(obj).flatMap(Parsers.isString);
-                const type = Parsers.getValueWithKey("sourceType")(obj).flatMap(Parsers.isString);
-                // relationType is nullable on the server; a row without one
-                // must still render (as the legacy panel does) rather than be
-                // silently dropped
-                const relationType = Parsers.getValueWithKey("relationType")(obj).flatMap(Parsers.isString).orElse("");
-                return Result.all(sourceGlobalId, name, type).map(([g, n, ty]) => ({
-                  globalId: g,
-                  name: n,
-                  type: ty,
-                  relationType,
-                  permalinkHref: `/globalId/${g}`,
-                  linkableRecord: {
-                    id: parseInt(g.replace(/^[A-Z]{2}/, ""), 10) || null,
-                    globalId: g,
-                    name: n,
-                    recordTypeLabel:
-                      INVENTORY_PREFIX_ICON_DATA[prefixOf(g) ?? ""]?.recordTypeLabel ??
-                      t("common:recordTypes.item.singular"),
-                    iconName: INVENTORY_PREFIX_ICON_DATA[prefixOf(g) ?? ""]?.iconName ?? "container",
-                    permalinkURL: `/globalId/${g}`,
-                  },
-                }));
-              })
-              .do((row) => rows.push(row));
-          }
-        });
+      const itemFallbackLabel = t("common:recordTypes.item.singular");
+      const isGalleryFile = globalId.startsWith(GALLERY_FILE_PREFIX);
+      const requests: Array<Promise<unknown>> = [
+        axios
+          .get<unknown>(`/workspace/getReferencingInventoryItems/${encodeURIComponent(globalId)}`)
+          .then((r) => r.data),
+      ];
+      if (isGalleryFile) {
+        requests.push(
+          axios
+            .get<unknown>(`/workspace/getAttachingInventoryItems/${encodeURIComponent(globalId)}`)
+            .then((r) => r.data),
+        );
+      }
+      const [linksBody, attachmentsBody] = await Promise.all(requests);
+      const rows = parseRows(linksBody, null, itemFallbackLabel);
+      if (isGalleryFile) {
+        // attachments carry no DataCite relation type, so their Relation column shows a fixed label
+        const attachmentLabel = t("inventory:fields.link.relatedInventoryItems.attachment");
+        rows.push(...parseRows(attachmentsBody, attachmentLabel, itemFallbackLabel));
+      }
       setItems(rows);
     } catch (e) {
       console.error(e);
@@ -99,4 +87,51 @@ export default function useReferencingInventoryItems(globalId: string | null): {
   }, [fetchReferencingItems]);
 
   return { items, loading, errorMessage };
+}
+
+/**
+ * Parse a `{ referencingItems: [...] }` payload into rows. When {@link relationTypeOverride} is
+ * given (attachments) it replaces the server's relation on every row; otherwise the server's
+ * nullable relationType is used, defaulting to a blank so a relation-less row still renders.
+ */
+function parseRows(
+  data: unknown,
+  relationTypeOverride: string | null,
+  itemFallbackLabel: string,
+): Array<ReferencingInventoryItem> {
+  const rows: Array<ReferencingInventoryItem> = [];
+  Parsers.objectPath(["referencingItems"], data)
+    .flatMap(Parsers.isArray)
+    .do((arr) => {
+      for (const item of arr) {
+        Parsers.isObject(item)
+          .flatMap(Parsers.isNotNull)
+          .flatMap((obj) => {
+            const sourceGlobalId = Parsers.getValueWithKey("sourceGlobalId")(obj).flatMap(Parsers.isString);
+            const name = Parsers.getValueWithKey("sourceName")(obj).flatMap(Parsers.isString);
+            const type = Parsers.getValueWithKey("sourceType")(obj).flatMap(Parsers.isString);
+            // relationType is nullable on the server; a row without one must still render (as the
+            // legacy panel does) rather than be silently dropped
+            const relationType =
+              relationTypeOverride ?? Parsers.getValueWithKey("relationType")(obj).flatMap(Parsers.isString).orElse("");
+            return Result.all(sourceGlobalId, name, type).map(([g, n, ty]) => ({
+              globalId: g,
+              name: n,
+              type: ty,
+              relationType,
+              permalinkHref: `/globalId/${g}`,
+              linkableRecord: {
+                id: parseInt(g.replace(/^[A-Z]{2}/, ""), 10) || null,
+                globalId: g,
+                name: n,
+                recordTypeLabel: INVENTORY_PREFIX_ICON_DATA[prefixOf(g) ?? ""]?.recordTypeLabel ?? itemFallbackLabel,
+                iconName: INVENTORY_PREFIX_ICON_DATA[prefixOf(g) ?? ""]?.iconName ?? "container",
+                permalinkURL: `/globalId/${g}`,
+              },
+            }));
+          })
+          .do((row) => rows.push(row));
+      }
+    });
+  return rows;
 }

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -943,6 +943,7 @@
         "targetDeleted": "Target deleted"
       },
       "relatedInventoryItems": {
+        "attachment": "Attachment",
         "columns": {
           "globalId": "Global ID",
           "name": "Name",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -3129,6 +3129,7 @@ export default interface Resources {
           "targetDeleted": "Target deleted"
         },
         "relatedInventoryItems": {
+          "attachment": "Attachment",
           "columns": {
             "globalId": "Global ID",
             "name": "Name",
@@ -3541,7 +3542,6 @@ export default interface Resources {
         "location": {
           "label": "Location",
           "listExplanation": "No location selection required for list containers.",
-          "mustStoreTypes": "inventory:instrument.createOptions.location.mustStoreTypes",
           "specificExplanation": "Specify a single location for where the new instrument should be placed."
         },
         "template": {

--- a/src/test/java/com/researchspace/service/inventory/InventoryFileApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryFileApiManagerTest.java
@@ -6,10 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.researchspace.api.v1.auth.ApiRuntimeException;
 import com.researchspace.api.v1.model.ApiContainerInfo;
 import com.researchspace.api.v1.model.ApiInventoryFile;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.core.util.ISearchResults;
+import com.researchspace.model.EcatImage;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdentifier;
@@ -20,6 +23,7 @@ import com.researchspace.service.impl.ContentInitializerForDevRunManager;
 import com.researchspace.testutils.SpringTransactionalTest;
 import com.researchspace.testutils.TestGroup;
 import java.io.IOException;
+import java.util.List;
 import javax.ws.rs.NotFoundException;
 import org.junit.Before;
 import org.junit.Test;
@@ -103,6 +107,44 @@ public class InventoryFileApiManagerTest extends SpringTransactionalTest {
     // verify attachment present on a copy
     dbSampleCopy = sampleApiMgr.getSampleById(copiedSample.getId(), user);
     assertEquals(2, dbSampleCopy.getAttachedFiles().size());
+  }
+
+  @Test
+  public void findAttachingItemsReturnsItemAttachingGalleryFile() throws IOException {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples sample = createBasicSampleForUser(user);
+
+    InventoryFile galleryAttachment =
+        addGalleryFileToInventoryItem(new GlobalIdentifier(sample.getGlobalId()), user);
+    String galleryFileGlobalId = galleryAttachment.getMediaFileGlobalIdentifier();
+
+    List<ApiInventoryReferencingItem> rows =
+        inventoryFileApiMgr.findAttachingItems(galleryFileGlobalId, user);
+
+    assertEquals(1, rows.size());
+    assertEquals(sample.getGlobalId(), rows.get(0).getSourceGlobalId());
+    // attachments have no DataCite relation; the label is added client-side
+    assertNull(rows.get(0).getRelationType());
+  }
+
+  @Test
+  public void findAttachingItemsReturnsEmptyForUnattachedGalleryFile() throws IOException {
+    User user = createInitAndLoginAnyUser();
+    // a gallery image no inventory item has attached; also exercises the attachment-field query
+    EcatImage image = addImageToGallery(user);
+
+    List<ApiInventoryReferencingItem> rows =
+        inventoryFileApiMgr.findAttachingItems(image.getOid().getIdString(), user);
+
+    assertEquals(0, rows.size());
+  }
+
+  @Test
+  public void findAttachingItemsRejectsMissingTarget() {
+    User user = createInitAndLoginAnyUser();
+    // same error as an unreadable file, so the response never confirms whether the file exists
+    assertThrows(
+        ApiRuntimeException.class, () -> inventoryFileApiMgr.findAttachingItems("GL9999", user));
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/InventoryFileApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryFileApiManagerTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.researchspace.api.v1.auth.ApiRuntimeException;
 import com.researchspace.api.v1.model.ApiContainerInfo;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryFile;
 import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
@@ -19,6 +21,7 @@ import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.service.impl.ContentInitializerForDevRunManager;
 import com.researchspace.testutils.SpringTransactionalTest;
 import com.researchspace.testutils.TestGroup;
@@ -145,6 +148,55 @@ public class InventoryFileApiManagerTest extends SpringTransactionalTest {
     // same error as an unreadable file, so the response never confirms whether the file exists
     assertThrows(
         ApiRuntimeException.class, () -> inventoryFileApiMgr.findAttachingItems("GL9999", user));
+  }
+
+  @Test
+  public void findAttachingItemsResolvesFieldLevelAttachmentToOwningItem() throws IOException {
+    // the headline field-level path: a Gallery file attached to a sample's ATTACHMENT field must
+    // surface against the owning sample (not the field), exercising the real
+    // InventoryAttachmentField
+    // join HQL that the mocked unit test cannot reach
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples sample = createComplexSampleForUser(user);
+    ApiInventoryEntityField attachmentField = sample.getFields().get(6);
+    assertEquals(ApiFieldType.ATTACHMENT, attachmentField.getType());
+
+    InventoryFile galleryAttachment =
+        addGalleryFileToInventoryItem(new GlobalIdentifier(attachmentField.getGlobalId()), user);
+    String galleryFileGlobalId = galleryAttachment.getMediaFileGlobalIdentifier();
+
+    List<ApiInventoryReferencingItem> rows =
+        inventoryFileApiMgr.findAttachingItems(galleryFileGlobalId, user);
+
+    assertEquals(1, rows.size());
+    assertEquals(sample.getGlobalId(), rows.get(0).getSourceGlobalId());
+  }
+
+  @Test
+  public void findAttachingItemsExcludesSoftDeletedAttachment() throws IOException {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples sample = createBasicSampleForUser(user);
+    InventoryFile galleryAttachment =
+        addGalleryFileToInventoryItem(new GlobalIdentifier(sample.getGlobalId()), user);
+    String galleryFileGlobalId = galleryAttachment.getMediaFileGlobalIdentifier();
+
+    inventoryFileApiMgr.markInventoryFileAsDeleted(galleryAttachment.getId(), user);
+
+    // a soft-deleted attachment must not surface as a back-reference
+    assertEquals(0, inventoryFileApiMgr.findAttachingItems(galleryFileGlobalId, user).size());
+  }
+
+  @Test
+  public void findAttachingItemsRejectsGalleryIdResolvingToNonMediaRecord() {
+    // a well-formed GL id whose number is actually a document must return the uniform not-found,
+    // never an uncaught 500 (ADR-0002 non-disclosure): the read-gate resolves the target's real
+    // type rather than blindly casting it to a media file
+    User user = createInitAndLoginAnyUser();
+    StructuredDocument doc = createBasicDocumentInRootFolderWithText(user, "not a gallery file");
+
+    assertThrows(
+        ApiRuntimeException.class,
+        () -> inventoryFileApiMgr.findAttachingItems("GL" + doc.getId(), user));
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImplAttachingTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImplAttachingTest.java
@@ -1,0 +1,193 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItem;
+import com.researchspace.dao.InventoryFileDao;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.InventoryFile;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.InventoryRecord.InventoryRecordType;
+import com.researchspace.model.inventory.field.InventoryAttachmentField;
+import com.researchspace.service.BaseRecordManager;
+import com.researchspace.service.inventory.InventoryPermissionUtils;
+import java.util.Collections;
+import java.util.List;
+import org.apache.shiro.authz.AuthorizationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Pure unit tests for {@link InventoryFileApiManagerImpl#findAttachingItems}: the reverse lookup
+ * behind the gallery info panel's "Related inventory items" attachment rows. Mirrors {@code
+ * InventoryLinkManagerImplReferencingTest} on the links side. The DB-backed HQL is covered by
+ * {@code InventoryFileApiManagerTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+class InventoryFileApiManagerImplAttachingTest {
+
+  @Mock private InventoryFileDao inventoryFileDao;
+  @Mock private InventoryPermissionUtils invPermissions;
+  @Mock private BaseRecordManager baseRecordManager;
+  @InjectMocks private InventoryFileApiManagerImpl manager;
+
+  private User actor;
+
+  @BeforeEach
+  void setUp() {
+    actor = new User("viewer");
+    // most tests exercise the source query, so the target read-gate is open by default (a mock
+    // retrieveMediaFile returns null without throwing); the gate tests override this
+    lenient()
+        .when(inventoryFileDao.findByMediaFileId(anyLong()))
+        .thenReturn(Collections.emptyList());
+    lenient()
+        .when(inventoryFileDao.findAttachmentFieldsByMediaFileId(anyLong()))
+        .thenReturn(Collections.emptyList());
+  }
+
+  private InventoryRecord parent(
+      String globalId, String name, InventoryRecordType type, boolean deleted) {
+    InventoryRecord rec = mock(InventoryRecord.class);
+    lenient().when(rec.getOid()).thenReturn(new GlobalIdentifier(globalId));
+    lenient().when(rec.getName()).thenReturn(name);
+    lenient().when(rec.getType()).thenReturn(type);
+    lenient().when(rec.isDeleted()).thenReturn(deleted);
+    return rec;
+  }
+
+  private InventoryFile recordAttachment(InventoryRecord owningRecord) {
+    InventoryFile file = mock(InventoryFile.class);
+    lenient().when(file.getInventoryRecord()).thenReturn(owningRecord);
+    return file;
+  }
+
+  private InventoryAttachmentField fieldAttachment(InventoryRecord owningRecord) {
+    InventoryAttachmentField field = mock(InventoryAttachmentField.class);
+    lenient().when(field.getInventoryRecord()).thenReturn(owningRecord);
+    return field;
+  }
+
+  @Test
+  void returnsRowForReadableRecordLevelAttachment() {
+    InventoryRecord sample = parent("SA1", "My sample", InventoryRecordType.SAMPLE, false);
+    // build the attachment mock BEFORE stubbing the dao: stubbing a mock inside a thenReturn
+    // argument trips Mockito's unfinished-stubbing detection
+    InventoryFile attachment = recordAttachment(sample);
+    when(inventoryFileDao.findByMediaFileId(5L)).thenReturn(List.of(attachment));
+    when(invPermissions.canUserReadInventoryRecord(sample, actor)).thenReturn(true);
+
+    List<ApiInventoryReferencingItem> rows = manager.findAttachingItems("GL5", actor);
+
+    assertEquals(1, rows.size());
+    ApiInventoryReferencingItem row = rows.get(0);
+    assertEquals("SA1", row.getSourceGlobalId());
+    assertEquals("My sample", row.getSourceName());
+    assertEquals("SAMPLE", row.getSourceType());
+    // attachments carry no DataCite relation type; the UI labels them client-side
+    assertNull(row.getRelationType());
+  }
+
+  @Test
+  void resolvesFieldLevelAttachmentToItsOwningItem() {
+    // a gallery file attached to a sample/template attachment field reports the owning sample, not
+    // the field
+    InventoryRecord template = parent("IT9", "My template", InventoryRecordType.SAMPLE, false);
+    InventoryAttachmentField field = fieldAttachment(template);
+    when(inventoryFileDao.findAttachmentFieldsByMediaFileId(5L)).thenReturn(List.of(field));
+    when(invPermissions.canUserReadInventoryRecord(template, actor)).thenReturn(true);
+
+    List<ApiInventoryReferencingItem> rows = manager.findAttachingItems("GL5", actor);
+
+    assertEquals(1, rows.size());
+    assertEquals("IT9", rows.get(0).getSourceGlobalId());
+  }
+
+  @Test
+  void oneRowPerConnectionWithoutDedup() {
+    // the same item attaching the same gallery file twice yields two rows (mirrors the links panel)
+    InventoryRecord sample = parent("SA1", "My sample", InventoryRecordType.SAMPLE, false);
+    InventoryFile first = recordAttachment(sample);
+    InventoryFile second = recordAttachment(sample);
+    when(inventoryFileDao.findByMediaFileId(5L)).thenReturn(List.of(first, second));
+    when(invPermissions.canUserReadInventoryRecord(sample, actor)).thenReturn(true);
+
+    assertEquals(2, manager.findAttachingItems("GL5", actor).size());
+  }
+
+  @Test
+  void filtersOutSourcesTheActorCannotRead() {
+    // leaking names/ids of items the caller may not read would defeat the per-record permission
+    // check the panel relies on
+    InventoryRecord readable = parent("SA10", "visible", InventoryRecordType.SAMPLE, false);
+    InventoryRecord hidden = parent("SA11", "secret", InventoryRecordType.SAMPLE, false);
+    InventoryFile readableAttachment = recordAttachment(readable);
+    InventoryFile hiddenAttachment = recordAttachment(hidden);
+    when(inventoryFileDao.findByMediaFileId(5L))
+        .thenReturn(List.of(readableAttachment, hiddenAttachment));
+    when(invPermissions.canUserReadInventoryRecord(readable, actor)).thenReturn(true);
+    when(invPermissions.canUserReadInventoryRecord(hidden, actor)).thenReturn(false);
+
+    List<ApiInventoryReferencingItem> rows = manager.findAttachingItems("GL5", actor);
+
+    assertEquals(1, rows.size());
+    assertEquals("SA10", rows.get(0).getSourceGlobalId());
+  }
+
+  @Test
+  void skipsSoftDeletedSourceRecords() {
+    InventoryRecord deleted = parent("SA12", "binned", InventoryRecordType.SAMPLE, true);
+    InventoryFile attachment = recordAttachment(deleted);
+    when(inventoryFileDao.findByMediaFileId(5L)).thenReturn(List.of(attachment));
+
+    assertTrue(manager.findAttachingItems("GL5", actor).isEmpty());
+  }
+
+  @Test
+  void skipsAttachmentWhoseOwningRecordCannotBeResolved() {
+    // a field-level attachment surfaced by the record query has a null owning record; it is found
+    // instead via the attachment-field query, so the null must be skipped rather than NPE
+    InventoryFile orphan = recordAttachment(null);
+    when(inventoryFileDao.findByMediaFileId(5L)).thenReturn(List.of(orphan));
+
+    assertTrue(manager.findAttachingItems("GL5", actor).isEmpty());
+  }
+
+  @Test
+  void rejectsNonGalleryTargetWithoutQuerying() {
+    // attachments only target gallery files; a non-GL id is treated as not-found and never queried
+    assertThrows(ApiRuntimeException.class, () -> manager.findAttachingItems("SA42", actor));
+    verify(inventoryFileDao, never()).findByMediaFileId(anyLong());
+  }
+
+  @Test
+  void rejectsMalformedGlobalId() {
+    assertThrows(ApiRuntimeException.class, () -> manager.findAttachingItems("not-a-gid", actor));
+  }
+
+  @Test
+  void rejectsTargetTheCallerCannotRead() {
+    // same not-found as a missing file, so the response never confirms the file exists
+    when(baseRecordManager.retrieveMediaFile(any(), any()))
+        .thenThrow(new AuthorizationException("no read"));
+
+    assertThrows(ApiRuntimeException.class, () -> manager.findAttachingItems("GL5", actor));
+    verify(inventoryFileDao, never()).findByMediaFileId(anyLong());
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImplAttachingTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImplAttachingTest.java
@@ -21,11 +21,10 @@ import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.InventoryRecord.InventoryRecordType;
 import com.researchspace.model.inventory.field.InventoryAttachmentField;
-import com.researchspace.service.BaseRecordManager;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
+import com.researchspace.service.inventory.LinkTargetResolver;
 import java.util.Collections;
 import java.util.List;
-import org.apache.shiro.authz.AuthorizationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +43,7 @@ class InventoryFileApiManagerImplAttachingTest {
 
   @Mock private InventoryFileDao inventoryFileDao;
   @Mock private InventoryPermissionUtils invPermissions;
-  @Mock private BaseRecordManager baseRecordManager;
+  @Mock private LinkTargetResolver linkTargetResolver;
   @InjectMocks private InventoryFileApiManagerImpl manager;
 
   private User actor;
@@ -52,8 +51,9 @@ class InventoryFileApiManagerImplAttachingTest {
   @BeforeEach
   void setUp() {
     actor = new User("viewer");
-    // most tests exercise the source query, so the target read-gate is open by default (a mock
-    // retrieveMediaFile returns null without throwing); the gate tests override this
+    // most tests exercise the source query, so the target read-gate is open by default; the gate
+    // test overrides this
+    lenient().when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
     lenient()
         .when(inventoryFileDao.findByMediaFileId(anyLong()))
         .thenReturn(Collections.emptyList());
@@ -182,10 +182,11 @@ class InventoryFileApiManagerImplAttachingTest {
   }
 
   @Test
-  void rejectsTargetTheCallerCannotRead() {
-    // same not-found as a missing file, so the response never confirms the file exists
-    when(baseRecordManager.retrieveMediaFile(any(), any()))
-        .thenThrow(new AuthorizationException("no read"));
+  void rejectsTargetThatIsNotAReadableGalleryFile() {
+    // the resolver returns false for an unreadable, missing, or wrong-type (non-media) target; all
+    // collapse to the same not-found so the response never confirms the file exists, and the source
+    // queries never run
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(false);
 
     assertThrows(ApiRuntimeException.class, () -> manager.findAttachingItems("GL5", actor));
     verify(inventoryFileDao, never()).findByMediaFileId(anyLong());

--- a/src/test/java/com/researchspace/webapp/controller/ReferencingInventoryItemsControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/ReferencingInventoryItemsControllerMVCIT.java
@@ -1,13 +1,17 @@
 package com.researchspace.webapp.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.researchspace.api.v1.controller.API_MVC_InventoryTestBase;
 import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.EcatImage;
 import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.record.StructuredDocument;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,6 +69,51 @@ public class ReferencingInventoryItemsControllerMVCIT extends API_MVC_InventoryT
         mockMvc
             .perform(
                 get("/workspace/getReferencingInventoryItems/" + target.getOid().getIdString())
+                    .principal(user::getUsername))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(0, body.getReferencingItems().size());
+  }
+
+  @Test
+  public void sessionAttachmentsEndpointReturnsItemsAttachingGalleryFile() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    ApiSampleWithFullSubSamples sample = createBasicSampleForUser(user);
+
+    // attach a gallery file to the sample; the returned attachment carries the gallery file's id
+    InventoryFile galleryAttachment =
+        addGalleryFileToInventoryItem(new GlobalIdentifier(sample.getGlobalId()), user);
+    String galleryFileGlobalId = galleryAttachment.getMediaFileGlobalIdentifier();
+
+    // read it back through the SESSION endpoint (no API key), as the gallery info panel does
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/workspace/getAttachingInventoryItems/" + galleryFileGlobalId)
+                    .principal(user::getUsername))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(result, ApiInventoryReferencingItems.class);
+    assertEquals(1, body.getReferencingItems().size());
+    assertEquals(sample.getGlobalId(), body.getReferencingItems().get(0).getSourceGlobalId());
+    // attachments carry no DataCite relation type; the client supplies the "Attachment" label
+    assertNull(body.getReferencingItems().get(0).getRelationType());
+  }
+
+  @Test
+  public void sessionAttachmentsEndpointReturnsEmptyForUnattachedGalleryFile() throws Exception {
+    User user = createInitAndLoginAnyUser();
+    EcatImage image = addImageToGallery(user);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/workspace/getAttachingInventoryItems/" + image.getOid().getIdString())
                     .principal(user::getUsername))
             .andExpect(status().isOk())
             .andReturn();

--- a/src/test/java/com/researchspace/webapp/controller/ReferencingInventoryItemsControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/ReferencingInventoryItemsControllerTest.java
@@ -15,6 +15,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.field.ErrorList;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.UserManager;
+import com.researchspace.service.inventory.InventoryFileApiManager;
 import com.researchspace.service.inventory.InventoryLinkManager;
 import java.security.Principal;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.springframework.http.ResponseEntity;
 class ReferencingInventoryItemsControllerTest {
 
   @Mock private InventoryLinkManager inventoryLinkManager;
+  @Mock private InventoryFileApiManager inventoryFileApiManager;
   @Mock private UserManager userManager;
   @Mock private MessageSourceUtils messageSource;
   @InjectMocks private ReferencingInventoryItemsController controller;
@@ -74,6 +76,38 @@ class ReferencingInventoryItemsControllerTest {
     Principal principal = () -> "bob";
 
     ResponseEntity<?> response = controller.getReferencingInventoryItems("bad!", principal);
+
+    assertEquals(404, response.getStatusCode().value());
+    assertTrue(response.getBody() instanceof ErrorList);
+  }
+
+  @Test
+  void attachingEndpointDelegatesToFileManager() {
+    User user = new User("bob");
+    when(userManager.getUserByUsername("bob")).thenReturn(user);
+    List<ApiInventoryReferencingItem> rows = List.of(new ApiInventoryReferencingItem());
+    when(inventoryFileApiManager.findAttachingItems("GL5", user)).thenReturn(rows);
+    Principal principal = () -> "bob";
+
+    ResponseEntity<?> response = controller.getAttachingInventoryItems("GL5", principal);
+
+    assertSame(rows, ((ApiInventoryReferencingItems) response.getBody()).getReferencingItems());
+    verify(inventoryFileApiManager).findAttachingItems(eq("GL5"), eq(user));
+  }
+
+  @Test
+  void attachingEndpointMalformedGlobalIdReturnsJsonNotFound() {
+    // the file manager throws ApiRuntimeException for a bad/non-gallery id; this @Controller has no
+    // @ControllerAdvice, so it must translate that to a JSON 404 rather than an HTML 500
+    User user = new User("bob");
+    when(userManager.getUserByUsername("bob")).thenReturn(user);
+    when(inventoryFileApiManager.findAttachingItems("bad!", user))
+        .thenThrow(new ApiRuntimeException("errors.inventory.field.link.targetNotFound", "bad!"));
+    when(messageSource.getMessage(eq("errors.inventory.field.link.targetNotFound"), any()))
+        .thenReturn("bad! does not exist, or you do not have permission to view it.");
+    Principal principal = () -> "bob";
+
+    ResponseEntity<?> response = controller.getAttachingInventoryItems("bad!", principal);
 
     assertEquals(404, response.getStatusCode().value());
     assertTrue(response.getBody() instanceof ErrorList);


### PR DESCRIPTION
## Description

Jira: RSDEV-173

Extends the Gallery item info panel's "Related inventory items" section (added in RSDEV-1131 for inventory Links) to also list Inventory items that **attach** the Gallery file, not just those that link to it. Link rows keep their DataCite relation type in the Relation column; attachment rows are labelled "Attachment", so the two kinds are distinguishable within the one grid. Both record-level attachments and attachments made through a sample/template attachment field are covered, each reported against its owning inventory item (Sample, SubSample, Container, Instrument, or Template).

## Design decisions

- **Separate endpoint, merged client-side.** Attachments are served from a new session endpoint `GET /workspace/getAttachingInventoryItems/{globalId}` and merged with the existing links endpoint in the shared hook, keeping InventoryFile concerns out of `InventoryLinkManager`.
- **Non-disclosure gate reused (ADR-0002).** The endpoint resolves the target through `LinkTargetResolver.targetExistsAndIsReadable` (as the links endpoint does), so an unreadable, missing, malformed, or non-Gallery Global ID all return one identical not-found and never leak a file's existence or its inbound attachments. This is collision-safe for the shared `GL`/`FL`/`SD` id space.
- **Record-level and field-level attachments.** Field-level attachments are resolved back to their owning item through the owning attachment field (the attachment's own record reference is null in that case). Both new queries filter out soft-deleted attachment files, and the field query also excludes soft-deleted fields.
- **One row per connection**, no de-duplication, matching the links panel's behaviour.
- **Graceful frontend degradation.** The hook only calls the attachments endpoint for Gallery (`GL`) targets, and if that request fails it degrades to showing links only rather than blanking the whole section.

## Testing notes

- Backend: manager unit tests (permission filtering, record/field resolution, the non-disclosure gate), DB-backed `SpringTransactionalTest` cases (record-level, field-level, soft-deleted exclusion, and a `GL`-id-resolving-to-a-non-media-record rejection), and an MVCIT for the session endpoint.
- Frontend: Vitest coverage for the two-endpoint merge, attachment labelling, `GL`-gating, graceful degradation on an attachments-endpoint failure, stale-response handling, and malformed-row skipping.
- CI note: the `integration-tests` job is red on a pre-existing, order-dependent flake in the quarantined `ExportApiControllerMVCIT` (fails in test setup, `initUser`). It reproduces on the base commit with this change reverted, so it is unrelated to this PR; this PR's own MVCIT passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
