### PR TITLE
PRT-1118: fix Gallery create-menu page freeze with DMP integrations enabled

### DIFF
--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.freeze.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.freeze.spec.tsx
@@ -1,0 +1,75 @@
+import { cleanup, render } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { page } from "vitest/browser";
+import { worker } from "@/__tests__/browserSetup";
+import { galleryAppShellHandlers } from "@/__tests__/mocks/galleryMocks";
+import { DefaultSidebar } from "./Sidebar.story";
+
+/*
+ * PRT-1118. With a DMP integration enabled, dismissing the Gallery create menu
+ * froze the page: a re-render landing while the menu was mid-exit cancelled
+ * react-transition-group's `onExited` (mui/material-ui#32286), so the menu's
+ * Modal never unmounted and its invisible (opacity-0) backdrop kept intercepting
+ * every click. The fix (Sidebar.tsx) makes the closed menu click-through.
+ *
+ * The freeze only manifests under a production React build (`-DgenerateReactDist`,
+ * not `-DreactDevMode`, which StrictMode-masks it) and the underlying race is too
+ * timing-dependent to reproduce deterministically here, so there is no automated
+ * test for the frozen state. This spec guards the deterministic half in the normal
+ * browser suite: the OPEN menu must stay interactive (the pointer-events condition
+ * must never be inverted onto the open state).
+ */
+
+function integrationInfoHandlers() {
+  const info = (name: string, o: { available?: boolean; enabled?: boolean } = {}) => ({
+    data: {
+      name,
+      displayName: name,
+      available: o.available ?? false,
+      enabled: o.enabled ?? false,
+      oauthConnected: false,
+      options: {},
+    },
+    error: null,
+    success: true,
+    errorMsg: null,
+  });
+  return [
+    http.get("/integration/integrationInfo", ({ request }) => {
+      const name = new URL(request.url).searchParams.get("name") ?? "";
+      return HttpResponse.json(name === "DMPTOOL" ? info("DMPTOOL", { available: true, enabled: true }) : info(name));
+    }),
+    http.get("/integration/allIntegrations", () =>
+      HttpResponse.json({ success: true, data: { DSW: { options: {} } }, error: null }),
+    ),
+    http.get("/apps/dmptool/baseUrlHost", () => HttpResponse.text("example.com")),
+    http.get("/apps/dmptool/plans*", () => HttpResponse.json({ success: true, data: { items: [] } })),
+    http.get("/api/v1/gallery/filesystems", () => HttpResponse.json([])),
+  ];
+}
+
+describe("Gallery create menu (DMP enabled)", () => {
+  beforeEach(() => {
+    worker.use(...galleryAppShellHandlers(), ...integrationInfoHandlers());
+  });
+  afterEach(() => cleanup());
+
+  test("the open menu and its DMP option are interactive (pointer-events not disabled)", async () => {
+    await page.viewport(1440, 900);
+    render(<DefaultSidebar />);
+
+    await page.getByRole("button", { name: "Create" }).click();
+    const dmptool = page.getByRole("menuitem", { name: /dmptool/i });
+    await expect.element(dmptool).toBeVisible();
+
+    // The fix disables pointer-events on the CLOSED menu; guard that it is never
+    // (e.g. via an inverted condition) applied to the OPEN menu, which would make
+    // every create action dead. Real-browser hit-testing resolves the emotion
+    // `sx` rule reliably, unlike jsdom.
+    const menu = document.querySelector(".MuiMenu-root") as HTMLElement | null;
+    expect(menu).not.toBeNull();
+    expect(getComputedStyle(menu as HTMLElement).pointerEvents).not.toBe("none");
+    expect(getComputedStyle(dmptool.element() as HTMLElement).pointerEvents).not.toBe("none");
+  });
+});

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.freeze.spec.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.freeze.spec.tsx
@@ -53,7 +53,7 @@ describe("Gallery create menu (DMP enabled)", () => {
   beforeEach(() => {
     worker.use(...galleryAppShellHandlers(), ...integrationInfoHandlers());
   });
-  afterEach(() => cleanup());
+  afterEach(cleanup);
 
   test("the open menu and its DMP option are interactive (pointer-events not disabled)", async () => {
     await page.viewport(1440, 900);
@@ -65,7 +65,7 @@ describe("Gallery create menu (DMP enabled)", () => {
 
     // The fix disables pointer-events on the CLOSED menu; guard that it is never
     // (e.g. via an inverted condition) applied to the OPEN menu, which would make
-    // every create action dead. Real-browser hit-testing resolves the emotion
+    // every create action dead. Real-browser hit-testing resolves the Emotion
     // `sx` rule reliably, unlike jsdom.
     const menu = document.querySelector(".MuiMenu-root") as HTMLElement | null;
     expect(menu).not.toBeNull();

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.tsx
@@ -502,12 +502,19 @@ const Sidebar = ({
             setNewMenuAnchorEl(null);
           }}
           sx={{
+            /*
+             * In production builds (-DgenerateReactDist) a re-render during this
+             * Menu's exit can cancel react-transition-group's onExited
+             * (mui/material-ui#32286), leaving the Modal mounted with its
+             * invisible backdrop still intercepting every click -- the page
+             * freezes until reload. Since we cannot make onExited fire reliably,
+             * make the closed menu click-through instead. pointer-events is
+             * inherited and MUI sets it on neither backdrop nor paper, so this
+             * root rule covers both; the open menu (anchorEl set) is unaffected.
+             */
+            ...(newMenuAnchorEl ? {} : { pointerEvents: "none" }),
             [`& .${paperClasses.root}`]: {
-              ...(newMenuAnchorEl
-                ? {
-                    transform: "translate(-4px, 4px) !important",
-                  }
-                : {}),
+              ...(newMenuAnchorEl ? { transform: "translate(-4px, 4px) !important" } : {}),
             },
           }}
           slotProps={{


### PR DESCRIPTION
## Summary

Fixes PRT-1118: with a DMP integration enabled (e.g. DMPTool), opening the Gallery "create" menu and then dismissing it (Esc or click-away) froze the whole page. Only a browser reload restored interactivity.

## Root cause

Confirmed from the frozen page: the stuck element is the create menu's own MUI Modal (`MuiPopover-root MuiMenu-root MuiModal-root`), left mounted after dismiss with `visibility: visible` and `pointer-events: auto`, covering the viewport. Its backdrop had faded to `opacity: 0` (invisible) but never unmounted.

When the menu closes, a re-render lands while it is mid-exit and cancels react-transition-group's `onExited` callback ([mui/material-ui#32286](https://github.com/mui/material-ui/issues/32286)). The Modal never reaches its `exited` state, so MUI never unmounts it or hides it, and the invisible full-screen backdrop keeps intercepting every click. The DMP integration is what triggers it: it adds async fetches that re-render the open menu. It is production-only (`-DgenerateReactDist`) because a dev build's StrictMode double-invoke masks the timing.

## Fix

`Sidebar.tsx`: make the create menu click-through (`pointer-events: none`) whenever it is closed, so a lingering closed Modal can no longer block the page. `pointer-events` is inherited and MUI sets it on neither backdrop nor paper, so the single root rule covers both. The open menu is unaffected.

We cannot make the upstream `onExited` fire reliably, so this neutralizes the symptom rather than the react-transition-group bug.

## Testing

- New browser-mode test `Sidebar.freeze.spec.tsx` guarding the deterministic half: the OPEN menu (and its DMP option) stays interactive, so the condition can never be inverted onto the open state.
- The freeze itself was reproduced and the fix verified manually under a production React build (`vitest --mode production` with a `requestAnimationFrame` re-render loop colliding with the menu exit): without the fix the stuck Modal intercepts clicks at screen centre; with it, the page stays clickable. The race is too timing-dependent to reproduce deterministically in CI, so it is documented rather than automated.
- Existing `Sidebar.test.tsx` (jsdom) passes, `pnpm tsc` and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
