### PR TITLE
Fix order-dependent Shiro failure in initUser(user, true)

### DIFF
--- a/src/main/webapp/ui/src/__tests__/e2e/components/inventory/TransferDialogComponent.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/components/inventory/TransferDialogComponent.ts
@@ -18,10 +18,17 @@ export class TransferDialogComponent {
     await this.root.waitFor({ state: "visible" });
   }
 
-  async selectRecipient(query: string): Promise<void> {
+  async selectRecipient(username: string): Promise<void> {
     await this.recipientCombobox.click();
-    await this.recipientCombobox.fill(query);
-    await this.page.getByRole("option", { name: query }).first().click();
+    await this.recipientCombobox.fill(username);
+    /*
+     * Options are labelled "First Last (username)", so a substring match on the username alone
+     * also matches anyone whose own username contains it - "user6f" matches the dynamic-user
+     * account "e2eDynUser6fb7179aaab", and .first() then silently transfers to the wrong person.
+     * Match the parenthesised username instead; usernames are unique, so this resolves to one
+     * option and a future ambiguity fails loudly as a strict-mode violation.
+     */
+    await this.page.getByRole("option", { name: new RegExp(`\\(${username}\\)`) }).click();
   }
 
   async confirmTransfer(): Promise<void> {

--- a/src/test/java/com/researchspace/testutils/RealTransactionSpringTestBase.java
+++ b/src/test/java/com/researchspace/testutils/RealTransactionSpringTestBase.java
@@ -84,6 +84,8 @@ import javax.sql.DataSource;
 import lombok.Value;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.util.ThreadContext;
 import org.hibernate.criterion.Projections;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -345,10 +347,32 @@ public class RealTransactionSpringTestBase extends BaseManagerTestCaseBase {
    */
   protected Folder initUser(User user, boolean createContent) throws IllegalAddChildOperation {
     contentInitializer.setCustomInitActive(createContent);
+    if (createContent) {
+      replaceSubjectIfItsUserHasBeenDeleted(user);
+    }
     Folder rc = contentInitializer.init(user.getId()).getUserRoot();
     contentInitializer.setCustomInitActive(true);
     user.setRootFolder(rc);
     return rc;
+  }
+
+  /**
+   * Creating example content saves a media file, and MediaManagerImpl.assertCanAddToFolder runs a
+   * Shiro permission check against the current Subject. Integration tests share one JVM fork and
+   * the Subject is thread-bound, while DatabaseCleaner.cleanUp() deletes every User row in {@link
+   * #after()}, so an earlier test class can leave us authenticated as a user that no longer exists.
+   * The realm then fails to reload authorisation info for that dead principal and throws
+   * ObjectRetrievalFailureException.
+   *
+   * <p>Only swap the Subject out when it is already dead. A live one may be a sysadmin the caller
+   * deliberately logged in as and still expects to be acting as once init returns.
+   */
+  private void replaceSubjectIfItsUserHasBeenDeleted(User user) {
+    Object principal = SecurityUtils.getSubject().getPrincipal();
+    if (principal instanceof String && !userMgr.userExists((String) principal)) {
+      ThreadContext.remove();
+      RSpaceTestUtils.login(user.getUsername(), TESTPASSWD);
+    }
   }
 
   /**


### PR DESCRIPTION
## Description ##
RealTransactionSpringTestBase.initUser(user, true) ran the dev content initializer without establishing a Shiro Subject. Creating example content saves a media file, and MediaManagerImpl.assertCanAddToFolder runs a Shiro permission check, so RSpaceRealm reloads authorization info for whatever principal happens to be bound to the thread.

Integration tests share one JVM fork and the Subject is thread-bound, while DatabaseCleaner.cleanUp() deletes every User row in @AfterClass. A class that leaves a logged-in Subject behind therefore poisons the next class:

  ObjectRetrievalFailureException: Object of class [User]
    with identifier [pi<random>]: not found

That is what breaks ExportApiControllerMVCIT in the nightly Coverage run's integration-tests-problematic execution, where
CreateMissingUserFoldersForLabAdminsAndPIsIT runs first. It reproduces on 4b0ad7c1d as well, so it is pre-existing and only surfaces when surefire's filesystem run order puts the two classes in that sequence.

Clear the thread and log in as the user being initialised, matching the fix already applied to SpringTransactionalTest.doInit in #962. Only the createContent path needs it; the folders-only path does no permission checks.
