### PR TITLE
PRT-1121: notify when notebook created directly in shared group folder

### DIFF
--- a/src/main/webapp/scripts/pages/journal.js
+++ b/src/main/webapp/scripts/pages/journal.js
@@ -790,4 +790,21 @@ function journal($, extensions = default_extensions) {
   $(window).on('resize', function(e) {
     repositionEntryNavButtons();
   });
+
+  // When a notebook is created directly in a shared group folder the server
+  // redirects here with ?sharedWithGroup=<group>. Mirror the document editor
+  // (coreEditor.js) and confirm the automatic share to the user, since the
+  // notebook editor does not load coreEditor.js.
+  $(document).ready(function() {
+    const searchParams = new URLSearchParams(window.location.search);
+    if (searchParams.has("sharedWithGroup")) {
+      RS.confirm(
+        "<b>This notebook has been automatically shared with edit rights with all members of " +
+          RS.escapeHtml(searchParams.get("sharedWithGroup")) +
+          ". It remains available in your own workspace.</b><br />To amend the permissions, visit the <a href=\"/record/share/manage\">Shared Documents</a> page.",
+        "success",
+        "infinite"
+      );
+    }
+  });
 };


### PR DESCRIPTION
## Description
Fixes [PRT-1121](https://researchspace.atlassian.net/browse/PRT-1121): no notification appeared when a user created a notebook directly in a shared group folder.

The backend already creates the notebook in the shared folder, shares it with the group with edit rights, and redirects to `/notebookEditor/<id>?sharedWithGroup=<group>`. But the notebook editor page loads `journal.js` (not `coreEditor.js`), and nothing there consumed the `sharedWithGroup` param, so no confirmation was shown. The document editor already shows an equivalent toast via `coreEditor.js`.

This mirrors that block in `journal.js`: on load, if `sharedWithGroup` is present, a success toast confirms the notebook was auto-shared with edit rights to all group members, notes it remains in the user's own workspace, and links to the Shared Documents page to change permissions.

## Design decisions
- Reused the existing `RS.confirm` "shared with group" pattern from `coreEditor.js` instead of adding a new mechanism, keeping notebook and document behaviour consistent.
- The block is guarded on `sharedWithGroup` being present in the URL, so it is a no-op everywhere except the create-in-shared-folder redirect.
- Acceptance criterion "easy access to the object location in the user's workspace" is served by the existing breadcrumb on the notebook page rather than a new link.

## Testing notes
No automated test added: `journal.js` is a legacy jQuery page script outside the tsc/Biome/Vitest scope, and the backend redirect this fix depends on is already covered by `SDocControllerMVCIT#createIntoSharedNotebook`.

Manual test:
1. Log in as a member of a lab group with at least two members.
2. Open the group's shared folder from the Workspace.
3. Create > Notebook, give it a name, confirm.
4. The notebook opens and a green success toast confirms it was shared with edit rights with the group, with a link to the Shared Documents page. Hard-refresh if an older `journal.js` is cached.
