### PR TITLE
Upgrade JUnit Mockito strictness

### DIFF
--- a/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletMimeTypeTest.java
+++ b/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletMimeTypeTest.java
@@ -5,10 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * inferFallbackContentType is a pure function of the request path, so it lives here rather than
- * alongside the proxying tests, where it would inherit an unrelated HTTP-exchange fixture.
- */
+/** Separate from the proxying tests: inferFallbackContentType needs no mocks. */
 public class ViteDevServerProxyServletMimeTypeTest {
 
   private final ViteDevServerProxyServlet servlet =

--- a/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletMimeTypeTest.java
+++ b/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletMimeTypeTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
-/** Separate from the proxying tests: inferFallbackContentType needs no mocks. */
 public class ViteDevServerProxyServletMimeTypeTest {
 
   private final ViteDevServerProxyServlet servlet =

--- a/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletMimeTypeTest.java
+++ b/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletMimeTypeTest.java
@@ -7,9 +7,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * inferFallbackContentType is a pure function of the request path, so it lives here rather than
- * alongside the proxying tests: sharing their class would mean inheriting a @BeforeEach that stubs
- * a whole HTTP exchange this test never touches, and every one of those stubs would then have to be
- * marked lenient to keep Mockito's strict-stub checking quiet.
+ * alongside the proxying tests, where it would inherit an unrelated HTTP-exchange fixture.
  */
 public class ViteDevServerProxyServletMimeTypeTest {
 

--- a/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletMimeTypeTest.java
+++ b/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletMimeTypeTest.java
@@ -1,0 +1,26 @@
+package com.axiope.webapp.dev;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * inferFallbackContentType is a pure function of the request path, so it lives here rather than
+ * alongside the proxying tests: sharing their class would mean inheriting a @BeforeEach that stubs
+ * a whole HTTP exchange this test never touches, and every one of those stubs would then have to be
+ * marked lenient to keep Mockito's strict-stub checking quiet.
+ */
+public class ViteDevServerProxyServletMimeTypeTest {
+
+  private final ViteDevServerProxyServlet servlet =
+      new ViteDevServerProxyServlet("http://127.0.0.1:5173", null);
+
+  @Test
+  public void doesNotInventMimeTypeForUnknownExtensions() {
+    assertNull(servlet.inferFallbackContentType("/ui/dist/assets/logo.svg"));
+    assertEquals("text/css", servlet.inferFallbackContentType("/ui/dist/assets/app.css"));
+    assertEquals(
+        "text/javascript", servlet.inferFallbackContentType("/ui/dist/chunks/editor-plugin.mjs"));
+  }
+}

--- a/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletTest.java
+++ b/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletTest.java
@@ -2,9 +2,9 @@ package com.axiope.webapp.dev;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,11 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 public class ViteDevServerProxyServletTest {
 
   @Mock private HttpClient client;
@@ -51,25 +48,17 @@ public class ViteDevServerProxyServletTest {
   public void setUp() throws Exception {
     servlet = new ViteDevServerProxyServlet("http://127.0.0.1:5173", client);
 
-    when(request.getMethod()).thenReturn("GET");
-    when(request.getHeader("Upgrade")).thenReturn(null);
-    when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
-    when(request.getQueryString()).thenReturn("v=fca605f6");
-    when(response.getOutputStream()).thenReturn(new TestServletOutputStream(responseBody));
-    when(response.getContentType()).thenAnswer(invocation -> responseContentType.get());
+    lenient().when(request.getMethod()).thenReturn("GET");
+    lenient().when(request.getHeader("Upgrade")).thenReturn(null);
+    lenient().when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+    lenient().when(request.getQueryString()).thenReturn("v=fca605f6");
+    lenient()
+        .when(response.getOutputStream())
+        .thenReturn(new TestServletOutputStream(responseBody));
+    lenient().when(response.getContentType()).thenAnswer(invocation -> responseContentType.get());
 
-    org.mockito.Mockito.doAnswer(
-            invocation -> {
-              String name = invocation.getArgument(0, String.class);
-              String value = invocation.getArgument(1, String.class);
-              if ("content-type".equalsIgnoreCase(name)) {
-                responseContentType.set(value);
-              }
-              return null;
-            })
-        .when(response)
-        .addHeader(any(String.class), any(String.class));
-    org.mockito.Mockito.doAnswer(
+    lenient()
+        .doAnswer(
             invocation -> {
               responseContentType.set(invocation.getArgument(0, String.class));
               return null;
@@ -77,12 +66,15 @@ public class ViteDevServerProxyServletTest {
         .when(response)
         .setContentType(any(String.class));
 
-    when(client.send(
-            any(HttpRequest.class),
-            org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+    lenient()
+        .when(
+            client.send(
+                any(HttpRequest.class),
+                org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
         .thenReturn(upstreamResponse);
-    when(upstreamResponse.statusCode()).thenReturn(HttpServletResponse.SC_OK);
-    when(upstreamResponse.body())
+    lenient().when(upstreamResponse.statusCode()).thenReturn(HttpServletResponse.SC_OK);
+    lenient()
+        .when(upstreamResponse.body())
         .thenReturn(
             new ByteArrayInputStream("export const ok = true;".getBytes(StandardCharsets.UTF_8)));
   }
@@ -173,8 +165,6 @@ public class ViteDevServerProxyServletTest {
       when(request.getRequestURI()).thenReturn("/ui/dist/src/entries/tinymceGallery.tsx");
       when(request.getHeaderNames())
           .thenReturn(Collections.enumeration(List.of("KEEP-ALIVE", "X-Test")));
-      when(request.getHeaders("KEEP-ALIVE"))
-          .thenReturn(Collections.enumeration(List.of("timeout=5")));
       when(request.getHeaders("X-Test")).thenReturn(Collections.enumeration(List.of("value")));
       when(upstreamResponse.headers())
           .thenReturn(HttpHeaders.of(Collections.emptyMap(), (a, b) -> true));
@@ -194,14 +184,6 @@ public class ViteDevServerProxyServletTest {
     } finally {
       Locale.setDefault(originalLocale);
     }
-  }
-
-  @Test
-  public void doesNotInventMimeTypeForUnknownExtensions() {
-    assertNull(servlet.inferFallbackContentType("/ui/dist/assets/logo.svg"));
-    assertEquals("text/css", servlet.inferFallbackContentType("/ui/dist/assets/app.css"));
-    assertEquals(
-        "text/javascript", servlet.inferFallbackContentType("/ui/dist/chunks/editor-plugin.mjs"));
   }
 
   private static final class TestServletOutputStream extends ServletOutputStream {

--- a/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletTest.java
+++ b/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,17 +48,14 @@ public class ViteDevServerProxyServletTest {
   public void setUp() throws Exception {
     servlet = new ViteDevServerProxyServlet("http://127.0.0.1:5173", client);
 
-    lenient().when(request.getMethod()).thenReturn("GET");
-    lenient().when(request.getHeader("Upgrade")).thenReturn(null);
-    lenient().when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
-    lenient().when(request.getQueryString()).thenReturn("v=fca605f6");
-    lenient()
-        .when(response.getOutputStream())
-        .thenReturn(new TestServletOutputStream(responseBody));
-    lenient().when(response.getContentType()).thenAnswer(invocation -> responseContentType.get());
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getHeader("Upgrade")).thenReturn(null);
+    when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getQueryString()).thenReturn("v=fca605f6");
+    when(response.getOutputStream()).thenReturn(new TestServletOutputStream(responseBody));
+    when(response.getContentType()).thenAnswer(invocation -> responseContentType.get());
 
-    lenient()
-        .doAnswer(
+    doAnswer(
             invocation -> {
               responseContentType.set(invocation.getArgument(0, String.class));
               return null;
@@ -66,15 +63,8 @@ public class ViteDevServerProxyServletTest {
         .when(response)
         .setContentType(any(String.class));
 
-    lenient()
-        .when(
-            client.send(
-                any(HttpRequest.class),
-                org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
-        .thenReturn(upstreamResponse);
-    lenient().when(upstreamResponse.statusCode()).thenReturn(HttpServletResponse.SC_OK);
-    lenient()
-        .when(upstreamResponse.body())
+    when(upstreamResponse.statusCode()).thenReturn(HttpServletResponse.SC_OK);
+    when(upstreamResponse.body())
         .thenReturn(
             new ByteArrayInputStream("export const ok = true;".getBytes(StandardCharsets.UTF_8)));
   }
@@ -82,6 +72,7 @@ public class ViteDevServerProxyServletTest {
   @Test
   public void fallsBackToJavaScriptMimeTypeForJsModuleWhenUpstreamOmitsContentType()
       throws Exception {
+    stubSuccessfulUpstreamRequest();
     when(request.getRequestURI())
         .thenReturn(
             "/ui/dist/node_modules/.vite/deps/@fortawesome_free-solid-svg-icons_faThList.js");
@@ -98,6 +89,7 @@ public class ViteDevServerProxyServletTest {
 
   @Test
   public void overridesTextPlainContentTypeForJsModuleResponses() throws Exception {
+    stubSuccessfulUpstreamRequest();
     when(request.getRequestURI())
         .thenReturn("/ui/dist/node_modules/.vite/deps/@mui_icons-material_CheckCircleOutline.js");
     when(upstreamResponse.headers())
@@ -142,6 +134,7 @@ public class ViteDevServerProxyServletTest {
 
   @Test
   public void preservesUpstreamContentTypeWhenPresent() throws Exception {
+    stubSuccessfulUpstreamRequest();
     when(request.getRequestURI()).thenReturn("/ui/dist/src/entries/tinymceGallery.tsx");
     when(upstreamResponse.headers())
         .thenReturn(
@@ -207,5 +200,12 @@ public class ViteDevServerProxyServletTest {
     public void write(int b) {
       target.write(b);
     }
+  }
+
+  private void stubSuccessfulUpstreamRequest() throws Exception {
+    when(client.send(
+            any(HttpRequest.class),
+            org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+        .thenReturn(upstreamResponse);
   }
 }

--- a/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletTest.java
+++ b/src/test/java/com/axiope/webapp/dev/ViteDevServerProxyServletTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -115,8 +116,7 @@ public class ViteDevServerProxyServletTest {
     when(upstreamResponse.headers())
         .thenReturn(HttpHeaders.of(Collections.emptyMap(), (a, b) -> true));
     when(client.send(
-            any(HttpRequest.class),
-            org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+            any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
         .thenAnswer(
             invocation -> {
               upstreamUri.set(invocation.getArgument(0, HttpRequest.class).uri());
@@ -163,7 +163,7 @@ public class ViteDevServerProxyServletTest {
           .thenReturn(HttpHeaders.of(Collections.emptyMap(), (a, b) -> true));
       when(client.send(
               any(HttpRequest.class),
-              org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+              ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
           .thenAnswer(
               invocation -> {
                 proxiedRequest.set(invocation.getArgument(0, HttpRequest.class));
@@ -204,8 +204,7 @@ public class ViteDevServerProxyServletTest {
 
   private void stubSuccessfulUpstreamRequest() throws Exception {
     when(client.send(
-            any(HttpRequest.class),
-            org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+            any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
         .thenReturn(upstreamResponse);
   }
 }

--- a/src/test/java/com/axiope/webapp/listener/StartupListenerViteProxyTest.java
+++ b/src/test/java/com/axiope/webapp/listener/StartupListenerViteProxyTest.java
@@ -1,6 +1,7 @@
 package com.axiope.webapp.listener;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,8 +36,7 @@ public class StartupListenerViteProxyTest {
     environment = new MockEnvironment();
     environment.setProperty(FrontendCacheVersion.REACT_DEV_MODE_PROPERTY, "true");
     when(applicationContext.getEnvironment()).thenReturn(environment);
-    when(servletContext.addServlet(
-            eq("viteDevServerProxy"), org.mockito.ArgumentMatchers.any(Servlet.class)))
+    when(servletContext.addServlet(eq("viteDevServerProxy"), any(Servlet.class)))
         .thenReturn(registration);
     listener = new StartupListener();
   }

--- a/src/test/java/com/axiope/webapp/listener/StartupListenerViteProxyTest.java
+++ b/src/test/java/com/axiope/webapp/listener/StartupListenerViteProxyTest.java
@@ -17,13 +17,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 public class StartupListenerViteProxyTest {
 
   @Mock private ApplicationContext applicationContext;

--- a/src/test/java/com/axiope/webapp/taglib/AssetUrlTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/AssetUrlTagTest.java
@@ -5,89 +5,56 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
-import java.util.LinkedHashMap;
+import java.io.StringWriter;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockJspWriter;
+import org.springframework.mock.web.MockServletContext;
 
 @ExtendWith(MockitoExtension.class)
 public class AssetUrlTagTest {
 
-  @Mock private HttpServletRequest request;
   @Mock private PageContext pageContext;
-  @Mock private ServletContext servletContext;
-  @Mock private JspWriter writer;
 
-  private final StringBuilder output = new StringBuilder();
-  private final Map<String, Object> requestAttributes = new LinkedHashMap<>();
-  private final Map<String, Object> servletContextAttributes = new LinkedHashMap<>();
+  private final StringWriter output = new StringWriter();
+  private MockHttpServletRequest request;
+  private MockServletContext servletContext;
+  private JspWriter writer;
   private AssetUrlTag tag;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     tag = new AssetUrlTag();
-    tag.setPageContext(pageContext);
-    output.setLength(0);
-    requestAttributes.clear();
-    servletContextAttributes.clear();
+    output.getBuffer().setLength(0);
+    servletContext = new MockServletContext();
+    request = new MockHttpServletRequest(servletContext);
+    writer = new MockJspWriter(output);
     System.clearProperty(FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY);
+    tag.setPageContext(pageContext);
+  }
 
-    lenient().when(pageContext.getRequest()).thenReturn(request);
-    lenient().when(pageContext.getOut()).thenReturn(writer);
-    lenient().when(pageContext.getServletContext()).thenReturn(servletContext);
-    lenient().when(request.getContextPath()).thenReturn("");
-    lenient()
-        .when(servletContext.getAttribute(anyString()))
-        .thenAnswer(
-            invocation -> servletContextAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              servletContextAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(servletContext)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-    lenient()
-        .when(request.getAttribute(anyString()))
-        .thenAnswer(invocation -> requestAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              requestAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(request)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-
-    lenient()
-        .doAnswer(
-            invocation -> {
-              output.append(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(writer)
-        .write(anyString());
+  private void stubPageContext() {
+    when(pageContext.getRequest()).thenReturn(request);
+    when(pageContext.getOut()).thenReturn(writer);
+    when(pageContext.getServletContext()).thenReturn(servletContext);
   }
 
   @Test
   public void appendsVersionTokenInProductionMode() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -97,19 +64,20 @@ public class AssetUrlTagTest {
 
   @Test
   public void cachesResolvedUrlsInProductionMode() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
 
     @SuppressWarnings("unchecked")
     Map<String, String> cache =
-        (Map<String, String>) servletContextAttributes.get(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR);
+        (Map<String, String>) servletContext.getAttribute(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR);
     assertEquals(1, cache.size());
     assertTrue(cache.containsValue("/scripts/global.js?v=2.23.0"));
 
-    output.setLength(0);
+    output.getBuffer().setLength(0);
     AssetUrlTag second = new AssetUrlTag();
     second.setPageContext(pageContext);
     second.setValue("/scripts/global.js");
@@ -121,19 +89,22 @@ public class AssetUrlTagTest {
 
   @Test
   public void doesNotPopulateProductionCacheInDevMode() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     System.setProperty(
         FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY, "true");
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
 
-    assertFalse(servletContextAttributes.containsKey(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR));
+    assertFalse(
+        servletContext.getAttribute(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR) instanceof Map<?, ?>);
   }
 
   @Test
   public void omitsVersionTokenForLegacyScriptsInDevModeByDefault() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -143,7 +114,8 @@ public class AssetUrlTagTest {
 
   @Test
   public void usesPerRequestUuidForLegacyScriptsInDevModeWhenEnabled() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     System.setProperty(
         FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY, "true");
     tag.setValue("/scripts/global.js");
@@ -154,7 +126,7 @@ public class AssetUrlTagTest {
     assertTrue(
         first.matches("/scripts/global\\.js\\?v=.+"), "expected ?v=<uuid> but was: " + first);
 
-    output.setLength(0);
+    output.getBuffer().setLength(0);
     AssetUrlTag second = new AssetUrlTag();
     second.setPageContext(pageContext);
     second.setValue("/styles/theme.css");
@@ -169,7 +141,8 @@ public class AssetUrlTagTest {
 
   @Test
   public void devModeUuidChangesAcrossRequestsWhenLegacyAssetFlagEnabled() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     System.setProperty(
         FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY, "true");
     tag.setValue("/scripts/global.js");
@@ -177,8 +150,8 @@ public class AssetUrlTagTest {
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
     String first = output.toString();
 
-    output.setLength(0);
-    requestAttributes.clear();
+    output.getBuffer().setLength(0);
+    request.clearAttributes();
     AssetUrlTag next = new AssetUrlTag();
     next.setPageContext(pageContext);
     next.setValue("/scripts/global.js");
@@ -189,9 +162,10 @@ public class AssetUrlTagTest {
 
   @Test
   public void prefixesContextPathForRelativeAssets() throws JspException {
-    lenient().when(request.getContextPath()).thenReturn("/rspace");
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubPageContext();
+    request.setContextPath("/rspace");
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -201,8 +175,9 @@ public class AssetUrlTagTest {
 
   @Test
   public void preservesExistingQueryString() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
     tag.setValue("/scripts/foo.js?bar=baz");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -212,7 +187,8 @@ public class AssetUrlTagTest {
 
   @Test
   public void omitsQueryWhenNoVersionAvailable() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -222,7 +198,8 @@ public class AssetUrlTagTest {
 
   @Test
   public void omitsVersionTokenForLegacyStylesInDevModeByDefault() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     tag.setValue("/styles/theme.css");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -232,7 +209,8 @@ public class AssetUrlTagTest {
 
   @Test
   public void usesPerRequestUuidForLegacyStylesInDevModeWhenEnabled() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     System.setProperty(
         FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY, "true");
     tag.setValue("/styles/theme.css");

--- a/src/test/java/com/axiope/webapp/taglib/AssetUrlTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/AssetUrlTagTest.java
@@ -1,94 +1,68 @@
 package com.axiope.webapp.taglib;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.io.StringWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockJspWriter;
+import org.springframework.mock.web.MockServletContext;
 
 @ExtendWith(MockitoExtension.class)
 public class AssetUrlTagTest {
 
-  @Mock private HttpServletRequest request;
   @Mock private PageContext pageContext;
-  @Mock private ServletContext servletContext;
-  @Mock private JspWriter writer;
 
-  private final StringBuilder output = new StringBuilder();
-  private final Map<String, Object> requestAttributes = new LinkedHashMap<>();
-  private final Map<String, Object> servletContextAttributes = new LinkedHashMap<>();
+  private final StringWriter output = new StringWriter();
+  private MockHttpServletRequest request;
+  private MockServletContext servletContext;
+  private JspWriter writer;
   private AssetUrlTag tag;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
+    output.getBuffer().setLength(0);
+    servletContext = new MockServletContext();
+    request = new MockHttpServletRequest(servletContext);
+    writer = new MockJspWriter(output);
     tag = new AssetUrlTag();
     tag.setPageContext(pageContext);
-    output.setLength(0);
-    requestAttributes.clear();
-    servletContextAttributes.clear();
     System.clearProperty(FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY);
+  }
 
-    lenient().when(pageContext.getRequest()).thenReturn(request);
-    lenient().when(pageContext.getOut()).thenReturn(writer);
-    lenient().when(pageContext.getServletContext()).thenReturn(servletContext);
-    lenient().when(request.getContextPath()).thenReturn("");
-    lenient()
-        .when(servletContext.getAttribute(anyString()))
-        .thenAnswer(
-            invocation -> servletContextAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              servletContextAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(servletContext)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-    lenient()
-        .when(request.getAttribute(anyString()))
-        .thenAnswer(invocation -> requestAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              requestAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(request)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
+  private void stubRequest() {
+    when(pageContext.getRequest()).thenReturn(request);
+  }
 
-    lenient()
-        .doAnswer(
-            invocation -> {
-              output.append(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(writer)
-        .write(anyString());
+  private void stubServletContext() {
+    when(pageContext.getServletContext()).thenReturn(servletContext);
+  }
+
+  private void stubWriter() {
+    when(pageContext.getOut()).thenReturn(writer);
   }
 
   @Test
   public void appendsVersionTokenInProductionMode() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -98,19 +72,22 @@ public class AssetUrlTagTest {
 
   @Test
   public void cachesResolvedUrlsInProductionMode() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
 
     AssetUrlTag.ProductionUrlCache cache =
         (AssetUrlTag.ProductionUrlCache)
-            servletContextAttributes.get(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR);
+            servletContext.getAttribute(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR);
     assertEquals(1, cache.urls.size());
     assertTrue(cache.urls.containsValue("/scripts/global.js?v=2.23.0"));
 
-    output.setLength(0);
+    output.getBuffer().setLength(0);
     AssetUrlTag second = new AssetUrlTag();
     second.setPageContext(pageContext);
     second.setValue("/scripts/global.js");
@@ -119,26 +96,32 @@ public class AssetUrlTagTest {
     assertEquals("/scripts/global.js?v=2.23.0", output.toString());
     assertSame(
         cache,
-        servletContextAttributes.get(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR),
+        servletContext.getAttribute(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR),
         "the cache must be reused, not rebuilt per invocation");
     assertEquals(1, cache.urls.size());
   }
 
   @Test
   public void doesNotPopulateProductionCacheInDevMode() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     System.setProperty(
         FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY, "true");
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
 
-    assertFalse(servletContextAttributes.containsKey(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR));
+    assertNull(servletContext.getAttribute(AssetUrlTag.PRODUCTION_URL_CACHE_ATTR));
   }
 
   @Test
   public void omitsVersionTokenForLegacyScriptsInDevModeByDefault() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -148,7 +131,10 @@ public class AssetUrlTagTest {
 
   @Test
   public void usesPerRequestUuidForLegacyScriptsInDevModeWhenEnabled() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     System.setProperty(
         FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY, "true");
     tag.setValue("/scripts/global.js");
@@ -159,7 +145,7 @@ public class AssetUrlTagTest {
     assertTrue(
         first.matches("/scripts/global\\.js\\?v=.+"), "expected ?v=<uuid> but was: " + first);
 
-    output.setLength(0);
+    output.getBuffer().setLength(0);
     AssetUrlTag second = new AssetUrlTag();
     second.setPageContext(pageContext);
     second.setValue("/styles/theme.css");
@@ -174,7 +160,10 @@ public class AssetUrlTagTest {
 
   @Test
   public void devModeUuidChangesAcrossRequestsWhenLegacyAssetFlagEnabled() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     System.setProperty(
         FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY, "true");
     tag.setValue("/scripts/global.js");
@@ -182,8 +171,9 @@ public class AssetUrlTagTest {
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
     String first = output.toString();
 
-    output.setLength(0);
-    requestAttributes.clear();
+    output.getBuffer().setLength(0);
+    request = new MockHttpServletRequest(servletContext);
+    stubRequest();
     AssetUrlTag next = new AssetUrlTag();
     next.setPageContext(pageContext);
     next.setValue("/scripts/global.js");
@@ -194,9 +184,12 @@ public class AssetUrlTagTest {
 
   @Test
   public void prefixesContextPathForRelativeAssets() throws JspException {
-    lenient().when(request.getContextPath()).thenReturn("/rspace");
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    request.setContextPath("/rspace");
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -206,8 +199,11 @@ public class AssetUrlTagTest {
 
   @Test
   public void preservesExistingQueryString() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
     tag.setValue("/scripts/foo.js?bar=baz");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -217,7 +213,10 @@ public class AssetUrlTagTest {
 
   @Test
   public void omitsQueryWhenNoVersionAvailable() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
     tag.setValue("/scripts/global.js");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -227,7 +226,10 @@ public class AssetUrlTagTest {
 
   @Test
   public void omitsVersionTokenForLegacyStylesInDevModeByDefault() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     tag.setValue("/styles/theme.css");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
@@ -237,7 +239,10 @@ public class AssetUrlTagTest {
 
   @Test
   public void usesPerRequestUuidForLegacyStylesInDevModeWhenEnabled() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubRequest();
+    stubServletContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
     System.setProperty(
         FrontendCacheVersion.LEGACY_ASSET_CACHE_BUSTING_IN_DEV_MODE_PROPERTY, "true");
     tag.setValue("/styles/theme.css");

--- a/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -259,9 +261,7 @@ public class BundleTagTest {
     assertEquals(TagSupport.SKIP_BODY, realTag.doStartTag());
     assertTrue(output.toString().contains("type=\"module\" src=\"/ui/dist/appBar-abc123.js\""));
     verify(servletContext)
-        .setAttribute(
-            org.mockito.ArgumentMatchers.eq(BundleTag.MANIFEST_CACHE_ATTR),
-            org.mockito.ArgumentMatchers.any(BundleTag.ChunkManifest.class));
+        .setAttribute(eq(BundleTag.MANIFEST_CACHE_ATTR), any(BundleTag.ChunkManifest.class));
   }
 
   @Test

--- a/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
@@ -123,6 +123,9 @@ public class BundleTagTest {
 
   @Test
   public void i18nMessagesTagRendersClassicViteBundle() throws JspException {
+    stubRequest();
+    stubServletContext();
+    stubWriter();
     manifest =
         BundleTag.ChunkManifest.fromBundles(
             Collections.singletonMap(
@@ -153,6 +156,8 @@ public class BundleTagTest {
 
   @Test
   public void i18nMessagesTagCacheBustsTheCatalogueUrl() throws JspException {
+    stubRequest();
+    stubServletContext();
     servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "1.2.3");
     I18nMessagesTag i18nTag =
         new I18nMessagesTag() {
@@ -173,6 +178,9 @@ public class BundleTagTest {
 
   @Test
   public void i18nMessagesTagRendersClassicEntrypointInHmrMode() throws JspException {
+    stubRequest();
+    stubServletContext();
+    stubWriter();
     I18nMessagesTag i18nTag =
         new I18nMessagesTag() {
           @Override

--- a/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
@@ -2,22 +2,21 @@ package com.axiope.webapp.taglib;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
 import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -31,19 +30,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockJspWriter;
+import org.springframework.mock.web.MockServletContext;
 
 @ExtendWith(MockitoExtension.class)
 public class BundleTagTest {
 
-  @Mock private HttpServletRequest request;
   @Mock private PageContext pageContext;
-  @Mock private ServletContext servletContext;
-  @Mock private JspWriter writer;
 
-  private final StringBuilder output = new StringBuilder();
-  private final Map<String, Object> requestAttributes = new LinkedHashMap<>();
-  private final Map<String, Object> servletContextAttributes = new LinkedHashMap<>();
+  private final StringWriter output = new StringWriter();
   private final Set<String> renderedAssets = new LinkedHashSet<>();
+  private MockHttpServletRequest request;
+  private MockServletContext servletContext;
+  private JspWriter writer;
   private BundleTag.ChunkManifest manifest;
   private TestBundleTag tag;
   private String originalReactDevModeProperty;
@@ -61,70 +61,17 @@ public class BundleTagTest {
   }
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     originalReactDevModeProperty = System.getProperty(FrontendCacheVersion.REACT_DEV_MODE_PROPERTY);
     System.clearProperty(FrontendCacheVersion.REACT_DEV_MODE_PROPERTY);
     manifest = BundleTag.ChunkManifest.fromBundles(new LinkedHashMap<>());
+    output.getBuffer().setLength(0);
+    renderedAssets.clear();
+    servletContext = spy(new MockServletContext());
+    request = new MockHttpServletRequest(servletContext);
+    writer = new MockJspWriter(output);
     tag = new TestBundleTag();
     tag.setPageContext(pageContext);
-    output.setLength(0);
-    requestAttributes.clear();
-    servletContextAttributes.clear();
-    renderedAssets.clear();
-
-    lenient().when(pageContext.getRequest()).thenReturn(request);
-    lenient().when(pageContext.getOut()).thenReturn(writer);
-    lenient().when(pageContext.getServletContext()).thenReturn(servletContext);
-    lenient()
-        .when(servletContext.getAttribute(anyString()))
-        .thenAnswer(
-            invocation -> servletContextAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              servletContextAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(servletContext)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-    lenient()
-        .doAnswer(
-            invocation -> {
-              servletContextAttributes.remove(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(servletContext)
-        .removeAttribute(anyString());
-    lenient()
-        .when(request.getAttribute(anyString()))
-        .thenAnswer(invocation -> requestAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              requestAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(request)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-    lenient()
-        .doAnswer(
-            invocation -> {
-              requestAttributes.remove(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(request)
-        .removeAttribute(anyString());
-
-    lenient()
-        .doAnswer(
-            invocation -> {
-              output.append(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(writer)
-        .write(anyString());
   }
 
   @AfterEach
@@ -137,8 +84,22 @@ public class BundleTagTest {
     }
   }
 
+  private void stubRequest() {
+    when(pageContext.getRequest()).thenReturn(request);
+  }
+
+  private void stubServletContext() {
+    when(pageContext.getServletContext()).thenReturn(servletContext);
+  }
+
+  private void stubWriter() {
+    when(pageContext.getOut()).thenReturn(writer);
+  }
+
   @Test
   public void rendersManifestBackedAssets() throws JspException {
+    stubServletContext();
+    stubWriter();
     manifest =
         BundleTag.ChunkManifest.fromBundles(
             Collections.singletonMap(
@@ -239,6 +200,8 @@ public class BundleTagTest {
 
   @Test
   public void renderingSameBundleTwiceDeduplicatesAssets() throws JspException {
+    stubServletContext();
+    stubWriter();
     manifest =
         BundleTag.ChunkManifest.fromBundles(
             Collections.singletonMap(
@@ -257,16 +220,21 @@ public class BundleTagTest {
 
   @Test
   public void missingBundleThrowsJspException() {
+    stubRequest();
+    stubServletContext();
     tag.setBundle("apps");
 
-    JspException error = assertThrows(JspException.class, () -> tag.doStartTag());
-    assertTrue(error.getMessage().contains("No bundle manifest entry found for bundle: apps"));
+    assertTrue(
+        assertThrows(JspException.class, () -> tag.doStartTag())
+            .getMessage()
+            .contains("No bundle manifest entry found for bundle: apps"));
   }
 
   @Test
   public void loadsManifestFromDistPath() {
     when(servletContext.getResourceAsStream(BundleTag.VITE_MANIFEST_PATH))
         .thenReturn(manifestStream("appBar", "appBar-abc123.js"));
+    clearInvocations(servletContext);
 
     BundleTag.ChunkManifest loadedManifest = BundleTag.ChunkManifest.load(servletContext);
 
@@ -286,6 +254,7 @@ public class BundleTagTest {
   public void loadsEntrypointsFromJsonPath() {
     when(servletContext.getResourceAsStream(BundleTag.VITE_ENTRYPOINTS_PATH))
         .thenReturn(entrypointsStream());
+    clearInvocations(servletContext);
 
     Map<String, String> entrypoints = BundleTag.loadEntrypoints(servletContext);
 
@@ -295,10 +264,13 @@ public class BundleTagTest {
 
   @Test
   public void getManifestCacheDoesNotCacheEmptyManifest() {
+    stubRequest();
+    stubServletContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
     BundleTag realTag = new BundleTag();
     realTag.setPageContext(pageContext);
-    when(servletContext.getAttribute(BundleTag.MANIFEST_CACHE_ATTR)).thenReturn(null);
     when(servletContext.getResourceAsStream(BundleTag.VITE_MANIFEST_PATH)).thenReturn(null);
+    clearInvocations(servletContext);
 
     BundleTag.ChunkManifest loadedManifest = realTag.getManifestCache();
 
@@ -311,12 +283,13 @@ public class BundleTagTest {
   public void preWarmManifestCacheCachesParsedManifestForNonDevMode() {
     when(servletContext.getResourceAsStream(BundleTag.VITE_MANIFEST_PATH))
         .thenReturn(manifestStream("appBar", "appBar-abc123.js"));
+    clearInvocations(servletContext);
 
     BundleTag.preWarmManifestCache(servletContext, false);
 
     assertEquals(
-        Boolean.FALSE, servletContextAttributes.get(FrontendCacheVersion.DEV_MODE_CACHE_ATTR));
-    Object cachedManifest = servletContextAttributes.get(BundleTag.MANIFEST_CACHE_ATTR);
+        Boolean.FALSE, servletContext.getAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR));
+    Object cachedManifest = servletContext.getAttribute(BundleTag.MANIFEST_CACHE_ATTR);
     assertTrue(cachedManifest instanceof BundleTag.ChunkManifest);
     assertEquals(
         List.of("/ui/dist/appBar-abc123.js"),
@@ -328,14 +301,17 @@ public class BundleTagTest {
     BundleTag.preWarmManifestCache(servletContext, true);
 
     assertEquals(
-        Boolean.TRUE, servletContextAttributes.get(FrontendCacheVersion.DEV_MODE_CACHE_ATTR));
-    assertTrue(!servletContextAttributes.containsKey(BundleTag.MANIFEST_CACHE_ATTR));
+        Boolean.TRUE, servletContext.getAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR));
+    assertNull(servletContext.getAttribute(BundleTag.MANIFEST_CACHE_ATTR));
     verify(servletContext, never()).getResourceAsStream(BundleTag.VITE_MANIFEST_PATH);
     verify(servletContext).removeAttribute(BundleTag.MANIFEST_CACHE_ATTR);
   }
 
   @Test
   public void missingBundleRefreshesManifestCacheBeforeThrowing() throws JspException {
+    stubRequest();
+    stubServletContext();
+    stubWriter();
     BundleTag realTag =
         new BundleTag() {
           @Override
@@ -350,9 +326,12 @@ public class BundleTagTest {
                 "toastMessage",
                 new BundleTag.ChunkManifest.BundleAssets(
                     List.of(), List.of(), List.of("/ui/dist/toastMessage-abc123.js"))));
-    doReturn(staleManifest).when(servletContext).getAttribute(BundleTag.MANIFEST_CACHE_ATTR);
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(BundleTag.MANIFEST_CACHE_ATTR, staleManifest);
+    clearInvocations(servletContext);
     when(servletContext.getResourceAsStream(BundleTag.VITE_MANIFEST_PATH))
         .thenReturn(manifestStream("appBar", "appBar-abc123.js"));
+    clearInvocations(servletContext);
 
     realTag.setBundle("appBar");
 
@@ -366,6 +345,9 @@ public class BundleTagTest {
 
   @Test
   public void devModeRefreshesManifestOncePerRequest() throws JspException {
+    stubRequest();
+    stubServletContext();
+    stubWriter();
     class DevModeBundleTag extends BundleTag {
       private final List<ChunkManifest> manifests =
           List.of(
@@ -390,7 +372,7 @@ public class BundleTagTest {
       ChunkManifest refreshManifestCache() {
         ChunkManifest nextManifest = manifests.get(refreshCount);
         refreshCount++;
-        requestAttributes.remove(REQUEST_MANIFEST_CACHE_ATTR);
+        request.removeAttribute(REQUEST_MANIFEST_CACHE_ATTR);
         return nextManifest;
       }
     }
@@ -403,8 +385,8 @@ public class BundleTagTest {
     assertTrue(output.toString().contains("src=\"/ui/dist/appBar-first.js\""));
     assertEquals(1, realTag.refreshCount);
 
-    output.setLength(0);
-    requestAttributes.clear();
+    output.getBuffer().setLength(0);
+    request.clearAttributes();
     assertEquals(TagSupport.SKIP_BODY, realTag.doStartTag());
     assertTrue(output.toString().contains("src=\"/ui/dist/appBar-second.js\""));
     assertEquals(2, realTag.refreshCount);
@@ -412,6 +394,7 @@ public class BundleTagTest {
 
   @Test
   public void hmrModeRendersSameOriginViteClientAndEntrypointScripts() throws JspException {
+    stubWriter();
     BundleTag realTag =
         new BundleTag() {
           @Override
@@ -447,6 +430,7 @@ public class BundleTagTest {
 
   @Test
   public void devModeReusesRefreshedManifestWithinSingleRequest() {
+    stubRequest();
     class DevModeBundleTag extends BundleTag {
       private int refreshCount;
 
@@ -458,7 +442,7 @@ public class BundleTagTest {
       @Override
       ChunkManifest refreshManifestCache() {
         refreshCount++;
-        requestAttributes.remove(REQUEST_MANIFEST_CACHE_ATTR);
+        request.removeAttribute(REQUEST_MANIFEST_CACHE_ATTR);
         return ChunkManifest.fromBundles(
             Collections.singletonMap(
                 "appBar",

--- a/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -338,9 +340,7 @@ public class BundleTagTest {
     assertEquals(TagSupport.SKIP_BODY, realTag.doStartTag());
     assertTrue(output.toString().contains("type=\"module\" src=\"/ui/dist/appBar-abc123.js\""));
     verify(servletContext)
-        .setAttribute(
-            org.mockito.ArgumentMatchers.eq(BundleTag.MANIFEST_CACHE_ATTR),
-            org.mockito.ArgumentMatchers.any(BundleTag.ChunkManifest.class));
+        .setAttribute(eq(BundleTag.MANIFEST_CACHE_ATTR), any(BundleTag.ChunkManifest.class));
   }
 
   @Test

--- a/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/BundleTagTest.java
@@ -2,22 +2,21 @@ package com.axiope.webapp.taglib;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
 import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -31,19 +30,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockJspWriter;
+import org.springframework.mock.web.MockServletContext;
 
 @ExtendWith(MockitoExtension.class)
 public class BundleTagTest {
 
-  @Mock private HttpServletRequest request;
   @Mock private PageContext pageContext;
-  @Mock private ServletContext servletContext;
-  @Mock private JspWriter writer;
 
-  private final StringBuilder output = new StringBuilder();
-  private final Map<String, Object> requestAttributes = new LinkedHashMap<>();
-  private final Map<String, Object> servletContextAttributes = new LinkedHashMap<>();
+  private final StringWriter output = new StringWriter();
   private final Set<String> renderedAssets = new LinkedHashSet<>();
+  private MockHttpServletRequest request;
+  private MockServletContext servletContext;
+  private JspWriter writer;
   private BundleTag.ChunkManifest manifest;
   private TestBundleTag tag;
   private String originalReactDevModeProperty;
@@ -61,70 +61,17 @@ public class BundleTagTest {
   }
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     originalReactDevModeProperty = System.getProperty(FrontendCacheVersion.REACT_DEV_MODE_PROPERTY);
     System.clearProperty(FrontendCacheVersion.REACT_DEV_MODE_PROPERTY);
     manifest = BundleTag.ChunkManifest.fromBundles(new LinkedHashMap<>());
+    output.getBuffer().setLength(0);
+    renderedAssets.clear();
+    servletContext = spy(new MockServletContext());
+    request = new MockHttpServletRequest(servletContext);
+    writer = new MockJspWriter(output);
     tag = new TestBundleTag();
     tag.setPageContext(pageContext);
-    output.setLength(0);
-    requestAttributes.clear();
-    servletContextAttributes.clear();
-    renderedAssets.clear();
-
-    lenient().when(pageContext.getRequest()).thenReturn(request);
-    lenient().when(pageContext.getOut()).thenReturn(writer);
-    lenient().when(pageContext.getServletContext()).thenReturn(servletContext);
-    lenient()
-        .when(servletContext.getAttribute(anyString()))
-        .thenAnswer(
-            invocation -> servletContextAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              servletContextAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(servletContext)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-    lenient()
-        .doAnswer(
-            invocation -> {
-              servletContextAttributes.remove(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(servletContext)
-        .removeAttribute(anyString());
-    lenient()
-        .when(request.getAttribute(anyString()))
-        .thenAnswer(invocation -> requestAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              requestAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(request)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-    lenient()
-        .doAnswer(
-            invocation -> {
-              requestAttributes.remove(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(request)
-        .removeAttribute(anyString());
-
-    lenient()
-        .doAnswer(
-            invocation -> {
-              output.append(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(writer)
-        .write(anyString());
   }
 
   @AfterEach
@@ -137,8 +84,22 @@ public class BundleTagTest {
     }
   }
 
+  private void stubRequest() {
+    when(pageContext.getRequest()).thenReturn(request);
+  }
+
+  private void stubServletContext() {
+    when(pageContext.getServletContext()).thenReturn(servletContext);
+  }
+
+  private void stubWriter() {
+    when(pageContext.getOut()).thenReturn(writer);
+  }
+
   @Test
   public void rendersManifestBackedAssets() throws JspException {
+    stubServletContext();
+    stubWriter();
     manifest =
         BundleTag.ChunkManifest.fromBundles(
             Collections.singletonMap(
@@ -160,6 +121,8 @@ public class BundleTagTest {
 
   @Test
   public void renderingSameBundleTwiceDeduplicatesAssets() throws JspException {
+    stubServletContext();
+    stubWriter();
     manifest =
         BundleTag.ChunkManifest.fromBundles(
             Collections.singletonMap(
@@ -178,16 +141,21 @@ public class BundleTagTest {
 
   @Test
   public void missingBundleThrowsJspException() {
+    stubRequest();
+    stubServletContext();
     tag.setBundle("apps");
 
-    JspException error = assertThrows(JspException.class, () -> tag.doStartTag());
-    assertTrue(error.getMessage().contains("No bundle manifest entry found for bundle: apps"));
+    assertTrue(
+        assertThrows(JspException.class, () -> tag.doStartTag())
+            .getMessage()
+            .contains("No bundle manifest entry found for bundle: apps"));
   }
 
   @Test
   public void loadsManifestFromDistPath() {
     when(servletContext.getResourceAsStream(BundleTag.VITE_MANIFEST_PATH))
         .thenReturn(manifestStream("appBar", "appBar-abc123.js"));
+    clearInvocations(servletContext);
 
     BundleTag.ChunkManifest loadedManifest = BundleTag.ChunkManifest.load(servletContext);
 
@@ -207,6 +175,7 @@ public class BundleTagTest {
   public void loadsEntrypointsFromJsonPath() {
     when(servletContext.getResourceAsStream(BundleTag.VITE_ENTRYPOINTS_PATH))
         .thenReturn(entrypointsStream());
+    clearInvocations(servletContext);
 
     Map<String, String> entrypoints = BundleTag.loadEntrypoints(servletContext);
 
@@ -216,10 +185,13 @@ public class BundleTagTest {
 
   @Test
   public void getManifestCacheDoesNotCacheEmptyManifest() {
+    stubRequest();
+    stubServletContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
     BundleTag realTag = new BundleTag();
     realTag.setPageContext(pageContext);
-    when(servletContext.getAttribute(BundleTag.MANIFEST_CACHE_ATTR)).thenReturn(null);
     when(servletContext.getResourceAsStream(BundleTag.VITE_MANIFEST_PATH)).thenReturn(null);
+    clearInvocations(servletContext);
 
     BundleTag.ChunkManifest loadedManifest = realTag.getManifestCache();
 
@@ -232,12 +204,13 @@ public class BundleTagTest {
   public void preWarmManifestCacheCachesParsedManifestForNonDevMode() {
     when(servletContext.getResourceAsStream(BundleTag.VITE_MANIFEST_PATH))
         .thenReturn(manifestStream("appBar", "appBar-abc123.js"));
+    clearInvocations(servletContext);
 
     BundleTag.preWarmManifestCache(servletContext, false);
 
     assertEquals(
-        Boolean.FALSE, servletContextAttributes.get(FrontendCacheVersion.DEV_MODE_CACHE_ATTR));
-    Object cachedManifest = servletContextAttributes.get(BundleTag.MANIFEST_CACHE_ATTR);
+        Boolean.FALSE, servletContext.getAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR));
+    Object cachedManifest = servletContext.getAttribute(BundleTag.MANIFEST_CACHE_ATTR);
     assertTrue(cachedManifest instanceof BundleTag.ChunkManifest);
     assertEquals(
         List.of("/ui/dist/appBar-abc123.js"),
@@ -249,14 +222,17 @@ public class BundleTagTest {
     BundleTag.preWarmManifestCache(servletContext, true);
 
     assertEquals(
-        Boolean.TRUE, servletContextAttributes.get(FrontendCacheVersion.DEV_MODE_CACHE_ATTR));
-    assertTrue(!servletContextAttributes.containsKey(BundleTag.MANIFEST_CACHE_ATTR));
+        Boolean.TRUE, servletContext.getAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR));
+    assertNull(servletContext.getAttribute(BundleTag.MANIFEST_CACHE_ATTR));
     verify(servletContext, never()).getResourceAsStream(BundleTag.VITE_MANIFEST_PATH);
     verify(servletContext).removeAttribute(BundleTag.MANIFEST_CACHE_ATTR);
   }
 
   @Test
   public void missingBundleRefreshesManifestCacheBeforeThrowing() throws JspException {
+    stubRequest();
+    stubServletContext();
+    stubWriter();
     BundleTag realTag =
         new BundleTag() {
           @Override
@@ -271,9 +247,12 @@ public class BundleTagTest {
                 "toastMessage",
                 new BundleTag.ChunkManifest.BundleAssets(
                     List.of(), List.of(), List.of("/ui/dist/toastMessage-abc123.js"))));
-    doReturn(staleManifest).when(servletContext).getAttribute(BundleTag.MANIFEST_CACHE_ATTR);
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(BundleTag.MANIFEST_CACHE_ATTR, staleManifest);
+    clearInvocations(servletContext);
     when(servletContext.getResourceAsStream(BundleTag.VITE_MANIFEST_PATH))
         .thenReturn(manifestStream("appBar", "appBar-abc123.js"));
+    clearInvocations(servletContext);
 
     realTag.setBundle("appBar");
 
@@ -287,6 +266,9 @@ public class BundleTagTest {
 
   @Test
   public void devModeRefreshesManifestOncePerRequest() throws JspException {
+    stubRequest();
+    stubServletContext();
+    stubWriter();
     class DevModeBundleTag extends BundleTag {
       private final List<ChunkManifest> manifests =
           List.of(
@@ -311,7 +293,7 @@ public class BundleTagTest {
       ChunkManifest refreshManifestCache() {
         ChunkManifest nextManifest = manifests.get(refreshCount);
         refreshCount++;
-        requestAttributes.remove(REQUEST_MANIFEST_CACHE_ATTR);
+        request.removeAttribute(REQUEST_MANIFEST_CACHE_ATTR);
         return nextManifest;
       }
     }
@@ -324,8 +306,8 @@ public class BundleTagTest {
     assertTrue(output.toString().contains("src=\"/ui/dist/appBar-first.js\""));
     assertEquals(1, realTag.refreshCount);
 
-    output.setLength(0);
-    requestAttributes.clear();
+    output.getBuffer().setLength(0);
+    request.clearAttributes();
     assertEquals(TagSupport.SKIP_BODY, realTag.doStartTag());
     assertTrue(output.toString().contains("src=\"/ui/dist/appBar-second.js\""));
     assertEquals(2, realTag.refreshCount);
@@ -333,6 +315,7 @@ public class BundleTagTest {
 
   @Test
   public void hmrModeRendersSameOriginViteClientAndEntrypointScripts() throws JspException {
+    stubWriter();
     BundleTag realTag =
         new BundleTag() {
           @Override
@@ -368,6 +351,7 @@ public class BundleTagTest {
 
   @Test
   public void devModeReusesRefreshedManifestWithinSingleRequest() {
+    stubRequest();
     class DevModeBundleTag extends BundleTag {
       private int refreshCount;
 
@@ -379,7 +363,7 @@ public class BundleTagTest {
       @Override
       ChunkManifest refreshManifestCache() {
         refreshCount++;
-        requestAttributes.remove(REQUEST_MANIFEST_CACHE_ATTR);
+        request.removeAttribute(REQUEST_MANIFEST_CACHE_ATTR);
         return ChunkManifest.fromBundles(
             Collections.singletonMap(
                 "appBar",

--- a/src/test/java/com/axiope/webapp/taglib/CacheVersionTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/CacheVersionTagTest.java
@@ -1,87 +1,58 @@
 package com.axiope.webapp.taglib;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.io.StringWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockJspWriter;
+import org.springframework.mock.web.MockServletContext;
 
 @ExtendWith(MockitoExtension.class)
 public class CacheVersionTagTest {
 
-  @Mock private HttpServletRequest request;
   @Mock private PageContext pageContext;
-  @Mock private ServletContext servletContext;
-  @Mock private JspWriter writer;
 
-  private final StringBuilder output = new StringBuilder();
-  private final Map<String, Object> requestAttributes = new LinkedHashMap<>();
-  private final Map<String, Object> servletContextAttributes = new LinkedHashMap<>();
+  private final StringWriter output = new StringWriter();
+  private MockHttpServletRequest request;
+  private MockServletContext servletContext;
+  private JspWriter writer;
   private CacheVersionTag tag;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     tag = new CacheVersionTag();
+    output.getBuffer().setLength(0);
+    servletContext = new MockServletContext();
+    request = new MockHttpServletRequest(servletContext);
+    writer = new MockJspWriter(output);
     tag.setPageContext(pageContext);
-    output.setLength(0);
-    requestAttributes.clear();
-    servletContextAttributes.clear();
+  }
 
-    lenient().when(pageContext.getRequest()).thenReturn(request);
-    lenient().when(pageContext.getOut()).thenReturn(writer);
-    lenient().when(pageContext.getServletContext()).thenReturn(servletContext);
-    lenient()
-        .when(servletContext.getAttribute(anyString()))
-        .thenAnswer(
-            invocation -> servletContextAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              servletContextAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(servletContext)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-    lenient()
-        .when(request.getAttribute(anyString()))
-        .thenAnswer(invocation -> requestAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              requestAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(request)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
+  private void stubPageContext() {
+    when(pageContext.getRequest()).thenReturn(request);
+    when(pageContext.getServletContext()).thenReturn(servletContext);
+  }
 
-    lenient()
-        .doAnswer(
-            invocation -> {
-              output.append(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(writer)
-        .write(anyString());
+  private void stubWriter() {
+    when(pageContext.getOut()).thenReturn(writer);
   }
 
   @Test
   public void emitsProductionVersionToken() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
-    servletContextAttributes.put(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
+    stubPageContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    servletContext.setAttribute(FrontendCacheVersion.CACHE_VERSION_ATTR, "2.23.0");
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
 
@@ -90,7 +61,9 @@ public class CacheVersionTagTest {
 
   @Test
   public void emitsRequestUuidInDevMode() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
+    stubPageContext();
+    stubWriter();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.TRUE);
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
 
@@ -100,7 +73,8 @@ public class CacheVersionTagTest {
 
   @Test
   public void emitsNothingWhenTokenAbsent() throws JspException {
-    servletContextAttributes.put(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
+    stubPageContext();
+    servletContext.setAttribute(FrontendCacheVersion.DEV_MODE_CACHE_ATTR, Boolean.FALSE);
 
     assertEquals(TagSupport.SKIP_BODY, tag.doStartTag());
 

--- a/src/test/java/com/axiope/webapp/taglib/ViteClientTagTest.java
+++ b/src/test/java/com/axiope/webapp/taglib/ViteClientTagTest.java
@@ -3,18 +3,14 @@ package com.axiope.webapp.taglib;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
-import java.util.LinkedHashMap;
+import java.io.StringWriter;
 import java.util.LinkedHashSet;
-import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,49 +18,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockJspWriter;
 
 @ExtendWith(MockitoExtension.class)
 public class ViteClientTagTest {
 
-  @Mock private HttpServletRequest request;
   @Mock private PageContext pageContext;
-  @Mock private ServletContext servletContext;
-  @Mock private JspWriter writer;
 
-  private final StringBuilder output = new StringBuilder();
-  private final Map<String, Object> requestAttributes = new LinkedHashMap<>();
+  private final StringWriter output = new StringWriter();
+  private MockHttpServletRequest request;
+  private JspWriter writer;
   private String originalReactDevModeProperty;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     originalReactDevModeProperty = System.getProperty(FrontendCacheVersion.REACT_DEV_MODE_PROPERTY);
     System.clearProperty(FrontendCacheVersion.REACT_DEV_MODE_PROPERTY);
-    output.setLength(0);
-    requestAttributes.clear();
-
-    lenient().when(pageContext.getRequest()).thenReturn(request);
-    lenient().when(pageContext.getOut()).thenReturn(writer);
-    lenient().when(pageContext.getServletContext()).thenReturn(servletContext);
-    lenient()
-        .when(request.getAttribute(anyString()))
-        .thenAnswer(invocation -> requestAttributes.get(invocation.getArgument(0, String.class)));
-    lenient()
-        .doAnswer(
-            invocation -> {
-              requestAttributes.put(
-                  invocation.getArgument(0, String.class), invocation.getArgument(1));
-              return null;
-            })
-        .when(request)
-        .setAttribute(anyString(), org.mockito.ArgumentMatchers.any());
-    lenient()
-        .doAnswer(
-            invocation -> {
-              output.append(invocation.getArgument(0, String.class));
-              return null;
-            })
-        .when(writer)
-        .write(anyString());
+    output.getBuffer().setLength(0);
+    request = new MockHttpServletRequest();
+    writer = new MockJspWriter(output);
   }
 
   @AfterEach
@@ -77,8 +50,14 @@ public class ViteClientTagTest {
     }
   }
 
+  private void stubPageContext() {
+    when(pageContext.getRequest()).thenReturn(request);
+    when(pageContext.getOut()).thenReturn(writer);
+  }
+
   @Test
   public void emitsViteClientInHmrMode() throws JspException {
+    stubPageContext();
     ViteClientTag tag =
         new ViteClientTag() {
           @Override
@@ -117,8 +96,9 @@ public class ViteClientTagTest {
 
   @Test
   public void deduplicatesAgainstSubsequentBundleTagInSameRequest() throws JspException {
+    stubPageContext();
     Set<String> sharedDedupe = new LinkedHashSet<>();
-    requestAttributes.put(BundleTag.RENDERED_ASSETS_ATTR, sharedDedupe);
+    request.setAttribute(BundleTag.RENDERED_ASSETS_ATTR, sharedDedupe);
 
     ViteClientTag clientTag =
         new ViteClientTag() {
@@ -142,6 +122,7 @@ public class ViteClientTagTest {
 
   @Test
   public void doesNotEmitTwiceWhenRenderedRepeatedly() throws JspException {
+    stubPageContext();
     ViteClientTag tag =
         new ViteClientTag() {
           @Override
@@ -152,8 +133,8 @@ public class ViteClientTagTest {
     tag.setPageContext(pageContext);
 
     tag.doStartTag();
-    int lengthAfterFirst = output.length();
+    int lengthAfterFirst = output.getBuffer().length();
     tag.doStartTag();
-    assertEquals(lengthAfterFirst, output.length());
+    assertEquals(lengthAfterFirst, output.getBuffer().length());
   }
 }

--- a/src/test/java/com/researchspace/admin/service/FileLocationBasedRetrieverTest.java
+++ b/src/test/java/com/researchspace/admin/service/FileLocationBasedRetrieverTest.java
@@ -2,7 +2,6 @@ package com.researchspace.admin.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,7 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class FileLocationBasedRetrieverTest {
   @Mock IPropertyHolder properties;
-  @Mock IPropertyHolder okProperties;
 
   FileLocationBasedLogRetriever logretriever;
   final File testLogPath = RSpaceTestUtils.getResource("sampleLogs/RSLogs.txt.1");
@@ -30,11 +28,12 @@ public class FileLocationBasedRetrieverTest {
   public void setUp() {
     logretriever = new FileLocationBasedLogRetriever();
     logretriever.setProperties(properties);
-    okProperties =
-        lenient()
-            .when(mock(IPropertyHolder.class).getErrorLogFile())
-            .thenReturn(testLogPath.getAbsolutePath())
-            .getMock();
+  }
+
+  private IPropertyHolder okProperties() {
+    return when(mock(IPropertyHolder.class).getErrorLogFile())
+        .thenReturn(testLogPath.getAbsolutePath())
+        .getMock();
   }
 
   @Test
@@ -51,7 +50,7 @@ public class FileLocationBasedRetrieverTest {
 
   @Test
   public void testInvalidLineNumberHandled() throws IOException {
-    logretriever.setProperties(okProperties);
+    logretriever.setProperties(okProperties());
     List<String> lines = logretriever.retrieveLastNLogLines(-1); // meaningless number
     assertEquals(FileLocationBasedLogRetriever.DEFAULT_NUM_LINES, lines.size());
 
@@ -62,7 +61,7 @@ public class FileLocationBasedRetrieverTest {
 
   @Test
   public void testRetrieveLastNLogLines() throws IOException {
-    logretriever.setProperties(okProperties);
+    logretriever.setProperties(okProperties());
     List<String> lines = logretriever.retrieveLastNLogLines(500);
     assertEquals(431, lines.size());
   }

--- a/src/test/java/com/researchspace/api/v1/auth/CombinedApiAuthenticatorTest.java
+++ b/src/test/java/com/researchspace/api/v1/auth/CombinedApiAuthenticatorTest.java
@@ -3,7 +3,6 @@ package com.researchspace.api.v1.auth;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -36,7 +35,6 @@ public class CombinedApiAuthenticatorTest {
     mockRequest = new MockHttpServletRequest();
     setMockRequestAuthorizationHeader();
     User user = TestFactory.createAnyUser("testOauthUser");
-    lenient().when(apiAvailabilityHandler.isApiAvailableForUser(null)).thenReturn(true);
     when(oAuthAuthenticator.authenticate(mockRequest)).thenReturn(user);
 
     /* run authenticator code with request using internal UI token */

--- a/src/test/java/com/researchspace/api/v1/config/APIProdConfigTestBase.java
+++ b/src/test/java/com/researchspace/api/v1/config/APIProdConfigTestBase.java
@@ -15,7 +15,7 @@ public abstract class APIProdConfigTestBase {
   @Autowired APIRequestThrottler globalThrottler;
 
   @BeforeAll
-  public static void BeforeClass() throws Exception {
+  public static void skipFastRuns() throws Exception {
     TestRunnerController.ignoreIfFastRun();
   }
 

--- a/src/test/java/com/researchspace/api/v1/controller/APIFileUploadThrottlingInterceptorTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/APIFileUploadThrottlingInterceptorTest.java
@@ -75,7 +75,6 @@ public class APIFileUploadThrottlingInterceptorTest {
   public void testPreHandleThrottlerNotCalledIfNotPOST() throws IOException {
     MockMultipartFile mockFile = setUpRequestWithFileUpload();
     request.setMethod("GET");
-    setUpStats();
     assertTrue(interceptor.preHandle(request, response, null));
     assertFileUploadResponseHeadersNotSet();
     // verify was not called
@@ -93,7 +92,7 @@ public class APIFileUploadThrottlingInterceptorTest {
 
   private void setUpStats() {
     Optional<APIFileUploadStats> stats = getStats(100, 50);
-    Mockito.lenient().when(throttler.getStats("any", ThrottleInterval.HOUR)).thenReturn(stats);
+    Mockito.when(throttler.getStats("any", ThrottleInterval.HOUR)).thenReturn(stats);
   }
 
   private MockMultipartFile setUpRequestWithFileUpload() throws IOException {

--- a/src/test/java/com/researchspace/api/v1/controller/FilesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/FilesApiControllerTest.java
@@ -51,7 +51,7 @@ public class FilesApiControllerTest {
   }
 
   private void mockBaseUrl() {
-    Mockito.lenient().when(properties.getServerUrl()).thenReturn("http://somewhere.com");
+    Mockito.when(properties.getServerUrl()).thenReturn("http://somewhere.com");
   }
 
   @AfterEach

--- a/src/test/java/com/researchspace/api/v1/controller/FilesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/FilesApiControllerTest.java
@@ -48,7 +48,6 @@ public class FilesApiControllerTest {
     fileController.setMessageSource(new MessageSourceUtils(new JsonMessageSource()));
     validDocFile = TestFactory.createEcatDocument(1L, subject);
     strucDoc = TestFactory.createAnySD();
-    mockBaseUrl();
   }
 
   private void mockBaseUrl() {
@@ -82,6 +81,7 @@ public class FilesApiControllerTest {
 
   @Test
   public void updateFileSuccess() throws Exception {
+    mockBaseUrl();
     MockMultipartFile mockFile = createAnyMultipartFile();
     when(recordMgr.getSafeNull(1L)).thenReturn(Optional.of(validDocFile));
     when(permissions.isPermitted(validDocFile, PermissionType.WRITE, subject)).thenReturn(true);

--- a/src/test/java/com/researchspace/api/v1/controller/FilesApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/FilesApiControllerTest.java
@@ -50,11 +50,10 @@ public class FilesApiControllerTest {
     fileController.setMessageSource(new MessageSourceUtils(messages));
     validDocFile = TestFactory.createEcatDocument(1L, subject);
     strucDoc = TestFactory.createAnySD();
-    mockBaseUrl();
   }
 
   private void mockBaseUrl() {
-    Mockito.lenient().when(properties.getServerUrl()).thenReturn("http://somewhere.com");
+    Mockito.when(properties.getServerUrl()).thenReturn("http://somewhere.com");
   }
 
   @Test
@@ -81,6 +80,7 @@ public class FilesApiControllerTest {
 
   @Test
   public void updateFileSuccess() throws Exception {
+    mockBaseUrl();
     MockMultipartFile mockFile = createAnyMultipartFile();
     when(recordMgr.getSafeNull(1L)).thenReturn(Optional.of(validDocFile));
     when(permissions.isPermitted(validDocFile, PermissionType.WRITE, subject)).thenReturn(true);

--- a/src/test/java/com/researchspace/api/v1/controller/FolderApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/FolderApiControllerTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -378,9 +377,6 @@ public class FolderApiControllerTest {
     subFolder.setId(3L);
     root.addChild(subFolder, subject);
     ISearchResults<BaseRecord> mockResults = createEmptySearchResults();
-    lenient()
-        .when(folderNavigationService.findParentForUser(subject, subFolder))
-        .thenReturn(Optional.of(root));
     when(recordMgr.listFolderRecords(
             eq(subFolder.getId()), any(PaginationCriteria.class), any(RecordTypeFilter.class)))
         .thenReturn(mockResults);
@@ -408,9 +404,6 @@ public class FolderApiControllerTest {
     folderSetup.getMediaImgExamples().addChild(imgFile, subject);
     ISearchResults<BaseRecord> mockResults = createMediaResults(imgFile);
     // set up mocks
-    lenient()
-        .when(folderNavigationService.findParentForUser(subject, folderSetup.getMediaImgExamples()))
-        .thenReturn(Optional.of(folderSetup.getMediaImgExamples().getParent()));
     when(recordMgr.listFolderRecords(
             eq(folderSetup.getMediaImgExamples().getId()),
             any(PaginationCriteria.class),

--- a/src/test/java/com/researchspace/api/v1/controller/FolderApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/FolderApiControllerTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -388,9 +387,6 @@ public class FolderApiControllerTest {
     subFolder.setId(3L);
     root.addChild(subFolder, subject);
     ISearchResults<BaseRecord> mockResults = createEmptySearchResults();
-    lenient()
-        .when(folderNavigationService.findParentForUser(subject, subFolder))
-        .thenReturn(Optional.of(root));
     when(recordMgr.listFolderRecords(
             eq(subFolder.getId()), any(PaginationCriteria.class), any(RecordTypeFilter.class)))
         .thenReturn(mockResults);
@@ -418,9 +414,6 @@ public class FolderApiControllerTest {
     folderSetup.getMediaImgExamples().addChild(imgFile, subject);
     ISearchResults<BaseRecord> mockResults = createMediaResults(imgFile);
     // set up mocks
-    lenient()
-        .when(folderNavigationService.findParentForUser(subject, folderSetup.getMediaImgExamples()))
-        .thenReturn(Optional.of(folderSetup.getMediaImgExamples().getParent()));
     when(recordMgr.listFolderRecords(
             eq(folderSetup.getMediaImgExamples().getId()),
             any(PaginationCriteria.class),

--- a/src/test/java/com/researchspace/api/v1/controller/FolderApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/FolderApiControllerTest.java
@@ -380,7 +380,7 @@ public class FolderApiControllerTest {
   }
 
   @Test
-  public void listSubfolderHasNonNullParentFolderLink() throws BindException {
+  public void listSubfolderReturnsEmptyListingWithFolderId() throws BindException {
     DocumentApiPaginationCriteria pgCriteria = new DocumentApiPaginationCriteria();
     mockBaseUrl();
     Folder subFolder = TestFactory.createAFolder("any", subject);

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
@@ -58,12 +58,14 @@ import java.util.Set;
 import org.apache.shiro.authz.AuthorizationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindException;
 
+@ExtendWith(MockitoExtension.class)
 class GalleryFilestoresApiControllerWriteOpsTest {
 
   private static final String USERNAME = "username";
@@ -92,8 +94,6 @@ class GalleryFilestoresApiControllerWriteOpsTest {
 
   @BeforeEach
   void setup() throws IOException {
-    MockitoAnnotations.openMocks(this);
-
     credentialsStore = new GalleryFilestoresCredentialsStore(nfsAuthentication);
 
     FilestoreWriteManagerImpl filestoreWriteManager = new FilestoreWriteManagerImpl();
@@ -121,6 +121,9 @@ class GalleryFilestoresApiControllerWriteOpsTest {
     controller.messages = mock(com.researchspace.service.MessageSourceUtils.class);
 
     when(propertyHolder.isNetFileStoresEnabled()).thenReturn(true);
+  }
+
+  private void stubUploadPrerequisites() throws IOException {
     when(nfsManager.getNfsFileStore(validFilestorePathId))
         .thenReturn(
             GalleryFilestoreTestUtils.createIrodsFileSystemAndFileStore(
@@ -128,23 +131,30 @@ class GalleryFilestoresApiControllerWriteOpsTest {
     when(nfsAuthentication.validateCredentials(any(), any(), any())).thenReturn(null);
     when(nfsAuthentication.login(eq(USERNAME), eq(PASSWORD), any(), any()))
         .thenReturn(nfsClientLoggedIn);
+  }
 
+  private void stubValidGalleryRecords() {
     when(baseRecordManager.get(eq(123L), any())).thenReturn(new EcatAudioFileStub(1L, "file1.wav"));
     when(baseRecordManager.get(eq(456L), any())).thenReturn(new EcatAudioFileStub(2L, "file2.wav"));
     when(baseRecordManager.retrieveMediaFile(any(User.class), eq(123L)))
         .thenReturn(new EcatAudioFileStub(1L, "file1.wav"));
     when(baseRecordManager.retrieveMediaFile(any(User.class), eq(456L)))
         .thenReturn(new EcatAudioFileStub(2L, "file2.wav"));
+  }
 
+  private void stubSuccessfulUpload() throws IOException {
     when(nfsManager.uploadFilesToNfs(
             anyCollection(), anyString(), any(WritableNfsClient.class), any()))
         .thenReturn(new ApiExternalStorageOperationResult());
-    when(deletionManager.deleteMediaFileSet(anySet(), any()))
-        .thenReturn(new CompositeRecordOperationResult<>());
   }
 
   @Test
   void uploadFromGallery_removeOriginal_invokesUploadAndDelete() throws BindException, IOException {
+    stubUploadPrerequisites();
+    stubValidGalleryRecords();
+    stubSuccessfulUpload();
+    when(deletionManager.deleteMediaFileSet(anySet(), any()))
+        .thenReturn(new CompositeRecordOperationResult<>());
     ApiGalleryFilestoreOperationRequest request =
         new ApiGalleryFilestoreOperationRequest(
             validRecordIds, new ApiNfsCredentials(null, USERNAME, PASSWORD), true);
@@ -160,6 +170,9 @@ class GalleryFilestoresApiControllerWriteOpsTest {
   @Test
   void uploadFromGallery_keepOriginal_invokesUploadButNotDelete()
       throws BindException, IOException {
+    stubUploadPrerequisites();
+    stubValidGalleryRecords();
+    stubSuccessfulUpload();
     ApiGalleryFilestoreOperationRequest request =
         new ApiGalleryFilestoreOperationRequest(
             validRecordIds, new ApiNfsCredentials(null, USERNAME, PASSWORD));
@@ -173,7 +186,8 @@ class GalleryFilestoresApiControllerWriteOpsTest {
   }
 
   @Test
-  void uploadFromGallery_multipleInvalidRecordIds_allErrorsReported() {
+  void uploadFromGallery_multipleInvalidRecordIds_allErrorsReported() throws IOException {
+    stubUploadPrerequisites();
     when(baseRecordManager.get(eq(789L), any()))
         .thenThrow(new ObjectRetrievalFailureException("EcatMediaFile", "789"));
     when(baseRecordManager.get(eq(987L), any()))
@@ -538,7 +552,8 @@ class GalleryFilestoresApiControllerWriteOpsTest {
   }
 
   @Test
-  void uploadFromGallery_folderRecordId_throwsBindException() {
+  void uploadFromGallery_folderRecordId_throwsBindException() throws IOException {
+    stubUploadPrerequisites();
     // folder rejection happens in retrieveMediaFiles, independent of the move/copy flag
     Long folderId = 999L;
     BaseRecord folderMock = mock(BaseRecord.class);
@@ -669,6 +684,7 @@ class GalleryFilestoresApiControllerWriteOpsTest {
   @Test
   void uploadFromGallery_unauthorizedMediaFile_propagatesAuthorizationExceptionAndDoesNotUpload()
       throws IOException {
+    stubUploadPrerequisites();
     // AuthorizationException must propagate (rather than be caught and translated to a
     // BindException), so the surrounding transaction rolls back cleanly.
     Long unauthorizedId = 888L;
@@ -754,7 +770,6 @@ class GalleryFilestoresApiControllerWriteOpsTest {
   void deleteFromFilestore_gateDeniesForeignItem_returns403() throws Exception {
     WritableNfsClient s3Client = setupS3FilestoreWithClient(5L);
     when(user.getUsername()).thenReturn(USERNAME);
-    when(propertyHolder.getS3DeleteWindowMinutes()).thenReturn(60);
     when(s3Client.resolveDeletableTarget("dir/f.txt"))
         .thenReturn(
             new DeletableTarget(

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
@@ -169,7 +169,7 @@ class GalleryFilestoresApiControllerWriteOpsTest {
 
     verify(nfsManager)
         .uploadFilesToNfs(anyCollection(), anyString(), any(WritableNfsClient.class), any());
-    verify(deletionManager, org.mockito.Mockito.never()).deleteMediaFileSet(anySet(), any());
+    verify(deletionManager, never()).deleteMediaFileSet(anySet(), any());
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/GalleryFilestoresApiControllerWriteOpsTest.java
@@ -160,7 +160,7 @@ class GalleryFilestoresApiControllerWriteOpsTest {
 
     verify(nfsManager)
         .uploadFilesToNfs(anyCollection(), anyString(), any(WritableNfsClient.class), any());
-    verify(deletionManager, org.mockito.Mockito.never()).deleteMediaFileSet(anySet(), any());
+    verify(deletionManager, never()).deleteMediaFileSet(anySet(), any());
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatesRevisionsEndpointTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatesRevisionsEndpointTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,9 +39,7 @@ public class InstrumentTemplatesRevisionsEndpointTest {
     ReflectionTestUtils.setField(controller, "instrumentApiMgr", instrumentMgr);
     ReflectionTestUtils.setField(controller, "inventoryAuditMgr", auditMgr);
     ReflectionTestUtils.setField(controller, "messages", messages);
-    lenient()
-        .when(messages.getResourceNotFoundMessage(anyString(), anyLong()))
-        .thenReturn("not found");
+    when(messages.getResourceNotFoundMessage(anyString(), anyLong())).thenReturn("not found");
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatesRevisionsEndpointTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplatesRevisionsEndpointTest.java
@@ -2,32 +2,31 @@ package com.researchspace.api.v1.controller;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.InstrumentTemplate;
-import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.inventory.InstrumentEntityApiManager;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.testutils.TestFactory;
 import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * Fast unit tests for the contract of the instrument template revisions listing endpoint. Populated
  * revision lists (with links) are covered by the MVC ITs.
  */
+@ExtendWith(MockitoExtension.class)
 public class InstrumentTemplatesRevisionsEndpointTest {
 
-  private final InventoryAuditApiManager auditMgr = mock(InventoryAuditApiManager.class);
-  private final InstrumentEntityApiManager instrumentMgr = mock(InstrumentEntityApiManager.class);
-  private final MessageSourceUtils messages = mock(MessageSourceUtils.class);
+  @Mock private InventoryAuditApiManager auditMgr;
+  @Mock private InstrumentEntityApiManager instrumentMgr;
 
   private final User user = TestFactory.createAnyUser("templateRevisionsUser");
 
@@ -38,8 +37,6 @@ public class InstrumentTemplatesRevisionsEndpointTest {
     controller = new InstrumentTemplatesApiController();
     ReflectionTestUtils.setField(controller, "instrumentApiMgr", instrumentMgr);
     ReflectionTestUtils.setField(controller, "inventoryAuditMgr", auditMgr);
-    ReflectionTestUtils.setField(controller, "messages", messages);
-    when(messages.getResourceNotFoundMessage(anyString(), anyLong())).thenReturn("not found");
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryVersionEndpointsNotFoundTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryVersionEndpointsNotFoundTest.java
@@ -3,7 +3,6 @@ package com.researchspace.api.v1.controller;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.model.User;
@@ -18,6 +17,9 @@ import com.researchspace.testutils.TestFactory;
 import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -25,14 +27,15 @@ import org.springframework.test.util.ReflectionTestUtils;
  * version or revision must surface as 404 (NotFoundException), never a 200 null body. Successful
  * responses are covered by the MVC ITs.
  */
+@ExtendWith(MockitoExtension.class)
 public class InventoryVersionEndpointsNotFoundTest {
 
-  private final InventoryAuditApiManager auditMgr = mock(InventoryAuditApiManager.class);
-  private final SampleApiManager sampleMgr = mock(SampleApiManager.class);
-  private final SubSampleApiManager subSampleMgr = mock(SubSampleApiManager.class);
-  private final ContainerApiManager containerMgr = mock(ContainerApiManager.class);
-  private final InstrumentEntityApiManager instrumentMgr = mock(InstrumentEntityApiManager.class);
-  private final MessageSourceUtils messages = mock(MessageSourceUtils.class);
+  @Mock private InventoryAuditApiManager auditMgr;
+  @Mock private SampleApiManager sampleMgr;
+  @Mock private SubSampleApiManager subSampleMgr;
+  @Mock private ContainerApiManager containerMgr;
+  @Mock private InstrumentEntityApiManager instrumentMgr;
+  @Mock private MessageSourceUtils messages;
 
   private final User user = TestFactory.createAnyUser("notFoundUser");
 

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryVersionEndpointsNotFoundTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryVersionEndpointsNotFoundTest.java
@@ -3,7 +3,6 @@ package com.researchspace.api.v1.controller;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,9 +38,7 @@ public class InventoryVersionEndpointsNotFoundTest {
 
   @BeforeEach
   public void setUp() {
-    lenient()
-        .when(messages.getResourceNotFoundMessage(anyString(), anyLong()))
-        .thenReturn("not found");
+    when(messages.getResourceNotFoundMessage(anyString(), anyLong())).thenReturn("not found");
   }
 
   /** Wires the BaseApiInventoryController/BaseApiController fields every controller inherits. */

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
@@ -2,32 +2,31 @@ package com.researchspace.api.v1.controller;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.api.v1.model.ApiInventoryRecordRevisionList;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.SampleTemplate;
-import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.SampleApiManager;
 import com.researchspace.testutils.TestFactory;
 import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * Fast unit tests for the contract of the sample template revisions listing endpoint. Populated
  * revision lists (with links) are covered by the MVC ITs.
  */
+@ExtendWith(MockitoExtension.class)
 public class SampleTemplatesRevisionsEndpointTest {
 
-  private final InventoryAuditApiManager auditMgr = mock(InventoryAuditApiManager.class);
-  private final SampleApiManager sampleMgr = mock(SampleApiManager.class);
-  private final MessageSourceUtils messages = mock(MessageSourceUtils.class);
+  @Mock private InventoryAuditApiManager auditMgr;
+  @Mock private SampleApiManager sampleMgr;
 
   private final User user = TestFactory.createAnyUser("templateRevisionsUser");
 
@@ -38,8 +37,6 @@ public class SampleTemplatesRevisionsEndpointTest {
     controller = new SampleTemplatesApiController();
     ReflectionTestUtils.setField(controller, "sampleApiMgr", sampleMgr);
     ReflectionTestUtils.setField(controller, "inventoryAuditMgr", auditMgr);
-    ReflectionTestUtils.setField(controller, "messages", messages);
-    when(messages.getResourceNotFoundMessage(anyString(), anyLong())).thenReturn("not found");
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplatesRevisionsEndpointTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,9 +39,7 @@ public class SampleTemplatesRevisionsEndpointTest {
     ReflectionTestUtils.setField(controller, "sampleApiMgr", sampleMgr);
     ReflectionTestUtils.setField(controller, "inventoryAuditMgr", auditMgr);
     ReflectionTestUtils.setField(controller, "messages", messages);
-    lenient()
-        .when(messages.getResourceNotFoundMessage(anyString(), anyLong()))
-        .thenReturn("not found");
+    when(messages.getResourceNotFoundMessage(anyString(), anyLong())).thenReturn("not found");
   }
 
   @Test

--- a/src/test/java/com/researchspace/api/v1/controller/SysadminApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SysadminApiControllerTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -126,6 +125,7 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
     User toDelete = createAnyUserWithId();
     toDelete.setTempAccount(true);
     setCreationDate2yearsAgo(toDelete);
+    stubSuccessfulDeletion(sysadmin, toDelete);
     basicDeleteTempUserRequest(sysadmin, toDelete);
     assertDeletionManagerInvoked();
   }
@@ -161,6 +161,7 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
         .thenReturn(exportResult);
     mockServerUrl();
     // test delete
+    stubSuccessfulDeletion(sysadmin, toDelete);
     basicDeleteAnyUserRequest(sysadmin, toDelete);
     // then
     assertDeletionManagerInvoked();
@@ -223,12 +224,13 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
 
   private void setUpMocksForDeletingUser(User sysadmin2, User toDelete) {
     when(userMgr.get(toDelete.getId())).thenReturn(toDelete);
-    lenient()
-        .when(
-            userDelMgr.removeUser(
-                Mockito.eq(toDelete.getId()),
-                Mockito.any(UserDeletionPolicy.class),
-                Mockito.eq(sysadmin2)))
+  }
+
+  private void stubSuccessfulDeletion(User sysadmin2, User toDelete) {
+    when(userDelMgr.removeUser(
+            Mockito.eq(toDelete.getId()),
+            Mockito.any(UserDeletionPolicy.class),
+            Mockito.eq(sysadmin2)))
         .thenReturn(new ServiceOperationResult<User>(toDelete, Boolean.TRUE, "OK"));
   }
 
@@ -349,17 +351,18 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
     when(groupManager.removeGroupIfNoMemberLoggedInWithinOneYear(toDelete.getId(), sysadmin))
         .thenThrow(new IllegalStateException("internal: user 'alice' logged in 5 days ago"));
 
-    IllegalArgumentException ex =
+    String message =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                controller.deleteGroupIfNoMemberLoggedInWithinOneYear(
-                    request, toDelete.getId(), sysadmin));
+                IllegalArgumentException.class,
+                () ->
+                    controller.deleteGroupIfNoMemberLoggedInWithinOneYear(
+                        request, toDelete.getId(), sysadmin))
+            .getMessage();
 
     // Generic message; no username leaked.
     Assertions.assertFalse(
-        ex.getMessage().contains("alice"), "response message must not leak internal usernames");
-    Assertions.assertTrue(ex.getMessage().contains("within the last year"));
+        message.contains("alice"), "response message must not leak internal usernames");
+    Assertions.assertTrue(message.contains("within the last year"));
     verify(auditService, never()).notify(Mockito.any(GenericEvent.class));
   }
 
@@ -507,8 +510,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
     userToEnable.setEnabled(false);
     userToEnable.addRole(Role.USER_ROLE);
     when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
-    when(userMgr.save(userToEnable)).thenReturn(userToEnable);
-
     // when
     controller.enableUser(request, sysadmin, userToEnable.getId());
 
@@ -527,8 +528,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
     userToEnable.setEnabled(true);
     userToEnable.addRole(Role.USER_ROLE);
     when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
-    lenient().when(userMgr.save(userToEnable)).thenReturn(userToEnable);
-
     // when
     controller.enableUser(request, sysadmin, userToEnable.getId());
 
@@ -545,7 +544,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
     userToEnable.setEnabled(false);
     userToEnable.addRole(Role.USER_ROLE);
     when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
-    lenient().when(userMgr.save(userToEnable)).thenReturn(userToEnable);
     doThrow(new LicenseServerUnavailableException())
         .when(userEnablementUtils)
         .checkLicenseForUserInRole(anyInt(), any(Role.class));
@@ -590,8 +588,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
     disableToDisable.setEnabled(false);
     disableToDisable.addRole(Role.USER_ROLE);
     when(userMgr.get(disableToDisable.getId())).thenReturn(disableToDisable);
-    lenient().when(userMgr.save(disableToDisable)).thenReturn(disableToDisable);
-
     // when
     controller.disableUser(request, sysadmin, disableToDisable.getId());
 
@@ -608,12 +604,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTestJU5 {
     userToEnable.setEnabled(false);
     userToEnable.addRole(Role.USER_ROLE);
     when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
-    lenient().when(userMgr.save(userToEnable)).thenReturn(userToEnable);
-    lenient()
-        .doThrow(new LicenseServerUnavailableException())
-        .when(userEnablementUtils)
-        .checkLicenseForUserInRole(anyInt(), any(Role.class));
-
     // when
     controller.disableUser(request, sysadmin, userToEnable.getId());
 

--- a/src/test/java/com/researchspace/api/v1/controller/SysadminApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SysadminApiControllerTest.java
@@ -603,17 +603,18 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
   public void doNotRaiseExceptionDisablingUserAccountWhenNoLicense() throws Exception {
     // given
     mockWhiteListedIP(true, sysadmin);
-    User userToEnable = createAnyUser("disabled_to_enable");
-    userToEnable.setEnabled(false);
-    userToEnable.addRole(Role.USER_ROLE);
-    when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
+    User userToDisable = createAnyUser("enabled_to_disable_without_license");
+    userToDisable.setEnabled(true);
+    userToDisable.addRole(Role.USER_ROLE);
+    when(userMgr.get(userToDisable.getId())).thenReturn(userToDisable);
+
     // when
-    controller.disableUser(request, sysadmin, userToEnable.getId());
+    controller.disableUser(request, sysadmin, userToDisable.getId());
 
     // then
-    verify(userMgr, times(0)).save(userToEnable);
-    verify(userEnablementUtils, times(0)).auditUserEnablementChangeEvent(true, userToEnable);
-    verify(userEnablementUtils, times(0))
-        .notifyByEmailUserEnablementChange(userToEnable, sysadmin, true);
+    verify(userMgr).save(userToDisable);
+    verify(userEnablementUtils, never()).checkLicenseForUserInRole(anyInt(), any(Role.class));
+    verify(userEnablementUtils).auditUserEnablementChangeEvent(false, userToDisable);
+    verify(userEnablementUtils).notifyByEmailUserEnablementChange(userToDisable, sysadmin, false);
   }
 }

--- a/src/test/java/com/researchspace/api/v1/controller/SysadminApiControllerTest.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SysadminApiControllerTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -129,6 +128,7 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
     User toDelete = createAnyUserWithId();
     toDelete.setTempAccount(true);
     setCreationDate2yearsAgo(toDelete);
+    stubSuccessfulDeletion(sysadmin, toDelete);
     basicDeleteTempUserRequest(sysadmin, toDelete);
     assertDeletionManagerInvoked();
   }
@@ -164,6 +164,7 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
         .thenReturn(exportResult);
     mockServerUrl();
     // test delete
+    stubSuccessfulDeletion(sysadmin, toDelete);
     basicDeleteAnyUserRequest(sysadmin, toDelete);
     // then
     assertDeletionManagerInvoked();
@@ -226,12 +227,13 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
 
   private void setUpMocksForDeletingUser(User sysadmin2, User toDelete) {
     when(userMgr.get(toDelete.getId())).thenReturn(toDelete);
-    lenient()
-        .when(
-            userDelMgr.removeUser(
-                Mockito.eq(toDelete.getId()),
-                Mockito.any(UserDeletionPolicy.class),
-                Mockito.eq(sysadmin2)))
+  }
+
+  private void stubSuccessfulDeletion(User sysadmin2, User toDelete) {
+    when(userDelMgr.removeUser(
+            Mockito.eq(toDelete.getId()),
+            Mockito.any(UserDeletionPolicy.class),
+            Mockito.eq(sysadmin2)))
         .thenReturn(new ServiceOperationResult<User>(toDelete, Boolean.TRUE, "OK"));
   }
 
@@ -352,17 +354,18 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
     when(groupManager.removeGroupIfNoMemberLoggedInWithinOneYear(toDelete.getId(), sysadmin))
         .thenThrow(new IllegalStateException("internal: user 'alice' logged in 5 days ago"));
 
-    IllegalArgumentException ex =
+    String message =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                controller.deleteGroupIfNoMemberLoggedInWithinOneYear(
-                    request, toDelete.getId(), sysadmin));
+                IllegalArgumentException.class,
+                () ->
+                    controller.deleteGroupIfNoMemberLoggedInWithinOneYear(
+                        request, toDelete.getId(), sysadmin))
+            .getMessage();
 
     // Generic message; no username leaked.
     Assertions.assertFalse(
-        ex.getMessage().contains("alice"), "response message must not leak internal usernames");
-    Assertions.assertTrue(ex.getMessage().contains("within the last year"));
+        message.contains("alice"), "response message must not leak internal usernames");
+    Assertions.assertTrue(message.contains("within the last year"));
     verify(auditService, never()).notify(Mockito.any(GenericEvent.class));
   }
 
@@ -510,8 +513,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
     userToEnable.setEnabled(false);
     userToEnable.addRole(Role.USER_ROLE);
     when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
-    when(userMgr.save(userToEnable)).thenReturn(userToEnable);
-
     // when
     controller.enableUser(request, sysadmin, userToEnable.getId());
 
@@ -530,8 +531,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
     userToEnable.setEnabled(true);
     userToEnable.addRole(Role.USER_ROLE);
     when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
-    lenient().when(userMgr.save(userToEnable)).thenReturn(userToEnable);
-
     // when
     controller.enableUser(request, sysadmin, userToEnable.getId());
 
@@ -548,7 +547,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
     userToEnable.setEnabled(false);
     userToEnable.addRole(Role.USER_ROLE);
     when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
-    lenient().when(userMgr.save(userToEnable)).thenReturn(userToEnable);
     doThrow(new LicenseServerUnavailableException())
         .when(userEnablementUtils)
         .checkLicenseForUserInRole(anyInt(), any(Role.class));
@@ -593,8 +591,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
     disableToDisable.setEnabled(false);
     disableToDisable.addRole(Role.USER_ROLE);
     when(userMgr.get(disableToDisable.getId())).thenReturn(disableToDisable);
-    lenient().when(userMgr.save(disableToDisable)).thenReturn(disableToDisable);
-
     // when
     controller.disableUser(request, sysadmin, disableToDisable.getId());
 
@@ -611,12 +607,6 @@ public class SysadminApiControllerTest extends JakartaValidatorTest {
     userToEnable.setEnabled(false);
     userToEnable.addRole(Role.USER_ROLE);
     when(userMgr.get(userToEnable.getId())).thenReturn(userToEnable);
-    lenient().when(userMgr.save(userToEnable)).thenReturn(userToEnable);
-    lenient()
-        .doThrow(new LicenseServerUnavailableException())
-        .when(userEnablementUtils)
-        .checkLicenseForUserInRole(anyInt(), any(Role.class));
-
     // when
     controller.disableUser(request, sysadmin, userToEnable.getId());
 

--- a/src/test/java/com/researchspace/api/v1/service/impl/ExportApiSpringBatchHandlerTest.java
+++ b/src/test/java/com/researchspace/api/v1/service/impl/ExportApiSpringBatchHandlerTest.java
@@ -91,14 +91,11 @@ public class ExportApiSpringBatchHandlerTest {
           JobRestartException,
           JobInstanceAlreadyCompleteException,
           JobParametersInvalidException {
-    Mockito.lenient()
-        .when(launcher.run(Mockito.eq(job), Mockito.any(JobParameters.class)))
-        .thenReturn(exe);
+    Mockito.when(launcher.run(Mockito.eq(job), Mockito.any(JobParameters.class))).thenReturn(exe);
   }
 
   private void mockCreateRecordList() {
-    Mockito.lenient()
-        .when(
+    Mockito.when(
             planner.createExportRecordList(
                 Mockito.any(IArchiveExportConfig.class), Mockito.any(ExportSelection.class)))
         .thenReturn(new ExportRecordList());
@@ -145,7 +142,6 @@ public class ExportApiSpringBatchHandlerTest {
     mockgetGroup();
     when(grpPermUtils.userCanExportGroup(pi, group)).thenReturn(true);
     exportHandler.export(cfg, pi);
-    mockCreateRecordList();
     verifyJobLaunched();
   }
 
@@ -191,7 +187,6 @@ public class ExportApiSpringBatchHandlerTest {
   public void nonSpecifiedGroupByUserNotAuthOK_7b() throws Exception {
     ExportApiConfig cfg = groupToHtml(group);
     cfg.setId(null);
-    mockLaunchJob();
     assertThrows(AuthorizationException.class, () -> exportHandler.export(cfg, user));
     verifyJobNotLaunched();
   }
@@ -254,7 +249,6 @@ public class ExportApiSpringBatchHandlerTest {
     Mockito.when(recMgr.getAllFrom(cfg.getSelections()))
         .thenReturn(TransformerUtils.toList(view, view2));
     exportHandler.export(cfg, pi);
-    mockCreateRecordList();
     verifyJobLaunched();
   }
 

--- a/src/test/java/com/researchspace/api/v1/service/impl/ExportApiSpringBatchHandlerTest.java
+++ b/src/test/java/com/researchspace/api/v1/service/impl/ExportApiSpringBatchHandlerTest.java
@@ -97,14 +97,11 @@ public class ExportApiSpringBatchHandlerTest {
           JobRestartException,
           JobInstanceAlreadyCompleteException,
           JobParametersInvalidException {
-    Mockito.lenient()
-        .when(launcher.run(Mockito.eq(job), Mockito.any(JobParameters.class)))
-        .thenReturn(exe);
+    Mockito.when(launcher.run(Mockito.eq(job), Mockito.any(JobParameters.class))).thenReturn(exe);
   }
 
   private void mockCreateRecordList() {
-    Mockito.lenient()
-        .when(
+    Mockito.when(
             planner.createExportRecordList(
                 Mockito.any(IArchiveExportConfig.class), Mockito.any(ExportSelection.class)))
         .thenReturn(new ExportRecordList());
@@ -151,7 +148,6 @@ public class ExportApiSpringBatchHandlerTest {
     mockgetGroup();
     when(grpPermUtils.userCanExportGroup(pi, group)).thenReturn(true);
     exportHandler.export(cfg, pi);
-    mockCreateRecordList();
     verifyJobLaunched();
   }
 
@@ -197,7 +193,6 @@ public class ExportApiSpringBatchHandlerTest {
   public void nonSpecifiedGroupByUserNotAuthOK_7b() throws Exception {
     ExportApiConfig cfg = groupToHtml(group);
     cfg.setId(null);
-    mockLaunchJob();
     assertExceptionThrown(() -> exportHandler.export(cfg, user), AuthorizationException.class);
     verifyJobNotLaunched();
   }
@@ -261,7 +256,6 @@ public class ExportApiSpringBatchHandlerTest {
     Mockito.when(recMgr.getAllFrom(cfg.getSelections()))
         .thenReturn(TransformerUtils.toList(view, view2));
     exportHandler.export(cfg, pi);
-    mockCreateRecordList();
     verifyJobLaunched();
   }
 

--- a/src/test/java/com/researchspace/auth/LdapRealmTest.java
+++ b/src/test/java/com/researchspace/auth/LdapRealmTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.ldap.UserLdapRepo;
@@ -58,7 +57,6 @@ public class LdapRealmTest {
     user1sid2.setId(1L);
     token = new UsernamePasswordToken(testUsername, "anypass");
     when(userLdapRepo.authenticate(anyString(), anyString())).thenReturn(user1sid2);
-    lenient().when(properties.isUserSignup()).thenReturn(false);
   }
 
   @Test

--- a/src/test/java/com/researchspace/auth/LdapRealmTest.java
+++ b/src/test/java/com/researchspace/auth/LdapRealmTest.java
@@ -88,6 +88,7 @@ public class LdapRealmTest {
   @Test
   public void testUserNotExistsReturnsNullIfUserSignupNotEnabled() throws Exception {
     when(userManager.userExists(any())).thenReturn(false);
+    when(properties.isUserSignup()).thenReturn(false);
     assertNull(ldapRealm.doGetAuthenticationInfo(token));
   }
 

--- a/src/test/java/com/researchspace/auth/UserPermissionUtilsTest.java
+++ b/src/test/java/com/researchspace/auth/UserPermissionUtilsTest.java
@@ -152,7 +152,7 @@ class UserPermissionUtilsTest {
   }
 
   private void enableLenientMockGetUser(User target) {
-    Mockito.lenient().when(userManager.getUserByUsername(target.getUsername())).thenReturn(target);
+    Mockito.when(userManager.getUserByUsername(target.getUsername())).thenReturn(target);
   }
 
   private static Stream<Arguments> targetUsersByRole() {

--- a/src/test/java/com/researchspace/auth/UserPermissionUtilsTest.java
+++ b/src/test/java/com/researchspace/auth/UserPermissionUtilsTest.java
@@ -1,16 +1,13 @@
 package com.researchspace.auth;
 
 import static com.researchspace.testutils.TestFactory.createAnyUserWithRole;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-import com.researchspace.model.Community;
 import com.researchspace.model.Role;
 import com.researchspace.model.User;
 import com.researchspace.service.UserManager;
-import com.researchspace.testutils.TestFactory;
-import java.util.Collections;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +19,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,8 +27,6 @@ class UserPermissionUtilsTest {
   User sysadminSubject, communityAdminSubject, piSubject, userSubject;
   private @Mock UserManager userManager;
   @InjectMocks UserPermissionUtils userPermissionUtils;
-  static Community c1 = TestFactory.createACommunity();
-  static Community c2 = TestFactory.createACommunity();
 
   @BeforeEach
   void setUp() {
@@ -73,27 +67,21 @@ class UserPermissionUtilsTest {
   @DisplayName("CA can't access any sysadmin")
   @Test
   void communityAdminCannotAccessSysadminRole() {
-    enableLenientMockGetUser(sysadminSubject);
+    stubGetUser(sysadminSubject);
     assertFalse(
         userPermissionUtils.isTargetUserValidForSubjectRole(
             communityAdminSubject, sysadminSubject.getUsername()));
   }
 
-  @DisplayName("CA can't access any  CA in other community")
-  @ParameterizedTest
-  @MethodSource("unauthorisedCommunityLists")
-  void communityAdminCannotAccessCAInOtherCommunity(List<Community> communities) {
-    assertCommunityAdminAccess(communityAdminSubject, List.of(c1), communities, false);
-  }
-
-  static Stream<List<Community>> unauthorisedCommunityLists() {
-    return Stream.of(Collections.emptyList(), List.of(c2), List.of(c1, c2));
-  }
-
-  @DisplayName("CA cannot access another CA in the same community")
+  @DisplayName("CA cannot access another CA")
   @Test
-  void communityAdminCannotAccessCAInSameCommunity() {
-    assertCommunityAdminAccess(communityAdminSubject, List.of(c1), List.of(c1), false);
+  void communityAdminCannotAccessAnotherCommunityAdmin() {
+    User targetCommunityAdmin = createTargetCommunityAdmin();
+    stubGetUser(targetCommunityAdmin);
+
+    assertFalse(
+        userPermissionUtils.isTargetUserValidForSubjectRole(
+            communityAdminSubject, targetCommunityAdmin.getUsername()));
   }
 
   @DisplayName("CA can access another user or PI in the same community")
@@ -101,7 +89,7 @@ class UserPermissionUtilsTest {
   @ValueSource(strings = {"ROLE_PI", "ROLE_USER"})
   void communityAdminCanAccessPIOrUserInSameCommunity(String roleName) {
     User target = createAnyUserWithRole("target", roleName);
-    enableLenientMockGetUser(target);
+    stubGetUser(target);
     setTargetUserInSameCommunity(target, true);
 
     assertTrue(
@@ -114,29 +102,12 @@ class UserPermissionUtilsTest {
   @ValueSource(strings = {"ROLE_PI", "ROLE_USER"})
   void communityAdminCannotAccessPIOrUserInDifferentCommunity(String roleName) {
     User target = createAnyUserWithRole("target", roleName);
-    enableLenientMockGetUser(target);
+    stubGetUser(target);
     setTargetUserInSameCommunity(target, false);
 
     assertFalse(
         userPermissionUtils.isTargetUserValidForSubjectRole(
             communityAdminSubject, target.getUsername()));
-  }
-
-  private void assertCommunityAdminAccess(
-      User subject,
-      List<Community> subjectCommunities,
-      List<Community> targetCommunities,
-      boolean expected) {
-    User targetCommunityAdmin = createTargetCommunityAdmin();
-    enableLenientMockGetUser(targetCommunityAdmin);
-    boolean accessible =
-        userPermissionUtils.isTargetUserValidForSubjectRole(
-            communityAdminSubject, targetCommunityAdmin.getUsername());
-    if (expected) {
-      assertTrue(accessible);
-    } else {
-      assertFalse(accessible);
-    }
   }
 
   private User createTargetCommunityAdmin() {
@@ -151,8 +122,8 @@ class UserPermissionUtilsTest {
         .thenReturn(sameCommunity);
   }
 
-  private void enableLenientMockGetUser(User target) {
-    Mockito.when(userManager.getUserByUsername(target.getUsername())).thenReturn(target);
+  private void stubGetUser(User target) {
+    when(userManager.getUserByUsername(target.getUsername())).thenReturn(target);
   }
 
   private static Stream<Arguments> targetUsersByRole() {

--- a/src/test/java/com/researchspace/core/util/RequestUtilsTest.java
+++ b/src/test/java/com/researchspace/core/util/RequestUtilsTest.java
@@ -3,7 +3,6 @@ package com.researchspace.core.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,7 +32,6 @@ public class RequestUtilsTest {
     assertEquals("unknown", RequestUtil.remoteAddr(mockRequest));
     // default
     when(mockRequest.getRemoteAddr()).thenReturn(defaultFRom);
-    lenient().when(mockRequest.getRemoteHost()).thenReturn(defaultFRom);
 
     assertEquals(defaultFRom, RequestUtil.remoteAddr(mockRequest));
     // but use this preferentially (RSPAC-553)

--- a/src/test/java/com/researchspace/dao/customliquibaseupdates/MySQLVersionPreconditionTest.java
+++ b/src/test/java/com/researchspace/dao/customliquibaseupdates/MySQLVersionPreconditionTest.java
@@ -29,7 +29,6 @@ public class MySQLVersionPreconditionTest {
 
   @Test
   public void invalidOperatorCausesError() throws DatabaseException {
-    setUpDBVersion(new SemanticVersion(5, 6, null, null));
     precondition.setVersion("5.7");
     assertThrows(IllegalArgumentException.class, () -> precondition.setOperator("notanoperator"));
   }
@@ -96,8 +95,8 @@ public class MySQLVersionPreconditionTest {
   }
 
   private void setUpDBVersion(SemanticVersion version) throws DatabaseException {
-    Mockito.lenient().when(db.getConnection()).thenReturn(conn);
-    Mockito.lenient().when(conn.getDatabaseMajorVersion()).thenReturn(version.getMajor());
-    Mockito.lenient().when(conn.getDatabaseMinorVersion()).thenReturn(version.getMinor());
+    Mockito.when(db.getConnection()).thenReturn(conn);
+    Mockito.when(conn.getDatabaseMajorVersion()).thenReturn(version.getMajor());
+    Mockito.when(conn.getDatabaseMinorVersion()).thenReturn(version.getMinor());
   }
 }

--- a/src/test/java/com/researchspace/dao/customliquibaseupdates/MySQLVersionPreconditionTest.java
+++ b/src/test/java/com/researchspace/dao/customliquibaseupdates/MySQLVersionPreconditionTest.java
@@ -29,7 +29,6 @@ public class MySQLVersionPreconditionTest {
 
   @Test
   public void invalidOperatorCausesError() throws DatabaseException {
-    setUpDBVersion(new SemanticVersion(5, 6, null, null));
     precondition.setVersion("5.7");
     assertThrows(IllegalArgumentException.class, () -> precondition.setOperator("notanoperator"));
   }
@@ -99,8 +98,8 @@ public class MySQLVersionPreconditionTest {
   }
 
   private void setUpDBVersion(SemanticVersion version) throws DatabaseException {
-    Mockito.lenient().when(db.getConnection()).thenReturn(conn);
-    Mockito.lenient().when(conn.getDatabaseMajorVersion()).thenReturn(version.getMajor());
-    Mockito.lenient().when(conn.getDatabaseMinorVersion()).thenReturn(version.getMinor());
+    Mockito.when(db.getConnection()).thenReturn(conn);
+    Mockito.when(conn.getDatabaseMajorVersion()).thenReturn(version.getMajor());
+    Mockito.when(conn.getDatabaseMinorVersion()).thenReturn(version.getMinor());
   }
 }

--- a/src/test/java/com/researchspace/export/pdf/HTMLStringGeneratorTest.java
+++ b/src/test/java/com/researchspace/export/pdf/HTMLStringGeneratorTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -86,21 +85,28 @@ public class HTMLStringGeneratorTest {
     VelocityEngine vel =
         VelocityTestUtils.setupVelocity("src/main/resources/velocityTemplates/textFieldElements");
     rtu.setVelocity(vel);
-    // empty nfs elements by default
-    lenient()
-        .when(
-            fieldParser.findFieldElementsInContentForCssClass(
-                Mockito.any(FieldContents.class), Mockito.anyString(), Mockito.anyString()))
+  }
+
+  private void stubEmptyNfsElements() {
+    when(fieldParser.findFieldElementsInContentForCssClass(
+            Mockito.any(FieldContents.class), Mockito.anyString(), Mockito.anyString()))
         .thenReturn(new FieldContents());
-    lenient()
-        .when(
-            resolver.getExternalIdForUser(
-                Mockito.any(User.class), Mockito.any(IdentifierScheme.class)))
+  }
+
+  private void stubNoExternalId() {
+    when(resolver.getExternalIdForUser(
+            Mockito.any(User.class), Mockito.any(IdentifierScheme.class)))
         .thenReturn(Optional.empty());
+  }
+
+  private void stubDefaults() {
+    stubEmptyNfsElements();
+    stubNoExternalId();
   }
 
   @Test
   public void testGetNfsElements() {
+    stubNoExternalId();
     // given a document with an NfsLink
     final long fileStoreId = 21L;
     final String relativeFilePath = "/file.txt";
@@ -138,6 +144,7 @@ public class HTMLStringGeneratorTest {
 
   @Test
   public void testGetComments() {
+    stubDefaults();
     String commentStr = rtu.generateURLStringForCommentLink("1");
     StructuredDocument anyDoc = createAnySDWithText(commentStr);
     anyDoc.setId(1L);
@@ -167,6 +174,7 @@ public class HTMLStringGeneratorTest {
 
   @Test
   public void testMakeLinksAbsolute() {
+    stubDefaults();
     EcatDocumentFile doc = TestFactory.createEcatDocument(2L, createAnyUser("any"));
     String attachmentHTML = rtu.generateURLString(doc);
     StructuredDocument anydoc = TestFactory.createAnySDWithText(attachmentHTML);
@@ -205,6 +213,7 @@ public class HTMLStringGeneratorTest {
 
   @Test
   public void testIncludeMetaInformation() {
+    stubEmptyNfsElements();
     when(resolver.getExternalIdForUser(
             Mockito.any(User.class), Mockito.any(IdentifierScheme.class)))
         .thenReturn(Optional.of(new ExternalId(IdentifierScheme.ORCID, OrcidId)));
@@ -226,6 +235,7 @@ public class HTMLStringGeneratorTest {
 
   @Test
   public void testIncludeListOfMaterials() {
+    stubDefaults();
     User anyUser = createAnyUser("any");
 
     // create a doc with list of materials
@@ -249,6 +259,7 @@ public class HTMLStringGeneratorTest {
 
   @Test
   public void testIncludeInstrumentInListOfMaterials() {
+    stubDefaults();
     // a document whose list of materials references an instrument (RSDEV-1032) must render the
     // instrument's name, identifier and a link to the RSpace entity in PDF/Word exports
     StructuredDocument anyDoc = createAnySDWithText("any");
@@ -272,6 +283,7 @@ public class HTMLStringGeneratorTest {
 
   @Test
   public void testScaleImages() {
+    stubDefaults();
     String html = "<img width ='1000' height = '1000'/>";
     StructuredDocument anydoc = TestFactory.createAnySDWithText(html);
     anydoc.setId(1L);
@@ -291,6 +303,7 @@ public class HTMLStringGeneratorTest {
 
   @Test
   public void testEmbedIframeFragment() {
+    stubDefaults();
     String html = "iframe: <iframe src='https://dummy.source/a?b=c&d=e'/>";
     StructuredDocument anydoc = TestFactory.createAnySDWithText(html);
     anydoc.setId(1L);
@@ -310,6 +323,7 @@ public class HTMLStringGeneratorTest {
   /** Tests that XSS doesn't work in the document's name & field names on export / preview */
   @Test
   public void testHtmlEscaping() {
+    stubDefaults();
     RSForm form = new RSForm("form", "desc", createAnyUser("user"));
     TextFieldForm fieldForm = new TextFieldForm();
     fieldForm.setName("<img src='' onerror='alert(1);'>");
@@ -350,6 +364,7 @@ public class HTMLStringGeneratorTest {
 
   @Test
   public void choiceFieldsPrintCorrectly() {
+    stubDefaults();
     ChoiceFieldForm choiceFieldForm = new ChoiceFieldForm();
     choiceFieldForm.setName("A choice name");
     choiceFieldForm.setChoiceOptions("fieldChoices=a&fieldChoices=b&fieldChoices=c");

--- a/src/test/java/com/researchspace/export/pdf/ImageRetrieverHelperTest.java
+++ b/src/test/java/com/researchspace/export/pdf/ImageRetrieverHelperTest.java
@@ -188,6 +188,11 @@ public class ImageRetrieverHelperTest {
     // nothing returned if permissions return false
     setPermissionsToReturn(annotation, false);
     assertArrayEquals(fallback, imgRetriever.getImageBytesFromImgSrc(annotationLink, config));
+
+    // authorization failures retrieving the original image also return the fallback image
+    setPermissionsToReturn(annotation, true);
+    when(mediaMgr.getImage(rawimg.getId(), config.getExporter(), true))
+        .thenThrow(AuthorizationException.class);
     assertArrayEquals(fallback, imgRetriever.getImageBytesFromImgSrc(annotationLink, config));
   }
 

--- a/src/test/java/com/researchspace/export/pdf/ImageRetrieverHelperTest.java
+++ b/src/test/java/com/researchspace/export/pdf/ImageRetrieverHelperTest.java
@@ -3,7 +3,6 @@ package com.researchspace.export.pdf;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -108,7 +107,6 @@ public class ImageRetrieverHelperTest {
   @Test
   public void testIncludeChemImageResource() throws IOException {
     RSChemElement chemElement = setUpChemElement();
-    setPermissionsToReturn(chemElement, true);
     when(chemMgr.get(2L, config.getExporter())).thenReturn(chemElement);
     String chemLink = textupdater.generateURLStringForRSChemElementLink(2L, 1L, 50, 50);
     assertNotNull(imgRetriever.getImageBytesFromImgSrc(chemLink, config));
@@ -170,7 +168,6 @@ public class ImageRetrieverHelperTest {
     // pdf config ignores annotations, so we want original image or working image...
     // here is working mage
     EcatImage rawimg = TestFactory.createEcatImage(5L);
-    setPermissionsToReturn(rawimg, true);
     annotation.setImageId(rawimg.getId());
     rawimg.setWorkingImage(new ImageBlob(getAnyPngImage()));
     config.setAnnotations(false);
@@ -191,18 +188,12 @@ public class ImageRetrieverHelperTest {
     // nothing returned if permissions return false
     setPermissionsToReturn(annotation, false);
     assertArrayEquals(fallback, imgRetriever.getImageBytesFromImgSrc(annotationLink, config));
-    // throwing auth exception handled as well.
-    lenient()
-        .when(mediaMgr.getImage(rawimg.getId(), config.getExporter(), true))
-        .thenThrow(AuthorizationException.class);
     assertArrayEquals(fallback, imgRetriever.getImageBytesFromImgSrc(annotationLink, config));
   }
 
   void setPermissionsToReturn(IFieldLinkableElement element, boolean allow) {
-    lenient()
-        .when(
-            permissions.isPermittedViaMediaLinksToRecords(
-                element, PermissionType.READ, config.getExporter()))
+    when(permissions.isPermittedViaMediaLinksToRecords(
+            element, PermissionType.READ, config.getExporter()))
         .thenReturn(allow);
   }
 

--- a/src/test/java/com/researchspace/export/pdf/MSWordProcessorTest.java
+++ b/src/test/java/com/researchspace/export/pdf/MSWordProcessorTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,9 +75,6 @@ public class MSWordProcessorTest {
     rtupdater = new RichTextUpdater();
     rtupdater.setVelocity(setupVelocityWithTextFieldTemplates());
     htmlProcessed = Jsoup.parse(STOICHIOMETRY_HTML).html();
-    lenient()
-        .when(stoichiometryHtmlGenerator.addStoichiometryLinks(eq(htmlProcessed), eq(exporter)))
-        .thenReturn(htmlProcessed);
   }
 
   @Test
@@ -128,6 +124,8 @@ public class MSWordProcessorTest {
 
   @Test
   public void testStoichiometryExportIsAdded() throws IOException {
+    when(stoichiometryHtmlGenerator.addStoichiometryLinks(eq(htmlProcessed), eq(exporter)))
+        .thenReturn(htmlProcessed);
     returnSuccesfullExport(outfile, success);
     mswordExporter.makeExport(outfile, input, rspaceDoc, cfg);
     verify(stoichiometryHtmlGenerator, never())

--- a/src/test/java/com/researchspace/export/pdf/MSWordProcessorTest.java
+++ b/src/test/java/com/researchspace/export/pdf/MSWordProcessorTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -84,9 +83,6 @@ public class MSWordProcessorTest {
     rtupdater = new RichTextUpdater();
     rtupdater.setVelocity(setupVelocityWithTextFieldTemplates());
     htmlProcessed = Jsoup.parse(STOICHIOMETRY_HTML).html();
-    lenient()
-        .when(stoichiometryHtmlGenerator.addStoichiometryLinks(eq(htmlProcessed), eq(exporter)))
-        .thenReturn(htmlProcessed);
   }
 
   @Test
@@ -136,6 +132,8 @@ public class MSWordProcessorTest {
 
   @Test
   public void testStoichiometryExportIsAdded() throws IOException {
+    when(stoichiometryHtmlGenerator.addStoichiometryLinks(eq(htmlProcessed), eq(exporter)))
+        .thenReturn(htmlProcessed);
     returnSuccesfullExport(outfile, success);
     mswordExporter.makeExport(outfile, input, rspaceDoc, cfg);
     verify(stoichiometryHtmlGenerator, never())

--- a/src/test/java/com/researchspace/export/pdf/SvgToPngConverterTest.java
+++ b/src/test/java/com/researchspace/export/pdf/SvgToPngConverterTest.java
@@ -20,7 +20,7 @@ public class SvgToPngConverterTest {
   public static final int SIMPLEST_SVG_CONVERTED_LENGTH = 1495;
 
   @BeforeAll
-  public static void BeforeClass() throws Exception {
+  public static void skipFastRuns() throws Exception {
     TestRunnerController.ignoreIfFastRun();
   }
 

--- a/src/test/java/com/researchspace/extmessages/msteams/MsTeamsMessageSenderTest.java
+++ b/src/test/java/com/researchspace/extmessages/msteams/MsTeamsMessageSenderTest.java
@@ -16,9 +16,12 @@ import com.researchspace.properties.IPropertyHolder;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 
+@ExtendWith(MockitoExtension.class)
 public class MsTeamsMessageSenderTest {
 
   private final ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/com/researchspace/extmessages/msteams/MsTeamsMessageSenderTest.java
+++ b/src/test/java/com/researchspace/extmessages/msteams/MsTeamsMessageSenderTest.java
@@ -3,7 +3,6 @@ package com.researchspace.extmessages.msteams;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -69,7 +68,7 @@ public class MsTeamsMessageSenderTest {
     Person owner = mock(Person.class);
     when(owner.getFullName()).thenReturn("Bob Smith");
     IRSpaceDoc doc = mock(IRSpaceDoc.class);
-    lenient().when(doc.getName()).thenReturn("My experiment");
+    when(doc.getName()).thenReturn("My experiment");
     when(doc.getGlobalIdentifier()).thenReturn("SD4005");
     when(doc.getOwner()).thenReturn(owner);
 

--- a/src/test/java/com/researchspace/files/service/ExternalFileServiceTest.java
+++ b/src/test/java/com/researchspace/files/service/ExternalFileServiceTest.java
@@ -17,9 +17,10 @@ import java.io.File;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
@@ -29,9 +30,8 @@ import org.springframework.http.HttpStatus;
  * test exceptional cases;
  */
 @EgnyteTestConfig
+@ExtendWith(MockitoExtension.class)
 public class ExternalFileServiceTest extends SpringTransactionalTest {
-
-  private AutoCloseable mocks;
 
   private @Autowired ExternalFileService extFS;
   private @Autowired FileMetadataDao fileMetaDao;
@@ -52,7 +52,6 @@ public class ExternalFileServiceTest extends SpringTransactionalTest {
     // getTargetObject(mediaMgr, MediaManagerImpl.class).setFileStore(localFs);
     mediaFile = addDocumentToGallery(anyUser);
     someFile = RSpaceTestUtils.getAnyAttachment();
-    mocks = MockitoAnnotations.openMocks(this);
     // this stores access token
     uc =
         createAndSaveEgnyteUserConnectionWithAccessToken(
@@ -100,10 +99,5 @@ public class ExternalFileServiceTest extends SpringTransactionalTest {
   private ExtFileOperationStatus<ExternalFileId> createMockFailureEgnyteSaveResult() {
     return new ExtFileOperationStatus<ExternalFileId>(
         HttpStatus.BAD_REQUEST.value(), "Some error message", null);
-  }
-
-  @AfterEach
-  void closeMocks() throws Exception {
-    mocks.close();
   }
 }

--- a/src/test/java/com/researchspace/files/service/ExternalFileServiceTest.java
+++ b/src/test/java/com/researchspace/files/service/ExternalFileServiceTest.java
@@ -59,9 +59,7 @@ public class ExternalFileServiceTest extends SpringTransactionalTest {
             anyUser, "anyToken - this is a mock API call");
   }
 
-  // Was annotated @Before (now @BeforeEach) despite being named after() and documented as tidy-up,
-  // so it has never run as teardown. A no-op today because the setFileStore(localFs) call it pairs
-  // with is commented out in before(); kept and corrected so restoring that line stays safe.
+  // A no-op while the setFileStore(localFs) call it pairs with stays commented out in before().
   @AfterEach
   public void restoreFileStore() throws Exception {
     getTargetObject(mediaMgr, MediaManagerImpl.class).setFileStore(fileStore);

--- a/src/test/java/com/researchspace/linkedelements/FieldParserTest.java
+++ b/src/test/java/com/researchspace/linkedelements/FieldParserTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 
 import com.researchspace.model.IFieldLinkableElement;
 import java.io.File;
@@ -47,9 +46,6 @@ public class FieldParserTest {
 
   @Test
   public void testGetElementsfromEmptyField() {
-    lenient()
-        .when(converterFactory.getConverterForClass(Mockito.anyString()))
-        .thenReturn(converter);
     FieldContents fieldContents = fieldParser.findFieldElementsInContent("");
     assertNotNull(fieldContents);
     assertNoElements(fieldContents);
@@ -58,9 +54,6 @@ public class FieldParserTest {
 
   @Test
   public void testGetElementsfromFieldWithNoElements() {
-    lenient()
-        .when(converterFactory.getConverterForClass(Mockito.anyString()))
-        .thenReturn(converter);
     FieldContents fieldContents =
         fieldParser.findFieldElementsInContent("Text field with out elements");
 

--- a/src/test/java/com/researchspace/netfiles/s3/S3NfsClientTest.java
+++ b/src/test/java/com/researchspace/netfiles/s3/S3NfsClientTest.java
@@ -118,7 +118,7 @@ public class S3NfsClientTest {
         assertThrows(
             IOException.class, () -> client.uploadFile(new File("Picture1.png"), "dest/folder"));
     assertTrue(ex.getMessage().contains("already exists"));
-    verify(s3Utilities, org.mockito.Mockito.never()).uploadToS3(any(), any(), any());
+    verify(s3Utilities, never()).uploadToS3(any(), any(), any());
   }
 
   @Test
@@ -389,8 +389,7 @@ public class S3NfsClientTest {
             IOException.class,
             () -> client.copyObject("source/huge.bin", dest.client, "dest/huge.bin"));
     assertTrue(ex.getMessage().contains("5"));
-    verify(dest.mockS3Utilities, org.mockito.Mockito.never())
-        .copyObjectFromBucket(any(), any(), any(), any());
+    verify(dest.mockS3Utilities, never()).copyObjectFromBucket(any(), any(), any(), any());
   }
 
   @Test
@@ -404,8 +403,7 @@ public class S3NfsClientTest {
             IOException.class,
             () -> client.copyObject("source/file.txt", dest.client, "dest/file.txt"));
     assertTrue(ex.getMessage().contains("already exists"));
-    verify(dest.mockS3Utilities, org.mockito.Mockito.never())
-        .copyObjectFromBucket(any(), any(), any(), any());
+    verify(dest.mockS3Utilities, never()).copyObjectFromBucket(any(), any(), any(), any());
   }
 
   @Test
@@ -421,8 +419,7 @@ public class S3NfsClientTest {
             IOException.class,
             () -> client.copyObject("source/photos", dest.client, "dest/photos"));
     assertTrue(ex.getMessage().contains("already exists"));
-    verify(dest.mockS3Utilities, org.mockito.Mockito.never())
-        .copyObjectFromBucket(any(), any(), any(), any());
+    verify(dest.mockS3Utilities, never()).copyObjectFromBucket(any(), any(), any(), any());
   }
 
   @Test

--- a/src/test/java/com/researchspace/netfiles/s3/S3NfsClientTest.java
+++ b/src/test/java/com/researchspace/netfiles/s3/S3NfsClientTest.java
@@ -35,19 +35,25 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class S3NfsClientTest {
 
-  private final S3Utilities s3Utilities = mock(S3Utilities.class);
-  private final S3NfsClient client = new S3NfsClient("testUser", s3Utilities);
+  @Mock private S3Utilities s3Utilities;
+  private S3NfsClient client;
 
-  /**
-   * Wires the source client's bucket name and returns a fresh destination client backed by its own
-   * mock {@link S3Utilities}. Use this in any test that exercises {@link S3NfsClient#copyObject}.
-   */
-  private DestClientFixture newDestClient(String sourceBucketName) {
-    when(s3Utilities.getBucketName()).thenReturn(sourceBucketName);
+  @BeforeEach
+  void setUp() {
+    client = new S3NfsClient("testUser", s3Utilities);
+  }
+
+  /** Returns a fresh destination client backed by its own mock {@link S3Utilities}. */
+  private DestClientFixture newDestClient() {
     S3Utilities destS3Utilities = mock(S3Utilities.class);
     return new DestClientFixture(new S3NfsClient("destUser", destS3Utilities), destS3Utilities);
   }
@@ -332,7 +338,8 @@ public class S3NfsClientTest {
   @Test
   public void copyObject_toAnotherS3Client_callsCopyObjectFromBucketOnDestination()
       throws IOException {
-    DestClientFixture dest = newDestClient("source-bucket");
+    DestClientFixture dest = newDestClient();
+    when(s3Utilities.getBucketName()).thenReturn("source-bucket");
 
     String resultKey = client.copyObject("source/file.txt", dest.client, "dest/file.txt");
 
@@ -344,7 +351,8 @@ public class S3NfsClientTest {
 
   @Test
   public void copyObject_withMetadata_passesMetadataToCopyObjectFromBucket() throws IOException {
-    DestClientFixture dest = newDestClient("source-bucket");
+    DestClientFixture dest = newDestClient();
+    when(s3Utilities.getBucketName()).thenReturn("source-bucket");
     Map<String, String> metadata = Map.of("rspace-user", "alice");
 
     String resultKey = client.copyObject("source/file.txt", dest.client, "dest/file.txt", metadata);
@@ -356,7 +364,8 @@ public class S3NfsClientTest {
 
   @Test
   public void copyObject_stripsLeadingSlashesFromBothSourceAndDestKeys() throws IOException {
-    DestClientFixture dest = newDestClient("source-bucket");
+    DestClientFixture dest = newDestClient();
+    when(s3Utilities.getBucketName()).thenReturn("source-bucket");
 
     String resultKey = client.copyObject("/source/file.txt", dest.client, "/dest/file.txt");
 
@@ -378,7 +387,7 @@ public class S3NfsClientTest {
 
   @Test
   public void copyObject_sourceOver5GB_throwsIOExceptionAndDoesNotCallCopy() {
-    DestClientFixture dest = newDestClient("source-bucket");
+    DestClientFixture dest = newDestClient();
     long fiveGbPlusOne = 5L * 1024L * 1024L * 1024L + 1L;
     S3FolderContentItem huge =
         new S3FolderContentItem("huge.bin", false, fiveGbPlusOne, Instant.now());
@@ -394,7 +403,7 @@ public class S3NfsClientTest {
 
   @Test
   public void copyObject_destinationKeyAlreadyExists_throwsIOExceptionAndDoesNotCopy() {
-    DestClientFixture dest = newDestClient("source-bucket");
+    DestClientFixture dest = newDestClient();
     when(dest.mockS3Utilities.getObjectDetails("dest/file.txt"))
         .thenReturn(new S3FolderContentItem("file.txt", false, 100L, Instant.now()));
 
@@ -410,7 +419,7 @@ public class S3NfsClientTest {
   public void copyObject_destinationIsExistingFolder_throwsIOExceptionAndDoesNotCopy() {
     // A folder at the dest key must also block the copy, else file dest/x sits beside folder
     // dest/x/.
-    DestClientFixture dest = newDestClient("source-bucket");
+    DestClientFixture dest = newDestClient();
     when(dest.mockS3Utilities.getObjectDetails("dest/photos"))
         .thenReturn(new S3FolderContentItem("photos", true, null, null));
 

--- a/src/test/java/com/researchspace/netfiles/s3/S3NfsClientTest.java
+++ b/src/test/java/com/researchspace/netfiles/s3/S3NfsClientTest.java
@@ -52,7 +52,6 @@ public class S3NfsClientTest {
     client = new S3NfsClient("testUser", s3Utilities);
   }
 
-  /** Returns a fresh destination client backed by its own mock {@link S3Utilities}. */
   private DestClientFixture newDestClient() {
     S3Utilities destS3Utilities = mock(S3Utilities.class);
     return new DestClientFixture(new S3NfsClient("destUser", destS3Utilities), destS3Utilities);

--- a/src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java
+++ b/src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,9 +59,7 @@ public class FolderOrganisationAndApiInboxFolderTest {
     user.setUserGroups(Set.of(mockUserGroup));
     when(mockUserGroup.getGroup()).thenReturn(mockGroup);
     when(mockGroup.getSharedSnippetGroupFolderId()).thenReturn(1L);
-    lenient().when(mockGroup.getUniqueName()).thenReturn("mockGroup");
     when(folderManagerMock.getFolder(eq(1L), eq(user))).thenReturn(folderMock);
-    lenient().when(folderMock.getName()).thenReturn("group shared folder");
     folderMgr = new FolderManagerImpl(recordFactory, folderDao, permUtils);
     ReflectionTestUtils.setField(
         folderMgr, "messageSourceUtils", new MessageSourceUtils(new JsonMessageSource()));
@@ -126,6 +123,7 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getImportFolderPermissions() {
+    stubGroupUniqueName();
     mockWorkspaceImportExists(null);
     mockGetRootFolder(setup);
     Folder importsFolderInWorkspace = folderMgr.getImportsFolder(user);
@@ -151,7 +149,7 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getApiInboxChildPermissions() {
-    mockWorkspaceApiInboxExists("", null);
+    stubGroupUniqueName();
     mockGetRootFolder(setup);
     Folder apiInboxInWorkspace = folderMgr.getApiUploadTargetFolder("", user, null);
     Folder normalSubfolder = recordFactory.createFolder("any", user);
@@ -171,7 +169,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
   @Test
   public void getApiInboxGalleryHappyCase() {
     mockWorkspaceApiInboxExists(AUDIO_MEDIA_FLDER_NAME, null);
-    mockGetRootFolder(setup);
     Folder audioFolder = findGalleryFolder(setup, AUDIO_MEDIA_FLDER_NAME);
     when(folderDao.getSystemFolderForUserByName(user, AUDIO_MEDIA_FLDER_NAME))
         .thenReturn(audioFolder);
@@ -201,7 +198,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          mockGetRootFolder(setup);
           mockGetFolderToReturn(setup.getShared());
           folderMgr.getApiUploadTargetFolder("", user, 1L);
         });
@@ -212,7 +208,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          mockGetRootFolder(setup);
           mockGetFolderToReturn(setup.getTemplateFolder());
           folderMgr.getApiUploadTargetFolder("", user, 1L);
         });
@@ -223,7 +218,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          mockGetRootFolder(setup);
           mockGetFolderToReturn(setup.getMediaRoot());
           folderMgr.getApiUploadTargetFolder("", user, 1L);
         });
@@ -234,7 +228,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
     assertThrows(
         AuthorizationException.class,
         () -> {
-          mockGetRootFolder(setup);
           mockGetFolderToReturn(setup.getUserRoot());
           when(permUtils.isPermitted(setup.getUserRoot(), PermissionType.READ, user))
               .thenReturn(false);
@@ -247,7 +240,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          mockGetRootFolder(setup);
           mockGetFolderToReturn(setup.getUserRoot());
           folderMgr.getApiUploadTargetFolder(MediaUtils.IMAGES_MEDIA_FLDER_NAME, user, 1L);
         });
@@ -258,7 +250,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          mockGetRootFolder(setup);
           mockGetFolderToReturn(setup.getTemplateFolder());
           folderMgr.getApiUploadTargetFolder(MediaUtils.IMAGES_MEDIA_FLDER_NAME, user, 1L);
         });
@@ -270,12 +261,11 @@ public class FolderOrganisationAndApiInboxFolderTest {
   }
 
   private void mockGetRootFolder(UserFolderSetup setup) {
-    lenient().when(folderDao.getRootRecordForUser(user)).thenReturn(setup.getUserRoot());
+    when(folderDao.getRootRecordForUser(user)).thenReturn(setup.getUserRoot());
   }
 
   private void mockWorkspaceApiInboxExists(String folderName, Folder optionalFolder) {
-    lenient()
-        .when(folderDao.getApiFolderForContentType(folderName, user))
+    when(folderDao.getApiFolderForContentType(folderName, user))
         .thenReturn(Optional.ofNullable(optionalFolder));
   }
 
@@ -312,5 +302,9 @@ public class FolderOrganisationAndApiInboxFolderTest {
     // now test that
     assertEquals(setup.getUserRoot(), sd.getOwnerParent().get());
     // if parent is null, we get null - not an exception:
+  }
+
+  private void stubGroupUniqueName() {
+    when(mockGroup.getUniqueName()).thenReturn("mockGroup");
   }
 }

--- a/src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java
+++ b/src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -59,9 +58,7 @@ public class FolderOrganisationAndApiInboxFolderTest {
     user.setUserGroups(Set.of(mockUserGroup));
     when(mockUserGroup.getGroup()).thenReturn(mockGroup);
     when(mockGroup.getSharedSnippetGroupFolderId()).thenReturn(1L);
-    lenient().when(mockGroup.getUniqueName()).thenReturn("mockGroup");
     when(folderManagerMock.getFolder(eq(1L), eq(user))).thenReturn(folderMock);
-    lenient().when(folderMock.getName()).thenReturn("group shared folder");
     folderMgr = new FolderManagerImpl(recordFactory, folderDao, permUtils, messages);
 
     setup = FolderTestUtils.createDefaultFolderStructure(user, folderManagerMock, folderMock);
@@ -120,6 +117,7 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getImportFolderPermissions() {
+    when(mockGroup.getUniqueName()).thenReturn("group");
     mockWorkspaceImportExists(null);
     mockGetRootFolder(setup);
     Folder importsFolderInWorkspace = folderMgr.getImportsFolder(user);
@@ -145,7 +143,8 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getApiInboxChildPermissions() {
-    mockWorkspaceApiInboxExists("", null);
+    when(mockGroup.getUniqueName()).thenReturn("group");
+    mockWorkspaceApiInboxExists(user.getUsername(), null);
     mockGetRootFolder(setup);
     Folder apiInboxInWorkspace = folderMgr.getApiUploadTargetFolder("", user, null);
     Folder normalSubfolder = recordFactory.createFolder("any", user);
@@ -165,7 +164,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
   @Test
   public void getApiInboxGalleryHappyCase() {
     mockWorkspaceApiInboxExists(AUDIO_MEDIA_FLDER_NAME, null);
-    mockGetRootFolder(setup);
     Folder audioFolder = findGalleryFolder(setup, AUDIO_MEDIA_FLDER_NAME);
     when(folderDao.getSystemFolderForUserByName(user, AUDIO_MEDIA_FLDER_NAME))
         .thenReturn(audioFolder);
@@ -192,7 +190,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getWorkspaceApiUploadTargetFolderThrowsIAEIfDesiredTargetInSharedFolder() {
-    mockGetRootFolder(setup);
     mockGetFolderToReturn(setup.getShared());
     assertThrows(
         IllegalArgumentException.class, () -> folderMgr.getApiUploadTargetFolder("", user, 1L));
@@ -200,7 +197,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getWorkspaceApiUploadTargetFolderThrowsIAEIfDesiredTargetInSTemplatesFolder() {
-    mockGetRootFolder(setup);
     mockGetFolderToReturn(setup.getTemplateFolder());
     assertThrows(
         IllegalArgumentException.class, () -> folderMgr.getApiUploadTargetFolder("", user, 1L));
@@ -208,7 +204,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getWorkspaceApiUploadTargetFolderThrowsIAEIfDesiredTargetInGalleryFolder() {
-    mockGetRootFolder(setup);
     mockGetFolderToReturn(setup.getMediaRoot());
     assertThrows(
         IllegalArgumentException.class, () -> folderMgr.getApiUploadTargetFolder("", user, 1L));
@@ -216,7 +211,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getWorkspaceApiUploadTargetFolderThrowsAuthIfNoReadPermissionOnTargetFolder() {
-    mockGetRootFolder(setup);
     mockGetFolderToReturn(setup.getUserRoot());
     when(permUtils.isPermitted(setup.getUserRoot(), PermissionType.READ, user)).thenReturn(false);
     assertThrows(
@@ -225,7 +219,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getGalleryApiUploadTargetFolderThrowThrowsIAEIfDesiredTargetInWorkspace() {
-    mockGetRootFolder(setup);
     mockGetFolderToReturn(setup.getUserRoot());
     assertThrows(
         IllegalArgumentException.class,
@@ -234,7 +227,6 @@ public class FolderOrganisationAndApiInboxFolderTest {
 
   @Test
   public void getGalleryApiUploadTargetFolderThrowThrowsIAEIfDesiredTargetInTemplates() {
-    mockGetRootFolder(setup);
     mockGetFolderToReturn(setup.getTemplateFolder());
     assertThrows(
         IllegalArgumentException.class,
@@ -247,14 +239,11 @@ public class FolderOrganisationAndApiInboxFolderTest {
   }
 
   private void mockGetRootFolder(UserFolderSetup setup) {
-    lenient().when(folderDao.getRootRecordForUser(user)).thenReturn(setup.getUserRoot());
+    when(folderDao.getRootRecordForUser(user)).thenReturn(setup.getUserRoot());
   }
 
   private void mockWorkspaceApiInboxExists(String folderName, Folder optionalFolder) {
-    // lenient: shared helper, and getApiInboxChildPermissions stubs a folderName the production
-    // path does not look up, so the stubbing goes unmatched there
-    lenient()
-        .when(folderDao.getApiFolderForContentType(folderName, user))
+    when(folderDao.getApiFolderForContentType(folderName, user))
         .thenReturn(Optional.ofNullable(optionalFolder));
   }
 

--- a/src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java
+++ b/src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java
@@ -64,7 +64,7 @@ public class FolderOrganisationAndApiInboxFolderTest {
     ReflectionTestUtils.setField(
         folderMgr, "messageSourceUtils", new MessageSourceUtils(new JsonMessageSource()));
 
-    setup = FolderTestUtils.createDefaultFolderStructure(user, folderManagerMock, folderMock);
+    setup = FolderTestUtils.createDefaultFolderStructure(user, folderManagerMock);
   }
 
   @AfterEach

--- a/src/test/java/com/researchspace/service/StoichiometryManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/StoichiometryManagerImplTest.java
@@ -11,7 +11,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -76,21 +75,6 @@ public class StoichiometryManagerImplTest {
   public void setUp() throws Exception {
     user = TestFactory.createAnyUser("testUser");
     record = TestFactory.createAnyRecord(user);
-    lenient()
-        .when(stoichiometryDao.save(stoichiometryCaptor.capture()))
-        .thenAnswer(
-            invocation -> {
-              Stoichiometry s = invocation.getArgument(0, Stoichiometry.class);
-              if (s.getMolecules() != null) {
-                long idCounter = 100L;
-                for (StoichiometryMolecule m : s.getMolecules()) {
-                  if (m.getId() == null) {
-                    m.setId(idCounter++);
-                  }
-                }
-              }
-              return s;
-            });
   }
 
   @Test
@@ -118,6 +102,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateFromAnalysis_thenReturnStoichiometryWithMolecules()
       throws IOException, ChemicalImportException {
+    stubSave();
     Long parentReactionId = 1L;
     RSChemElement parentReaction = createRSChemElement(parentReactionId);
     ElementalAnalysisDTO analysisDTO = createElementalAnalysisDTO();
@@ -150,6 +135,7 @@ public class StoichiometryManagerImplTest {
   public void
       whenCreateFromAnalysisWithChemicalSearcherException_thenReturnStoichiometryWithNullName()
           throws IOException, ChemicalImportException {
+    stubSave();
     Long parentReactionId = 1L;
     RSChemElement parentReaction = createRSChemElement(parentReactionId);
     ElementalAnalysisDTO analysisDTO = createElementalAnalysisDTO();
@@ -176,6 +162,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateFromAnalysis_withReactants_thenFirstReactantSetAsLimitingReagent()
       throws IOException, ChemicalImportException {
+    stubSave();
     Long parentReactionId = 1L;
     RSChemElement parentReaction = createRSChemElement(parentReactionId);
 
@@ -257,6 +244,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateFromAnalysis_withOnlyProducts_thenNoLimitingReagentSet()
       throws IOException, ChemicalImportException {
+    stubSave();
     Long parentReactionId = 1L;
     RSChemElement parentReaction = createRSChemElement(parentReactionId);
 
@@ -352,6 +340,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdateMoleculeWithValidData_thenUpdatesSuccessfully() {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometryWith2Molecules(stoichiometryId, 1L);
     Long existingMoleculeId = existingStoichiometry.getMolecules().get(0).getId();
@@ -386,6 +375,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdate_withNewMolecules_thenAddsThemCorrectly() throws Exception {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometry(stoichiometryId, 1L, record);
     Long existingMoleculeId = existingStoichiometry.getMolecules().get(0).getId();
@@ -438,6 +428,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdate_withMultipleOperations_thenHandlesAllCorrectly() throws Exception {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometryWith2Molecules(stoichiometryId, 1L);
     Long existingMoleculeId = existingStoichiometry.getMolecules().get(0).getId();
@@ -496,6 +487,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenCopyForReaction_withValidSource_thenCreatesCopyWithNewParent() throws Exception {
+    stubSave();
     Long sourceParentReactionId = 1L;
     Long targetParentReactionId = 2L;
     Stoichiometry sourceStoichiometry =
@@ -521,6 +513,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenCopy_withInventoryLinks_thenLinksAreCreatedForNewMolecules() throws Exception {
+    stubSave();
     Long sourceParentReactionId = 11L;
     RSChemElement targetParentReaction = createRSChemElement(22L);
 
@@ -596,6 +589,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenCopy_withIOException_thenThrowsStoichiometryException() throws Exception {
+    stubSave();
     Long sourceParentReactionId = 1L;
     Long targetParentReactionId = 2L;
     Stoichiometry sourceStoichiometry =
@@ -704,6 +698,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdateWithInventoryLink_thenCreatesLink() {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometry(stoichiometryId, 1L, record);
     StoichiometryMolecule mol = existingStoichiometry.getMolecules().get(0);
@@ -731,6 +726,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdateWithNullInventoryLink_thenRemovesLink() {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometry(stoichiometryId, 1L, record);
     StoichiometryMolecule mol = existingStoichiometry.getMolecules().get(0);
@@ -754,6 +750,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateReactionlessFromArchive_thenStoichiometryHasNoParentReactionAndMolecules()
       throws Exception {
+    stubSave();
     StoichiometryDTO archived = new StoichiometryDTO();
     StoichiometryMoleculeDTO mol1 =
         StoichiometryMoleculeDTO.builder()
@@ -812,6 +809,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateReactionlessFromArchive_withNoMolecules_thenCreatesEmptyStoichiometry()
       throws Exception {
+    stubSave();
     StoichiometryDTO archived = new StoichiometryDTO();
     archived.setMolecules(null);
 
@@ -853,5 +851,22 @@ public class StoichiometryManagerImplTest {
     when(stoichiometryDao.get(stoichiometryId)).thenReturn(existingStoichiometry);
 
     assertThrows(StoichiometryException.class, () -> stoichiometryManager.update(updateDTO, user));
+  }
+
+  private void stubSave() {
+    when(stoichiometryDao.save(stoichiometryCaptor.capture()))
+        .thenAnswer(
+            invocation -> {
+              Stoichiometry s = invocation.getArgument(0, Stoichiometry.class);
+              if (s.getMolecules() != null) {
+                long idCounter = 100L;
+                for (StoichiometryMolecule m : s.getMolecules()) {
+                  if (m.getId() == null) {
+                    m.setId(idCounter++);
+                  }
+                }
+              }
+              return s;
+            });
   }
 }

--- a/src/test/java/com/researchspace/service/StoichiometryManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/StoichiometryManagerImplTest.java
@@ -11,7 +11,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -73,8 +72,10 @@ public class StoichiometryManagerImplTest {
   public void setUp() throws Exception {
     user = TestFactory.createAnyUser("testUser");
     record = TestFactory.createAnyRecord(user);
-    lenient()
-        .when(stoichiometryDao.save(stoichiometryCaptor.capture()))
+  }
+
+  private void stubSave() {
+    when(stoichiometryDao.save(stoichiometryCaptor.capture()))
         .thenAnswer(
             invocation -> {
               Stoichiometry s = invocation.getArgument(0, Stoichiometry.class);
@@ -115,6 +116,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateFromAnalysis_thenReturnStoichiometryWithMolecules()
       throws IOException, ChemicalImportException {
+    stubSave();
     Long parentReactionId = 1L;
     RSChemElement parentReaction = createRSChemElement(parentReactionId);
     ElementalAnalysisDTO analysisDTO = createElementalAnalysisDTO();
@@ -147,6 +149,7 @@ public class StoichiometryManagerImplTest {
   public void
       whenCreateFromAnalysisWithChemicalSearcherException_thenReturnStoichiometryWithNullName()
           throws IOException, ChemicalImportException {
+    stubSave();
     Long parentReactionId = 1L;
     RSChemElement parentReaction = createRSChemElement(parentReactionId);
     ElementalAnalysisDTO analysisDTO = createElementalAnalysisDTO();
@@ -173,6 +176,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateFromAnalysis_withReactants_thenFirstReactantSetAsLimitingReagent()
       throws IOException, ChemicalImportException {
+    stubSave();
     Long parentReactionId = 1L;
     RSChemElement parentReaction = createRSChemElement(parentReactionId);
 
@@ -254,6 +258,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateFromAnalysis_withOnlyProducts_thenNoLimitingReagentSet()
       throws IOException, ChemicalImportException {
+    stubSave();
     Long parentReactionId = 1L;
     RSChemElement parentReaction = createRSChemElement(parentReactionId);
 
@@ -349,6 +354,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdateMoleculeWithValidData_thenUpdatesSuccessfully() {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometryWith2Molecules(stoichiometryId, 1L);
     Long existingMoleculeId = existingStoichiometry.getMolecules().get(0).getId();
@@ -383,6 +389,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdate_withNewMolecules_thenAddsThemCorrectly() throws Exception {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometry(stoichiometryId, 1L, record);
     Long existingMoleculeId = existingStoichiometry.getMolecules().get(0).getId();
@@ -435,6 +442,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdate_withMultipleOperations_thenHandlesAllCorrectly() throws Exception {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometryWith2Molecules(stoichiometryId, 1L);
     Long existingMoleculeId = existingStoichiometry.getMolecules().get(0).getId();
@@ -493,6 +501,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenCopyForReaction_withValidSource_thenCreatesCopyWithNewParent() throws Exception {
+    stubSave();
     Long sourceParentReactionId = 1L;
     Long targetParentReactionId = 2L;
     Stoichiometry sourceStoichiometry =
@@ -518,6 +527,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenCopy_withInventoryLinks_thenLinksAreCreatedForNewMolecules() throws Exception {
+    stubSave();
     Long sourceParentReactionId = 11L;
     RSChemElement targetParentReaction = createRSChemElement(22L);
 
@@ -593,6 +603,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenCopy_withIOException_thenThrowsStoichiometryException() throws Exception {
+    stubSave();
     Long sourceParentReactionId = 1L;
     Long targetParentReactionId = 2L;
     Stoichiometry sourceStoichiometry =
@@ -703,6 +714,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdateWithInventoryLink_thenCreatesLink() {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometry(stoichiometryId, 1L, record);
     StoichiometryMolecule mol = existingStoichiometry.getMolecules().get(0);
@@ -730,6 +742,7 @@ public class StoichiometryManagerImplTest {
 
   @Test
   public void whenUpdateWithNullInventoryLink_thenRemovesLink() {
+    stubSave();
     Long stoichiometryId = 1L;
     Stoichiometry existingStoichiometry = createStoichiometry(stoichiometryId, 1L, record);
     StoichiometryMolecule mol = existingStoichiometry.getMolecules().get(0);
@@ -753,6 +766,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateReactionlessFromArchive_thenStoichiometryHasNoParentReactionAndMolecules()
       throws Exception {
+    stubSave();
     StoichiometryDTO archived = new StoichiometryDTO();
     StoichiometryMoleculeDTO mol1 =
         StoichiometryMoleculeDTO.builder()
@@ -811,6 +825,7 @@ public class StoichiometryManagerImplTest {
   @Test
   public void whenCreateReactionlessFromArchive_withNoMolecules_thenCreatesEmptyStoichiometry()
       throws Exception {
+    stubSave();
     StoichiometryDTO archived = new StoichiometryDTO();
     archived.setMolecules(null);
 

--- a/src/test/java/com/researchspace/service/archive/ExportTreeTraversorTest.java
+++ b/src/test/java/com/researchspace/service/archive/ExportTreeTraversorTest.java
@@ -16,7 +16,10 @@ import com.researchspace.testutils.TestFactory;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class ExportTreeTraversorTest {
 
   ExportArchiveTreeTraversor traversor;

--- a/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
+++ b/src/test/java/com/researchspace/service/archive/StoichiometryImportRevisionFixupManagerTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.when;
 import com.researchspace.model.User;
 import com.researchspace.model.audit.AuditedEntity;
 import com.researchspace.model.field.Field;
+import com.researchspace.model.field.TextField;
+import com.researchspace.model.field.TextFieldForm;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.model.record.Folder;
 import com.researchspace.model.record.StructuredDocument;
@@ -62,18 +64,9 @@ public class StoichiometryImportRevisionFixupManagerTest {
   }
 
   private Field mockFieldWithData(long id, String fieldData) {
-    Field field = Mockito.mock(Field.class);
-    Mockito.lenient().when(field.getId()).thenReturn(id);
-    final String[] data = {fieldData};
-    when(field.getFieldData()).thenAnswer(inv -> data[0]);
-    Mockito.lenient()
-        .doAnswer(
-            inv -> {
-              data[0] = inv.getArgument(0);
-              return null;
-            })
-        .when(field)
-        .setFieldData(Mockito.anyString());
+    Field field = new TextField(new TextFieldForm());
+    field.setId(id);
+    field.setFieldData(fieldData);
     return field;
   }
 

--- a/src/test/java/com/researchspace/service/impl/ApiAvailabilityHandlerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/ApiAvailabilityHandlerImplTest.java
@@ -88,7 +88,6 @@ class ApiAvailabilityHandlerImplTest {
 
   @Test
   void testInventoryAndDataciteEnabled() {
-    setSystemProperty(SystemPropertyName.IGSN_DATACITE_ENABLED, Boolean.TRUE);
     setSystemProperty(SystemPropertyName.INVENTORY_AVAILABLE, Boolean.TRUE);
     assertTrue(handler.isInventoryAndDataciteEnabled(anyUser));
     handler.assertInventoryAndDataciteEnabled(anyUser);
@@ -174,9 +173,7 @@ class ApiAvailabilityHandlerImplTest {
   }
 
   private void setSystemProperty(SystemPropertyName apiAvailable, Boolean aTrue) {
-    Mockito.lenient()
-        .when(mockSysPropMgr.isPropertyAllowed(anyUser, apiAvailable))
-        .thenReturn(aTrue);
+    Mockito.when(mockSysPropMgr.isPropertyAllowed(anyUser, apiAvailable)).thenReturn(aTrue);
   }
 
   private void assertApiEnabled() {

--- a/src/test/java/com/researchspace/service/impl/ApiAvailabilityHandlerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/ApiAvailabilityHandlerImplTest.java
@@ -91,7 +91,6 @@ class ApiAvailabilityHandlerImplTest {
 
   @Test
   void testInventoryAndDataciteEnabled() {
-    setSystemProperty(SystemPropertyName.IGSN_DATACITE_ENABLED, Boolean.TRUE);
     setSystemProperty(SystemPropertyName.INVENTORY_AVAILABLE, Boolean.TRUE);
     assertTrue(handler.isInventoryAndDataciteEnabled(anyUser));
     handler.assertInventoryAndDataciteEnabled(anyUser);
@@ -177,9 +176,7 @@ class ApiAvailabilityHandlerImplTest {
   }
 
   private void setSystemProperty(SystemPropertyName apiAvailable, Boolean aTrue) {
-    Mockito.lenient()
-        .when(mockSysPropMgr.isPropertyAllowed(anyUser, apiAvailable))
-        .thenReturn(aTrue);
+    Mockito.when(mockSysPropMgr.isPropertyAllowed(anyUser, apiAvailable)).thenReturn(aTrue);
   }
 
   private void assertApiEnabled() {

--- a/src/test/java/com/researchspace/service/impl/BioPortalOntologiesServiceTest.java
+++ b/src/test/java/com/researchspace/service/impl/BioPortalOntologiesServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.client.BioPortalOntologiesClient;
@@ -49,9 +48,6 @@ public class BioPortalOntologiesServiceTest {
 
   @Test
   public void shouldReturnEmptyListWhenFilterTermLessThanTwoChars() {
-    lenient()
-        .when(bioOntologiesClientMock.getBioOntologyData(any(String.class)))
-        .thenReturn(realBioData);
     assertEquals(0, testee.getBioOntologyDataForQuery("aa").size());
   }
 

--- a/src/test/java/com/researchspace/service/impl/ImageProcessorImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/ImageProcessorImplTest.java
@@ -113,6 +113,8 @@ public class ImageProcessorImplTest {
     // set up as tiff
     img.setExtension("tif");
     img.setWorkingImage(anyImageBlob());
+    int originalWidth = img.getWidth();
+    int originalHeight = img.getHeight();
 
     //		when(mediaFac.updateThumbnailImage(Mockito.eq(img), Mockito.any(BufferedImage.class)))
     //		  .thenReturn(img);
@@ -121,8 +123,8 @@ public class ImageProcessorImplTest {
     imgHandler.rotate(img, (byte) 1, anyUser);
 
     verify(rcdMgr, never()).save(img, anyUser);
-    assertEquals(img.getWidth(), img.getWidth());
-    assertEquals(img.getHeight(), img.getHeight());
+    assertEquals(originalWidth, img.getWidth());
+    assertEquals(originalHeight, img.getHeight());
     assertEquals(0, img.getRotation());
   }
 

--- a/src/test/java/com/researchspace/service/impl/ImageProcessorImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/ImageProcessorImplTest.java
@@ -1,7 +1,6 @@
 package com.researchspace.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,9 +70,9 @@ public class ImageProcessorImplTest {
   @Test
   public void rotateOKSmallFileWitoutWorkingImage() throws IOException {
     setupImage();
+    when(rcdMgr.save(img, anyUser)).thenReturn(img);
     //		when(mediaFac.updateThumbnailImage(Mockito.eq(img), Mockito.any(BufferedImage.class)))
     //		  .thenReturn(img);
-    when(rcdMgr.save(img, anyUser)).thenReturn(img);
     imgHandler.rotate(img, (byte) 1, anyUser);
     verify(rcdMgr).save(img, anyUser);
     assertEquals(anyBR.getWidth(), img.getWidth());
@@ -119,7 +118,6 @@ public class ImageProcessorImplTest {
     //		  .thenReturn(img);
     //		when(mediaFac.updateWorkingImage(Mockito.eq(img), Mockito.any(BufferedImage.class)))
     //		  .thenReturn(img);
-    lenient().when(rcdMgr.save(img, anyUser)).thenReturn(img);
     imgHandler.rotate(img, (byte) 1, anyUser);
 
     verify(rcdMgr, never()).save(img, anyUser);

--- a/src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java
+++ b/src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java
@@ -624,14 +624,6 @@ public class IntegrationsHandlerTest {
                 new PropertyDescriptor(DSW_APIKEY, SettingsType.STRING, null)),
             origDswToken));
 
-    UserConnection existingConnection = new UserConnection();
-    existingConnection.setDisplayName("DSW Display Name");
-    existingConnection.setRank(1);
-    existingConnection.setId(
-        new UserConnectionId(subject.getUsername(), DSW_APP_NAME, origDswAlias));
-    existingConnection.setExpireTime(0l);
-    existingConnection.setAccessToken(origDswToken);
-
     when(appCfgMgr.findByAppConfigElementSetId(1l)).thenReturn(Optional.of(aces));
 
     Map<String, String> dswOptions = new HashMap<>();
@@ -642,6 +634,8 @@ public class IntegrationsHandlerTest {
     handler.saveAppOptions(1l, dswOptions, DSW_APP_NAME, false, subject);
     // There will be no interactions with the userConnectionManager methods since
     // the URL is not stored in the UserConnection table.
+    Mockito.verify(userConnectionManager, never())
+        .findByUserNameProviderName(subject.getUsername(), DSW_APP_NAME, origDswAlias);
     Mockito.verify(userConnectionManager, times(0))
         .deleteByUserAndProvider(subject.getUsername(), DSW_APP_NAME, origDswAlias);
     Mockito.verify(userConnectionManager, times(0)).save(any());

--- a/src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java
+++ b/src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -104,9 +103,6 @@ public class IntegrationsHandlerTest {
   @BeforeEach
   public void setup() {
     subject = TestFactory.createAnyUser("any");
-    lenient()
-        .when(communityMgr.listCommunitiesForUser(eq(subject.getId())))
-        .thenReturn(new ArrayList<>());
     handler.setUserConnectionManager(userConnectionManager);
     ReflectionTestUtils.setField(
         handler, "messages", new MessageSourceUtils(new JsonMessageSource()));
@@ -542,13 +538,6 @@ public class IntegrationsHandlerTest {
     existingConnection.setExpireTime(0l);
     existingConnection.setAccessToken(origDswToken);
 
-    lenient().when(appCfgMgr.findByAppConfigElementSetId(1l)).thenReturn(Optional.of(aces));
-    lenient()
-        .when(
-            userConnectionManager.findByUserNameProviderName(
-                subject.getUsername(), DSW_APP_NAME, origDswAlias))
-        .thenReturn(Optional.of(existingConnection));
-
     // The potentially updated options that are being passed in
     // from the UI.  Note that the API Key is set as the default
     // masked value that is returned to the UI.
@@ -644,11 +633,6 @@ public class IntegrationsHandlerTest {
     existingConnection.setAccessToken(origDswToken);
 
     when(appCfgMgr.findByAppConfigElementSetId(1l)).thenReturn(Optional.of(aces));
-    lenient()
-        .when(
-            userConnectionManager.findByUserNameProviderName(
-                subject.getUsername(), DSW_APP_NAME, origDswAlias))
-        .thenReturn(Optional.of(existingConnection));
 
     Map<String, String> dswOptions = new HashMap<>();
     dswOptions.put(DSW_ALIAS, origDswAlias);

--- a/src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java
+++ b/src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -99,9 +98,6 @@ public class IntegrationsHandlerTest {
   @BeforeEach
   public void setup() {
     subject = TestFactory.createAnyUser("any");
-    lenient()
-        .when(communityMgr.listCommunitiesForUser(eq(subject.getId())))
-        .thenReturn(new ArrayList<>());
     handler.setUserConnectionManager(userConnectionManager);
   }
 
@@ -484,15 +480,6 @@ public class IntegrationsHandlerTest {
     existingConnection.setExpireTime(0l);
     existingConnection.setAccessToken(origDswToken);
 
-    lenient().when(appCfgMgr.findByAppConfigElementSetId(1l)).thenReturn(Optional.of(aces));
-    // lenient: updateUserConnectionForMultipleOptionApp looks this up with a null alias, so the
-    // aliased stubbing below is not matched
-    lenient()
-        .when(
-            userConnectionManager.findByUserNameProviderName(
-                subject.getUsername(), DSW_APP_NAME, origDswAlias))
-        .thenReturn(Optional.of(existingConnection));
-
     // The potentially updated options that are being passed in
     // from the UI.  Note that the API Key is set as the default
     // masked value that is returned to the UI.
@@ -543,7 +530,6 @@ public class IntegrationsHandlerTest {
     when(userConnectionManager.findByUserNameProviderName(
             subject.getUsername(), DSW_APP_NAME, origDswAlias))
         .thenReturn(Optional.of(existingConnection));
-
     Map<String, String> dswOptions = new HashMap<>();
     dswOptions.put(DSW_ALIAS, updatedDswAlias);
     dswOptions.put(DSW_URL, origDswUrl);
@@ -579,20 +565,7 @@ public class IntegrationsHandlerTest {
                 new PropertyDescriptor(DSW_APIKEY, SettingsType.STRING, null)),
             origDswToken));
 
-    UserConnection existingConnection = new UserConnection();
-    existingConnection.setDisplayName("DSW Display Name");
-    existingConnection.setRank(1);
-    existingConnection.setId(
-        new UserConnectionId(subject.getUsername(), DSW_APP_NAME, origDswAlias));
-    existingConnection.setExpireTime(0l);
-    existingConnection.setAccessToken(origDswToken);
-
     when(appCfgMgr.findByAppConfigElementSetId(1l)).thenReturn(Optional.of(aces));
-    lenient()
-        .when(
-            userConnectionManager.findByUserNameProviderName(
-                subject.getUsername(), DSW_APP_NAME, origDswAlias))
-        .thenReturn(Optional.of(existingConnection));
 
     Map<String, String> dswOptions = new HashMap<>();
     dswOptions.put(DSW_ALIAS, origDswAlias);

--- a/src/test/java/com/researchspace/service/impl/MockFolderStructure.java
+++ b/src/test/java/com/researchspace/service/impl/MockFolderStructure.java
@@ -1,7 +1,6 @@
 package com.researchspace.service.impl;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -12,7 +11,6 @@ import com.researchspace.model.User;
 import com.researchspace.model.permissions.DefaultPermissionFactory;
 import com.researchspace.model.permissions.PermissionFactory;
 import com.researchspace.model.record.Folder;
-import com.researchspace.model.record.Record;
 import com.researchspace.model.record.RecordFactory;
 import com.researchspace.service.FolderManager;
 import com.researchspace.service.IContentInitialiserUtils;
@@ -32,7 +30,6 @@ public class MockFolderStructure {
   UserDao userDao = Mockito.mock(UserDao.class);
   RecordDao recordDao = Mockito.mock(RecordDao.class);
   @Mock private FolderManager folderManagerMock;
-  @Mock private Folder folderMock;
 
   public UserFolderSetup create(User subject) {
     return create(subject, null, null);
@@ -41,13 +38,8 @@ public class MockFolderStructure {
   public UserFolderSetup create(
       User subject, FolderManager extfolderManagerMock, Folder extfolderMock) {
     openMocks(this);
-    boolean extFolderManagerMockExists = false;
     if (extfolderManagerMock != null) {
       folderManagerMock = extfolderManagerMock;
-      extFolderManagerMockExists = true;
-    }
-    if (extfolderMock != null) {
-      folderMock = extfolderMock;
     }
     // use concrete classes to set up permissions and folders correctly
     RecordFactory rfac = new RecordFactory();
@@ -59,11 +51,6 @@ public class MockFolderStructure {
     // saves
     setupMockDaos();
     Folder root = utils.setupRootFolder(subject);
-    if (!extFolderManagerMockExists) {
-      lenient()
-          .when(folderManagerMock.getFolder(any(Long.class), any(User.class)))
-          .thenReturn(folderMock);
-    }
     DefaultUserFolderCreator folderCreator =
         new DefaultUserFolderCreator(rfac, permFac, folderDao, utils, folderManagerMock);
 
@@ -72,12 +59,6 @@ public class MockFolderStructure {
 
   private void setupMockDaos() {
     when(folderDao.save(any(Folder.class)))
-        .thenAnswer(
-            invocation -> {
-              return invocation.getArgument(0);
-            });
-    lenient()
-        .when(recordDao.save(any(Record.class)))
         .thenAnswer(
             invocation -> {
               return invocation.getArgument(0);

--- a/src/test/java/com/researchspace/service/impl/MockFolderStructure.java
+++ b/src/test/java/com/researchspace/service/impl/MockFolderStructure.java
@@ -2,7 +2,6 @@ package com.researchspace.service.impl;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.researchspace.dao.FolderDao;
 import com.researchspace.dao.RecordDao;
@@ -15,7 +14,6 @@ import com.researchspace.model.record.RecordFactory;
 import com.researchspace.service.FolderManager;
 import com.researchspace.service.IContentInitialiserUtils;
 import com.researchspace.service.UserFolderSetup;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 /**
@@ -29,15 +27,13 @@ public class MockFolderStructure {
   FolderDao folderDao = Mockito.mock(FolderDao.class);
   UserDao userDao = Mockito.mock(UserDao.class);
   RecordDao recordDao = Mockito.mock(RecordDao.class);
-  @Mock private FolderManager folderManagerMock;
+  private FolderManager folderManagerMock = Mockito.mock(FolderManager.class);
 
   public UserFolderSetup create(User subject) {
-    return create(subject, null, null);
+    return create(subject, null);
   }
 
-  public UserFolderSetup create(
-      User subject, FolderManager extfolderManagerMock, Folder extfolderMock) {
-    openMocks(this);
+  public UserFolderSetup create(User subject, FolderManager extfolderManagerMock) {
     if (extfolderManagerMock != null) {
       folderManagerMock = extfolderManagerMock;
     }

--- a/src/test/java/com/researchspace/service/impl/MovePermissionCheckerTest.java
+++ b/src/test/java/com/researchspace/service/impl/MovePermissionCheckerTest.java
@@ -98,7 +98,6 @@ public class MovePermissionCheckerTest {
     grp1.addChild(target, user);
   }
 
-  // these 2 tests assert that loading root folder does not trigger an unnecessary DB call
   @Test
   public void homeFolderMoveOKDoesNotCallDatabaseMethod() throws IllegalAddChildOperation {
     setUpPermissionsOK(rootFolder);

--- a/src/test/java/com/researchspace/service/impl/MovePermissionCheckerTest.java
+++ b/src/test/java/com/researchspace/service/impl/MovePermissionCheckerTest.java
@@ -2,7 +2,6 @@ package com.researchspace.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -70,6 +69,7 @@ public class MovePermissionCheckerTest {
     target.setSystemFolder(true);
 
     setUpSharedFolderHierarchy();
+    when(fDao.getUserSharedFolder(user)).thenReturn(sharedFolder);
     // move across groups, disallowed
     assertFalse(checker.checkMovePermissions(user, target, toMove));
 
@@ -97,7 +97,7 @@ public class MovePermissionCheckerTest {
     grp1.addChild(target, user);
   }
 
-  // these 2 tests assert that loaading root folder does not trigger unnecessry DB call
+  // these 2 tests assert that loading root folder does not trigger an unnecessary DB call
   @Test
   public void homeFolderMoveOKDoesNotCallDatabaseMethod() throws IllegalAddChildOperation {
     setUpPermissionsOK(rootFolder);
@@ -108,18 +108,12 @@ public class MovePermissionCheckerTest {
   @Test
   public void someoneElseshomeFolderMoveOKDoesNotCallDatabaseMethod()
       throws IllegalAddChildOperation {
-    setUpPermissionsOK(rootFolder);
     assertFalse(checker.checkMovePermissions(other, rootFolder, toMove));
     verify(fDao, never()).getUserSharedFolder(user);
   }
 
   protected void setUpPermissionsOK(Folder target) {
-    // lenient: someoneElseshomeFolderMoveOKDoesNotCallDatabaseMethod deliberately checks a
-    // different user, so these stubbings are not matched by that test
-    lenient()
-        .when(permUtil.isPermitted(target, PermissionType.FOLDER_RECEIVE, user))
-        .thenReturn(true);
-    lenient().when(permUtil.isPermitted(toMove, PermissionType.SEND, user)).thenReturn(true);
-    lenient().when(fDao.getUserSharedFolder(user)).thenReturn(sharedFolder);
+    when(permUtil.isPermitted(target, PermissionType.FOLDER_RECEIVE, user)).thenReturn(true);
+    when(permUtil.isPermitted(toMove, PermissionType.SEND, user)).thenReturn(true);
   }
 }

--- a/src/test/java/com/researchspace/service/impl/MovePermissionCheckerTest.java
+++ b/src/test/java/com/researchspace/service/impl/MovePermissionCheckerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.dao.FolderDao;
@@ -106,10 +107,12 @@ public class MovePermissionCheckerTest {
   }
 
   @Test
-  public void someoneElseshomeFolderMoveOKDoesNotCallDatabaseMethod()
+  public void moveToSomeoneElsesHomeFolderIsRejectedWithoutDatabaseLookup()
       throws IllegalAddChildOperation {
+    when(permUtil.isPermitted(rootFolder, PermissionType.FOLDER_RECEIVE, other)).thenReturn(false);
+
     assertFalse(checker.checkMovePermissions(other, rootFolder, toMove));
-    verify(fDao, never()).getUserSharedFolder(user);
+    verifyNoInteractions(fDao);
   }
 
   protected void setUpPermissionsOK(Folder target) {

--- a/src/test/java/com/researchspace/service/impl/OntologyDocManagerTest.java
+++ b/src/test/java/com/researchspace/service/impl/OntologyDocManagerTest.java
@@ -3,7 +3,6 @@ package com.researchspace.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -80,12 +79,13 @@ public class OntologyDocManagerTest {
     singleColumnNoCommasSpecifiedDocument =
         new File(classLoader.getResource(singleColumnNoCommasSpecifiedResourceName).getFile());
     tooLargeResourceFile = new File(classLoader.getResource(tooLargeResourceName).getFile());
-    lenient().when(ontologyDocumentCreatedInWorkspaceMock.getId()).thenReturn(1L);
     witnesses = new String[] {"NoWitnesses"};
   }
 
   @Test
   public void shouldWriteCSVWithLineBreakMidQuotedTextToontologyDocument() throws IOException {
+    when(ontologyDocumentCreatedInWorkspaceMock.getId()).thenReturn(1L);
+    when(userManager.getAuthenticatedUserInSession()).thenReturn(userMock);
     setUpMocksForCreatingontologyDocumentToWriteTo();
     ArgumentCaptor<String> captor = setupMocksForWritingDataToOntologyDocument();
     testee.writeImportToOntologyDoc(
@@ -104,6 +104,8 @@ public class OntologyDocManagerTest {
 
   @Test
   public void shouldWriteCSVWithSingleColumnNoCommasToOntologyDocument() throws IOException {
+    when(ontologyDocumentCreatedInWorkspaceMock.getId()).thenReturn(1L);
+    when(userManager.getAuthenticatedUserInSession()).thenReturn(userMock);
     setUpMocksForCreatingontologyDocumentToWriteTo();
     ArgumentCaptor<String> captor = setupMocksForWritingDataToOntologyDocument();
     testee.writeImportToOntologyDoc(
@@ -124,6 +126,8 @@ public class OntologyDocManagerTest {
 
   @Test
   public void shouldWriteCSVWithMultipleLinesToontologyDocument() throws IOException {
+    when(ontologyDocumentCreatedInWorkspaceMock.getId()).thenReturn(1L);
+    when(userManager.getAuthenticatedUserInSession()).thenReturn(userMock);
     setUpMocksForCreatingontologyDocumentToWriteTo();
     ArgumentCaptor<String> captor = setupMocksForWritingDataToOntologyDocument();
     testee.writeImportToOntologyDoc(
@@ -143,8 +147,8 @@ public class OntologyDocManagerTest {
 
   @Test
   public void shouldThrowExceptionWhenIncorrectUrlColumnSpecified() {
+    when(userManager.getAuthenticatedUserInSession()).thenReturn(userMock);
     setUpMocksForCreatingontologyDocumentToWriteTo();
-    ArgumentCaptor<String> captor = setupMocksForWritingDataToOntologyDocument();
     Exception thrown =
         assertThrows(
             RuntimeException.class,
@@ -241,6 +245,7 @@ public class OntologyDocManagerTest {
     Set<String> tags = Set.of("tag1", "tag2", "tag3");
     setupMocksForWritingDataToOntologyDocument();
     setUpMocksForUsersOwnOntologyDocumentDoesNotExist();
+    when(rootFolderMock.getId()).thenReturn(USER_ROOT_FOLDER_ID);
     setupMocksForOntologyFolderAndFileCreation();
     testee.writeTagsToUsersOntologyTagDoc(userMock, tags);
     verify(folderManagerMock)
@@ -256,7 +261,6 @@ public class OntologyDocManagerTest {
     when(recordMgr.createNewStructuredDocument(
             eq(ONTOLOGY_FOLDER_ID), eq(ONTOLOGY_FORM_ID), eq(userMock)))
         .thenReturn(ontologyDocumentCreatedInWorkspaceMock);
-    lenient().when(ontologyFolderMock.getName()).thenReturn("Ontologies");
   }
 
   @Test
@@ -265,8 +269,10 @@ public class OntologyDocManagerTest {
     Set<String> tags = Set.of("tag1", "tag2", "tag3");
     setupMocksForWritingDataToOntologyDocument();
     setUpMocksForUsersOwnOntologyDocumentDoesNotExist();
+    when(rootFolderMock.getId()).thenReturn(USER_ROOT_FOLDER_ID);
     setupMocksForOntologyFolderAndFileCreation();
     when(rootFolderMock.getChildrens()).thenReturn(Set.of(ontologyFolderMock));
+    when(ontologyFolderMock.getName()).thenReturn("Ontologies");
     when(ontologyFolderMock.isDeleted()).thenReturn(true);
     testee.writeTagsToUsersOntologyTagDoc(userMock, tags);
     verify(folderManagerMock)
@@ -323,9 +329,7 @@ public class OntologyDocManagerTest {
   @NotNull
   private ArgumentCaptor<String> setupMocksForWritingDataToOntologyDocument() {
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-    lenient().when(userManager.getAuthenticatedUserInSession()).thenReturn(userMock);
-    lenient()
-        .when(ontologyDocumentCreatedInWorkspaceMock.getFields())
+    when(ontologyDocumentCreatedInWorkspaceMock.getFields())
         .thenReturn(List.of(firstFieldInontologyDocumentMock, secondFieldInontologyDocumentMock));
     return captor;
   }
@@ -336,7 +340,6 @@ public class OntologyDocManagerTest {
     when(formManager.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
         .thenReturn(ontologyForm);
     when(folderManagerMock.getRootRecordForUser(userMock, userMock)).thenReturn(rootFolderMock);
-    lenient().when(rootFolderMock.getId()).thenReturn(USER_ROOT_FOLDER_ID);
     when(recordMgr.getOntologyTagsFilesForUserCalled(
             eq(userMock), eq(OntologyDocManager.USER_TAGS_ONTOLOGY_FILE)))
         .thenReturn(List.of(ontologyDocumentCreatedInWorkspaceMock));
@@ -348,7 +351,6 @@ public class OntologyDocManagerTest {
     when(formManager.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
         .thenReturn(ontologyForm);
     when(folderManagerMock.getRootRecordForUser(userMock, userMock)).thenReturn(rootFolderMock);
-    lenient().when(rootFolderMock.getId()).thenReturn(USER_ROOT_FOLDER_ID);
     when(recordMgr.getOntologyTagsFilesForUserCalled(
             eq(userMock), eq(OntologyDocManager.USER_TAGS_ONTOLOGY_FILE)))
         .thenReturn(new ArrayList<>());
@@ -362,7 +364,7 @@ public class OntologyDocManagerTest {
     when(folderManagerMock.getRootRecordForUser(userMock, userMock)).thenReturn(rootFolderMock);
     when(rootFolderMock.getId()).thenReturn(USER_ROOT_FOLDER_ID);
     when(recordMgr.createNewStructuredDocument(
-            eq(rootFolderMock.getId()), eq(ontologyForm.getId()), eq(userMock)))
+            eq(USER_ROOT_FOLDER_ID), eq(ontologyForm.getId()), eq(userMock)))
         .thenReturn(ontologyDocumentCreatedInWorkspaceMock);
   }
 
@@ -373,10 +375,6 @@ public class OntologyDocManagerTest {
     when(userManager.getUserByUsername(eq(uName), eq(true))).thenReturn(userMock);
     when(formManager.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
         .thenReturn(ontologyForm);
-    lenient()
-        .when(folderManagerMock.getRootRecordForUser(userMock, userMock))
-        .thenReturn(rootFolderMock);
-    lenient().when(rootFolderMock.getId()).thenReturn(USER_ROOT_FOLDER_ID);
     when(recordMgr.getontologyDocumentsCreatedInPastThirtyMinutesByCurrentUser(eq(uName)))
         .thenReturn(List.of(ontologyDocumentCreatedInWorkspaceMock));
   }

--- a/src/test/java/com/researchspace/service/impl/RecordSharingManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/RecordSharingManagerImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import com.researchspace.auth.PermissionUtils;
 import com.researchspace.core.util.ISearchResults;
 import com.researchspace.dao.FolderDao;
 import com.researchspace.dao.GroupDao;
@@ -45,6 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest {
 
   private PermissionFactory perFactory = new DefaultPermissionFactory();
+  private PermissionUtils permissionUtils = new PermissionUtils();
 
   @InjectMocks protected RecordSharingManagerImpl recordSharingManager;
 
@@ -88,7 +90,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
     when(permissnUtils.createFromString(anyString()))
         .thenAnswer(
             invocation ->
-                PermissionType.valueOf(invocation.getArgument(0, String.class).toUpperCase()));
+                permissionUtils.createFromString(invocation.getArgument(0, String.class)));
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/impl/RecordSharingManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/RecordSharingManagerImplTest.java
@@ -3,7 +3,7 @@ package com.researchspace.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.core.util.ISearchResults;
@@ -78,22 +78,22 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
     rgs = new RecordGroupSharing();
     rgs.setSharee(u);
     rgs.setShared(record);
+  }
 
+  private void stubPermissionUpdate() {
     ConstraintBasedPermission cbp =
         perFactory.createIdPermission(PermissionDomain.RECORD, PermissionType.READ, record.getId());
-
-    lenient().when(groupshareRecordDao.get(anyLong())).thenReturn(rgs);
-    lenient().when(permissnUtils.findBy(any(), any(), any(), any())).thenReturn(cbp);
-    lenient().when(permissnUtils.createFromString("WRITE")).thenReturn(PermissionType.WRITE);
-    lenient().when(permissnUtils.createFromString("READ")).thenReturn(PermissionType.READ);
-    lenient().when(baseRecordManager.get(docId01, u)).thenReturn(record);
-    lenient()
-        .when(groupshareRecordDao.getRecordGroupSharingsForRecordIds(List.of(docId01)))
-        .thenReturn(List.of(rgs));
+    when(groupshareRecordDao.get(anyLong())).thenReturn(rgs);
+    when(permissnUtils.findBy(any(), any(), any(), any())).thenReturn(cbp);
+    when(permissnUtils.createFromString(anyString()))
+        .thenAnswer(
+            invocation ->
+                PermissionType.valueOf(invocation.getArgument(0, String.class).toUpperCase()));
   }
 
   @Test
   public void testUserSingleSharedDocChangeFromReadToWrite() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:READ:id=" + docId01);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "WRITE", "unused");
 
@@ -113,6 +113,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testUserSingleSharedDocChangeFromReadToRead() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:READ:id=" + docId01);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "READ", "unused");
 
@@ -132,6 +133,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testUserSingleSharedDocChangeFromEditToRead() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:WRITE:id=" + docId01);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "READ", "unused");
 
@@ -151,6 +153,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testUserSingleSharedDocChangeFromEditToEdit() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:WRITE:id=" + docId01);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "WRITE", "unused");
 
@@ -170,6 +173,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testUserTwoSharedDocsChangeOneFromReadToWrite() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:READ:id=" + docId01);
     u.addPermission("RECORD:READ:id=" + docId02);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "WRITE", "unused");
@@ -202,6 +206,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testUserTwoSharedDocsChangeOneFromWriteToRead() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:WRITE:id=" + docId01);
     u.addPermission("RECORD:READ:id=" + docId02);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "READ", "unused");
@@ -244,6 +249,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
   // then the permissions would not update correctly.
   @Test
   public void testUserTwoSharedDocsChangeOneFromReadToWriteTwoIDsInOnePerm() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:READ:id=" + docId02 + "," + docId01);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "WRITE", "unused");
 
@@ -275,6 +281,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testUserTwoSharedDocsChangeOneFromReadToReadTwoIDsInOnePerm() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:READ:id=" + docId02 + "," + docId01);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "READ", "unused");
 
@@ -313,6 +320,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testUserTwoSharedDocsChangeOneFromWriteToReadTwoIDsInOnePerm() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:WRITE:id=" + docId02 + "," + docId01);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "READ", "unused");
 
@@ -344,6 +352,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testUserTwoSharedDocsChangeOneFromWriteToWriteTwoIDsInOnePerm() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:WRITE:id=" + docId02 + "," + docId01);
     ErrorList el = recordSharingManager.updatePermissionForRecord(1L, "WRITE", "unused");
 
@@ -385,6 +394,7 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
   // we can correctly clear up the permissions
   @Test
   public void testUserThreeSharedDocsChangeOneFromReadToWrite() {
+    stubPermissionUpdate();
     u.addPermission("RECORD:WRITE:id=" + docId01);
     u.addPermission("RECORD:WRITE:id=" + docId01);
     u.addPermission("RECORD:WRITE:id=" + docId01);
@@ -443,6 +453,9 @@ public class RecordSharingManagerImplTest { // } extends SpringTransactionalTest
 
   @Test
   public void testRetrieveSharesForListOfRecordIds() {
+    when(baseRecordManager.get(docId01, u)).thenReturn(record);
+    when(groupshareRecordDao.getRecordGroupSharingsForRecordIds(List.of(docId01)))
+        .thenReturn(List.of(rgs));
     ISearchResults<RecordGroupSharing> shares =
         recordSharingManager.listSharesForRecordsAndUser(
             List.of(docId01), new PaginationCriteria<>(), u);

--- a/src/test/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImplTest.java
@@ -110,9 +110,10 @@ public class StoichiometryInventoryLinkManagerImplTest {
 
     when(moleculeManager.getById(10L)).thenReturn(molecule);
 
-    IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user));
-    assertEquals("Stoichiometry molecule already has an inventory link", ex.getMessage());
+    assertEquals(
+        "Stoichiometry molecule already has an inventory link",
+        assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user))
+            .getMessage());
   }
 
   @Test
@@ -127,12 +128,11 @@ public class StoichiometryInventoryLinkManagerImplTest {
     when(invPerms.assertUserCanEditInventoryRecord(any(GlobalIdentifier.class), eq(user)))
         .thenReturn(invSampleTemplate);
 
-    IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user));
     assertEquals(
         "IT200 is a sample template. Only Containers, Samples and Subsamples are valid for"
             + " linking.",
-        ex.getMessage());
+        assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user))
+            .getMessage());
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/StoichiometryInventoryLinkManagerImplTest.java
@@ -100,9 +100,10 @@ public class StoichiometryInventoryLinkManagerImplTest {
 
     when(moleculeManager.getById(10L)).thenReturn(molecule);
 
-    IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user));
-    assertEquals("Stoichiometry molecule already has an inventory link", ex.getMessage());
+    assertEquals(
+        "Stoichiometry molecule already has an inventory link",
+        assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user))
+            .getMessage());
   }
 
   @Test
@@ -117,12 +118,11 @@ public class StoichiometryInventoryLinkManagerImplTest {
     when(invPerms.assertUserCanEditInventoryRecord(any(GlobalIdentifier.class), eq(user)))
         .thenReturn(invSampleTemplate);
 
-    IllegalArgumentException ex =
-        assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user));
     assertEquals(
         "IT200 is a sample template. Only Containers, Samples and Subsamples are valid for"
             + " linking.",
-        ex.getMessage());
+        assertThrows(IllegalArgumentException.class, () -> manager.createLink(10L, req, user))
+            .getMessage());
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
+++ b/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
@@ -1,6 +1,5 @@
 package com.researchspace.service.impl;
 
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -69,8 +68,7 @@ public class SystemConfigurationInitializorTest extends SpringTransactionalTest 
     systemConfigurationInitialisor.setChemistryServiceUrl("http://indigoService:8090");
 
     // system setting is 'ALLOWED' and properties are configured - do nothing
-    lenient()
-        .when(mockSystemPropertyManager.findByName(SystemPropertyName.CHEMISTRY_AVAILABLE))
+    when(mockSystemPropertyManager.findByName(SystemPropertyName.CHEMISTRY_AVAILABLE))
         .thenReturn(
             new SystemPropertyValue(
                 new SystemProperty(null), HierarchicalPermission.ALLOWED.name()));

--- a/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
+++ b/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
@@ -67,11 +67,7 @@ public class SystemConfigurationInitializorTest extends SpringTransactionalTest 
     systemConfigurationInitialisor.setChemistryProvider("indigo");
     systemConfigurationInitialisor.setChemistryServiceUrl("http://indigoService:8090");
 
-    // system setting is 'ALLOWED' and properties are configured - do nothing
-    when(mockSystemPropertyManager.findByName(SystemPropertyName.CHEMISTRY_AVAILABLE))
-        .thenReturn(
-            new SystemPropertyValue(
-                new SystemProperty(null), HierarchicalPermission.ALLOWED.name()));
+    // properties are configured, so the system setting is not consulted
     systemConfigurationInitialisor.onAppStartup(null);
     verify(mockSystemPropertyManager, Mockito.times(1))
         .save(Mockito.any(), (HierarchicalPermission) Mockito.any(), Mockito.any());

--- a/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
+++ b/src/test/java/com/researchspace/service/impl/SystemConfigurationInitializorTest.java
@@ -67,7 +67,6 @@ public class SystemConfigurationInitializorTest extends SpringTransactionalTest 
     systemConfigurationInitialisor.setChemistryProvider("indigo");
     systemConfigurationInitialisor.setChemistryServiceUrl("http://indigoService:8090");
 
-    // properties are configured, so the system setting is not consulted
     systemConfigurationInitialisor.onAppStartup(null);
     verify(mockSystemPropertyManager, Mockito.times(1))
         .save(Mockito.any(), (HierarchicalPermission) Mockito.any(), Mockito.any());

--- a/src/test/java/com/researchspace/service/impl/TemplateTransferServiceTest.java
+++ b/src/test/java/com/researchspace/service/impl/TemplateTransferServiceTest.java
@@ -18,7 +18,6 @@ import com.researchspace.service.RecordManager;
 import com.researchspace.service.SharingHandler;
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -50,19 +49,15 @@ class TemplateTransferServiceTest {
 
   @InjectMocks TemplateTransferService templateTransferService;
 
-  @BeforeEach
   void setUpMessageSourceStubs() {
-    Mockito.lenient()
-        .when(
+    Mockito.when(
             messageSource.getMessage(
                 TemplateTransferService.DELETED_USER_TEMPLATES_FOLDER, null, null))
         .thenReturn("Deleted Users");
-    Mockito.lenient()
-        .when(
+    Mockito.when(
             messageSource.getMessage(TemplateTransferService.DELETED_USER_NAME_SUFFIX, null, null))
         .thenReturn(" (Deleted)");
-    Mockito.lenient()
-        .when(
+    Mockito.when(
             messageSource.getMessage(
                 Mockito.eq("templates.transfer.audit.description"),
                 Mockito.any(Object[].class),
@@ -92,6 +87,7 @@ class TemplateTransferServiceTest {
 
   @Test
   void transferOwnershipUnsharesMovesTransfersAndNotifiesAuditTrail_whenFoldersExist() {
+    setUpMessageSourceStubs();
     templateTransferService =
         new TemplateTransferService(
             messageSource,
@@ -174,6 +170,7 @@ class TemplateTransferServiceTest {
 
   @Test
   void transferOwnershipCreatesDeletedUsersFoldersWhenMissing() {
+    setUpMessageSourceStubs();
     templateTransferService =
         new TemplateTransferService(
             messageSource,
@@ -241,6 +238,7 @@ class TemplateTransferServiceTest {
 
   @Test
   void transferOwnership_transfersGalleryItemsLinkedFromTemplates() {
+    setUpMessageSourceStubs();
     templateTransferService =
         new TemplateTransferService(
             messageSource,
@@ -341,6 +339,7 @@ class TemplateTransferServiceTest {
 
   @Test
   void transferOwnership_skipsGalleryTransferWhenNoItemsLinkedFromTemplates() {
+    setUpMessageSourceStubs();
     templateTransferService =
         new TemplateTransferService(
             messageSource,

--- a/src/test/java/com/researchspace/service/impl/TemplateTransferServiceTest.java
+++ b/src/test/java/com/researchspace/service/impl/TemplateTransferServiceTest.java
@@ -19,7 +19,6 @@ import com.researchspace.service.RecordManager;
 import com.researchspace.service.SharingHandler;
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -50,18 +49,14 @@ class TemplateTransferServiceTest {
 
   @InjectMocks TemplateTransferService templateTransferService;
 
-  @BeforeEach
-  void setUpMessageSourceStubs() {
-    Mockito.lenient()
-        .when(messageSource.getMessage(TemplateTransferService.DELETED_USER_TEMPLATES_FOLDER))
+  private void stubMessageSource() {
+    Mockito.when(messageSource.getMessage(TemplateTransferService.DELETED_USER_TEMPLATES_FOLDER))
         .thenReturn("Deleted Users");
-    Mockito.lenient()
-        .when(
+    Mockito.when(
             messageSource.getMessage(
                 Mockito.eq(TemplateTransferService.DELETED_USER_NAME), Mockito.any(Object[].class)))
         .thenAnswer(invocation -> ((Object[]) invocation.getArgument(1))[0] + " (Deleted)");
-    Mockito.lenient()
-        .when(
+    Mockito.when(
             messageSource.getMessage(
                 Mockito.eq("templates.transfer.audit.description"), Mockito.any(Object[].class)))
         .thenAnswer(
@@ -89,6 +84,7 @@ class TemplateTransferServiceTest {
 
   @Test
   void transferOwnershipUnsharesMovesTransfersAndNotifiesAuditTrail_whenFoldersExist() {
+    stubMessageSource();
     templateTransferService =
         new TemplateTransferService(
             messageSource,
@@ -171,6 +167,7 @@ class TemplateTransferServiceTest {
 
   @Test
   void transferOwnershipCreatesDeletedUsersFoldersWhenMissing() {
+    stubMessageSource();
     templateTransferService =
         new TemplateTransferService(
             messageSource,
@@ -238,6 +235,7 @@ class TemplateTransferServiceTest {
 
   @Test
   void transferOwnership_transfersGalleryItemsLinkedFromTemplates() {
+    stubMessageSource();
     templateTransferService =
         new TemplateTransferService(
             messageSource,
@@ -338,6 +336,7 @@ class TemplateTransferServiceTest {
 
   @Test
   void transferOwnership_skipsGalleryTransferWhenNoItemsLinkedFromTemplates() {
+    stubMessageSource();
     templateTransferService =
         new TemplateTransferService(
             messageSource,

--- a/src/test/java/com/researchspace/service/impl/UserDeletionManagerTest.java
+++ b/src/test/java/com/researchspace/service/impl/UserDeletionManagerTest.java
@@ -4,7 +4,6 @@ import static com.researchspace.core.util.TransformerUtils.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -82,13 +81,15 @@ public class UserDeletionManagerTest {
     sysadmin1 = createSysadminWithID(3L, Constants.SYSADMIN_UNAME);
     sysadminToDelete = createSysadminWithID(4L, "sysadminToDelete");
     sysadmin3 = createSysadminWithID(5L, "sysadmin3");
+  }
 
-    lenient().when(fileStore.verifyUserFilestoreFiles(Mockito.any())).thenReturn(true);
-    lenient().when(deletedResourcesHelper.isUserResourcesListWriteable()).thenReturn(true);
-    lenient()
-        .when(
-            deletedResourcesHelper.saveUserResourcesListToTemporaryFile(
-                Mockito.any(), Mockito.any()))
+  private void stubWritableResourcesList() {
+    when(deletedResourcesHelper.isUserResourcesListWriteable()).thenReturn(true);
+  }
+
+  private void stubSuccessfulFileChecks() throws IOException {
+    when(fileStore.verifyUserFilestoreFiles(Mockito.any())).thenReturn(true);
+    when(deletedResourcesHelper.saveUserResourcesListToTemporaryFile(Mockito.any(), Mockito.any()))
         .thenReturn(true);
   }
 
@@ -101,6 +102,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeSelfUserFails() {
+    stubWritableResourcesList();
     enablePermissions();
     when(userDao.get(1L)).thenReturn(deleter);
     ServiceOperationResult<User> result = userDeletionMgr.removeUser(1L, noRestriction(), deleter);
@@ -112,9 +114,9 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeSysadmin1Fails() {
+    stubWritableResourcesList();
     enablePermissions();
     when(userDao.get(1L)).thenReturn(sysadmin1);
-    mockSysadminListing(toList(sysadminToDelete, sysadmin1));
     ServiceOperationResult<User> result = userDeletionMgr.removeUser(1L, noRestriction(), deleter);
     assertFalse(result.isSucceeded());
     assertEquals("failed-sysadmin", result.getMessage());
@@ -123,7 +125,9 @@ public class UserDeletionManagerTest {
   }
 
   @Test
-  public void removeAnySysadminSucceeds() {
+  public void removeAnySysadminSucceeds() throws IOException {
+    stubWritableResourcesList();
+    stubSuccessfulFileChecks();
     standardMockSetup();
 
     mockSysadminListing(toList(sysadminToDelete, sysadmin1));
@@ -135,6 +139,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeAnySysadminRequiresAtLeast1OtherActiveSysadmin() {
+    stubWritableResourcesList();
     standardMockSetup();
     mockSysadminListing(toList(sysadminToDelete, sysadmin3));
     // disable remaining sysadmin
@@ -147,6 +152,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeAnySysadminRequiresAtLeast1_UnlockedSysadmin() {
+    stubWritableResourcesList();
     standardMockSetup();
     mockSysadminListing(toList(sysadminToDelete, sysadmin3));
     // lock remaining sysadmin
@@ -159,6 +165,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeOnlyPiFails() {
+    stubWritableResourcesList();
     User pi = TestFactory.createAnyUserWithRole("pi", Role.PI_ROLE.getName());
     Group grp = TestFactory.createAnyGroup(pi, new User[] {});
     when(userDao.get(1L)).thenReturn(pi);
@@ -172,7 +179,9 @@ public class UserDeletionManagerTest {
   }
 
   @Test
-  public void strictUserDeletionRequiresInactiveGroup() {
+  public void strictUserDeletionRequiresInactiveGroup() throws IOException {
+    stubWritableResourcesList();
+    stubSuccessfulFileChecks();
     User pi = TestFactory.createAnyUserWithRole("pi", Role.PI_ROLE.getName());
     User u1 = TestFactory.createAnyUser("u1");
     u1.setId(1L);
@@ -213,6 +222,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void isUserRemovableChecksResourcesFolderCconfiguration() throws IOException {
+    stubWritableResourcesList();
     enablePermissions();
     when(userDao.get(toDelete.getId())).thenReturn(toDelete);
 
@@ -232,8 +242,8 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeUserFailsIfFilestoreResourcesListIncorrect() throws IOException {
+    stubWritableResourcesList();
     enablePermissions();
-    mockDeletion();
     when(userDao.get(toDelete.getId())).thenReturn(toDelete);
     when(fileStore.verifyUserFilestoreFiles(Mockito.any())).thenReturn(false);
 
@@ -263,16 +273,13 @@ public class UserDeletionManagerTest {
   }
 
   private void mockDeletion() {
-    lenient()
-        .when(deletionDao.deleteUser(Mockito.anyLong(), Mockito.any(UserDeletionPolicy.class)))
+    when(deletionDao.deleteUser(Mockito.anyLong(), Mockito.any(UserDeletionPolicy.class)))
         .thenReturn(new ServiceOperationResult<User>(toDelete, Boolean.TRUE, ""));
   }
 
   private void mockSysadminListing(List<User> allSysadminUsers) {
-    lenient()
-        .when(
-            userDao.listUsersByRole(
-                Mockito.eq(Role.SYSTEM_ROLE), Mockito.any(PaginationCriteria.class)))
+    when(userDao.listUsersByRole(
+            Mockito.eq(Role.SYSTEM_ROLE), Mockito.any(PaginationCriteria.class)))
         .thenReturn(searchResultsOf(allSysadminUsers));
   }
 

--- a/src/test/java/com/researchspace/service/impl/UserDeletionManagerTest.java
+++ b/src/test/java/com/researchspace/service/impl/UserDeletionManagerTest.java
@@ -4,7 +4,6 @@ import static com.researchspace.core.util.TransformerUtils.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,14 +71,6 @@ public class UserDeletionManagerTest {
     sysadmin1 = createSysadminWithID(3L, Constants.SYSADMIN_UNAME);
     sysadminToDelete = createSysadminWithID(4L, "sysadminToDelete");
     sysadmin3 = createSysadminWithID(5L, "sysadmin3");
-
-    lenient().when(fileStore.verifyUserFilestoreFiles(Mockito.any())).thenReturn(true);
-    lenient().when(deletedResourcesHelper.isUserResourcesListWriteable()).thenReturn(true);
-    lenient()
-        .when(
-            deletedResourcesHelper.saveUserResourcesListToTemporaryFile(
-                Mockito.any(), Mockito.any()))
-        .thenReturn(true);
   }
 
   User createSysadminWithID(Long id, String uname) {
@@ -91,6 +82,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeSelfUserFails() {
+    stubResourcesListWriteable();
     enablePermissions();
     when(userDao.get(1L)).thenReturn(deleter);
     ServiceOperationResult<User> result = userDeletionMgr.removeUser(1L, noRestriction(), deleter);
@@ -102,9 +94,9 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeSysadmin1Fails() {
+    stubResourcesListWriteable();
     enablePermissions();
     when(userDao.get(1L)).thenReturn(sysadmin1);
-    mockSysadminListing(toList(sysadminToDelete, sysadmin1));
     ServiceOperationResult<User> result = userDeletionMgr.removeUser(1L, noRestriction(), deleter);
     assertFalse(result.isSucceeded());
     assertEquals(
@@ -117,6 +109,9 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeAnySysadminSucceeds() {
+    stubResourcesListSaved();
+    stubResourcesListWriteable();
+    stubFilestoreFilesVerified();
     standardMockSetup();
 
     mockSysadminListing(toList(sysadminToDelete, sysadmin1));
@@ -128,6 +123,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeAnySysadminRequiresAtLeast1OtherActiveSysadmin() {
+    stubResourcesListWriteable();
     standardMockSetup();
     mockSysadminListing(toList(sysadminToDelete, sysadmin3));
     // disable remaining sysadmin
@@ -140,6 +136,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeAnySysadminRequiresAtLeast1_UnlockedSysadmin() {
+    stubResourcesListWriteable();
     standardMockSetup();
     mockSysadminListing(toList(sysadminToDelete, sysadmin3));
     // lock remaining sysadmin
@@ -152,6 +149,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeOnlyPiFails() {
+    stubResourcesListWriteable();
     User pi = TestFactory.createAnyUserWithRole("pi", Role.PI_ROLE.getName());
     Group grp = TestFactory.createAnyGroup(pi, new User[] {});
     when(userDao.get(1L)).thenReturn(pi);
@@ -169,6 +167,9 @@ public class UserDeletionManagerTest {
 
   @Test
   public void strictUserDeletionRequiresInactiveGroup() {
+    stubResourcesListSaved();
+    stubResourcesListWriteable();
+    stubFilestoreFilesVerified();
     User pi = TestFactory.createAnyUserWithRole("pi", Role.PI_ROLE.getName());
     User u1 = TestFactory.createAnyUser("u1");
     u1.setId(1L);
@@ -209,6 +210,7 @@ public class UserDeletionManagerTest {
 
   @Test
   public void isUserRemovableChecksResourcesFolderCconfiguration() throws IOException {
+    stubResourcesListWriteable();
     enablePermissions();
     when(userDao.get(toDelete.getId())).thenReturn(toDelete);
 
@@ -228,8 +230,9 @@ public class UserDeletionManagerTest {
 
   @Test
   public void removeUserFailsIfFilestoreResourcesListIncorrect() throws IOException {
+    stubResourcesListWriteable();
+    stubFilestoreFilesVerified();
     enablePermissions();
-    mockDeletion();
     when(userDao.get(toDelete.getId())).thenReturn(toDelete);
     when(fileStore.verifyUserFilestoreFiles(Mockito.any())).thenReturn(false);
 
@@ -259,16 +262,13 @@ public class UserDeletionManagerTest {
   }
 
   private void mockDeletion() {
-    lenient()
-        .when(deletionDao.deleteUser(Mockito.anyLong(), Mockito.any(UserDeletionPolicy.class)))
+    when(deletionDao.deleteUser(Mockito.anyLong(), Mockito.any(UserDeletionPolicy.class)))
         .thenReturn(new ServiceOperationResult<User>(toDelete, Boolean.TRUE, ""));
   }
 
   private void mockSysadminListing(List<User> allSysadminUsers) {
-    lenient()
-        .when(
-            userDao.listUsersByRole(
-                Mockito.eq(Role.SYSTEM_ROLE), Mockito.any(PaginationCriteria.class)))
+    when(userDao.listUsersByRole(
+            Mockito.eq(Role.SYSTEM_ROLE), Mockito.any(PaginationCriteria.class)))
         .thenReturn(searchResultsOf(allSysadminUsers));
   }
 
@@ -287,5 +287,18 @@ public class UserDeletionManagerTest {
 
   private UserDeletionPolicy noRestriction() {
     return new UserDeletionPolicy(UserTypeRestriction.NO_RESTRICTION);
+  }
+
+  private void stubResourcesListSaved() {
+    when(deletedResourcesHelper.saveUserResourcesListToTemporaryFile(Mockito.any(), Mockito.any()))
+        .thenReturn(true);
+  }
+
+  private void stubResourcesListWriteable() {
+    when(deletedResourcesHelper.isUserResourcesListWriteable()).thenReturn(true);
+  }
+
+  private void stubFilestoreFilesVerified() {
+    when(fileStore.verifyUserFilestoreFiles(Mockito.any())).thenReturn(true);
   }
 }

--- a/src/test/java/com/researchspace/service/impl/ZipCopyTest.java
+++ b/src/test/java/com/researchspace/service/impl/ZipCopyTest.java
@@ -12,7 +12,7 @@ public class ZipCopyTest {
 
   private static final Path SRC_MAIN_RESOURCES_START_UP_DATA_C4_ZIP =
       Path.of("src/main/resources/StartUpData/chemical-data-sheet.zip");
-  private static final String START_UP_DATA_C4_ZCIP = "/StartUpData/chemical-data-sheet.zip";
+  private static final String START_UP_DATA_C4_ZIP = "/StartUpData/chemical-data-sheet.zip";
 
   // Guards against Maven resource filtering corrupting the binary fixture.
   @Test
@@ -26,6 +26,6 @@ public class ZipCopyTest {
   }
 
   private InputStream fromClasspath() {
-    return getClass().getResourceAsStream(START_UP_DATA_C4_ZCIP);
+    return getClass().getResourceAsStream(START_UP_DATA_C4_ZIP);
   }
 }

--- a/src/test/java/com/researchspace/service/impl/ZipCopyTest.java
+++ b/src/test/java/com/researchspace/service/impl/ZipCopyTest.java
@@ -12,7 +12,7 @@ public class ZipCopyTest {
 
   private static final Path SRC_MAIN_RESOURCES_START_UP_DATA_C4_ZIP =
       Path.of("src/main/resources/StartUpData/chemical-data-sheet.zip");
-  private static final String START_UP_DATA_C4_ZCIP = "/StartUpData/chemical-data-sheet.zip";
+  private static final String START_UP_DATA_C4_ZIP = "/StartUpData/chemical-data-sheet.zip";
 
   // tests that maven filtering is not messing up zip file when copying from src to target
   // https://maven.apache.org/plugins/maven-resources-plugin/examples/binaries-filtering.html
@@ -30,6 +30,6 @@ public class ZipCopyTest {
   }
 
   private InputStream fromClasspath() {
-    return getClass().getResourceAsStream(START_UP_DATA_C4_ZCIP);
+    return getClass().getResourceAsStream(START_UP_DATA_C4_ZIP);
   }
 }

--- a/src/test/java/com/researchspace/service/impl/ZipCopyTest.java
+++ b/src/test/java/com/researchspace/service/impl/ZipCopyTest.java
@@ -19,9 +19,6 @@ public class ZipCopyTest {
   // https://stackoverflow.com/questions/50594360/gzipinputstream-works-with-fileinputstream-but-not-inputstream/50610474#50610474
   @Test
   public void classPathAndFileReadsAreTheSameBytes() throws IOException {
-    // readAllBytes rather than a fixed-size buffer: a buffer larger than the zip zero-pads both
-    // sides equally and a buffer smaller than it compares only a prefix, so either way a
-    // difference in the tail passes unnoticed once the file outgrows the number.
     try (InputStream fromClasspath = fromClasspath()) {
       assertArrayEquals(
           fromClasspath.readAllBytes(),

--- a/src/test/java/com/researchspace/service/inventory/ApiExtraFieldsHelperLinkUpdateTest.java
+++ b/src/test/java/com/researchspace/service/inventory/ApiExtraFieldsHelperLinkUpdateTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -137,9 +138,9 @@ class ApiExtraFieldsHelperLinkUpdateTest {
   void selfLinkViaUpdatePathIsRejected() {
     // the controller-layer validator can be bypassed by omitting "type", so
     // the service-layer apply must enforce no-self-links itself
-    ExtraLinkField selfField = org.mockito.Mockito.mock(ExtraLinkField.class);
-    org.mockito.Mockito.when(selfField.getId()).thenReturn(5L);
-    org.mockito.Mockito.when(selfField.getConnectedRecordGlobalIdentifier()).thenReturn("SA9");
+    ExtraLinkField selfField = mock(ExtraLinkField.class);
+    when(selfField.getId()).thenReturn(5L);
+    when(selfField.getConnectedRecordGlobalIdentifier()).thenReturn("SA9");
     ApiExtraField apiField = incomingLinkField(5L, "SA9", null);
 
     org.junit.jupiter.api.Assertions.assertThrows(

--- a/src/test/java/com/researchspace/service/inventory/ApiExtraFieldsHelperLinkUpdateTest.java
+++ b/src/test/java/com/researchspace/service/inventory/ApiExtraFieldsHelperLinkUpdateTest.java
@@ -138,11 +138,8 @@ class ApiExtraFieldsHelperLinkUpdateTest {
     // the controller-layer validator can be bypassed by omitting "type", so
     // the service-layer apply must enforce no-self-links itself
     ExtraLinkField selfField = org.mockito.Mockito.mock(ExtraLinkField.class);
-    org.mockito.Mockito.lenient().when(selfField.getId()).thenReturn(5L);
-    org.mockito.Mockito.lenient().when(selfField.getLink()).thenReturn(dbLink);
-    org.mockito.Mockito.lenient()
-        .when(selfField.getConnectedRecordGlobalIdentifier())
-        .thenReturn("SA9");
+    org.mockito.Mockito.when(selfField.getId()).thenReturn(5L);
+    org.mockito.Mockito.when(selfField.getConnectedRecordGlobalIdentifier()).thenReturn("SA9");
     ApiExtraField apiField = incomingLinkField(5L, "SA9", null);
 
     org.junit.jupiter.api.Assertions.assertThrows(

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryBulkOperationHandlerGuardTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryBulkOperationHandlerGuardTest.java
@@ -1,7 +1,6 @@
 package com.researchspace.service.inventory.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +23,7 @@ class InventoryBulkOperationHandlerGuardTest {
       returnsUndeletable =
           (rec, user) -> {
             ApiSample undeletable = mock(ApiSample.class);
-            lenient().when(undeletable.getCanBeDeleted()).thenReturn(false);
+            when(undeletable.getCanBeDeleted()).thenReturn(false);
             return undeletable;
           };
 

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryBulkOperationHandlerGuardTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryBulkOperationHandlerGuardTest.java
@@ -1,7 +1,6 @@
 package com.researchspace.service.inventory.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,7 +21,7 @@ class InventoryBulkOperationHandlerGuardTest {
       returnsUndeletable =
           (rec, user) -> {
             ApiSample undeletable = mock(ApiSample.class);
-            lenient().when(undeletable.getCanBeDeleted()).thenReturn(false);
+            when(undeletable.getCanBeDeleted()).thenReturn(false);
             return undeletable;
           };
 

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryBulkOperationHandlerGuardTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryBulkOperationHandlerGuardTest.java
@@ -15,15 +15,18 @@ import com.researchspace.service.MessageSourceUtils;
 import java.util.List;
 import java.util.function.BiFunction;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+@ExtendWith(MockitoExtension.class)
 class InventoryBulkOperationHandlerGuardTest {
 
   private final BiFunction<ApiInventoryRecordInfo, User, ApiInventoryRecordInfo>
       returnsUndeletable =
           (rec, user) -> {
-            ApiSample undeletable = mock(ApiSample.class);
-            when(undeletable.getCanBeDeleted()).thenReturn(false);
+            ApiSample undeletable = new ApiSample();
+            undeletable.setCanBeDeleted(false);
             return undeletable;
           };
 

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImplAttachingTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryFileApiManagerImplAttachingTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -51,42 +50,45 @@ class InventoryFileApiManagerImplAttachingTest {
   @BeforeEach
   void setUp() {
     actor = new User("viewer");
-    // most tests exercise the source query, so the target read-gate is open by default; the gate
-    // test overrides this
-    lenient().when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
-    lenient()
-        .when(inventoryFileDao.findByMediaFileId(anyLong()))
-        .thenReturn(Collections.emptyList());
-    lenient()
-        .when(inventoryFileDao.findAttachmentFieldsByMediaFileId(anyLong()))
+  }
+
+  private void stubReadableTarget() {
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+    when(inventoryFileDao.findByMediaFileId(anyLong())).thenReturn(Collections.emptyList());
+    when(inventoryFileDao.findAttachmentFieldsByMediaFileId(anyLong()))
         .thenReturn(Collections.emptyList());
   }
 
-  private InventoryRecord parent(
-      String globalId, String name, InventoryRecordType type, boolean deleted) {
+  private InventoryRecord parent(boolean deleted) {
     InventoryRecord rec = mock(InventoryRecord.class);
-    lenient().when(rec.getOid()).thenReturn(new GlobalIdentifier(globalId));
-    lenient().when(rec.getName()).thenReturn(name);
-    lenient().when(rec.getType()).thenReturn(type);
-    lenient().when(rec.isDeleted()).thenReturn(deleted);
+    when(rec.isDeleted()).thenReturn(deleted);
     return rec;
+  }
+
+  private void stubIdentity(
+      InventoryRecord record, String globalId, String name, InventoryRecordType type) {
+    when(record.getOid()).thenReturn(new GlobalIdentifier(globalId));
+    when(record.getName()).thenReturn(name);
+    when(record.getType()).thenReturn(type);
   }
 
   private InventoryFile recordAttachment(InventoryRecord owningRecord) {
     InventoryFile file = mock(InventoryFile.class);
-    lenient().when(file.getInventoryRecord()).thenReturn(owningRecord);
+    when(file.getInventoryRecord()).thenReturn(owningRecord);
     return file;
   }
 
   private InventoryAttachmentField fieldAttachment(InventoryRecord owningRecord) {
     InventoryAttachmentField field = mock(InventoryAttachmentField.class);
-    lenient().when(field.getInventoryRecord()).thenReturn(owningRecord);
+    when(field.getInventoryRecord()).thenReturn(owningRecord);
     return field;
   }
 
   @Test
   void returnsRowForReadableRecordLevelAttachment() {
-    InventoryRecord sample = parent("SA1", "My sample", InventoryRecordType.SAMPLE, false);
+    stubReadableTarget();
+    InventoryRecord sample = parent(false);
+    stubIdentity(sample, "SA1", "My sample", InventoryRecordType.SAMPLE);
     // build the attachment mock BEFORE stubbing the dao: stubbing a mock inside a thenReturn
     // argument trips Mockito's unfinished-stubbing detection
     InventoryFile attachment = recordAttachment(sample);
@@ -106,9 +108,11 @@ class InventoryFileApiManagerImplAttachingTest {
 
   @Test
   void resolvesFieldLevelAttachmentToItsOwningItem() {
+    stubReadableTarget();
     // a gallery file attached to a sample/template attachment field reports the owning sample, not
     // the field
-    InventoryRecord template = parent("IT9", "My template", InventoryRecordType.SAMPLE, false);
+    InventoryRecord template = parent(false);
+    stubIdentity(template, "IT9", "My template", InventoryRecordType.SAMPLE);
     InventoryAttachmentField field = fieldAttachment(template);
     when(inventoryFileDao.findAttachmentFieldsByMediaFileId(5L)).thenReturn(List.of(field));
     when(invPermissions.canUserReadInventoryRecord(template, actor)).thenReturn(true);
@@ -121,8 +125,10 @@ class InventoryFileApiManagerImplAttachingTest {
 
   @Test
   void oneRowPerConnectionWithoutDedup() {
+    stubReadableTarget();
     // the same item attaching the same gallery file twice yields two rows (mirrors the links panel)
-    InventoryRecord sample = parent("SA1", "My sample", InventoryRecordType.SAMPLE, false);
+    InventoryRecord sample = parent(false);
+    stubIdentity(sample, "SA1", "My sample", InventoryRecordType.SAMPLE);
     InventoryFile first = recordAttachment(sample);
     InventoryFile second = recordAttachment(sample);
     when(inventoryFileDao.findByMediaFileId(5L)).thenReturn(List.of(first, second));
@@ -133,10 +139,12 @@ class InventoryFileApiManagerImplAttachingTest {
 
   @Test
   void filtersOutSourcesTheActorCannotRead() {
+    stubReadableTarget();
     // leaking names/ids of items the caller may not read would defeat the per-record permission
     // check the panel relies on
-    InventoryRecord readable = parent("SA10", "visible", InventoryRecordType.SAMPLE, false);
-    InventoryRecord hidden = parent("SA11", "secret", InventoryRecordType.SAMPLE, false);
+    InventoryRecord readable = parent(false);
+    InventoryRecord hidden = parent(false);
+    stubIdentity(readable, "SA10", "visible", InventoryRecordType.SAMPLE);
     InventoryFile readableAttachment = recordAttachment(readable);
     InventoryFile hiddenAttachment = recordAttachment(hidden);
     when(inventoryFileDao.findByMediaFileId(5L))
@@ -152,7 +160,8 @@ class InventoryFileApiManagerImplAttachingTest {
 
   @Test
   void skipsSoftDeletedSourceRecords() {
-    InventoryRecord deleted = parent("SA12", "binned", InventoryRecordType.SAMPLE, true);
+    stubReadableTarget();
+    InventoryRecord deleted = parent(true);
     InventoryFile attachment = recordAttachment(deleted);
     when(inventoryFileDao.findByMediaFileId(5L)).thenReturn(List.of(attachment));
 
@@ -161,6 +170,7 @@ class InventoryFileApiManagerImplAttachingTest {
 
   @Test
   void skipsAttachmentWhoseOwningRecordCannotBeResolved() {
+    stubReadableTarget();
     // a field-level attachment surfaced by the record query has a null owning record; it is found
     // instead via the attachment-field query, so the null must be skipped rather than NPE
     InventoryFile orphan = recordAttachment(null);

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplReferencingTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplReferencingTest.java
@@ -3,7 +3,6 @@ package com.researchspace.service.inventory.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,7 +42,7 @@ class InventoryLinkManagerImplReferencingTest {
     actor = new User("viewer");
     // these tests cover the source query, so the target read-permission gate is open;
     // InventoryLinkManagerImplUnitTest covers the gate itself
-    lenient().when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
   }
 
   @Test
@@ -78,18 +77,20 @@ class InventoryLinkManagerImplReferencingTest {
 
   private InventoryRecord parent(String globalIdString, String name, boolean deleted) {
     InventoryRecord rec = mock(InventoryRecord.class, org.mockito.Mockito.RETURNS_DEEP_STUBS);
-    org.mockito.Mockito.lenient()
-        .when(rec.getOid())
-        .thenReturn(new com.researchspace.model.core.GlobalIdentifier(globalIdString));
-    org.mockito.Mockito.lenient().when(rec.getName()).thenReturn(name);
-    org.mockito.Mockito.lenient().when(rec.isDeleted()).thenReturn(deleted);
+    org.mockito.Mockito.when(rec.isDeleted()).thenReturn(deleted);
     return rec;
+  }
+
+  private void stubSourceIdentity(InventoryRecord record, String globalId, String name) {
+    org.mockito.Mockito.when(record.getOid())
+        .thenReturn(new com.researchspace.model.core.GlobalIdentifier(globalId));
+    org.mockito.Mockito.when(record.getName()).thenReturn(name);
   }
 
   private ExtraLinkField extraFieldRow(InventoryRecord rec, InventoryLink link) {
     ExtraLinkField field = mock(ExtraLinkField.class);
-    org.mockito.Mockito.lenient().when(field.getInventoryRecord()).thenReturn(rec);
-    org.mockito.Mockito.lenient().when(field.getLink()).thenReturn(link);
+    org.mockito.Mockito.when(field.getInventoryRecord()).thenReturn(rec);
+    org.mockito.Mockito.when(field.getLink()).thenReturn(link);
     return field;
   }
 
@@ -107,6 +108,7 @@ class InventoryLinkManagerImplReferencingTest {
     // caller may not read into the back-links panels
     InventoryRecord readable = parent("SA10", "visible sample", false);
     InventoryRecord hidden = parent("SA11", "secret sample", false);
+    stubSourceIdentity(readable, "SA10", "visible sample");
     InventoryLink linkA = linkWith("References", 2L, new Date(1700000000000L));
     InventoryLink linkB = linkWith("Cites", null, null);
     // build the field mocks BEFORE stubbing linkDao: stubbing inside thenReturn
@@ -141,6 +143,7 @@ class InventoryLinkManagerImplReferencingTest {
   @Test
   void toleratesRowWithoutModificationDate() {
     InventoryRecord rec = parent("SA13", "no date", false);
+    stubSourceIdentity(rec, "SA13", "no date");
     ExtraLinkField row = extraFieldRow(rec, linkWith("References", null, null));
     when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L)).thenReturn(List.of(row));
     when(permissionUtils.canUserReadInventoryRecord(rec, actor)).thenReturn(true);
@@ -157,10 +160,11 @@ class InventoryLinkManagerImplReferencingTest {
     // the target through one must appear in the back-references like an
     // extra-field link does
     InventoryRecord sample = parent("SA20", "templated sample", false);
+    stubSourceIdentity(sample, "SA20", "templated sample");
     InventoryLink link = linkWith("IsPartOf", null, null);
     InventoryLinkField structured = mock(InventoryLinkField.class);
-    org.mockito.Mockito.lenient().when(structured.getInventoryRecord()).thenReturn(sample);
-    org.mockito.Mockito.lenient().when(structured.getLink()).thenReturn(link);
+    org.mockito.Mockito.when(structured.getInventoryRecord()).thenReturn(sample);
+    org.mockito.Mockito.when(structured.getLink()).thenReturn(link);
     when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L))
         .thenReturn(java.util.Collections.emptyList());
     when(linkDao.findReferencingStructuredLinkFields(GlobalIdPrefix.SD, 123L))

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplReferencingTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplReferencingTest.java
@@ -3,6 +3,7 @@ package com.researchspace.service.inventory.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,21 +77,20 @@ class InventoryLinkManagerImplReferencingTest {
   }
 
   private InventoryRecord parent(String globalIdString, String name, boolean deleted) {
-    InventoryRecord rec = mock(InventoryRecord.class, org.mockito.Mockito.RETURNS_DEEP_STUBS);
-    org.mockito.Mockito.when(rec.isDeleted()).thenReturn(deleted);
+    InventoryRecord rec = mock(InventoryRecord.class, RETURNS_DEEP_STUBS);
+    when(rec.isDeleted()).thenReturn(deleted);
     return rec;
   }
 
   private void stubSourceIdentity(InventoryRecord record, String globalId, String name) {
-    org.mockito.Mockito.when(record.getOid())
-        .thenReturn(new com.researchspace.model.core.GlobalIdentifier(globalId));
-    org.mockito.Mockito.when(record.getName()).thenReturn(name);
+    when(record.getOid()).thenReturn(new com.researchspace.model.core.GlobalIdentifier(globalId));
+    when(record.getName()).thenReturn(name);
   }
 
   private ExtraLinkField extraFieldRow(InventoryRecord rec, InventoryLink link) {
     ExtraLinkField field = mock(ExtraLinkField.class);
-    org.mockito.Mockito.when(field.getInventoryRecord()).thenReturn(rec);
-    org.mockito.Mockito.when(field.getLink()).thenReturn(link);
+    when(field.getInventoryRecord()).thenReturn(rec);
+    when(field.getLink()).thenReturn(link);
     return field;
   }
 
@@ -163,8 +163,8 @@ class InventoryLinkManagerImplReferencingTest {
     stubSourceIdentity(sample, "SA20", "templated sample");
     InventoryLink link = linkWith("IsPartOf", null, null);
     InventoryLinkField structured = mock(InventoryLinkField.class);
-    org.mockito.Mockito.when(structured.getInventoryRecord()).thenReturn(sample);
-    org.mockito.Mockito.when(structured.getLink()).thenReturn(link);
+    when(structured.getInventoryRecord()).thenReturn(sample);
+    when(structured.getLink()).thenReturn(link);
     when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L))
         .thenReturn(java.util.Collections.emptyList());
     when(linkDao.findReferencingStructuredLinkFields(GlobalIdPrefix.SD, 123L))

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplReferencingTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplReferencingTest.java
@@ -76,7 +76,7 @@ class InventoryLinkManagerImplReferencingTest {
     verify(linkDao).findReferencingLinkFields(GlobalIdPrefix.SA, 42L);
   }
 
-  private InventoryRecord parent(String globalIdString, String name, boolean deleted) {
+  private InventoryRecord parent(boolean deleted) {
     InventoryRecord rec = mock(InventoryRecord.class, RETURNS_DEEP_STUBS);
     when(rec.isDeleted()).thenReturn(deleted);
     return rec;
@@ -106,8 +106,8 @@ class InventoryLinkManagerImplReferencingTest {
   void buildsRowsOnlyForSourcesTheActorCanRead() {
     // inverting or dropping this filter would leak names/ids of items the
     // caller may not read into the back-links panels
-    InventoryRecord readable = parent("SA10", "visible sample", false);
-    InventoryRecord hidden = parent("SA11", "secret sample", false);
+    InventoryRecord readable = parent(false);
+    InventoryRecord hidden = parent(false);
     stubSourceIdentity(readable, "SA10", "visible sample");
     InventoryLink linkA = linkWith("References", 2L, new Date(1700000000000L));
     InventoryLink linkB = linkWith("Cites", null, null);
@@ -133,7 +133,7 @@ class InventoryLinkManagerImplReferencingTest {
 
   @Test
   void skipsSoftDeletedSourceRecords() {
-    InventoryRecord deleted = parent("SA12", "binned sample", true);
+    InventoryRecord deleted = parent(true);
     ExtraLinkField row = extraFieldRow(deleted, linkWith("References", null, null));
     when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L)).thenReturn(List.of(row));
 
@@ -142,7 +142,7 @@ class InventoryLinkManagerImplReferencingTest {
 
   @Test
   void toleratesRowWithoutModificationDate() {
-    InventoryRecord rec = parent("SA13", "no date", false);
+    InventoryRecord rec = parent(false);
     stubSourceIdentity(rec, "SA13", "no date");
     ExtraLinkField row = extraFieldRow(rec, linkWith("References", null, null));
     when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SD, 123L)).thenReturn(List.of(row));
@@ -159,7 +159,7 @@ class InventoryLinkManagerImplReferencingTest {
     // template-defined link fields are first-class links; a sample linking to
     // the target through one must appear in the back-references like an
     // extra-field link does
-    InventoryRecord sample = parent("SA20", "templated sample", false);
+    InventoryRecord sample = parent(false);
     stubSourceIdentity(sample, "SA20", "templated sample");
     InventoryLink link = linkWith("IsPartOf", null, null);
     InventoryLinkField structured = mock(InventoryLinkField.class);

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplUnitTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplUnitTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -21,7 +20,6 @@ import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
 import com.researchspace.service.inventory.LinkTargetResolver;
 import com.researchspace.service.inventory.LinkTargetSnapshotResolver;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -44,14 +42,18 @@ class InventoryLinkManagerImplUnitTest {
 
   private final User actor = mock(User.class);
 
-  @BeforeEach
-  void setUp() {
-    lenient().when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
-    lenient().when(linkDao.save(any())).thenAnswer(inv -> inv.getArgument(0));
+  private void stubReadableTarget() {
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(true);
+  }
+
+  private void stubSavedLink() {
+    when(linkDao.save(any())).thenAnswer(inv -> inv.getArgument(0));
   }
 
   @Test
   void createLinkCapturesResolvedRevisionForPinnedTarget() {
+    stubReadableTarget();
+    stubSavedLink();
     when(snapshotResolver.resolveRevisionForVersion(GlobalIdPrefix.SD, 42L, 3L)).thenReturn(99L);
     ApiInventoryLink api = new ApiInventoryLink();
     api.setRelationType("References");
@@ -65,6 +67,8 @@ class InventoryLinkManagerImplUnitTest {
 
   @Test
   void createLinkLeavesRevisionNullForLatestTarget() {
+    stubReadableTarget();
+    stubSavedLink();
     ApiInventoryLink api = new ApiInventoryLink();
     api.setRelationType("References");
     api.setTargetGlobalId("SD42");
@@ -78,6 +82,8 @@ class InventoryLinkManagerImplUnitTest {
 
   @Test
   void updateLinkClearsRevisionWhenRepointedToLatest() {
+    stubReadableTarget();
+    stubSavedLink();
     InventoryLink existing = new InventoryLink();
     existing.setVersionPin(3L);
     existing.setTargetRevisionId(99L);
@@ -94,6 +100,8 @@ class InventoryLinkManagerImplUnitTest {
 
   @Test
   void updateLinkRecapturesRevisionWhenRepointedToPinnedTarget() {
+    stubReadableTarget();
+    stubSavedLink();
     when(snapshotResolver.resolveRevisionForVersion(GlobalIdPrefix.SD, 42L, 7L)).thenReturn(55L);
     InventoryLink existing = new InventoryLink();
     ApiInventoryLink update = new ApiInventoryLink();
@@ -118,6 +126,7 @@ class InventoryLinkManagerImplUnitTest {
 
   @Test
   void findReferencingItemsQueriesSourcesWhenTargetIsReadable() {
+    stubReadableTarget();
     when(linkDao.findReferencingLinkFields(GlobalIdPrefix.SA, 42L))
         .thenReturn(java.util.Collections.emptyList());
 

--- a/src/test/java/com/researchspace/service/inventory/impl/LinkTargetResolverImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/LinkTargetResolverImplTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -135,7 +136,7 @@ class LinkTargetResolverImplTest {
 
   @Test
   void elnDocumentTargetReadableResolvesTrue() {
-    BaseRecord document = org.mockito.Mockito.mock(BaseRecord.class);
+    BaseRecord document = mock(BaseRecord.class);
     when(document.getOid()).thenReturn(new GlobalIdentifier("SD123"));
     when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
         .thenReturn(List.of(document));
@@ -161,9 +162,9 @@ class LinkTargetResolverImplTest {
 
   @Test
   void notebookAndGalleryTargetsResolveViaBaseRecordManager() {
-    BaseRecord notebook = org.mockito.Mockito.mock(BaseRecord.class);
+    BaseRecord notebook = mock(BaseRecord.class);
     when(notebook.getOid()).thenReturn(new GlobalIdentifier("NB7"));
-    BaseRecord galleryFile = org.mockito.Mockito.mock(BaseRecord.class);
+    BaseRecord galleryFile = mock(BaseRecord.class);
     when(galleryFile.getOid()).thenReturn(new GlobalIdentifier("GL55"));
     when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
         .thenReturn(List.of(notebook), List.of(galleryFile));
@@ -176,7 +177,7 @@ class LinkTargetResolverImplTest {
   void versionSuffixIsStrippedBeforeResolving() {
     ArgumentCaptor<List<GlobalIdentifier>> captor = ArgumentCaptor.forClass(List.class);
     when(baseRecordManager.getByGlobalIdsAndReadPermission(captor.capture(), eq(user)))
-        .thenReturn(List.of(org.mockito.Mockito.mock(BaseRecord.class)));
+        .thenReturn(List.of(mock(BaseRecord.class)));
 
     resolver.targetExistsAndIsReadable(new GlobalIdentifier("SD123v5"), user);
 
@@ -191,7 +192,7 @@ class LinkTargetResolverImplTest {
     // the workspace loader resolves by numeric id alone, so "GL150" loads
     // whatever record has id 150 (e.g. folder FL150); only a record whose own
     // oid prefix matches the requested one may count as the link target
-    BaseRecord folder = org.mockito.Mockito.mock(BaseRecord.class);
+    BaseRecord folder = mock(BaseRecord.class);
     when(folder.getOid()).thenReturn(new GlobalIdentifier("FL150"));
     when(baseRecordManager.getByGlobalIdsAndReadPermission(any(), eq(user)))
         .thenReturn(List.of(folder));

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplSamplesToUpdateCountTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplSamplesToUpdateCountTest.java
@@ -1,7 +1,6 @@
 package com.researchspace.service.inventory.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,8 +42,8 @@ class SampleApiManagerImplSamplesToUpdateCountTest {
 
   private SampleTemplate templateWith(Long id, Long version) {
     SampleTemplate template = mock(SampleTemplate.class);
-    lenient().when(template.getId()).thenReturn(id);
-    lenient().when(template.getVersion()).thenReturn(version);
+    when(template.getId()).thenReturn(id);
+    when(template.getVersion()).thenReturn(version);
     return template;
   }
 

--- a/src/test/java/com/researchspace/service/inventory/impl/TransactionScopedVersionBumpGuardTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/TransactionScopedVersionBumpGuardTest.java
@@ -11,6 +11,8 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -19,6 +21,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * TransactionSynchronizationManager} directly the way Spring's transaction manager would
  * (RSDEV-1319). No Spring context or database.
  */
+@ExtendWith(MockitoExtension.class)
 public class TransactionScopedVersionBumpGuardTest {
 
   private static final String BUMPED_IN_TX =
@@ -39,10 +42,16 @@ public class TransactionScopedVersionBumpGuardTest {
     TransactionSynchronizationManager.setActualTransactionActive(false);
   }
 
-  private InventoryRecord record(Long id, String globalId) {
+  private InventoryRecord persistedRecord(Long id, String globalId) {
     InventoryRecord record = mock(InventoryRecord.class);
     when(record.getId()).thenReturn(id);
     when(record.getGlobalIdentifier()).thenReturn(globalId);
+    return record;
+  }
+
+  private InventoryRecord transientRecord() {
+    InventoryRecord record = mock(InventoryRecord.class);
+    when(record.getId()).thenReturn(null);
     return record;
   }
 
@@ -57,7 +66,7 @@ public class TransactionScopedVersionBumpGuardTest {
 
   @Test
   public void sameRecordBumpsOncePerTransaction() {
-    InventoryRecord sample = record(5L, "SA5");
+    InventoryRecord sample = persistedRecord(5L, "SA5");
 
     increaseVersionOncePerTransaction(sample);
     increaseVersionOncePerTransaction(sample);
@@ -67,8 +76,8 @@ public class TransactionScopedVersionBumpGuardTest {
 
   @Test
   public void distinctRecordsEachBump() {
-    InventoryRecord sample = record(5L, "SA5");
-    InventoryRecord otherSample = record(6L, "SA6");
+    InventoryRecord sample = persistedRecord(5L, "SA5");
+    InventoryRecord otherSample = persistedRecord(6L, "SA6");
 
     increaseVersionOncePerTransaction(sample);
     increaseVersionOncePerTransaction(otherSample);
@@ -79,8 +88,8 @@ public class TransactionScopedVersionBumpGuardTest {
 
   @Test
   public void sameNumericIdDifferentTypeBothBump() {
-    InventoryRecord sample = record(5L, "SA5");
-    InventoryRecord subSample = record(5L, "SS5");
+    InventoryRecord sample = persistedRecord(5L, "SA5");
+    InventoryRecord subSample = persistedRecord(5L, "SS5");
 
     increaseVersionOncePerTransaction(sample);
     increaseVersionOncePerTransaction(subSample);
@@ -93,8 +102,8 @@ public class TransactionScopedVersionBumpGuardTest {
   public void transientRecordsWithNullIdAlwaysBump() {
     // an unsaved record has no id, so getGlobalIdentifier() is null and there is no revision to
     // deduplicate against; two distinct transient records must not suppress each other
-    InventoryRecord transientA = record(null, null);
-    InventoryRecord transientB = record(null, null);
+    InventoryRecord transientA = transientRecord();
+    InventoryRecord transientB = transientRecord();
 
     increaseVersionOncePerTransaction(transientA);
     increaseVersionOncePerTransaction(transientB);
@@ -107,7 +116,7 @@ public class TransactionScopedVersionBumpGuardTest {
   @Test
   public void outsideTransactionEveryCallBumps() {
     completeTransaction(TransactionSynchronization.STATUS_COMMITTED);
-    InventoryRecord sample = record(5L, "SA5");
+    InventoryRecord sample = mock(InventoryRecord.class);
 
     increaseVersionOncePerTransaction(sample);
     increaseVersionOncePerTransaction(sample);
@@ -117,7 +126,7 @@ public class TransactionScopedVersionBumpGuardTest {
 
   @Test
   public void guardResetsAfterCommit() {
-    InventoryRecord sample = record(5L, "SA5");
+    InventoryRecord sample = persistedRecord(5L, "SA5");
     increaseVersionOncePerTransaction(sample);
     completeTransaction(TransactionSynchronization.STATUS_COMMITTED);
 
@@ -132,7 +141,7 @@ public class TransactionScopedVersionBumpGuardTest {
   public void guardResetsAfterRollback() {
     // if afterCompletion only fired on commit, a rolled-back transaction would leave the set
     // bound to the pooled thread and suppress this record's bumps forever
-    InventoryRecord sample = record(5L, "SA5");
+    InventoryRecord sample = persistedRecord(5L, "SA5");
     increaseVersionOncePerTransaction(sample);
     completeTransaction(TransactionSynchronization.STATUS_ROLLED_BACK);
 
@@ -147,7 +156,7 @@ public class TransactionScopedVersionBumpGuardTest {
   public void suspendedTransactionDoesNotLeakGuardIntoInnerTransaction() {
     // REQUIRES_NEW: Spring suspends the outer transaction's synchronizations, runs the inner
     // transaction (its own Envers revision, so its own bump), then resumes the outer one
-    InventoryRecord sample = record(5L, "SA5");
+    InventoryRecord sample = persistedRecord(5L, "SA5");
     increaseVersionOncePerTransaction(sample);
 
     List<TransactionSynchronization> outerSyncs =

--- a/src/test/java/com/researchspace/slack/SlackPosterTest.java
+++ b/src/test/java/com/researchspace/slack/SlackPosterTest.java
@@ -19,8 +19,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-// @Disabled rather than gated on -Dnightly like the other real-connection tests: this one needs a
-// secret webhook URL that no environment supplies, so a nightly gate would never fire either.
 @Disabled("requires correct real secret webhook")
 public class SlackPosterTest extends SpringTransactionalTest {
 

--- a/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
+++ b/src/test/java/com/researchspace/testutils/BaseManagerTestCaseBase.java
@@ -216,7 +216,7 @@ public abstract class BaseManagerTestCaseBase {
   protected static final Logger log = LoggerFactory.getLogger(BaseManagerTestCaseBase.class);
 
   @BeforeAll
-  public static void BeforeClass() throws Exception {
+  public static void skipFastRuns() throws Exception {
     TestRunnerController.ignoreIfFastRun();
   }
 

--- a/src/test/java/com/researchspace/testutils/DatabaseCleaner.java
+++ b/src/test/java/com/researchspace/testutils/DatabaseCleaner.java
@@ -22,10 +22,8 @@ public class DatabaseCleaner {
   /** Manually deletes records and folders from tables. */
   public static void cleanUp() {
     if (jdbcTemplate == null) {
-      // Nothing was ever injected, so no context loaded in this fork and there is nothing to clean.
-      // Callers already skip this on a fast run; this covers the other way @AfterAll can be reached
-      // without a context, namely a context *load failure*, which Jupiter follows with @AfterAll
-      // where JUnit 4 skipped @AfterClass. Without this, that NPEs here and hides the Spring error.
+      // No context loaded, so nothing to clean. Jupiter runs @AfterAll even when the context failed
+      // to load, and without this that NPEs here and hides the underlying Spring error.
       return;
     }
     // delete from Batch tables

--- a/src/test/java/com/researchspace/testutils/FolderTestUtils.java
+++ b/src/test/java/com/researchspace/testutils/FolderTestUtils.java
@@ -1,7 +1,6 @@
 package com.researchspace.testutils;
 
 import com.researchspace.model.User;
-import com.researchspace.model.record.Folder;
 import com.researchspace.service.FolderManager;
 import com.researchspace.service.UserFolderSetup;
 import com.researchspace.service.impl.MockFolderStructure;
@@ -28,9 +27,8 @@ public class FolderTestUtils {
     return setup;
   }
 
-  public static UserFolderSetup createDefaultFolderStructure(
-      User any, FolderManager fm, Folder folder) {
-    UserFolderSetup setup = new MockFolderStructure().create(any, fm, folder);
+  public static UserFolderSetup createDefaultFolderStructure(User any, FolderManager fm) {
+    UserFolderSetup setup = new MockFolderStructure().create(any, fm);
     setup
         .getUserRoot()
         .process(

--- a/src/test/java/com/researchspace/testutils/ProdConfigWiringTest.java
+++ b/src/test/java/com/researchspace/testutils/ProdConfigWiringTest.java
@@ -57,7 +57,7 @@ public class ProdConfigWiringTest {
   @Autowired private FolderManager folderManager;
 
   @BeforeAll
-  public static void BeforeClass() throws Exception {
+  public static void skipFastRuns() throws Exception {
     TestRunnerController.ignoreIfFastRun();
   }
 

--- a/src/test/java/com/researchspace/testutils/WithSpringContext.java
+++ b/src/test/java/com/researchspace/testutils/WithSpringContext.java
@@ -9,20 +9,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
- * Wires a test class into the Spring TestContext framework.
- *
- * <p>This is the composed-annotation equivalent of extending a Spring base class. JUnit 4 needed a
- * base class because a runner is class-level and cannot be composed, which is why Spring shipped
- * {@code AbstractJUnit4SpringContextTests}; Jupiter registers the equivalent behaviour through an
- * extension instead, so the single superclass a test gets to spend stays free.
- *
- * <p>Deliberately adds nothing but the extension. In particular it declares no
- * {@code @TestExecutionListeners}: naming any set here would replace Spring's defaults for every
- * annotated class that does not declare its own, silently dropping listeners such as {@code
- * ServletTestExecutionListener} and {@code TransactionalTestExecutionListener}.
- *
- * <p>Combine it with a context annotation such as {@link DefaultTestContext}, or with
+ * Wires a test class into the Spring TestContext framework, leaving its single superclass free.
+ * Combine with a context annotation such as {@link DefaultTestContext}, or
  * {@code @ContextConfiguration} directly.
+ *
+ * <p>Do not add {@code @TestExecutionListeners} here: naming any set replaces Spring's defaults for
+ * every annotated class that does not declare its own, silently dropping listeners such as {@code
+ * TransactionalTestExecutionListener}.
  */
 @ExtendWith(SpringExtension.class)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -149,8 +148,6 @@ public class ExportControllerTest {
     exportController.setResponseUtil(new ResponseUtil());
 
     user = TestFactory.createAnyUser("user1a");
-
-    lenient().when(diskSpaceChecker.canStartArchiveProcess()).thenReturn(true);
   }
 
   private static ExportSelection createExportSelection(Long[] ids, String[] names, String[] types) {
@@ -377,6 +374,7 @@ public class ExportControllerTest {
 
   @Test
   public void exportArchiveSelectionValidation() throws Exception {
+    stubArchiveProcessCanStart();
     Long[] tooMany = ids(ExportController.maxIdsToProcess + 1);
     String[] tooManyTypes = types(ExportController.maxIdsToProcess + 1);
     String[] tooManyNames = names(ExportController.maxIdsToProcess + 1);
@@ -637,6 +635,7 @@ public class ExportControllerTest {
 
   @Test
   public void depositArchiveHappyCase() throws Exception {
+    stubArchiveProcessCanStart();
     Long[] ids = ids(5);
     String[] types = types(5);
     String[] names = names(5);
@@ -691,5 +690,9 @@ public class ExportControllerTest {
       Matcher m4 = ExportController.VALID_PDF_FILE_CHARS.matcher(pdf);
       assertTrue(m4.matches(), pdf + " doesn't match");
     }
+  }
+
+  private void stubArchiveProcessCanStart() {
+    when(diskSpaceChecker.canStartArchiveProcess()).thenReturn(true);
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/ExportControllerTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -131,8 +130,6 @@ public class ExportControllerTest {
     exportController.setResponseUtil(new ResponseUtil());
 
     user = TestFactory.createAnyUser("user1a");
-
-    lenient().when(diskSpaceChecker.canStartArchiveProcess()).thenReturn(true);
   }
 
   private void setupMessageSources() {
@@ -637,6 +634,7 @@ public class ExportControllerTest {
 
   @Test
   public void depositArchiveHappyCase() throws Exception {
+    when(diskSpaceChecker.canStartArchiveProcess()).thenReturn(true);
     Long[] ids = ids(5);
     String[] types = types(5);
     String[] names = names(5);

--- a/src/test/java/com/researchspace/webapp/controller/IntegrationControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/IntegrationControllerTest.java
@@ -3,7 +3,6 @@ package com.researchspace.webapp.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.model.User;
@@ -77,8 +76,8 @@ public class IntegrationControllerTest {
 
   @Test
   public void testGetAllIntegrationsInfo() {
-    lenient()
-        .when(handler.getIntegration(Mockito.eq(subject), Mockito.anyString()))
+    when(userMgr.getAuthenticatedUserInSession()).thenReturn(subject);
+    when(handler.getIntegration(Mockito.eq(subject), Mockito.anyString()))
         .thenReturn(new IntegrationInfo());
     AjaxReturnObject<Map<String, IntegrationInfo>> infos =
         integrationCtrller.getAllIntegrationsInfo(principal);

--- a/src/test/java/com/researchspace/webapp/controller/JournalControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/JournalControllerTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import com.axiope.search.SearchManager;
 import com.researchspace.core.util.ISearchResults;
 import com.researchspace.core.util.SearchResultsImpl;
-import com.researchspace.model.RecordGroupSharing;
 import com.researchspace.model.User;
 import com.researchspace.model.dtos.WorkspaceListingConfig;
 import com.researchspace.model.field.StringFieldForm;
@@ -93,7 +92,8 @@ public class JournalControllerTest extends SpringTransactionalTest {
 
   @BeforeEach
   public void setUp() throws IOException {
-    setupLoggedInUser("user1a");
+    subjectThreadState = new SubjectThreadState(subject);
+    subjectThreadState.bind();
     recordManagerStub = new JournalRecordManagerStub();
     searchManagerStub = new JournalSearchManagerStub();
     journalController.setRecordManager(recordManagerStub);
@@ -118,14 +118,16 @@ public class JournalControllerTest extends SpringTransactionalTest {
     subjectThreadState.clear();
   }
 
-  private void setupLoggedInUser(String userName) {
-    subjectThreadState = new SubjectThreadState(subject);
-    subjectThreadState.bind();
-    when(subject.getSession()).thenReturn(shiroSessionMock);
+  private void stubSessionUserLookup(String userName) {
+    when(subject.getSession(false)).thenReturn(shiroSessionMock);
     when(shiroSessionMock.getAttribute(eq(SessionAttributeUtils.USER))).thenReturn(userMock);
     when(userMock.getUsername()).thenReturn(userName);
-    when(userMock.isAnonymousGuestAccount())
-        .thenReturn(RecordGroupSharing.ANONYMOUS_USER.equals(userName));
+  }
+
+  private void stubAuthenticatedUser(boolean anonymous) {
+    when(subject.getSession()).thenReturn(shiroSessionMock);
+    when(shiroSessionMock.getAttribute(eq(SessionAttributeUtils.USER))).thenReturn(userMock);
+    when(userMock.isAnonymousGuestAccount()).thenReturn(anonymous);
   }
 
   private void setUpSearchResults() throws IOException {
@@ -135,12 +137,16 @@ public class JournalControllerTest extends SpringTransactionalTest {
     }
     searchResults = new SearchResultsImpl<BaseRecord>(found, 7, 3L);
     noSearchResults = new SearchResultsImpl<BaseRecord>(new ArrayList<BaseRecord>(), 7, 3L);
+  }
+
+  private void stubSearchResults() throws IOException {
     when(searchMgr.searchWorkspaceRecords(any(WorkspaceListingConfig.class), eq(userMock)))
         .thenReturn(searchResults);
   }
 
   @Test
   public void retrieveEntryTest() throws Exception {
+    stubSessionUserLookup("user1a");
 
     // 0L represents root record and is not used in the stubs
     final Long targetParent = 0L;
@@ -254,6 +260,7 @@ public class JournalControllerTest extends SpringTransactionalTest {
 
   @Test
   public void retrieveHistoryTest() {
+    stubSessionUserLookup("user1a");
     // 0l represents root record and is not used in the stubs
     final Long targetParent = 0l;
 
@@ -290,6 +297,8 @@ public class JournalControllerTest extends SpringTransactionalTest {
 
   @Test
   public void searchTextTest() throws IOException {
+    stubAuthenticatedUser(false);
+    stubSearchResults();
     final Long targetParent = 0l;
 
     // test search should return 20 records
@@ -317,7 +326,8 @@ public class JournalControllerTest extends SpringTransactionalTest {
     when(folderManager.getNotebook(eq(targetParent))).thenReturn(notebookMock);
     when(notebookMock.getOwner()).thenReturn(userMock);
     when(notebookMock.isPublished()).thenReturn(true);
-    setupLoggedInUser(RecordGroupSharing.ANONYMOUS_USER);
+    stubAuthenticatedUser(true);
+    stubSearchResults();
     // test search should return 20 records
     List<JournalEntry> searchEntries =
         journalController.searchText("abc", targetParent, 0, mockPrincipal).getBody();
@@ -330,8 +340,7 @@ public class JournalControllerTest extends SpringTransactionalTest {
       throws IOException {
     final Long targetParent = 0l;
     when(folderManager.getNotebook(eq(targetParent))).thenReturn(notebookMock);
-    when(notebookMock.getOwner()).thenReturn(userMock);
-    setupLoggedInUser(RecordGroupSharing.ANONYMOUS_USER);
+    stubAuthenticatedUser(true);
     Exception exception =
         assertThrows(
             AuthorizationException.class,

--- a/src/test/java/com/researchspace/webapp/controller/JournalControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/JournalControllerTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.axiope.search.SearchManager;
@@ -122,13 +121,10 @@ public class JournalControllerTest extends SpringTransactionalTest {
   private void setupLoggedInUser(String userName) {
     subjectThreadState = new SubjectThreadState(subject);
     subjectThreadState.bind();
-    lenient().when(subject.getSession()).thenReturn(shiroSessionMock);
-    lenient()
-        .when(shiroSessionMock.getAttribute(eq(SessionAttributeUtils.USER)))
-        .thenReturn(userMock);
-    lenient().when(userMock.getUsername()).thenReturn(userName);
-    lenient()
-        .when(userMock.isAnonymousGuestAccount())
+    when(subject.getSession()).thenReturn(shiroSessionMock);
+    when(shiroSessionMock.getAttribute(eq(SessionAttributeUtils.USER))).thenReturn(userMock);
+    when(userMock.getUsername()).thenReturn(userName);
+    when(userMock.isAnonymousGuestAccount())
         .thenReturn(RecordGroupSharing.ANONYMOUS_USER.equals(userName));
   }
 
@@ -139,8 +135,7 @@ public class JournalControllerTest extends SpringTransactionalTest {
     }
     searchResults = new SearchResultsImpl<BaseRecord>(found, 7, 3L);
     noSearchResults = new SearchResultsImpl<BaseRecord>(new ArrayList<BaseRecord>(), 7, 3L);
-    lenient()
-        .when(searchMgr.searchWorkspaceRecords(any(WorkspaceListingConfig.class), eq(userMock)))
+    when(searchMgr.searchWorkspaceRecords(any(WorkspaceListingConfig.class), eq(userMock)))
         .thenReturn(searchResults);
   }
 
@@ -335,7 +330,7 @@ public class JournalControllerTest extends SpringTransactionalTest {
       throws IOException {
     final Long targetParent = 0l;
     when(folderManager.getNotebook(eq(targetParent))).thenReturn(notebookMock);
-    lenient().when(notebookMock.getOwner()).thenReturn(userMock);
+    when(notebookMock.getOwner()).thenReturn(userMock);
     setupLoggedInUser(RecordGroupSharing.ANONYMOUS_USER);
     Exception exception =
         assertThrows(

--- a/src/test/java/com/researchspace/webapp/controller/MessageAndRequestControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/MessageAndRequestControllerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.Constants;
@@ -90,8 +89,6 @@ public class MessageAndRequestControllerTest {
             admin, PaginationCriteria.createDefaultForClass(User.class).setGetAllResults()))
         .thenReturn(results);
     when(results.getResults()).thenReturn(Collections.EMPTY_LIST);
-    lenient().when(usrMgr.getUserByUsername("target")).thenReturn(recipient);
-
     Set<String> users =
         ctrller.getUsernamesFromInput(
             admin, cfg, result, comTargetPolicy, TransformerUtils.toSet(recipient));

--- a/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NfsSysAdminControllerTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,21 +48,22 @@ public class NfsSysAdminControllerTest {
     sysadmin = TestFactory.createAnyUserWithRole("any", Constants.SYSADMIN_ROLE);
     otherUser = TestFactory.createAnyUserWithRole("any", Constants.ADMIN_ROLE);
     when(userMgr.getAuthenticatedUserInSession()).thenReturn(sysadmin);
-    // resolve any i18n key to a string containing the first arg so existing
-    // assertions on exception message content keep working
-    lenient()
-        .when(msgSource.getMessage(anyString(), any(Object[].class)))
+    nfs = new NfsFileSystem();
+    nfs.setId(12L);
+  }
+
+  private void resolveMessagesToFirstArgument() {
+    when(msgSource.getMessage(anyString(), any(Object[].class)))
         .thenAnswer(
             inv -> {
               Object[] args = inv.getArgument(1);
               return args == null || args.length == 0 ? "" : String.valueOf(args[0]);
             });
-    nfs = new NfsFileSystem();
-    nfs.setId(12L);
   }
 
   @Test
   public void testGetFileSystemsViewOnlyForSysadmin() throws Exception {
+    resolveMessagesToFirstArgument();
     assertNotNull(nfsSystemCtrller.getFileSystemsView(new ExtendedModelMap()));
     assertAuthExceptionThrown(
         () -> {
@@ -80,6 +80,7 @@ public class NfsSysAdminControllerTest {
 
   @Test
   public void getFileSystemsListFailsForNonSysadmin() throws Exception {
+    resolveMessagesToFirstArgument();
     when(userMgr.getAuthenticatedUserInSession()).thenReturn(otherUser);
     assertThrows(AuthorizationException.class, () -> nfsSystemCtrller.getFileSystemsList());
     verify(netFilesMgr, never()).getFileSystems();
@@ -112,15 +113,16 @@ public class NfsSysAdminControllerTest {
 
   @Test
   public void saveFileSystem_usernameInBothLists_rejectedAndNotSaved() {
+    resolveMessagesToFirstArgument();
     nfs.setReadAllowlist("alice,carol");
     nfs.setWriteAllowlist("alice,bob");
 
-    IllegalArgumentException ex =
+    String message =
         Assertions.assertThrows(
-            IllegalArgumentException.class, () -> nfsSystemCtrller.saveFileSystem(nfs));
+                IllegalArgumentException.class, () -> nfsSystemCtrller.saveFileSystem(nfs))
+            .getMessage();
     Assertions.assertTrue(
-        ex.getMessage().contains("alice"),
-        "expected error to name the duplicated user, got: " + ex.getMessage());
+        message.contains("alice"), "expected error to name the duplicated user, got: " + message);
     verify(netFilesMgr, never()).saveNfsFileSystem(nfs);
   }
 

--- a/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
@@ -78,7 +78,6 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    when(anonymousUser.getUniqueName()).thenReturn(RecordGroupSharing.ANONYMOUS_USER);
     user = createAndSaveUserIfNotExists(getRandomAlphabeticString("nbTestUser"));
     logoutAndLoginAs(user);
 
@@ -181,6 +180,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
   public void handleRequestWhenPublishedNotebook() throws Exception {
     FolderManagerStub.noteBooksArePublished = true;
     FolderManagerStub.anonymousUser = anonymousUser;
+    when(anonymousUser.getUniqueName()).thenReturn(RecordGroupSharing.ANONYMOUS_USER);
     // when you have permission to edit record
     when(permissionUtils.isPermitted(
             any(BaseRecord.class), any(PermissionType.class), any(User.class)))

--- a/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/NotebookEditorControllerTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.model.EditStatus;
@@ -79,7 +78,7 @@ public class NotebookEditorControllerTest extends SpringTransactionalTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    lenient().when(anonymousUser.getUniqueName()).thenReturn(RecordGroupSharing.ANONYMOUS_USER);
+    when(anonymousUser.getUniqueName()).thenReturn(RecordGroupSharing.ANONYMOUS_USER);
     user = createAndSaveUserIfNotExists(getRandomAlphabeticString("nbTestUser"));
     logoutAndLoginAs(user);
 

--- a/src/test/java/com/researchspace/webapp/controller/RSChemControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/RSChemControllerTest.java
@@ -3,7 +3,6 @@ package com.researchspace.webapp.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,7 +14,6 @@ import com.researchspace.model.dtos.chemistry.ChemConversionInputDto;
 import com.researchspace.model.dtos.chemistry.ChemicalSearchRequestDTO;
 import com.researchspace.model.dtos.chemistry.ConvertedStructureDto;
 import com.researchspace.model.field.ErrorList;
-import com.researchspace.model.record.Folder;
 import com.researchspace.service.ChemistryService;
 import com.researchspace.service.FolderManager;
 import com.researchspace.service.RSChemElementManager;
@@ -71,11 +69,9 @@ public class RSChemControllerTest {
 
   @Test
   public void testSearchChemElement() {
-    final Folder rootFolder = TestFactory.createAFolder("root", user);
     final ChemicalSearchResults hits = new ChemicalSearchResults();
     String smile = "CCC(C1)";
     when(userMgr.getAuthenticatedUserInSession()).thenReturn(user);
-    lenient().when(folderManager.getRootFolderForUser(user)).thenReturn(rootFolder);
     when(chemicalService.searchChemicals(smile, "SUBSTRUCTURE", 0, 10, user)).thenReturn(hits);
 
     ChemSearchResultsPage resultsPage =

--- a/src/test/java/com/researchspace/webapp/controller/RepositoryConfigurationControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/RepositoryConfigurationControllerTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.model.User;
@@ -162,14 +161,18 @@ class RepositoryConfigurationControllerTest {
 
   @Test
   void getAllActiveReposDetectsOAuthConnected() throws Exception {
-    App app = new App("app.figshare", "figshare", true);
-    UserAppConfig appCfg = new UserAppConfig(exporter, app, true);
     // initially inactive for figshare - not oauthconnec
     IntegrationInfo figshareIntegrationInfo = createEnabledAvailableInfo(FIGSHARE_APP_NAME);
-    lenient()
-        .when(integrationsHandler.getIntegration(exporter, FIGSHARE_APP_NAME))
-        .thenReturn(figshareIntegrationInfo);
-    mockUICfgInfo();
+    when(integrationsHandler.getIntegration(eq(exporter), anyString()))
+        .thenAnswer(
+            invocation ->
+                FIGSHARE_APP_NAME.equals(invocation.getArgument(1))
+                    ? figshareIntegrationInfo
+                    : null);
+    RepoUIConfigInfo uiCfgInfo =
+        new RepoUIConfigInfo("A repo", null, null, Collections.emptyList());
+    when(repositoryDepositHandler.getFigshareRepoUIConfigInfo(any(User.class)))
+        .thenReturn(uiCfgInfo);
     assertEquals(1, repositoryConfigurationController.getAllActiveRepositories().size());
     figshareIntegrationInfo.setOauthConnected(false);
     assertEquals(0, repositoryConfigurationController.getAllActiveRepositories().size());
@@ -182,13 +185,8 @@ class RepositoryConfigurationControllerTest {
   }
 
   private void mockRepoConfigInfo(RepoUIConfigInfo mockResult) throws MalformedURLException {
-    lenient()
-        .when(
-            repositoryDepositHandler.getDataverseRepoUIConfigInfo(
-                any(AppConfigElementSet.class), any(User.class)))
-        .thenReturn(mockResult);
-    lenient()
-        .when(repositoryDepositHandler.getFigshareRepoUIConfigInfo(any(User.class)))
+    when(repositoryDepositHandler.getDataverseRepoUIConfigInfo(
+            any(AppConfigElementSet.class), any(User.class)))
         .thenReturn(mockResult);
   }
 

--- a/src/test/java/com/researchspace/webapp/controller/ScheduledMaintenanceControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/controller/ScheduledMaintenanceControllerMVCIT.java
@@ -78,10 +78,9 @@ public class ScheduledMaintenanceControllerMVCIT extends MVCTestBase {
 
   private void initDates() {
     if (dateNextHour == null) {
-      // The trailing -00:00 in the pattern is a literal, and the server parses these strings as
-      // UTC. Formatting must therefore happen in UTC too, otherwise local wall-clock time is
-      // labelled as UTC and every relative date is shifted by the machine's offset: in a
-      // negative-offset zone the "future" maintenance dates below land in the past.
+      // The -00:00 in the pattern is a literal and the server parses these as UTC, so format in
+      // UTC too or local wall-clock time gets labelled UTC and every date below shifts by the
+      // machine's offset.
       dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.000-00:00");
       dateFormat.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC));
 
@@ -189,11 +188,8 @@ public class ScheduledMaintenanceControllerMVCIT extends MVCTestBase {
   @Test
   public void testActiveMaintenanceCreateRetrieveFinishNow() throws Exception {
     String testMessage = "test maintenance message";
-    // The start date is posted as an absolute instant but the server renders it back in the user's
-    // timezone (SessionTimeZoneUtils, which falls back to the JVM default when the session carries
-    // no preference, as it does here), so the expected strings have to be derived rather than
-    // hard-coded or the test only passes under UTC. Everything below comes from this one instant:
-    // a second literal for the posted form of it would silently drift out of sync with it.
+    // Rendered back in the session's timezone, which falls back to the JVM default here, so the
+    // expected strings are derived from this one instant rather than hard-coded under UTC.
     Instant start = Instant.parse("2015-01-01T00:00:01Z");
     String oldDateString = dateFormat.format(Date.from(start));
     DateTimeFormatter clientFormat =

--- a/src/test/java/com/researchspace/webapp/controller/SelfServiceLabGroupControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SelfServiceLabGroupControllerTest.java
@@ -183,11 +183,13 @@ public class SelfServiceLabGroupControllerTest {
   }
 
   @Test
-  public void shouldNotDeleteLabGroupWhenNotSelfServiceEVenWhenPIisCreator() {
+  public void shouldNotDeleteLabGroupWhenNotSelfServiceEvenWhenPIIsCreator() {
     Long groupID = 1L;
+    Group nonSelfServiceLabGroup = new Group();
+    nonSelfServiceLabGroup.setOwner(piUser);
+    nonSelfServiceLabGroup.setSelfService(false);
     when(userManager.getAuthenticatedUserInSession()).thenReturn(piUser);
-    when(groupManager.getGroup(eq(groupID))).thenReturn(newLabGroup);
-    when(newLabGroup.isSelfService()).thenReturn(false);
+    when(groupManager.getGroup(eq(groupID))).thenReturn(nonSelfServiceLabGroup);
     // Note that the redirect is actually handled by JS code.
     assertThrows(AuthorizationException.class, () -> controller.removeGroup(groupID));
   }

--- a/src/test/java/com/researchspace/webapp/controller/SelfServiceLabGroupControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SelfServiceLabGroupControllerTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,7 +32,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.shiro.authz.AuthorizationException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -67,26 +65,19 @@ public class SelfServiceLabGroupControllerTest {
   @Mock private MessageSourceUtils messages;
   private Long newLabGroupID = 10L;
 
-  @BeforeEach
-  public void setUp() throws Exception {
-    lenient().when(createCloudGroup.getEmails()).thenReturn(new String[] {""});
-    lenient().when(createCloudGroup.getGroupName()).thenReturn("grpName");
+  private void stubValidGroupCreation() {
+    when(createCloudGroup.getEmails()).thenReturn(new String[] {""});
+    when(createCloudGroup.getGroupName()).thenReturn("grpName");
     when(userManager.getAuthenticatedUserInSession()).thenReturn(piUser);
-    lenient()
-        .when(
-            cloudGroupManager.createAndSaveGroup(
-                eq(true),
-                eq("grpName"),
-                eq(piUser),
-                eq(piUser),
-                eq(GroupType.LAB_GROUP),
-                eq(piUser)))
+    when(cloudGroupManager.createAndSaveGroup(
+            eq(true), eq("grpName"), eq(piUser), eq(piUser), eq(GroupType.LAB_GROUP), eq(piUser)))
         .thenReturn(newLabGroup);
-    lenient().when(newLabGroup.getId()).thenReturn(newLabGroupID);
+    when(newLabGroup.getId()).thenReturn(newLabGroupID);
   }
 
   @Test
   public void shouldValidate() {
+    stubValidGroupCreation();
     controller.createSelfServiceLabGroup(createCloudGroup, bindingResult, request);
     verify(validator, times(1)).validate(any(), eq(bindingResult));
   }
@@ -107,6 +98,7 @@ public class SelfServiceLabGroupControllerTest {
 
   @Test
   public void shouldCreateAndSaveSelfServiceLabGroup() {
+    stubValidGroupCreation();
     AjaxReturnObject response =
         controller.createSelfServiceLabGroup(createCloudGroup, bindingResult, request);
     assertNull(response.getErrorMsg());
@@ -117,6 +109,8 @@ public class SelfServiceLabGroupControllerTest {
 
   @Test
   public void shouldReturnErrorWhenDuplicateNameForSelfServiceLabGroup() {
+    when(createCloudGroup.getGroupName()).thenReturn("grpName");
+    when(userManager.getAuthenticatedUserInSession()).thenReturn(piUser);
     BindingResult errorsEx = new BeanPropertyBindingResult(createCloudGroup, "");
     when(createCloudGroup.getGroupName()).thenReturn("grpName");
     Group existingWithSameDisplayName = new Group();
@@ -146,6 +140,7 @@ public class SelfServiceLabGroupControllerTest {
     when(cloudGroupManager.createAndSaveGroup(
             eq(true), eq("grpName"), eq(piUser), eq(piUser), eq(GroupType.LAB_GROUP), eq(piUser)))
         .thenReturn(newLabGroup);
+    when(newLabGroup.getId()).thenReturn(newLabGroupID);
     when(cloudUserManager.createInvitedUserList(eq(Arrays.asList(emails))))
         .thenReturn(invitedUsers);
     controller.createSelfServiceLabGroup(createCloudGroup, bindingResult, request);
@@ -159,23 +154,13 @@ public class SelfServiceLabGroupControllerTest {
 
   @Test
   public void shouldNotSendJoinGroupRequestsIfNoUsersInvitedToJoin() {
-    String[] emails = new String[] {"email1@com", "email2@com"};
-    List<User> invitedUsers = List.of(invitedUser1, invitedUser2);
-    lenient().when(createCloudGroup.getGroupName()).thenReturn("grpName");
-    lenient().when(userManager.getAuthenticatedUserInSession()).thenReturn(piUser);
-    lenient()
-        .when(
-            cloudGroupManager.createAndSaveGroup(
-                eq(true),
-                eq("grpName"),
-                eq(piUser),
-                eq(piUser),
-                eq(GroupType.LAB_GROUP),
-                eq(piUser)))
+    when(createCloudGroup.getEmails()).thenReturn(new String[] {""});
+    when(createCloudGroup.getGroupName()).thenReturn("grpName");
+    when(userManager.getAuthenticatedUserInSession()).thenReturn(piUser);
+    when(cloudGroupManager.createAndSaveGroup(
+            eq(true), eq("grpName"), eq(piUser), eq(piUser), eq(GroupType.LAB_GROUP), eq(piUser)))
         .thenReturn(newLabGroup);
-    lenient()
-        .when(cloudUserManager.createInvitedUserList(eq(Arrays.asList(emails))))
-        .thenReturn(invitedUsers);
+    when(newLabGroup.getId()).thenReturn(newLabGroupID);
     controller.createSelfServiceLabGroup(createCloudGroup, bindingResult, request);
     verify(permissionUtils, never()).refreshCache();
     verify(cloudNotificationManager, never()).sendJoinGroupRequest(eq(piUser), eq(newLabGroup));
@@ -202,8 +187,7 @@ public class SelfServiceLabGroupControllerTest {
     Long groupID = 1L;
     when(userManager.getAuthenticatedUserInSession()).thenReturn(piUser);
     when(groupManager.getGroup(eq(groupID))).thenReturn(newLabGroup);
-    lenient().when(newLabGroup.isSelfService()).thenReturn(false);
-    lenient().when(newLabGroup.getOwner()).thenReturn(piUser);
+    when(newLabGroup.isSelfService()).thenReturn(false);
     // Note that the redirect is actually handled by JS code.
     assertThrows(AuthorizationException.class, () -> controller.removeGroup(groupID));
   }

--- a/src/test/java/com/researchspace/webapp/controller/StructuredDocumentControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/StructuredDocumentControllerTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -287,9 +286,6 @@ public class StructuredDocumentControllerTest {
 
     // invalid tags rejected
     tagText = "<img src='' onerror='alert(3);'>";
-    lenient()
-        .when(documentTagManager.saveTag(recordId, tagText, user))
-        .thenReturn(anySuccessResult());
 
     when(validator.validateAndGetErrorList(
             Mockito.any(RSpaceTag.class), Mockito.any(TagValidator.class)))
@@ -367,7 +363,6 @@ public class StructuredDocumentControllerTest {
     Field field = sd.getFields().iterator().next();
     field.setId(1L);
     final List<Field> rc = TransformerUtils.toList(field);
-    generalExpectations();
     when(fieldManager.getFieldsByRecordId(1L, null)).thenReturn(rc);
 
     // no temp fields, returns empty list
@@ -388,7 +383,7 @@ public class StructuredDocumentControllerTest {
   }
 
   private void generalExpectations() {
-    lenient().when(userMgr.getUserByUsername(eq(user.getUsername()))).thenReturn(user);
+    when(userMgr.getUserByUsername(eq(user.getUsername()))).thenReturn(user);
   }
 
   @Test
@@ -397,7 +392,6 @@ public class StructuredDocumentControllerTest {
 
     Field field = sd.getFields().iterator().next();
     field.setId(1L);
-    generalExpectations();
     verify(mediaMgr, never())
         .insertEcatComment(
             Mockito.any(String.class), Mockito.any(String.class), Mockito.any(User.class));
@@ -428,7 +422,6 @@ public class StructuredDocumentControllerTest {
     Field field = sd.getFields().iterator().next();
     field.setId(1L);
     final EcatComment createdComment = TestFactory.createEcatComment(1L, sd, 2L);
-    generalExpectations();
     verify(mediaMgr, never())
         .insertEcatComment(
             Mockito.any(String.class), Mockito.any(String.class), Mockito.any(User.class));

--- a/src/test/java/com/researchspace/webapp/controller/StructuredDocumentControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/StructuredDocumentControllerTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -294,10 +293,6 @@ public class StructuredDocumentControllerTest {
     // invalid tags rejected
     messageSource.addMessage("errors.invalidchars", Locale.getDefault(), "xss");
     tagText = "<img src='' onerror='alert(3);'>";
-    lenient()
-        .when(documentTagManager.saveTag(recordId, tagText, user))
-        .thenReturn(anySuccessResult());
-
     when(validator.validateAndGetErrorList(
             Mockito.any(RSpaceTag.class), Mockito.any(TagValidator.class)))
         .thenReturn(ErrorList.createErrListWithSingleMsg("msg"));
@@ -378,7 +373,6 @@ public class StructuredDocumentControllerTest {
     Field field = sd.getFields().iterator().next();
     field.setId(1L);
     final List<Field> rc = TransformerUtils.toList(field);
-    generalExpectations();
     when(fieldManager.getFieldsByRecordId(1L, null)).thenReturn(rc);
 
     // no temp fields, returns empty list
@@ -399,7 +393,7 @@ public class StructuredDocumentControllerTest {
   }
 
   private void generalExpectations() {
-    lenient().when(userMgr.getUserByUsername(eq(user.getUsername()))).thenReturn(user);
+    when(userMgr.getUserByUsername(eq(user.getUsername()))).thenReturn(user);
   }
 
   @Test
@@ -408,7 +402,6 @@ public class StructuredDocumentControllerTest {
 
     Field field = sd.getFields().iterator().next();
     field.setId(1L);
-    generalExpectations();
     messageSource.addMessage("errors.emptyString.polite", Locale.getDefault(), "any");
     verify(mediaMgr, never())
         .insertEcatComment(
@@ -441,7 +434,6 @@ public class StructuredDocumentControllerTest {
     Field field = sd.getFields().iterator().next();
     field.setId(1L);
     final EcatComment createdComment = TestFactory.createEcatComment(1L, sd, 2L);
-    generalExpectations();
     messageSource.addMessage("errors.emptyString.polite", Locale.getDefault(), "any");
     verify(mediaMgr, never())
         .insertEcatComment(

--- a/src/test/java/com/researchspace/webapp/controller/SysAdminControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SysAdminControllerTest.java
@@ -4,7 +4,6 @@ import static com.researchspace.Constants.SYSADMIN_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,7 +71,6 @@ public class SysAdminControllerTest {
   public void deleteUserRequiresSetDeploymentProperty() {
     sysadmin = TestFactory.createAnyUserWithRole("sys", SYSADMIN_ROLE);
 
-    lenient().when(userManager.getAuthenticatedUserInSession()).thenReturn(sysadmin);
     when(properties.getDeleteUser()).thenReturn(Boolean.FALSE.toString());
     CoreTestUtils.assertIllegalStateExceptionThrown(() -> ctrller.removeUserAccount(2L));
     Mockito.verifyNoInteractions(userExportHandler);
@@ -108,7 +106,6 @@ public class SysAdminControllerTest {
     Principal mockPrincipal = sysadmin::getUsername;
     PaginationCriteria<User> pgcrit = PaginationCriteria.createDefaultForClass(User.class);
     when(userManager.getUserByUsername(sysadmin.getUniqueName())).thenReturn(sysadmin);
-    lenient().when(userManager.getAuthenticatedUserInSession()).thenReturn(sysadmin);
     when(sysMgr.getUserUsageInfo(sysadmin, pgcrit))
         .thenReturn(new SearchResultsImpl<>(Collections.emptyList(), pgcrit, 0));
     final int totalEnabledusers = 4;

--- a/src/test/java/com/researchspace/webapp/controller/SysAdminControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/SysAdminControllerTest.java
@@ -4,7 +4,6 @@ import static com.researchspace.Constants.SYSADMIN_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,7 +83,6 @@ public class SysAdminControllerTest {
   public void deleteUserRequiresSetDeploymentProperty() {
     sysadmin = TestFactory.createAnyUserWithRole("sys", SYSADMIN_ROLE);
 
-    lenient().when(userManager.getAuthenticatedUserInSession()).thenReturn(sysadmin);
     when(properties.getDeleteUser()).thenReturn(Boolean.FALSE.toString());
     CoreTestUtils.assertIllegalStateExceptionThrown(() -> ctrller.removeUserAccount(2L));
     Mockito.verifyNoInteractions(userExportHandler);
@@ -120,7 +118,6 @@ public class SysAdminControllerTest {
     Principal mockPrincipal = sysadmin::getUsername;
     PaginationCriteria<User> pgcrit = PaginationCriteria.createDefaultForClass(User.class);
     when(userManager.getUserByUsername(sysadmin.getUniqueName())).thenReturn(sysadmin);
-    lenient().when(userManager.getAuthenticatedUserInSession()).thenReturn(sysadmin);
     when(sysMgr.getUserUsageInfo(sysadmin, pgcrit))
         .thenReturn(new SearchResultsImpl<>(Collections.emptyList(), pgcrit, 0));
     final int totalEnabledusers = 4;

--- a/src/test/java/com/researchspace/webapp/controller/UserProfileControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/UserProfileControllerTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -232,11 +231,6 @@ public class UserProfileControllerTest {
     when(usrMgr.getUser(2L + "")).thenReturn(anyUser);
     when(properties.isProfileHidingEnabled()).thenReturn(true);
     when(usrMgr.populateConnectedUserSet(sessionUser)).thenReturn(Collections.emptySet());
-    lenient()
-        .when(
-            messages.getMessage(
-                Mockito.eq("errors.resource.inaccessible"), Mockito.any(Long[].class)))
-        .thenReturn("error");
     sessionUser.setConnectedUsers(Collections.emptySet());
     anyUser.setPrivateProfile(true);
 

--- a/src/test/java/com/researchspace/webapp/controller/UserProfileControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/UserProfileControllerTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -232,9 +231,6 @@ public class UserProfileControllerTest {
     when(usrMgr.getUser(2L + "")).thenReturn(anyUser);
     when(properties.isProfileHidingEnabled()).thenReturn(true);
     when(usrMgr.populateConnectedUserSet(sessionUser)).thenReturn(Collections.emptySet());
-    lenient()
-        .when(messages.getMessage(Mockito.eq("record.inaccessible"), Mockito.any(Long[].class)))
-        .thenReturn("error");
     sessionUser.setConnectedUsers(Collections.emptySet());
     anyUser.setPrivateProfile(true);
 

--- a/src/test/java/com/researchspace/webapp/controller/UserRoleHandlerImplTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/UserRoleHandlerImplTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,11 +40,11 @@ public class UserRoleHandlerImplTest {
   @BeforeEach
   public void setUp() throws Exception {
     admin = TestFactory.createAnyUserWithRole("admin", Role.SYSTEM_ROLE.getName());
-    lenient().when(roleMgr.getRole(Role.PI_ROLE.getName())).thenReturn(Role.PI_ROLE);
   }
 
   @Test
   public void grantPiRoleToUser() {
+    when(roleMgr.getRole(Role.PI_ROLE.getName())).thenReturn(Role.PI_ROLE);
     User toPromote = TestFactory.createAnyUser("user");
     roleHandler.grantGlobalPiRoleToUser(admin, toPromote);
     verify(userManager).save(toPromote);
@@ -82,6 +81,7 @@ public class UserRoleHandlerImplTest {
 
   @Test
   public void revokePiRole() {
+    when(roleMgr.getRole(Role.PI_ROLE.getName())).thenReturn(Role.PI_ROLE);
     User toDemote = createAPi();
     when(userManager.save(toDemote)).thenReturn(toDemote);
     toDemote = roleHandler.revokeGlobalPiRoleFromUser(admin, toDemote);

--- a/src/test/java/com/researchspace/webapp/controller/UserRoleHandlerImplTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/UserRoleHandlerImplTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,13 +43,13 @@ public class UserRoleHandlerImplTest {
   @BeforeEach
   public void setUp() throws Exception {
     admin = TestFactory.createAnyUserWithRole("admin", Role.SYSTEM_ROLE.getName());
-    lenient().when(roleMgr.getRole(Role.PI_ROLE.getName())).thenReturn(Role.PI_ROLE);
     ReflectionTestUtils.setField(
         roleHandler, "messages", new MessageSourceUtils(new JsonMessageSource()));
   }
 
   @Test
   public void grantPiRoleToUser() {
+    stubPiRole();
     User toPromote = TestFactory.createAnyUser("user");
     roleHandler.grantGlobalPiRoleToUser(admin, toPromote);
     verify(userManager).save(toPromote);
@@ -90,6 +89,7 @@ public class UserRoleHandlerImplTest {
 
   @Test
   public void revokePiRole() {
+    stubPiRole();
     User toDemote = createAPi();
     when(userManager.save(toDemote)).thenReturn(toDemote);
     toDemote = roleHandler.revokeGlobalPiRoleFromUser(admin, toDemote);
@@ -131,5 +131,9 @@ public class UserRoleHandlerImplTest {
           verify(userManager, never()).save(toDemote);
           assertTrue(toDemote.hasRole(Role.PI_ROLE));
         });
+  }
+
+  private void stubPiRole() {
+    when(roleMgr.getRole(Role.PI_ROLE.getName())).thenReturn(Role.PI_ROLE);
   }
 }

--- a/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
@@ -143,8 +143,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   }
 
   private void clearUsersCustomFormsAddedToMenu() {
-    // Map<?, ?> rather than Map<Long, Boolean>: clear() takes no type parameter, so the wildcard
-    // cast is one the compiler can check, leaving no unchecked warning to suppress.
+    // Map<?, ?> keeps the cast checkable; clear() needs no type parameter.
     ((Map<?, ?>)
             ReflectionTestUtils.getField(
                 WorkspaceController.class, "USERS_CUSTOM_FORMS_ADDED_TO_MENU"))
@@ -364,8 +363,6 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_allowed"));
-    // Wildcard plus an explicit element cast: both are checkable, so neither needs suppressing.
-    // Erasure put the same checkcast on Record at the getId() call before, so this is equivalent.
     ISearchResults<?> res = (ISearchResults<?>) model.asMap().get("searchResults");
     Long recordId = ((Record) res.getResults().get(0)).getId();
     tss.clear();

--- a/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
@@ -23,7 +23,6 @@ import com.researchspace.model.User;
 import com.researchspace.model.UserPreference;
 import com.researchspace.model.audit.AuditedRecord;
 import com.researchspace.model.audittrail.AuditTrailService;
-import com.researchspace.model.dtos.FormMenu;
 import com.researchspace.model.dtos.WorkspaceSettings;
 import com.researchspace.model.preference.HierarchicalPermission;
 import com.researchspace.model.preference.Preference;
@@ -33,7 +32,6 @@ import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.Record;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.model.system.SystemPropertyValue;
-import com.researchspace.model.views.CompositeRecordOperationResult;
 import com.researchspace.model.views.RecordCopyResult;
 import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.service.AuditManager;
@@ -63,6 +61,7 @@ import java.io.IOException;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -129,9 +128,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     anyUser.setId(666L);
     ReflectionTestUtils.setField(postLoginHandler, "userContentUpdater", userContentUpdaterMock);
     ReflectionTestUtils.setField(paginationSettingsPreferences, "userManager", mockUserMgr);
-    UserPreference up =
-        new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
-    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
+    clearUsersCustomFormsAddedToMenu();
     tss = new ExtendedModelMap();
     model = tss;
     workspaceController.setFormManager(formMgr);
@@ -143,9 +140,14 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();
     setupSystemPropertyForPublishAllowedAndSeoAllowed();
-    when(formMgr.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
-        .thenReturn(mockOntologyForm);
-    when(mockOntologyForm.getStableID()).thenReturn("mockOntologyFormStableID");
+  }
+
+  @SuppressWarnings("unchecked")
+  private void clearUsersCustomFormsAddedToMenu() {
+    ((Map<Long, Boolean>)
+            ReflectionTestUtils.getField(
+                WorkspaceController.class, "USERS_CUSTOM_FORMS_ADDED_TO_MENU"))
+        .clear();
   }
 
   private void setupSystemPropertyForPublishAllowedAndSeoAllowed() {
@@ -208,7 +210,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   @Test
   public void testHandleRequestModel() throws Exception {
     workspaceController.setRecordManager(recordManagerStub);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
 
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
@@ -221,7 +223,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   public void shouldAddPublishAllowedAndSeoAllowedBooleanBasedOnSystemProperty()
       throws IOException {
     workspaceController.setRecordManager(recordManagerStub);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_allowed"));
@@ -244,7 +246,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
     workspaceController.setRecordManager(recordManagerStub);
     setUpGroupWithPiNonPIAllowPublishAndSeo(false, false);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_own_documents"));
@@ -259,7 +261,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
           throws Exception {
     workspaceController.setRecordManager(recordManagerStub);
     setUpGroupWithPiNonPIAllowPublishAndSeo(false, false);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipalNonPI, request, session, response, new WorkspaceSettings());
     assertFalse((Boolean) model.getAttribute("publish_own_documents"));
@@ -292,7 +294,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
       g.setPublicationAllowed(true);
       groupManager.saveGroup(g, nonPI);
     }
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipalNonPI, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_own_documents"));
@@ -308,7 +310,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     workspaceController.setRecordManager(recordManagerStub);
     setUpGroupWithPiNonPIAllowPublishAndSeo(true, true);
     setUpGroupWithPiNonPIAllowPublishAndSeo(false, false);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipalNonPI, request, session, response, new WorkspaceSettings());
     assertFalse((Boolean) model.getAttribute("publish_own_documents"));
@@ -319,7 +321,13 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
   private void setUpCommonMocks() {
     Mockito.when(grpMgr.listGroupsForUser()).thenReturn(Collections.emptySet());
-    Mockito.when(formMgr.generateFormMenu(Mockito.any(User.class))).thenReturn(new FormMenu());
+  }
+
+  private void setUpRootFolderMocks() {
+    setUpCommonMocks();
+    when(formMgr.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
+        .thenReturn(mockOntologyForm);
+    when(mockOntologyForm.getStableID()).thenReturn("mockOntologyFormStableID");
   }
 
   @Test
@@ -344,7 +352,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   }
 
   private Long getAValidRecordId() throws Exception {
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_allowed"));
@@ -390,10 +398,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
       sc.setAttribute(USERS_KEY, tracker);
       workspaceController.setServletContext(sc);
       final Long anyId = 1L;
-      final Long anyId2 = 2L;
       setUpCommonMocks();
-      when(mockDeleteManager.deleteRecord(eq(anyId), eq(anyId), Mockito.any(User.class)))
-          .thenReturn(new CompositeRecordOperationResult(null, null, null));
 
       final WorkspaceSettings srchInput = new WorkspaceSettings();
       srchInput.setParentFolderId(anyId);
@@ -462,8 +467,10 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   @Test
   public void viewDeletedDocuments() {
     workspaceController.setUserManager(mockUserMgr);
+    UserPreference up =
+        new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
+    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
     when(mockUserMgr.getUserByUsername(any())).thenReturn(anyUser);
-    when(mockUserMgr.get(eq(666L))).thenReturn(anyUser);
     when(mockUserMgr.getUserByUsername(any(), eq(true))).thenReturn(anyUser);
 
     final AuditedRecord ar = new AuditedRecord();

--- a/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -132,9 +131,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     ReflectionTestUtils.setField(paginationSettingsPreferences, "userManager", mockUserMgr);
     UserPreference up =
         new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
-    lenient()
-        .when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class)))
-        .thenReturn(up);
+    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
     tss = new ExtendedModelMap();
     model = tss;
     workspaceController.setFormManager(formMgr);
@@ -146,10 +143,9 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();
     setupSystemPropertyForPublishAllowedAndSeoAllowed();
-    lenient()
-        .when(formMgr.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
+    when(formMgr.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
         .thenReturn(mockOntologyForm);
-    lenient().when(mockOntologyForm.getStableID()).thenReturn("mockOntologyFormStableID");
+    when(mockOntologyForm.getStableID()).thenReturn("mockOntologyFormStableID");
   }
 
   private void setupSystemPropertyForPublishAllowedAndSeoAllowed() {
@@ -323,9 +319,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
   private void setUpCommonMocks() {
     Mockito.when(grpMgr.listGroupsForUser()).thenReturn(Collections.emptySet());
-    Mockito.lenient()
-        .when(formMgr.generateFormMenu(Mockito.any(User.class)))
-        .thenReturn(new FormMenu());
+    Mockito.when(formMgr.generateFormMenu(Mockito.any(User.class))).thenReturn(new FormMenu());
   }
 
   @Test
@@ -398,8 +392,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
       final Long anyId = 1L;
       final Long anyId2 = 2L;
       setUpCommonMocks();
-      lenient()
-          .when(mockDeleteManager.deleteRecord(eq(anyId), eq(anyId), Mockito.any(User.class)))
+      when(mockDeleteManager.deleteRecord(eq(anyId), eq(anyId), Mockito.any(User.class)))
           .thenReturn(new CompositeRecordOperationResult(null, null, null));
 
       final WorkspaceSettings srchInput = new WorkspaceSettings();
@@ -470,7 +463,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   public void viewDeletedDocuments() {
     workspaceController.setUserManager(mockUserMgr);
     when(mockUserMgr.getUserByUsername(any())).thenReturn(anyUser);
-    lenient().when(mockUserMgr.get(eq(666L))).thenReturn(anyUser);
+    when(mockUserMgr.get(eq(666L))).thenReturn(anyUser);
     when(mockUserMgr.getUserByUsername(any(), eq(true))).thenReturn(anyUser);
 
     final AuditedRecord ar = new AuditedRecord();

--- a/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
@@ -142,9 +142,10 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     setupSystemPropertyForPublishAllowedAndSeoAllowed();
   }
 
-  @SuppressWarnings("unchecked")
   private void clearUsersCustomFormsAddedToMenu() {
-    ((Map<Long, Boolean>)
+    // Map<?, ?> rather than Map<Long, Boolean>: clear() takes no type parameter, so the wildcard
+    // cast is one the compiler can check, leaving no unchecked warning to suppress.
+    ((Map<?, ?>)
             ReflectionTestUtils.getField(
                 WorkspaceController.class, "USERS_CUSTOM_FORMS_ADDED_TO_MENU"))
         .clear();
@@ -321,6 +322,13 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
   private void setUpCommonMocks() {
     Mockito.when(grpMgr.listGroupsForUser()).thenReturn(Collections.emptySet());
+    stubDeletedRecordsPreference();
+  }
+
+  private void stubDeletedRecordsPreference() {
+    UserPreference up =
+        new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
+    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
   }
 
   private void setUpRootFolderMocks() {
@@ -356,8 +364,10 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_allowed"));
-    ISearchResults<Record> res = (ISearchResults<Record>) model.asMap().get("searchResults");
-    Long recordId = res.getResults().get(0).getId();
+    // Wildcard plus an explicit element cast: both are checkable, so neither needs suppressing.
+    // Erasure put the same checkcast on Record at the getId() call before, so this is equivalent.
+    ISearchResults<?> res = (ISearchResults<?>) model.asMap().get("searchResults");
+    Long recordId = ((Record) res.getResults().get(0)).getId();
     tss.clear();
     if (recordId == null) {
       recordId = 1L;
@@ -467,9 +477,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   @Test
   public void viewDeletedDocuments() {
     workspaceController.setUserManager(mockUserMgr);
-    UserPreference up =
-        new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
-    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
+    stubDeletedRecordsPreference();
     when(mockUserMgr.getUserByUsername(any())).thenReturn(anyUser);
     when(mockUserMgr.getUserByUsername(any(), eq(true))).thenReturn(anyUser);
 

--- a/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -132,9 +131,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     ReflectionTestUtils.setField(paginationSettingsPreferences, "userManager", mockUserMgr);
     UserPreference up =
         new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
-    lenient()
-        .when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class)))
-        .thenReturn(up);
+    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
     tss = new ExtendedModelMap();
     model = tss;
     workspaceController.setFormManager(formMgr);
@@ -146,10 +143,9 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();
     setupSystemPropertyForPublishAllowedAndSeoAllowed();
-    lenient()
-        .when(formMgr.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
+    when(formMgr.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
         .thenReturn(mockOntologyForm);
-    lenient().when(mockOntologyForm.getStableID()).thenReturn("mockOntologyFormStableID");
+    when(mockOntologyForm.getStableID()).thenReturn("mockOntologyFormStableID");
   }
 
   private void setupSystemPropertyForPublishAllowedAndSeoAllowed() {
@@ -323,9 +319,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
   private void setUpCommonMocks() {
     Mockito.when(grpMgr.listGroupsForUser()).thenReturn(Collections.emptySet());
-    Mockito.lenient()
-        .when(formMgr.generateFormMenu(Mockito.any(User.class)))
-        .thenReturn(new FormMenu());
+    Mockito.when(formMgr.generateFormMenu(Mockito.any(User.class))).thenReturn(new FormMenu());
   }
 
   @Test
@@ -399,8 +393,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
       final Long anyId = 1L;
       final Long anyId2 = 2L;
       setUpCommonMocks();
-      lenient()
-          .when(mockDeleteManager.deleteRecord(eq(anyId), eq(anyId), Mockito.any(User.class)))
+      when(mockDeleteManager.deleteRecord(eq(anyId), eq(anyId), Mockito.any(User.class)))
           .thenReturn(new CompositeRecordOperationResult(null, null, null));
 
       final WorkspaceSettings srchInput = new WorkspaceSettings();
@@ -471,7 +464,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   public void viewDeletedDocuments() {
     workspaceController.setUserManager(mockUserMgr);
     when(mockUserMgr.getUserByUsername(any())).thenReturn(anyUser);
-    lenient().when(mockUserMgr.get(eq(666L))).thenReturn(anyUser);
+    when(mockUserMgr.get(eq(666L))).thenReturn(anyUser);
     when(mockUserMgr.getUserByUsername(any(), eq(true))).thenReturn(anyUser);
 
     final AuditedRecord ar = new AuditedRecord();

--- a/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
@@ -23,7 +23,6 @@ import com.researchspace.model.User;
 import com.researchspace.model.UserPreference;
 import com.researchspace.model.audit.AuditedRecord;
 import com.researchspace.model.audittrail.AuditTrailService;
-import com.researchspace.model.dtos.FormMenu;
 import com.researchspace.model.dtos.WorkspaceSettings;
 import com.researchspace.model.preference.HierarchicalPermission;
 import com.researchspace.model.preference.Preference;
@@ -33,7 +32,6 @@ import com.researchspace.model.record.RSForm;
 import com.researchspace.model.record.Record;
 import com.researchspace.model.record.StructuredDocument;
 import com.researchspace.model.system.SystemPropertyValue;
-import com.researchspace.model.views.CompositeRecordOperationResult;
 import com.researchspace.model.views.RecordCopyResult;
 import com.researchspace.model.views.ServiceOperationResult;
 import com.researchspace.service.AuditManager;
@@ -63,6 +61,7 @@ import java.io.IOException;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -129,9 +128,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     anyUser.setId(666L);
     ReflectionTestUtils.setField(postLoginHandler, "userContentUpdater", userContentUpdaterMock);
     ReflectionTestUtils.setField(paginationSettingsPreferences, "userManager", mockUserMgr);
-    UserPreference up =
-        new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
-    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
+    clearUsersCustomFormsAddedToMenu();
     tss = new ExtendedModelMap();
     model = tss;
     workspaceController.setFormManager(formMgr);
@@ -143,9 +140,14 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();
     setupSystemPropertyForPublishAllowedAndSeoAllowed();
-    when(formMgr.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
-        .thenReturn(mockOntologyForm);
-    when(mockOntologyForm.getStableID()).thenReturn("mockOntologyFormStableID");
+  }
+
+  @SuppressWarnings("unchecked")
+  private void clearUsersCustomFormsAddedToMenu() {
+    ((Map<Long, Boolean>)
+            ReflectionTestUtils.getField(
+                WorkspaceController.class, "USERS_CUSTOM_FORMS_ADDED_TO_MENU"))
+        .clear();
   }
 
   private void setupSystemPropertyForPublishAllowedAndSeoAllowed() {
@@ -208,7 +210,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   @Test
   public void testHandleRequestModel() throws Exception {
     workspaceController.setRecordManager(recordManagerStub);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
 
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
@@ -221,7 +223,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   public void shouldAddPublishAllowedAndSeoAllowedBooleanBasedOnSystemProperty()
       throws IOException {
     workspaceController.setRecordManager(recordManagerStub);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_allowed"));
@@ -244,7 +246,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
     workspaceController.setRecordManager(recordManagerStub);
     setUpGroupWithPiNonPIAllowPublishAndSeo(false, false);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_own_documents"));
@@ -259,7 +261,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
           throws Exception {
     workspaceController.setRecordManager(recordManagerStub);
     setUpGroupWithPiNonPIAllowPublishAndSeo(false, false);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipalNonPI, request, session, response, new WorkspaceSettings());
     assertFalse((Boolean) model.getAttribute("publish_own_documents"));
@@ -292,7 +294,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
       g.setPublicationAllowed(true);
       groupManager.saveGroup(g, nonPI);
     }
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipalNonPI, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_own_documents"));
@@ -308,7 +310,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     workspaceController.setRecordManager(recordManagerStub);
     setUpGroupWithPiNonPIAllowPublishAndSeo(true, true);
     setUpGroupWithPiNonPIAllowPublishAndSeo(false, false);
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipalNonPI, request, session, response, new WorkspaceSettings());
     assertFalse((Boolean) model.getAttribute("publish_own_documents"));
@@ -319,7 +321,13 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
   private void setUpCommonMocks() {
     Mockito.when(grpMgr.listGroupsForUser()).thenReturn(Collections.emptySet());
-    Mockito.when(formMgr.generateFormMenu(Mockito.any(User.class))).thenReturn(new FormMenu());
+  }
+
+  private void setUpRootFolderMocks() {
+    setUpCommonMocks();
+    when(formMgr.findOldestFormByName(eq(CustomFormAppInitialiser.ONTOLOGY_FORM_NAME)))
+        .thenReturn(mockOntologyForm);
+    when(mockOntologyForm.getStableID()).thenReturn("mockOntologyFormStableID");
   }
 
   @Test
@@ -345,7 +353,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
   @SuppressWarnings("unchecked")
   private Long getAValidRecordId() throws Exception {
-    setUpCommonMocks();
+    setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_allowed"));
@@ -391,10 +399,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
       sc.setAttribute(USERS_KEY, tracker);
       workspaceController.setServletContext(sc);
       final Long anyId = 1L;
-      final Long anyId2 = 2L;
       setUpCommonMocks();
-      when(mockDeleteManager.deleteRecord(eq(anyId), eq(anyId), Mockito.any(User.class)))
-          .thenReturn(new CompositeRecordOperationResult(null, null, null));
 
       final WorkspaceSettings srchInput = new WorkspaceSettings();
       srchInput.setParentFolderId(anyId);
@@ -463,8 +468,10 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   @Test
   public void viewDeletedDocuments() {
     workspaceController.setUserManager(mockUserMgr);
+    UserPreference up =
+        new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
+    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
     when(mockUserMgr.getUserByUsername(any())).thenReturn(anyUser);
-    when(mockUserMgr.get(eq(666L))).thenReturn(anyUser);
     when(mockUserMgr.getUserByUsername(any(), eq(true))).thenReturn(anyUser);
 
     final AuditedRecord ar = new AuditedRecord();

--- a/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java
@@ -142,9 +142,10 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
     setupSystemPropertyForPublishAllowedAndSeoAllowed();
   }
 
-  @SuppressWarnings("unchecked")
   private void clearUsersCustomFormsAddedToMenu() {
-    ((Map<Long, Boolean>)
+    // Map<?, ?> rather than Map<Long, Boolean>: clear() takes no type parameter, so the wildcard
+    // cast is one the compiler can check, leaving no unchecked warning to suppress.
+    ((Map<?, ?>)
             ReflectionTestUtils.getField(
                 WorkspaceController.class, "USERS_CUSTOM_FORMS_ADDED_TO_MENU"))
         .clear();
@@ -321,6 +322,13 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
 
   private void setUpCommonMocks() {
     Mockito.when(grpMgr.listGroupsForUser()).thenReturn(Collections.emptySet());
+    stubDeletedRecordsPreference();
+  }
+
+  private void stubDeletedRecordsPreference() {
+    UserPreference up =
+        new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
+    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
   }
 
   private void setUpRootFolderMocks() {
@@ -351,14 +359,15 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
         .doUserContentUpdates(eq(userMgr.getUserByUsername(mockPrincipal.getName())));
   }
 
-  @SuppressWarnings("unchecked")
   private Long getAValidRecordId() throws Exception {
     setUpRootFolderMocks();
     workspaceController.listRootFolder(
         "", model, mockPrincipal, request, session, response, new WorkspaceSettings());
     assertTrue((Boolean) model.getAttribute("publish_allowed"));
-    ISearchResults<Record> res = (ISearchResults<Record>) model.asMap().get("searchResults");
-    Long recordId = res.getResults().get(0).getId();
+    // Wildcard plus an explicit element cast: both are checkable, so neither needs suppressing.
+    // Erasure put the same checkcast on Record at the getId() call before, so this is equivalent.
+    ISearchResults<?> res = (ISearchResults<?>) model.asMap().get("searchResults");
+    Long recordId = ((Record) res.getResults().get(0)).getId();
     tss.clear();
     if (recordId == null) {
       recordId = 1L;
@@ -468,9 +477,7 @@ public class WorkspaceControllerTest extends SpringTransactionalTest {
   @Test
   public void viewDeletedDocuments() {
     workspaceController.setUserManager(mockUserMgr);
-    UserPreference up =
-        new UserPreference(Preference.DELETED_RECORDS_RESULTS_PER_PAGE, anyUser, "10");
-    when(mockUserMgr.getPreferenceForUser(any(User.class), any(Preference.class))).thenReturn(up);
+    stubDeletedRecordsPreference();
     when(mockUserMgr.getUserByUsername(any())).thenReturn(anyUser);
     when(mockUserMgr.getUserByUsername(any(), eq(true))).thenReturn(anyUser);
 

--- a/src/test/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilderTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilderTest.java
@@ -92,6 +92,7 @@ public class WorkspacePermissionsDTOBuilderTest {
     // can't copy or move from workspace
     assertFalse(can(result, DOC_ID, PermissionType.SEND));
     assertFalse(can(result, DOC_ID, PermissionType.COPY));
+    Mockito.verify(recMger, Mockito.never()).canMove(media, parentFolder, user);
   }
 
   @Test
@@ -154,6 +155,7 @@ public class WorkspacePermissionsDTOBuilderTest {
             parentFolder, user, model, results.getResults(), parentFolderId, true);
     assertFalse(can(result, DOC_ID, PermissionType.SEND));
     assertFalse(can(result, DOC_ID, PermissionType.EXPORT));
+    Mockito.verify(recMger, Mockito.never()).canMove(snip, parentFolder, user);
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilderTest.java
+++ b/src/test/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilderTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.Constants;
@@ -68,7 +67,6 @@ public class WorkspacePermissionsDTOBuilderTest {
     user = TestFactory.createAnyUser("any");
     parentFolder = TestFactory.createAFolder("folder", user);
     recordFac = new RecordFactory();
-    lenient().when(permissionUtils.isPermitted(any(), any(), any())).thenReturn(true);
   }
 
   @Test
@@ -84,8 +82,6 @@ public class WorkspacePermissionsDTOBuilderTest {
 
     parentFolder.addChild(media, user);
     Mockito.when(results.getResults()).thenReturn(records);
-    Mockito.lenient().when(recMger.canMove(media, parentFolder, user)).thenReturn(true);
-
     // folder owned by user enables crud operations on contents
     ActionPermissionsDTO result =
         dtoBuilder.addCreateAndOptionsMenuPermissions(
@@ -148,9 +144,6 @@ public class WorkspacePermissionsDTOBuilderTest {
     final List<BaseRecord> records = toList(snip);
     parentFolder.addChild(snip, user);
     when(results.getResults()).thenReturn(records);
-    lenient()
-        .when(recMger.canMove(Mockito.eq(snip), Mockito.eq(parentFolder), any(User.class)))
-        .thenReturn(true);
     ActionPermissionsDTO result =
         dtoBuilder.addCreateAndOptionsMenuPermissions(
             parentFolder, user, model, results.getResults(), parentFolderId, false);
@@ -242,6 +235,7 @@ public class WorkspacePermissionsDTOBuilderTest {
   // RSPAC-940
   @Test
   public void notebookOwnerCanCopySharedNotebookEntry() throws IllegalAddChildOperation {
+    when(permissionUtils.isPermitted(any(), any(), any())).thenReturn(true);
 
     User pi = TestFactory.createAnyUserWithRole("pi", Constants.PI_ROLE);
     parentFolder = TestFactory.createAFolder("folder", pi);
@@ -293,6 +287,7 @@ public class WorkspacePermissionsDTOBuilderTest {
 
   @Test
   public void testAddCreateAndOptionsMenuPermissions() throws IllegalAddChildOperation {
+    when(permissionUtils.isPermitted(any(), any(), any())).thenReturn(true);
 
     final StructuredDocument sdoc = TestFactory.createAnySD();
     sdoc.setId(DOC_ID);

--- a/src/test/java/com/researchspace/webapp/filter/FullPathSiteMeshFilterTest.java
+++ b/src/test/java/com/researchspace/webapp/filter/FullPathSiteMeshFilterTest.java
@@ -9,15 +9,16 @@ import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class FullPathSiteMeshFilterTest {
 
   private HttpServletRequest forwardedRequest(String contextPath, String forwardRequestUri) {
     HttpServletRequest req = mock(HttpServletRequest.class);
     when(req.getContextPath()).thenReturn(contextPath);
     when(req.getAttribute(FORWARD_REQUEST_URI)).thenReturn(forwardRequestUri);
-    // What the container reports for a servlet path-mapped forward: only the mapping prefix.
-    when(req.getAttribute(FORWARD_SERVLET_PATH)).thenReturn("/workspace");
     return req;
   }
 

--- a/src/test/java/com/researchspace/webapp/filter/FullPathSiteMeshFilterTest.java
+++ b/src/test/java/com/researchspace/webapp/filter/FullPathSiteMeshFilterTest.java
@@ -4,7 +4,6 @@ import static com.researchspace.webapp.filter.FullPathSiteMeshFilter.FORWARD_REQ
 import static com.researchspace.webapp.filter.FullPathSiteMeshFilter.FORWARD_SERVLET_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,7 +17,7 @@ class FullPathSiteMeshFilterTest {
     when(req.getContextPath()).thenReturn(contextPath);
     when(req.getAttribute(FORWARD_REQUEST_URI)).thenReturn(forwardRequestUri);
     // What the container reports for a servlet path-mapped forward: only the mapping prefix.
-    lenient().when(req.getAttribute(FORWARD_SERVLET_PATH)).thenReturn("/workspace");
+    when(req.getAttribute(FORWARD_SERVLET_PATH)).thenReturn("/workspace");
     return req;
   }
 

--- a/src/test/java/com/researchspace/webapp/filter/OriginRefererCheckingInterceptorTest.java
+++ b/src/test/java/com/researchspace/webapp/filter/OriginRefererCheckingInterceptorTest.java
@@ -37,7 +37,6 @@ public class OriginRefererCheckingInterceptorTest {
   public void setUp() throws Exception {
     originRefererChecker = new OriginRefererCheckerImpl();
     originRefererChecker.setProperties(propertyHolder);
-    Mockito.lenient().when(propertyHolder.getServerUrl()).thenReturn(testServerUrl);
     originRefererChecker.setAcceptedDomainsDeploymentProp(extraDomains);
   }
 
@@ -55,6 +54,7 @@ public class OriginRefererCheckingInterceptorTest {
 
   @Test
   public void testValidOriginsAndHeaders() throws IOException {
+    Mockito.when(propertyHolder.getServerUrl()).thenReturn(testServerUrl);
 
     req = new MockHttpServletRequest();
     req.addHeader("origin", testValidHeaderUrl);
@@ -85,6 +85,7 @@ public class OriginRefererCheckingInterceptorTest {
 
   @Test
   public void testInvalidHeaders() throws IOException {
+    Mockito.when(propertyHolder.getServerUrl()).thenReturn(testServerUrl);
     req = new MockHttpServletRequest();
     req.addHeader("origin", "siteA");
     Optional<String> errOptional = originRefererChecker.checkOriginReferer(req, resp);
@@ -113,6 +114,7 @@ public class OriginRefererCheckingInterceptorTest {
 
   @Test
   public void testSetupValidDomains() {
+    Mockito.when(propertyHolder.getServerUrl()).thenReturn(testServerUrl);
     List<String> defaultDomains = originRefererChecker.listAcceptedDomains();
     assertEquals(5, defaultDomains.size());
     assertEquals(testServerUrl, defaultDomains.get(0));

--- a/src/test/java/com/researchspace/webapp/integrations/argos/ArgosApiRealConnectionTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/argos/ArgosApiRealConnectionTest.java
@@ -3,20 +3,16 @@ package com.researchspace.webapp.integrations.argos;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.researchspace.argos.model.ArgosDMP;
 import com.researchspace.argos.model.ArgosDMPListing;
 import com.researchspace.argos.model.DataTableData;
-import com.researchspace.properties.PropertyHolder;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.web.client.RestTemplate;
 
 // The following tests run nightly and assert that the Argos API has not
@@ -26,14 +22,10 @@ public class ArgosApiRealConnectionTest {
 
   private RestTemplate restTemplate;
 
-  @Mock private PropertyHolder propertyHolder;
-
-  @InjectMocks private ArgosDMPProvider argosClient;
+  private ArgosDMPProvider argosClient;
 
   @BeforeEach
   public void setUp() throws Exception {
-    openMocks(this);
-
     restTemplate = new RestTemplate();
 
     this.argosClient = new ArgosDMPProvider(new URL("https://devel.opendmp.eu/srv/api/public"));

--- a/src/test/java/com/researchspace/webapp/integrations/dsw/DSWControllerRealConnectionTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/dsw/DSWControllerRealConnectionTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -43,12 +42,15 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 
+@ExtendWith(MockitoExtension.class)
 public class DSWControllerRealConnectionTest extends SpringTransactionalTest {
 
   private static String TEST_PROJECT_NAME = "RSpace Nightly Test Project";
@@ -62,11 +64,11 @@ public class DSWControllerRealConnectionTest extends SpringTransactionalTest {
 
   private DSWController dswController;
 
-  UserManager userManager;
-  UserAppConfigManager userAppConfigMgr;
-  UserConnectionManager source;
-  MediaManager mediaManager;
-  DMPManager dmpManager;
+  @Mock private UserManager userManager;
+  @Mock private UserAppConfigManager userAppConfigMgr;
+  @Mock private UserConnectionManager source;
+  @Mock private MediaManager mediaManager;
+  @Mock private DMPManager dmpManager;
 
   private ObjectMapper mapper = new ObjectMapper();
 
@@ -80,12 +82,6 @@ public class DSWControllerRealConnectionTest extends SpringTransactionalTest {
 
   @BeforeEach
   public void setup() throws Exception {
-    userManager = Mockito.mock(UserManager.class);
-    userAppConfigMgr = Mockito.mock(UserAppConfigManager.class);
-    source = Mockito.mock(UserConnectionManager.class);
-    mediaManager = Mockito.mock(MediaManager.class);
-    dmpManager = Mockito.mock(DMPManager.class);
-
     dswClient = new DSWClient(source, userManager, mediaManager, dmpManager);
     dswController = new DSWController(dswClient, userManager, userAppConfigMgr);
 
@@ -114,23 +110,22 @@ public class DSWControllerRealConnectionTest extends SpringTransactionalTest {
 
     uacfg.getAppConfigElementSets().add(aces);
 
+    when(userAppConfigMgr.getByAppName("app.dsw", u)).thenReturn(uacfg);
+  }
+
+  private void stubAuthenticatedConnection() {
     UserConnection connection = new UserConnection();
     connection.setAccessToken(apiKey);
 
-    when(userManager.get(anyLong())).thenReturn(u);
     when(userManager.getAuthenticatedUserInSession()).thenReturn(u);
-    when(userAppConfigMgr.getByAppName("app.dsw", u)).thenReturn(uacfg);
-    when(userAppConfigMgr.findByAppConfigElementSetId(anyLong())).thenReturn(Optional.of(aces));
-    when(userAppConfigMgr.findByAppConfigElementSetId(null)).thenReturn(Optional.of(aces));
     when(source.findByUserNameProviderName(anyString(), anyString(), anyString()))
         .thenReturn(Optional.of(connection));
-    when(mediaManager.saveNewDMPWithDescription(anyString(), any(), any(), any(), anyString()))
-        .thenReturn(new EcatDocumentFile());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "nightly", matches = "(|true)")
   public void testCurrentUserDetails() {
+    stubAuthenticatedConnection();
     try {
       ResponseEntity usersResponse = dswController.currentUsers(DSW_SERVER_ALIAS);
       assertNotNull(usersResponse);
@@ -144,6 +139,7 @@ public class DSWControllerRealConnectionTest extends SpringTransactionalTest {
   @Test
   @EnabledIfSystemProperty(named = "nightly", matches = "(|true)")
   public void testPlans() {
+    stubAuthenticatedConnection();
     try {
       AjaxReturnObject plansResponse = dswController.listDSWPlans(DSW_SERVER_ALIAS);
       assertNotNull(plansResponse);
@@ -161,7 +157,10 @@ public class DSWControllerRealConnectionTest extends SpringTransactionalTest {
   @Test
   @EnabledIfSystemProperty(named = "nightly", matches = "(|true)")
   public void testImportPlan() {
+    stubAuthenticatedConnection();
     try {
+      when(mediaManager.saveNewDMPWithDescription(anyString(), any(), any(), any(), anyString()))
+          .thenReturn(new EcatDocumentFile());
       AjaxReturnObject plansResponse = dswController.listDSWPlans(DSW_SERVER_ALIAS);
       assertNotNull(plansResponse);
       DSWProject[] projects =
@@ -194,6 +193,7 @@ public class DSWControllerRealConnectionTest extends SpringTransactionalTest {
   @Test
   @EnabledIfSystemProperty(named = "nightly", matches = "(|true)")
   public void testImportPlanIncorrectUuid() {
+    stubAuthenticatedConnection();
     try {
       String invalidUuid = "Not-a-valid-uuid";
       AjaxReturnObject<JsonNode> project = dswController.importPlan(DSW_SERVER_ALIAS, invalidUuid);
@@ -211,6 +211,7 @@ public class DSWControllerRealConnectionTest extends SpringTransactionalTest {
   @Test
   @EnabledIfSystemProperty(named = "nightly", matches = "(|true)")
   public void testImportPlanNullFileWhenSaving() {
+    stubAuthenticatedConnection();
     try {
       when(mediaManager.saveNewDMPWithDescription(anyString(), any(), any(), any(), anyString()))
           .thenReturn(null);

--- a/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOControllerTest.java
@@ -1,7 +1,6 @@
 package com.researchspace.webapp.integrations.protocolsio;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -50,29 +49,25 @@ public class ProtocolsIOControllerTest {
     sharedNotebook.setId(4L);
     workspaceRootFolder.setId(5L);
     when(userMgr.getAuthenticatedUserInSession()).thenReturn(subject);
-    lenient()
-        .when(converter.generateFromProtocol(protocol, subject, importsFolder.getId()))
-        .thenReturn(anyDoc);
-    lenient()
-        .when(converter.generateFromProtocol(protocol, subject, sharedNotebook.getId()))
-        .thenReturn(anyDoc);
     when(folderMgr.getImportsFolder(subject)).thenReturn(importsFolder);
-    lenient().when(folderMgr.getFolder(sharedFolder.getId(), subject)).thenReturn(sharedFolder);
-    lenient().when(folderMgr.getFolder(sharedNotebook.getId(), subject)).thenReturn(sharedNotebook);
-    lenient()
-        .when(folderMgr.getFolder(workspaceRootFolder.getId(), subject))
-        .thenReturn(workspaceRootFolder);
+  }
+
+  private void stubImportIntoImportsFolder() {
+    when(converter.generateFromProtocol(protocol, subject, importsFolder.getId()))
+        .thenReturn(anyDoc);
+  }
+
+  private void stubImportIntoSharedNotebook() {
+    when(converter.generateFromProtocol(protocol, subject, sharedNotebook.getId()))
+        .thenReturn(anyDoc);
   }
 
   @Test
   public void importExternalDataOK() {
+    stubImportIntoImportsFolder();
+    when(folderMgr.getFolder(workspaceRootFolder.getId(), subject)).thenReturn(workspaceRootFolder);
     when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
             subject, workspaceRootFolder))
-        .thenReturn(false);
-    lenient()
-        .when(
-            recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
-                subject, importsFolder))
         .thenReturn(false);
     AjaxReturnObject<ProtocolsIOController.PIOResponse> rc =
         ctrller.importExternalData(
@@ -84,6 +79,8 @@ public class ProtocolsIOControllerTest {
 
   @Test
   public void importExternalDataIntoASharedFolder() {
+    stubImportIntoImportsFolder();
+    when(folderMgr.getFolder(sharedFolder.getId(), subject)).thenReturn(sharedFolder);
     when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(subject, sharedFolder))
         .thenReturn(true);
     AjaxReturnObject<ProtocolsIOController.PIOResponse> rc =
@@ -96,6 +93,8 @@ public class ProtocolsIOControllerTest {
 
   @Test
   public void importExternalData_INTO_OWNED_SharedNotebook() {
+    stubImportIntoSharedNotebook();
+    when(folderMgr.getFolder(sharedNotebook.getId(), subject)).thenReturn(sharedNotebook);
     when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
             subject, sharedNotebook))
         .thenReturn(false);
@@ -111,6 +110,8 @@ public class ProtocolsIOControllerTest {
 
   @Test
   public void importExternalData_INTO_NOT_OWNED_SharedNotebook() {
+    stubImportIntoImportsFolder();
+    when(folderMgr.getFolder(sharedNotebook.getId(), subject)).thenReturn(sharedNotebook);
     when(recordManager.isSharedFolderOrSharedNotebookWithoutCreatePermission(
             subject, sharedNotebook))
         .thenReturn(true);
@@ -127,6 +128,7 @@ public class ProtocolsIOControllerTest {
 
   @Test
   public void importExternalDataIntoDocumentEditor() {
+    stubImportIntoImportsFolder();
     AjaxReturnObject<ProtocolsIOController.PIOResponse> rc =
         ctrller.importExternalData(TransformerUtils.toList(protocol));
     assertEquals(anyDoc.getId(), rc.getData().getResults().get(0).getId());

--- a/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOConverterTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOConverterTest.java
@@ -5,7 +5,6 @@ import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -159,7 +158,6 @@ public class ProtocolsIOConverterTest {
             Mockito.any(DefaultRecordContext.class),
             Mockito.eq(false)))
         .thenReturn(doc);
-    lenient().when(recordMgr.save(doc, any)).thenReturn(doc);
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOConverterTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOConverterTest.java
@@ -5,7 +5,6 @@ import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -165,7 +164,6 @@ public class ProtocolsIOConverterTest {
             Mockito.any(DefaultRecordContext.class),
             Mockito.eq(false)))
         .thenReturn(doc);
-    lenient().when(recordMgr.save(doc, any)).thenReturn(doc);
   }
 
   @Test

--- a/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOOAuthTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOOAuthTest.java
@@ -68,7 +68,6 @@ public class ProtocolsIOOAuthTest {
   public void setUp() throws Exception {
     shiroUtils = new ShiroTestUtils();
     shiroUtils.setSubject(subjct);
-    Mockito.lenient().when(subjct.getSession()).thenReturn(new SimpleSession());
     ReflectionTestUtils.setField(
         ctrller, "protocolsioAccessTokenUrl", PROTOCOLSIO_ACCESS_TOKEN_URL);
     ReflectionTestUtils.setField(ctrller, "protocolsioAuthUrl", PROTOCOLSIO_AUTH_URL);
@@ -86,6 +85,7 @@ public class ProtocolsIOOAuthTest {
 
   @Test
   public void connect() throws MalformedURLException {
+    Mockito.when(subjct.getSession()).thenReturn(new SimpleSession());
     Mockito.when(properties.getServerUrl()).thenReturn("http://somerspace.com");
     RedirectView view = ctrller.connect();
     // assert is valid URL syntax

--- a/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOOAuthTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIOOAuthTest.java
@@ -71,7 +71,6 @@ public class ProtocolsIOOAuthTest {
     ctrller.setMessageSource(new MessageSourceUtils(new JsonMessageSource()));
     shiroUtils = new ShiroTestUtils();
     shiroUtils.setSubject(subjct);
-    Mockito.lenient().when(subjct.getSession()).thenReturn(new SimpleSession());
     ReflectionTestUtils.setField(
         ctrller, "protocolsioAccessTokenUrl", PROTOCOLSIO_ACCESS_TOKEN_URL);
     ReflectionTestUtils.setField(ctrller, "protocolsioAuthUrl", PROTOCOLSIO_AUTH_URL);
@@ -89,6 +88,7 @@ public class ProtocolsIOOAuthTest {
 
   @Test
   public void connect() throws MalformedURLException {
+    Mockito.when(subjct.getSession()).thenReturn(new SimpleSession());
     Mockito.when(properties.getServerUrl()).thenReturn("http://somerspace.com");
     RedirectView view = ctrller.connect();
     // assert is valid URL syntax

--- a/src/test/java/com/researchspace/webapp/integrations/snapgene/DNAViewerControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/snapgene/DNAViewerControllerTest.java
@@ -9,7 +9,6 @@ import static com.researchspace.testutils.TestFactory.createAFileProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -71,15 +70,16 @@ public class DNAViewerControllerTest {
   public void before() {
     dnaController.setMessageSource(messages);
     edf.setExtension("gb");
-    lenient()
-        .when(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE))
-        .thenReturn(isSnapgeneAllowed);
-    lenient().when(isSnapgeneAllowed.getValue()).thenReturn(ALLOWED.name());
+  }
+
+  private void stubSnapgeneAllowed() {
+    when(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE)).thenReturn(isSnapgeneAllowed);
+    when(isSnapgeneAllowed.getValue()).thenReturn(ALLOWED.name());
   }
 
   @Test
   public void successScenario() throws IOException {
-    setupMocks();
+    setupPngMocks(true);
     mockSuccessfulSnapgeneCall();
     ResponseEntity<byte[]> bytes =
         dnaController.getPngView(1L, GeneratePngMapConfig.builder().build());
@@ -89,7 +89,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void snapGeneFailsScenario() throws IOException {
-    setupMocks();
+    setupPngMocks(true);
     mockErrorSnapgeneCall(HttpStatus.BAD_REQUEST);
     ResponseEntity<byte[]> bytes =
         dnaController.getPngView(1L, GeneratePngMapConfig.builder().build());
@@ -101,6 +101,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void statusFails() throws IOException {
+    stubSnapgeneAllowed();
     mockErrorSnapgeneStatus(HttpStatus.NOT_FOUND);
     ResponseEntity<String> bytes = dnaController.status();
     assertThat(
@@ -111,6 +112,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void statusSucceeds() throws IOException {
+    stubSnapgeneAllowed();
     mockSuccessfulSnapgeneStatus(HttpStatus.OK);
     ResponseEntity<String> bytes = dnaController.status();
     assertEquals("{\"json\": \"someData\"}", bytes.getBody());
@@ -119,6 +121,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void testEmptyErrorApiSucceedsWithoutThrowingException() {
+    stubSnapgeneAllowed();
     when(wsClient.status()).thenReturn(Either.left(null));
     ResponseEntity<String> bytes = dnaController.status();
     verify(wsClient).status();
@@ -129,6 +132,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void testWhenSnapgeneDeniedDoesNotAskForStatus() {
+    when(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE)).thenReturn(isSnapgeneAllowed);
     when(isSnapgeneAllowed.getValue()).thenReturn(DENIED.name());
     ResponseEntity<String> bytes = dnaController.status();
     verifyNoInteractions(wsClient);
@@ -138,6 +142,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void testWhenSnapgeneDeniedByDefaultDoesNotAskForStatus() {
+    when(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE)).thenReturn(isSnapgeneAllowed);
     when(isSnapgeneAllowed.getValue()).thenReturn(DENIED_BY_DEFAULT.name());
     ResponseEntity<String> bytes = dnaController.status();
     verifyNoInteractions(wsClient);
@@ -147,7 +152,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void permissionFailureOccursBeforeWSCall() throws Exception {
-    setupMocks();
+    setupPngMocks(false);
     when(perms.isRecordAccessPermitted(user, edf, PermissionType.READ)).thenReturn(false);
     assertThrows(
         AuthorizationException.class,
@@ -157,7 +162,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void rejectTooBigFileBeforeWsCall() throws Exception {
-    setupMocks();
+    setupPngMocks(false);
     edf.setSize(DNAViewerController.MAX_SNAPGENE_FILE_SIZE + 1);
     CoreTestUtils.assertIllegalArgumentException(
         () -> dnaController.getPngView(1L, GeneratePngMapConfig.builder().build()));
@@ -166,17 +171,19 @@ public class DNAViewerControllerTest {
 
   @Test
   public void rejectUnsupportedFileTypeBeforeWsCall() throws Exception {
-    setupMocks();
+    setupPngMocks(false);
     edf.setExtension("xyzz");
     assertIllegalArgumentException(
         () -> dnaController.getPngView(1L, GeneratePngMapConfig.builder().build()));
     verifyNoInteractions(wsClient);
   }
 
-  private void setupMocks() throws IOException {
+  private void setupPngMocks(boolean includeFileLookup) throws IOException {
     edf.setFileProperty(fp);
     when(userManager.getAuthenticatedUserInSession()).thenReturn(user);
-    lenient().when(fileStore.findFile(Mockito.eq(fp))).thenReturn(someGenbankFile);
+    if (includeFileLookup) {
+      when(fileStore.findFile(Mockito.eq(fp))).thenReturn(someGenbankFile);
+    }
     when(rcdMgr.get(1L)).thenReturn(edf);
     when(perms.isRecordAccessPermitted(user, edf, PermissionType.READ)).thenReturn(true);
   }

--- a/src/test/java/com/researchspace/webapp/integrations/snapgene/DNAViewerControllerTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/snapgene/DNAViewerControllerTest.java
@@ -9,7 +9,6 @@ import static com.researchspace.testutils.TestFactory.createAFileProperty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -69,15 +68,16 @@ public class DNAViewerControllerTest {
   @BeforeEach
   public void before() {
     edf.setExtension("gb");
-    lenient()
-        .when(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE))
-        .thenReturn(isSnapgeneAllowed);
-    lenient().when(isSnapgeneAllowed.getValue()).thenReturn(ALLOWED.name());
+  }
+
+  private void stubSnapgeneAllowed() {
+    when(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE)).thenReturn(isSnapgeneAllowed);
+    when(isSnapgeneAllowed.getValue()).thenReturn(ALLOWED.name());
   }
 
   @Test
   public void successScenario() throws IOException {
-    setupMocks();
+    setupPngMocks(true);
     mockSuccessfulSnapgeneCall();
     ResponseEntity<byte[]> bytes =
         dnaController.getPngView(1L, GeneratePngMapConfig.builder().build());
@@ -87,7 +87,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void snapGeneFailsScenario() throws IOException {
-    setupMocks();
+    setupPngMocks(true);
     mockErrorSnapgeneCall(HttpStatus.BAD_REQUEST);
     ResponseEntity<byte[]> bytes =
         dnaController.getPngView(1L, GeneratePngMapConfig.builder().build());
@@ -99,6 +99,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void statusFails() throws IOException {
+    stubSnapgeneAllowed();
     mockErrorSnapgeneStatus(HttpStatus.NOT_FOUND);
     ResponseEntity<String> bytes = dnaController.status();
     assertThat(bytes.getBody(), Matchers.startsWith("Snapgene webservice call failed"));
@@ -107,6 +108,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void statusSucceeds() throws IOException {
+    stubSnapgeneAllowed();
     mockSuccessfulSnapgeneStatus(HttpStatus.OK);
     ResponseEntity<String> bytes = dnaController.status();
     assertEquals("{\"json\": \"someData\"}", bytes.getBody());
@@ -115,6 +117,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void testEmptyErrorApiSucceedsWithoutThrowingException() {
+    stubSnapgeneAllowed();
     when(wsClient.status()).thenReturn(Either.left(null));
     ResponseEntity<String> bytes = dnaController.status();
     verify(wsClient).status();
@@ -124,6 +127,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void testWhenSnapgeneDeniedDoesNotAskForStatus() {
+    when(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE)).thenReturn(isSnapgeneAllowed);
     when(isSnapgeneAllowed.getValue()).thenReturn(DENIED.name());
     ResponseEntity<String> bytes = dnaController.status();
     verifyNoInteractions(wsClient);
@@ -133,6 +137,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void testWhenSnapgeneDeniedByDefaultDoesNotAskForStatus() {
+    when(systemPropertyManagerImpl.findByName(SNAPGENE_AVAILABLE)).thenReturn(isSnapgeneAllowed);
     when(isSnapgeneAllowed.getValue()).thenReturn(DENIED_BY_DEFAULT.name());
     ResponseEntity<String> bytes = dnaController.status();
     verifyNoInteractions(wsClient);
@@ -142,7 +147,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void permissionFailureOccursBeforeWSCall() throws Exception {
-    setupMocks();
+    setupPngMocks(false);
     when(perms.isRecordAccessPermitted(user, edf, PermissionType.READ)).thenReturn(false);
     assertThrows(
         AuthorizationException.class,
@@ -152,7 +157,7 @@ public class DNAViewerControllerTest {
 
   @Test
   public void rejectTooBigFileBeforeWsCall() throws Exception {
-    setupMocks();
+    setupPngMocks(false);
     edf.setSize(DNAViewerController.MAX_SNAPGENE_FILE_SIZE + 1);
     CoreTestUtils.assertIllegalArgumentException(
         () -> dnaController.getPngView(1L, GeneratePngMapConfig.builder().build()));
@@ -161,17 +166,19 @@ public class DNAViewerControllerTest {
 
   @Test
   public void rejectUnsupportedFileTypeBeforeWsCall() throws Exception {
-    setupMocks();
+    setupPngMocks(false);
     edf.setExtension("xyzz");
     assertIllegalArgumentException(
         () -> dnaController.getPngView(1L, GeneratePngMapConfig.builder().build()));
     verifyNoInteractions(wsClient);
   }
 
-  private void setupMocks() throws IOException {
+  private void setupPngMocks(boolean includeFileLookup) throws IOException {
     edf.setFileProperty(fp);
     when(userManager.getAuthenticatedUserInSession()).thenReturn(user);
-    lenient().when(fileStore.findFile(Mockito.eq(fp))).thenReturn(someGenbankFile);
+    if (includeFileLookup) {
+      when(fileStore.findFile(Mockito.eq(fp))).thenReturn(someGenbankFile);
+    }
     when(rcdMgr.get(1L)).thenReturn(edf);
     when(perms.isRecordAccessPermitted(user, edf, PermissionType.READ)).thenReturn(true);
   }

--- a/src/test/java/com/researchspace/webapp/integrations/wopi/WopiAuthorisationInterceptorTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/wopi/WopiAuthorisationInterceptorTest.java
@@ -45,7 +45,7 @@ public class WopiAuthorisationInterceptorTest extends SpringTransactionalTest {
     testUser = doCreateAndInitUser(getRandomAlphabeticString("wopi"));
     shiroTestUtils = new ShiroTestUtils();
     shiroTestUtils.setSubject(subject);
-    Mockito.lenient().when(subject.getSession()).thenReturn(new SimpleSession());
+    Mockito.when(subject.getSession()).thenReturn(new SimpleSession());
   }
 
   @AfterEach

--- a/src/test/java/com/researchspace/webapp/integrations/wopi/WopiAuthorisationInterceptorTest.java
+++ b/src/test/java/com/researchspace/webapp/integrations/wopi/WopiAuthorisationInterceptorTest.java
@@ -12,14 +12,12 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.shiro.session.mgt.SimpleSession;
 import org.apache.shiro.subject.Subject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -45,7 +43,6 @@ public class WopiAuthorisationInterceptorTest extends SpringTransactionalTest {
     testUser = doCreateAndInitUser(getRandomAlphabeticString("wopi"));
     shiroTestUtils = new ShiroTestUtils();
     shiroTestUtils.setSubject(subject);
-    Mockito.when(subject.getSession()).thenReturn(new SimpleSession());
   }
 
   @AfterEach

--- a/src/test/java/com/researchspace/webapp/integrations/wopi/WopiControllerTestMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/wopi/WopiControllerTestMVCIT.java
@@ -13,14 +13,12 @@ import com.researchspace.model.EcatDocumentFile;
 import com.researchspace.model.User;
 import com.researchspace.service.impl.ShiroTestUtils;
 import com.researchspace.webapp.controller.MVCTestBase;
-import org.apache.shiro.session.mgt.SimpleSession;
 import org.apache.shiro.subject.Subject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
@@ -54,7 +52,6 @@ public class WopiControllerTestMVCIT extends MVCTestBase {
     setUpUserWithInitialisedContent(testUser);
     shiroTestUtils = new ShiroTestUtils();
     shiroTestUtils.setSubject(subject);
-    Mockito.when(subject.getSession()).thenReturn(new SimpleSession());
 
     // proof keys only validated in a specific test
     proofKeyInterceptor.setProofKeyValidationEnabled("false");

--- a/src/test/java/com/researchspace/webapp/integrations/wopi/WopiControllerTestMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/wopi/WopiControllerTestMVCIT.java
@@ -54,7 +54,7 @@ public class WopiControllerTestMVCIT extends MVCTestBase {
     setUpUserWithInitialisedContent(testUser);
     shiroTestUtils = new ShiroTestUtils();
     shiroTestUtils.setSubject(subject);
-    Mockito.lenient().when(subject.getSession()).thenReturn(new SimpleSession());
+    Mockito.when(subject.getSession()).thenReturn(new SimpleSession());
 
     // proof keys only validated in a specific test
     proofKeyInterceptor.setProofKeyValidationEnabled("false");


### PR DESCRIPTION
-- AI Writing below --

## Summary

Tightens Mockito strict-stubbing across the test suite. Shared setup now contains only stubs used by every test, while scenario-specific stubs live beside the tests that need them.

Strict stubbing also exposed several tests that passed without exercising the behavior described by their names. Those tests now assert the intended interactions directly.

This PR changes 83 files, all under `src/test/java`. It does not change production code or runtime behavior.

## What changed

- Removed `lenient()` calls and lenient class-level Mockito settings.
- Deleted unused stubs and moved conditional stubs into focused setup helpers.
- Added `MockitoExtension` to standalone tests that previously created unmanaged mocks.
- Replaced hand-written servlet and JSP mock state with Spring test doubles.
- Removed dead parameters from shared test fixtures.
- Fixed tests that previously passed because mocks returned default values.

## Files for human review

| File | Review focus |
| --- | --- |
| `src/test/java/com/researchspace/webapp/controller/IntegrationControllerTest.java` | The integration listing test now supplies the authenticated user. Previously the controller received `null`, the mock did not match, and the assertion passed on an empty result. |
| `src/test/java/com/researchspace/webapp/controller/WorkspacePermissionsDTOBuilderTest.java` | Media records and snippets now directly assert that move-permission evaluation short-circuits before `RecordManager.canMove`. This preserves the RSPAC-999 behavior check. |
| `src/test/java/com/researchspace/api/v1/controller/SysadminApiControllerTest.java` | The licence-unavailable disable test now starts with an enabled user and proves that disabling succeeds without consulting the licence service. |
| `src/test/java/com/researchspace/service/impl/IntegrationsHandlerTest.java` | A DSW URL-only edit now asserts that credential lookup, deletion, and saving are never attempted. |
| `src/test/java/com/researchspace/service/impl/RecordSharingManagerImplTest.java` | Permission parsing delegates to the real `PermissionUtils` mapping instead of duplicating it in a mock answer. |
| `src/test/java/com/axiope/webapp/taglib/AssetUrlTagTest.java` and `BundleTagTest.java` | These fixtures now use Spring servlet test doubles. Review request, application, writer, cache, development-mode, and HMR behavior. |
| `src/test/java/com/researchspace/webapp/controller/WorkspaceControllerTest.java` | Shared stubs were split by scenario, and the static custom-form menu cache is cleared between tests. |
| `src/test/java/com/researchspace/service/impl/MockFolderStructure.java`, `src/test/java/com/researchspace/testutils/FolderTestUtils.java`, and `src/test/java/com/researchspace/service/FolderOrganisationAndApiInboxFolderTest.java` | The unused external-folder parameter was removed. Callers now own any `FolderManager.getFolder` setup they require. |

The remaining changes are mostly mechanical removal or relocation of unused Mockito stubs.

## Verification

- 106 distinct focused tests passed across 11 affected test classes.
- The final 43-test DSW and sysadmin rerun passed after the strictness cleanup.
- `git diff --check` passes.
- Repository scan confirms no `lenient(...)` calls remain under `src/test/java`.
