### PR TITLE
RSDEV-1246: template link fields with a default link (+ RSDEV-1270 link-row fix, link UI rework)

### DIFF
--- a/DevDocs/CONTEXT.md
+++ b/DevDocs/CONTEXT.md
@@ -23,6 +23,30 @@ these causes, and the state is indistinguishable from "record does not exist"
 so that existence is never disclosed (see ADR-0002).
 _Avoid_: Item unshared, unshared, hidden
 
+**Allowed relationship types**:
+The whitelist a template's Link field declares, naming which DataCite relation
+types items created from that template may use. An empty whitelist means all of
+them. It constrains choice; it does not supply a value.
+_Avoid_: permitted relations, relation options
+
+**Default link**:
+The complete relation-type-and-target pair a template's Link field may carry,
+stamped onto every item created from that template as that item's own ordinary,
+editable link. Its relation type must be one the same field allows. Both halves
+are set together or not at all: a relation type without a target, or a target
+without a relation type, is not a link and cannot be a default (RSDEV-1246).
+Distinct from the **allowed relationship types**, which constrain what an item
+may choose rather than choosing for it.
+_Avoid_: default target, default relation, template link, pre-set link
+
+**Stamped**:
+Copied onto an item at the moment that item is created from a template, after
+which the copy belongs to the item alone. A later edit to the template's default
+link never reaches items already created, and an item updated to a newer
+template version is never re-stamped. The same word already describes how a
+custom field's default value reaches a new item.
+_Avoid_: inherited, synced, propagated, applied
+
 **Open (link card action)**:
 Navigates to the link target. Offered only when following it lands somewhere
 useful: removed for deleted or inaccessible ELN targets (their routes produce

--- a/DevDocs/adr/0006-template-default-link-is-whole-or-nothing.md
+++ b/DevDocs/adr/0006-template-default-link-is-whole-or-nothing.md
@@ -1,0 +1,109 @@
+---
+status: proposed
+---
+
+# A template's default link is whole or nothing
+
+## Context
+
+RSDEV-1131 gave Inventory items structured Link fields. A template's Link field
+declares a name and a set of **allowed relationship types**; the item created
+from it supplies the actual link. RSDEV-1246 asks templates to also supply a
+default, so items arrive with the link already set.
+
+An `InventoryLink` row is `(relation_type, target_globalid, target_prefix,
+target_db_id, version_pin?)` and the first four columns are all `NOT NULL`
+(`changeLog-rsdev-1131.xml`). Nothing half-built is ever persisted today,
+because an item's link row is only created at the moment a user picks both
+halves at once in the editor.
+
+Two facts shape the options:
+
+- `InventoryEntityField` is the single table behind both template fields and
+  item fields, and it already carries `link_id`. On an item field that column
+  holds the item's link. On a template field it is always `NULL`, deliberately:
+  `ApiFieldToModelFieldFactory` never sets a link when building a template
+  field, `ApiInventoryEntityField.applyChangesToDatabaseTemplateField`
+  re-applies only the whitelist, and `SampleApiManagerImpl.updateDbSample`
+  skips the link write path when the entity is a template.
+- Every other field type already puts a template's default value in the same
+  column an item's value lives in: a text template field's default sits in
+  `data`, and `SampleEntity.copy` clones it onto the new item via
+  `shallowCopy()`. `InventoryLinkField.shallowCopy()` already deep-copies the
+  link, so a template field holding a link would already be stamped onto items
+  with no new copy code.
+
+The tension: putting the default in `link_id` matches every other field type
+and needs no schema change, but a link row cannot express "target chosen,
+relation type not yet" or the reverse. Supporting each half independently
+therefore costs either two new nullable columns on `InventoryEntityField` or a
+relaxation of `InventoryLink`'s `NOT NULL` constraints.
+
+## Considered options
+
+1. **Whole or nothing, stored in the existing `link_id`.** The template author
+   picks a relation type and a target together or leaves the field with no
+   default. No schema change, no new API fields, no new copy code.
+2. **Two nullable default columns** (`default_relation_type`,
+   `default_target_globalid`) beside `allowed_relation_types`. Each half
+   settable alone. Costs a changeset, two API fields, and a second notion of
+   "a link" that the rest of the system does not understand.
+3. **Relax `InventoryLink`'s `NOT NULL` columns** so one storage slot holds
+   partial defaults. Cheapest schema-wise, but every consumer of
+   `InventoryLink` (API serialisation, mandatory-field validation, referencing
+   items, target summary, archive export, Envers audit) must then tolerate
+   half-empty rows, including for real item links, forever.
+
+## Decision
+
+Option 1. A template's Link field either carries a complete `InventoryLink` in
+its existing `link_id`, or it carries no default at all. `InventoryLink` keeps
+its `NOT NULL` constraints and gains no new states.
+
+Consequences that follow from reusing the item write path rather than inventing
+a template one:
+
+- The default is validated exactly like an item's link: relation type in the
+  DataCite vocabulary, target syntactically valid, of an allowed target kind,
+  existing and readable by the template author, and not the template itself.
+  Its relation type must additionally be one the field's own whitelist allows.
+- The default may pin a target version, because the editor already offers it
+  and `InventoryLink.shallowCopy()` already carries `version_pin` and
+  `target_revision_id`. A pinned default stays pinned: an item created a year
+  later links to the version captured when the template was edited.
+- A default whose target is later deleted, or which the item's creator cannot
+  read, is stamped verbatim anyway. Both states already have defined behaviour
+  for links made directly on an item (ADR-0002), and the alternative would make
+  the same template produce different items for different users.
+- A template holding a default link appears in its target's "referenced by"
+  list, because `findReferencingItems` already queries every
+  `InventoryLinkField` without excluding templates. This is wanted: it shows
+  that new items will keep being created pointing at that record.
+
+## Consequences
+
+Good:
+
+- No Liquibase changeset, no new API field, no new model state. The work is
+  removing three deliberate suppressions of a path that already exists.
+- `InventoryLink` stays a type that is always complete, so no read path
+  anywhere gains a null branch.
+- Items are stamped by the existing `shallowCopy()` chain, so bulk creation,
+  API creation and UI creation behave identically without three code paths.
+
+Bad:
+
+- A template author cannot pre-select a relation type without also choosing a
+  target. If that turns out to be wanted, it arrives as option 2 later; the
+  migration is additive, but items created in the meantime will have been
+  stamped under the older rule.
+- Once templates hold links, `InventoryLink` rows are no longer exclusively
+  owned by concrete items. Anything that assumes "a link implies an item" must
+  be checked; `findReferencingItems` is the known case and is being embraced
+  rather than filtered.
+
+Neutral:
+
+- Archive export/import does not carry `InventoryLink` at all today, so a
+  default link does not survive export. Pre-existing gap, unchanged by this
+  decision.

--- a/DevDocs/adr/0006-template-default-link-is-whole-or-nothing.md
+++ b/DevDocs/adr/0006-template-default-link-is-whole-or-nothing.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # A template's default link is whole or nothing

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
@@ -67,6 +67,24 @@ public class ApiInventoryEntityField extends ApiField {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private ApiInventoryLink link;
 
+  /**
+   * Whether the incoming payload mentioned {@code link} at all, so that an explicit {@code "link":
+   * null} ("clear it") can be told apart from a partial update that simply does not mention it. Set
+   * by the hand-written {@link #setLink} below, which replaces Lombok's generated one.
+   *
+   * <p>Without the distinction, absent meant clear: a template PUT naming only the field's
+   * allowed-relation-types (exactly the request the whitelist-conflict error asks the user to make)
+   * silently destroyed that field's default link, and left the whitelist guard seeing a null link
+   * so it passed (RSDEV-1246). Excluded from JSON, equals and toString: it describes the payload,
+   * not the field.
+   */
+  @JsonIgnore @EqualsAndHashCode.Exclude @ToString.Exclude private boolean linkProvided;
+
+  public void setLink(ApiInventoryLink link) {
+    this.link = link;
+    this.linkProvided = true;
+  }
+
   @JsonProperty("mandatory")
   private Boolean mandatory;
 

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
@@ -68,15 +68,11 @@ public class ApiInventoryEntityField extends ApiField {
   private ApiInventoryLink link;
 
   /**
-   * Whether the incoming payload mentioned {@code link} at all, so that an explicit {@code "link":
-   * null} ("clear it") can be told apart from a partial update that simply does not mention it. Set
-   * by the hand-written {@link #setLink} below, which replaces Lombok's generated one.
-   *
-   * <p>Without the distinction, absent meant clear: a template PUT naming only the field's
-   * allowed-relation-types (exactly the request the whitelist-conflict error asks the user to make)
-   * silently destroyed that field's default link, and left the whitelist guard seeing a null link
-   * so it passed (RSDEV-1246). Excluded from JSON, equals and toString: it describes the payload,
-   * not the field.
+   * Whether the incoming payload mentioned {@code link} at all, telling an explicit {@code "link":
+   * null} apart from a partial update that never mentions it. Without the distinction, a template
+   * PUT naming only allowed-relation-types destroyed that field's default link (RSDEV-1246). Set by
+   * the hand-written {@link #setLink} below. Excluded from JSON, equals and toString: it describes
+   * the payload, not the field.
    */
   @JsonIgnore @EqualsAndHashCode.Exclude @ToString.Exclude private boolean linkProvided;
 
@@ -161,9 +157,8 @@ public class ApiInventoryEntityField extends ApiField {
       InventoryLinkField linkField = (InventoryLinkField) field;
       setAllowedRelationTypes(splitRelationTypes(linkField.getAllowedRelationTypes()));
       if (linkField.getLink() != null) {
-        // assign the field, not the setter: linkProvided means "the client sent a link key", and
-        // this is the outgoing direction. Going through setLink would make it true on every
-        // serialized field and rob the flag of its meaning.
+        // the field, not the setter: this is the outgoing direction, and setLink would set
+        // linkProvided on every serialized field, robbing the flag of its meaning
         this.link = new ApiInventoryLink(linkField.getLink());
       }
     }

--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryEntityField.java
@@ -161,7 +161,10 @@ public class ApiInventoryEntityField extends ApiField {
       InventoryLinkField linkField = (InventoryLinkField) field;
       setAllowedRelationTypes(splitRelationTypes(linkField.getAllowedRelationTypes()));
       if (linkField.getLink() != null) {
-        setLink(new ApiInventoryLink(linkField.getLink()));
+        // assign the field, not the setter: linkProvided means "the client sent a link key", and
+        // this is the outgoing direction. Going through setLink would make it true on every
+        // serialized field and rob the flag of its meaning.
+        this.link = new ApiInventoryLink(linkField.getLink());
       }
     }
 

--- a/src/main/java/com/researchspace/service/inventory/ApiExtraFieldsHelper.java
+++ b/src/main/java/com/researchspace/service/inventory/ApiExtraFieldsHelper.java
@@ -187,8 +187,8 @@ public class ApiExtraFieldsHelper implements Validator {
    * would linger with {@code deleted=false} after its parent field is gone. (The
    * structured-link-field clear path differs deliberately: clearing a value dereferences the row,
    * which the orphanRemoval mapping hard-deletes at flush; see {@code
-   * SampleApiManagerImpl#applyLinkFieldValue}.) No-op for non-link fields or a link field that has
-   * no link yet.
+   * InventoryApiManagerImpl#applyLinkFieldValue}.) No-op for non-link fields or a link field that
+   * has no link yet.
    */
   private void softDeleteLinkIfPresent(ExtraField dbField, User user) {
     if (dbField instanceof ExtraLinkField) {

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -264,8 +264,25 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
    * so the target is parsed/validated and the Envers revision captured. Mirrors the implementation
    * in {@link SampleApiManagerImpl}.
    */
+  /** Item semantics: see the four-argument overload. */
   boolean applyLinkFieldValue(
       InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    return applyLinkFieldValue(field, apiField, user, false);
+  }
+
+  /**
+   * @param omittedLinkPreservesExisting how to read a payload carrying no {@code link} key at all.
+   *     True for a <b>template</b> field, whose PUT accepts a partial field list, so a
+   *     whitelist-only edit must not destroy the default link. False for an <b>item</b> field,
+   *     whose field list always arrives complete, so an absent link means the user cleared it
+   *     (RSDEV-1131). An explicit {@code "link": null} clears in both cases. Mirrors {@link
+   *     SampleApiManagerImpl}.
+   */
+  boolean applyLinkFieldValue(
+      InventoryLinkField field,
+      ApiInventoryEntityField apiField,
+      User user,
+      boolean omittedLinkPreservesExisting) {
     ApiInventoryLink apiLink = apiField.getLink();
     String target = apiLink == null ? null : apiLink.getTargetGlobalId();
     InventoryLink existing = field.getLink();
@@ -273,8 +290,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       if (existing == null) {
         return false;
       }
-      if (!apiField.isLinkProvided()) {
-        // a partial update that never mentions the link: leave it alone rather than destroy it
+      if (omittedLinkPreservesExisting && !apiField.isLinkProvided()) {
+        // a partial template update that never mentions the link: leave it alone
         return false;
       }
       field.setLink(null);
@@ -330,7 +347,9 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
               .findFirst();
       if (dbFieldOpt.isPresent()) {
         rejectSelfLink(apiField.getLink(), dbInstrument);
-        changed |= applyLinkFieldValue((InventoryLinkField) dbFieldOpt.get(), apiField, user);
+        changed |=
+            applyLinkFieldValue(
+                (InventoryLinkField) dbFieldOpt.get(), apiField, user, dbInstrument.isTemplate());
       }
     }
     return changed;
@@ -349,7 +368,10 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
 
   private void rejectSelfLink(ApiInventoryLink apiLink, InstrumentEntity dbInstrument) {
     // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
-    // now reached while creating a template, which has no id yet (and so nothing to self-link to)
+    // now reached while creating a template, which has no id yet (and so nothing to self-link to).
+    // Returning early there is not a hole: the template is not in the database yet either, so
+    // InventoryLinkManager.createLink's target-exists-and-readable check rejects its own future
+    // Global ID before any link row is written. Same reasoning as SampleApiManagerImpl.
     if (apiLink == null || dbInstrument.getId() == null || dbInstrument.getOid() == null) {
       return;
     }
@@ -702,7 +724,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       // the same self-link rejection the edit path applies: adding a link field to an already-saved
       // template must not be a way in for a default that targets that very template
       rejectSelfLink(apiField.getLink(), dbTemplate);
-      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user, true);
     }
   }
 

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -50,7 +50,6 @@ import com.researchspace.service.inventory.SampleApiManager;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -81,7 +80,6 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   private @Autowired InstrumentTemplateDao instrumentTemplateDao;
   private @Autowired InventoryEntityFieldDao inventoryEntityFieldDao;
   private @Autowired SampleApiManager sampleApiManager;
-  private @Autowired InventoryLinkManager inventoryLinkManager;
   private @Autowired InventoryMoveHelper inventoryMoveHelper;
   private @Autowired InventoryAuditApiManager inventoryAuditMgr;
   private @Autowired ApiFieldToModelFieldFactory apiFieldToModelFieldFactory;
@@ -302,9 +300,13 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
    * Applies link values to an existing instrument's structured link fields (the update path). The
    * DTO apply loop leaves link fields untouched because it cannot reach the service-layer {@link
    * InventoryLinkManager}; this matches each modified link field by id and applies it here.
+   *
+   * <p>Takes an {@link ApiInstrumentEntity}/{@link InstrumentEntity}, not the concrete instrument
+   * pair: a template's link field carries an editable default link of its own (RSDEV-1246), so
+   * templates go through the same write path as instruments.
    */
-  private boolean applyLinkFieldValuesOnUpdate(
-      ApiInstrument apiInstrument, Instrument dbInstrument, User user) {
+  boolean applyLinkFieldValuesOnUpdate(
+      ApiInstrumentEntity apiInstrument, InstrumentEntity dbInstrument, User user) {
     if (apiInstrument.getFields() == null) {
       return false;
     }
@@ -335,17 +337,13 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       throw new ApiRuntimeException(
           "errors.inventory.field.link.relationTypeInvalid", relationType);
     }
-    String allowed = field.getAllowedRelationTypes();
-    if (allowed == null || allowed.trim().isEmpty()) {
-      return;
-    }
-    if (!Arrays.asList(allowed.split("\\|")).contains(relationType)) {
+    if (!isRelationPermitted(field, relationType)) {
       throw new ApiRuntimeException(
           "errors.inventory.field.link.relationTypeNotPermitted", relationType, field.getName());
     }
   }
 
-  private void rejectSelfLink(ApiInventoryLink apiLink, Instrument dbInstrument) {
+  private void rejectSelfLink(ApiInventoryLink apiLink, InstrumentEntity dbInstrument) {
     if (apiLink == null || dbInstrument.getOid() == null) {
       return;
     }
@@ -660,7 +658,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     template.setCreatedBy(user.getUsername());
     template.setModifiedBy(user.getUsername(), IActiveUserStrategy.CHECK_OPERATE_AS);
     setBasicFieldsFromNewIncomingApiInventoryRecord(template, post, user);
-    addFieldsToNewInstrumentTemplate(post, template);
+    addFieldsToNewInstrumentTemplate(post, template, user);
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNames(template);
     InstrumentTemplate savedTemplate = instrumentTemplateDao.persistInstrumentTemplate(template);
     saveIncomingInstrumentImage(savedTemplate, post, user);
@@ -672,12 +670,27 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     return result;
   }
 
-  private void addFieldsToNewInstrumentTemplate(
-      ApiInstrumentTemplatePost post, InstrumentTemplate template) {
+  void addFieldsToNewInstrumentTemplate(
+      ApiInstrumentTemplatePost post, InstrumentTemplate template, User user) {
     for (ApiInventoryEntityField apiField : post.getFields()) {
       InventoryEntityField toAdd =
           apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
+      applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
       addNewFieldToInstrumentTemplate(template, toAdd);
+    }
+  }
+
+  /**
+   * Applies a template link field's optional default link (RSDEV-1246). The stateless {@link
+   * ApiFieldToModelFieldFactory} sets only the allowed-relation-types whitelist, so the default has
+   * to be created here, through the same {@link InventoryLinkManager} write path an instrument's
+   * link uses. Mirrors the equivalent in {@link SampleApiManagerImpl}. No-op for any other field
+   * type, and for a link field whose payload carries no link.
+   */
+  private void applyDefaultLinkOfNewTemplateField(
+      InventoryEntityField toAdd, ApiInventoryEntityField apiField, User user) {
+    if (toAdd instanceof InventoryLinkField) {
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
     }
   }
 
@@ -710,7 +723,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     try {
       dbTemplate = (InstrumentTemplate) getIfExists(dbTemplate.getId());
       boolean contentChanged =
-          createDeleteRequestedFieldsInDbInstrumentTemplate(apiTemplate, dbTemplate);
+          createDeleteRequestedFieldsInDbInstrumentTemplate(apiTemplate, dbTemplate, user);
       contentChanged |=
           extraFieldHelper.createDeleteRequestedExtraFieldsInDatabaseInstrument(
               apiTemplate, dbTemplate, user);
@@ -723,6 +736,10 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
           identifiersHelper.createAssignRequestedIdentifiers(
               apiTemplate.getIdentifiers(), dbTemplate, user);
       contentChanged |= apiTemplate.applyChangesToDatabaseInstrument(dbTemplate, user);
+      // a template link field carries an editable default link of its own (RSDEV-1246), so the
+      // template goes through the same link write path as a concrete instrument
+      contentChanged |= applyLinkFieldValuesOnUpdate(apiTemplate, dbTemplate, user);
+      assertDefaultLinksMatchWhitelists(dbTemplate.getActiveFields());
       contentChanged |= saveSharingACLForIncomingApiInvRec(dbTemplate, apiTemplate);
       contentChanged |= saveIncomingInstrumentImage(dbTemplate, apiTemplate, user);
       if (contentChanged) {
@@ -741,8 +758,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     return result;
   }
 
-  private boolean createDeleteRequestedFieldsInDbInstrumentTemplate(
-      ApiInstrumentTemplate apiTemplate, InstrumentTemplate dbTemplate) {
+  boolean createDeleteRequestedFieldsInDbInstrumentTemplate(
+      ApiInstrumentTemplate apiTemplate, InstrumentTemplate dbTemplate, User user) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiTemplate.getFields(), null);
     boolean changed = false;
@@ -750,6 +767,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       if (apiField.isNewFieldRequest()) {
         InventoryEntityField toAdd =
             apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
+        applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
         addNewFieldToInstrumentTemplate(dbTemplate, toAdd);
         changed = true;
       }
@@ -770,6 +788,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
                   + " doesn't match id of any pre-existing template field");
         }
         dbTemplate.deleteInstrumentField(dbFieldOpt.get(), apiField.isDeleteFieldOnSampleUpdate());
+        softDeleteLinkOfDeletedLinkField(dbFieldOpt.get(), user);
         changed = true;
       }
     }
@@ -883,12 +902,22 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     try {
       dbInstrument = (Instrument) getIfExists(dbInstrument.getId());
       if (!dbTemplate.getVersion().equals(dbInstrument.getTemplateLinkedVersion())) {
+        // Snapshot the link fields before the sync: propagating a deleted template link-field marks
+        // the matching instrument field deleted in the model layer, which cannot soft-delete the
+        // field's InventoryLink. Reconcile those orphaned links once the sync has run, since
+        // getActiveFields() no longer returns them afterwards (RSDEV-1270).
+        List<InventoryLinkField> linkFieldsBeforeUpdate =
+            dbInstrument.getActiveFields().stream()
+                .filter(InventoryLinkField.class::isInstance)
+                .map(InventoryLinkField.class::cast)
+                .collect(Collectors.toList());
         boolean updated = dbInstrument.updateToLatestTemplateVersion();
         // the model sync above does not copy link-field allowed-relation-types whitelists, so an
         // existing instrument would otherwise keep its create-time whitelist after a template edit
         // (RSDEV-1200) — mirror the sample path and re-apply them here.
         boolean whitelistsChanged =
             syncLinkFieldWhitelistsFromTemplate(dbInstrument.getActiveFields());
+        linkFieldsBeforeUpdate.forEach(field -> softDeleteLinkOfDeletedLinkField(field, user));
         if (updated || whitelistsChanged) {
           saveDbInstrumentUpdate(dbInstrument, user);
         }

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -273,6 +273,10 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       if (existing == null) {
         return false;
       }
+      if (!apiField.isLinkProvided()) {
+        // a partial update that never mentions the link: leave it alone rather than destroy it
+        return false;
+      }
       field.setLink(null);
       return true;
     }
@@ -344,7 +348,9 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   }
 
   private void rejectSelfLink(ApiInventoryLink apiLink, InstrumentEntity dbInstrument) {
-    if (apiLink == null || dbInstrument.getOid() == null) {
+    // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
+    // now reached while creating a template, which has no id yet (and so nothing to self-link to)
+    if (apiLink == null || dbInstrument.getId() == null || dbInstrument.getOid() == null) {
       return;
     }
     GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
@@ -675,7 +681,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     for (ApiInventoryEntityField apiField : post.getFields()) {
       InventoryEntityField toAdd =
           apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
-      applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
+      applyDefaultLinkOfNewTemplateField(toAdd, apiField, template, user);
       addNewFieldToInstrumentTemplate(template, toAdd);
     }
   }
@@ -688,8 +694,14 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
    * type, and for a link field whose payload carries no link.
    */
   private void applyDefaultLinkOfNewTemplateField(
-      InventoryEntityField toAdd, ApiInventoryEntityField apiField, User user) {
+      InventoryEntityField toAdd,
+      ApiInventoryEntityField apiField,
+      InstrumentEntity dbTemplate,
+      User user) {
     if (toAdd instanceof InventoryLinkField) {
+      // the same self-link rejection the edit path applies: adding a link field to an already-saved
+      // template must not be a way in for a default that targets that very template
+      rejectSelfLink(apiField.getLink(), dbTemplate);
       applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
     }
   }
@@ -767,25 +779,24 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       if (apiField.isNewFieldRequest()) {
         InventoryEntityField toAdd =
             apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
-        applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
+        applyDefaultLinkOfNewTemplateField(toAdd, apiField, dbTemplate, user);
         addNewFieldToInstrumentTemplate(dbTemplate, toAdd);
         changed = true;
       }
       if (apiField.isDeleteFieldRequest()) {
+        // externalized, and an ApiRuntimeException so it maps to a 422 with the resolved bundle
+        // message; a raw IllegalArgumentException reached API clients as untranslated English.
+        // Same keys the sample counterpart uses.
         if (apiField.getId() == null) {
-          throw new IllegalArgumentException(
-              "'id' property not provided "
-                  + "for a template field with 'deleteFieldRequest' flag");
+          throw new ApiRuntimeException("errors.inventory.field.deleteRequest.idMissing");
         }
         Optional<InventoryEntityField> dbFieldOpt =
             dbTemplate.getActiveFields().stream()
                 .filter(f -> apiField.getId().equals(f.getId()))
                 .findFirst();
         if (dbFieldOpt.isEmpty()) {
-          throw new IllegalArgumentException(
-              "Field id: "
-                  + apiField.getId()
-                  + " doesn't match id of any pre-existing template field");
+          throw new ApiRuntimeException(
+              "errors.inventory.field.deleteRequest.idUnknown", apiField.getId());
         }
         dbTemplate.deleteInstrumentField(dbFieldOpt.get(), apiField.isDeleteFieldOnSampleUpdate());
         softDeleteLinkOfDeletedLinkField(dbFieldOpt.get(), user);
@@ -917,6 +928,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
         // (RSDEV-1200) — mirror the sample path and re-apply them here.
         boolean whitelistsChanged =
             syncLinkFieldWhitelistsFromTemplate(dbInstrument.getActiveFields());
+        clearRetroStampedDefaultLinks(dbInstrument, linkFieldsBeforeUpdate);
         linkFieldsBeforeUpdate.forEach(field -> softDeleteLinkOfDeletedLinkField(field, user));
         if (updated || whitelistsChanged) {
           saveDbInstrumentUpdate(dbInstrument, user);
@@ -928,6 +940,29 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       }
     }
     return getApiInstrumentById(instrumentId, user);
+  }
+
+  /**
+   * Clears the link of any link field the template sync has just cloned onto this instrument, so a
+   * template's default link is stamped at creation only and never retro-applied (see the "Stamped"
+   * entry in {@code DevDocs/CONTEXT.md} and ADR-0006).
+   *
+   * <p>Needed because the two model-layer syncs differ: {@code
+   * Sample#updateToLatestTemplateVersion} calls {@code clearValue()} on each newly cloned field,
+   * which {@code InventoryLinkField} overrides to null its link, whereas {@code
+   * Instrument#updateToLatestTemplateVersion} calls {@code setFieldData(null)}, which link fields
+   * do not override. Without this an existing instrument would silently acquire a copy of the
+   * template's current default.
+   *
+   * @param before the link fields active before the sync ran; anything not in it is newly cloned
+   */
+  private void clearRetroStampedDefaultLinks(
+      InstrumentEntity dbInstrument, List<InventoryLinkField> before) {
+    dbInstrument.getActiveFields().stream()
+        .filter(InventoryLinkField.class::isInstance)
+        .map(InventoryLinkField.class::cast)
+        .filter(field -> before.stream().noneMatch(seen -> seen == field))
+        .forEach(InventoryLinkField::clearValue);
   }
 
   @Override

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -51,7 +51,6 @@ import com.researchspace.service.inventory.SampleApiManager;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -75,7 +74,6 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   private @Autowired InstrumentTemplateDao instrumentTemplateDao;
   private @Autowired InventoryEntityFieldDao inventoryEntityFieldDao;
   private @Autowired SampleApiManager sampleApiManager;
-  private @Autowired InventoryLinkManager inventoryLinkManager;
   private @Autowired InventoryMoveHelper inventoryMoveHelper;
   private @Autowired InventoryAuditApiManager inventoryAuditMgr;
   private @Autowired ApiFieldToModelFieldFactory apiFieldToModelFieldFactory;
@@ -376,9 +374,13 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
    * Applies link values to an existing instrument's structured link fields (the update path). The
    * DTO apply loop leaves link fields untouched because it cannot reach the service-layer {@link
    * InventoryLinkManager}; this matches each modified link field by id and applies it here.
+   *
+   * <p>Takes an {@link ApiInstrumentEntity}/{@link InstrumentEntity}, not the concrete instrument
+   * pair: a template's link field carries an editable default link of its own (RSDEV-1246), so
+   * templates go through the same write path as instruments.
    */
-  private boolean applyLinkFieldValuesOnUpdate(
-      ApiInstrument apiInstrument, Instrument dbInstrument, User user) {
+  boolean applyLinkFieldValuesOnUpdate(
+      ApiInstrumentEntity apiInstrument, InstrumentEntity dbInstrument, User user) {
     if (apiInstrument.getFields() == null) {
       return false;
     }
@@ -408,17 +410,13 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     if (!DataCiteRelationType.isValid(relationType)) {
       throw new ApiRuntimeException("errors.inventory.field.linkRelationTypeInvalid", relationType);
     }
-    String allowed = field.getAllowedRelationTypes();
-    if (allowed == null || allowed.trim().isEmpty()) {
-      return;
-    }
-    if (!Arrays.asList(allowed.split("\\|")).contains(relationType)) {
+    if (!isRelationPermitted(field, relationType)) {
       throw new ApiRuntimeException(
           "errors.inventory.field.linkRelationTypeNotPermitted", relationType, field.getName());
     }
   }
 
-  private void rejectSelfLink(ApiInventoryLink apiLink, Instrument dbInstrument) {
+  private void rejectSelfLink(ApiInventoryLink apiLink, InstrumentEntity dbInstrument) {
     if (apiLink == null || dbInstrument.getOid() == null) {
       return;
     }
@@ -735,7 +733,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     template.setCreatedBy(user.getUsername());
     template.setModifiedBy(user.getUsername(), IActiveUserStrategy.CHECK_OPERATE_AS);
     setBasicFieldsFromNewIncomingApiInventoryRecord(template, post, user);
-    addFieldsToNewInstrumentTemplate(post, template);
+    addFieldsToNewInstrumentTemplate(post, template, user);
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNames(template);
     InstrumentTemplate savedTemplate = instrumentTemplateDao.persistInstrumentTemplate(template);
     saveIncomingInstrumentImage(savedTemplate, post, user);
@@ -747,12 +745,27 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     return result;
   }
 
-  private void addFieldsToNewInstrumentTemplate(
-      ApiInstrumentTemplatePost post, InstrumentTemplate template) {
+  void addFieldsToNewInstrumentTemplate(
+      ApiInstrumentTemplatePost post, InstrumentTemplate template, User user) {
     for (ApiInventoryEntityField apiField : post.getFields()) {
       InventoryEntityField toAdd =
           apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
+      applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
       addNewFieldToInstrumentTemplate(template, toAdd);
+    }
+  }
+
+  /**
+   * Applies a template link field's optional default link (RSDEV-1246). The stateless {@link
+   * ApiFieldToModelFieldFactory} sets only the allowed-relation-types whitelist, so the default has
+   * to be created here, through the same {@link InventoryLinkManager} write path an instrument's
+   * link uses. Mirrors the equivalent in {@link SampleApiManagerImpl}. No-op for any other field
+   * type, and for a link field whose payload carries no link.
+   */
+  private void applyDefaultLinkOfNewTemplateField(
+      InventoryEntityField toAdd, ApiInventoryEntityField apiField, User user) {
+    if (toAdd instanceof InventoryLinkField) {
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
     }
   }
 
@@ -785,7 +798,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     try {
       dbTemplate = (InstrumentTemplate) getIfExists(dbTemplate.getId());
       boolean contentChanged =
-          createDeleteRequestedFieldsInDbInstrumentTemplate(apiTemplate, dbTemplate);
+          createDeleteRequestedFieldsInDbInstrumentTemplate(apiTemplate, dbTemplate, user);
       contentChanged |=
           extraFieldHelper.createDeleteRequestedExtraFieldsInDatabaseInstrument(
               apiTemplate, dbTemplate, user);
@@ -798,6 +811,10 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
           identifiersHelper.createAssignRequestedIdentifiers(
               apiTemplate.getIdentifiers(), dbTemplate, user);
       contentChanged |= apiTemplate.applyChangesToDatabaseInstrument(dbTemplate, user);
+      // a template link field carries an editable default link of its own (RSDEV-1246), so the
+      // template goes through the same link write path as a concrete instrument
+      contentChanged |= applyLinkFieldValuesOnUpdate(apiTemplate, dbTemplate, user);
+      assertDefaultLinksMatchWhitelists(dbTemplate.getActiveFields());
       contentChanged |= saveSharingACLForIncomingApiInvRec(dbTemplate, apiTemplate);
       contentChanged |= saveIncomingInstrumentImage(dbTemplate, apiTemplate, user);
       if (contentChanged) {
@@ -816,8 +833,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     return result;
   }
 
-  private boolean createDeleteRequestedFieldsInDbInstrumentTemplate(
-      ApiInstrumentTemplate apiTemplate, InstrumentTemplate dbTemplate) {
+  boolean createDeleteRequestedFieldsInDbInstrumentTemplate(
+      ApiInstrumentTemplate apiTemplate, InstrumentTemplate dbTemplate, User user) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiTemplate.getFields(), null);
     boolean changed = false;
@@ -825,6 +842,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       if (apiField.isNewFieldRequest()) {
         InventoryEntityField toAdd =
             apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
+        applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
         addNewFieldToInstrumentTemplate(dbTemplate, toAdd);
         changed = true;
       }
@@ -845,6 +863,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
                   + " doesn't match id of any pre-existing template field");
         }
         dbTemplate.deleteInstrumentField(dbFieldOpt.get(), apiField.isDeleteFieldOnSampleUpdate());
+        softDeleteLinkOfDeletedLinkField(dbFieldOpt.get(), user);
         changed = true;
       }
     }
@@ -959,12 +978,22 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     try {
       dbInstrument = (Instrument) getIfExists(dbInstrument.getId());
       if (!dbTemplate.getVersion().equals(dbInstrument.getTemplateLinkedVersion())) {
+        // Snapshot the link fields before the sync: propagating a deleted template link-field marks
+        // the matching instrument field deleted in the model layer, which cannot soft-delete the
+        // field's InventoryLink. Reconcile those orphaned links once the sync has run, since
+        // getActiveFields() no longer returns them afterwards (RSDEV-1270).
+        List<InventoryLinkField> linkFieldsBeforeUpdate =
+            dbInstrument.getActiveFields().stream()
+                .filter(InventoryLinkField.class::isInstance)
+                .map(InventoryLinkField.class::cast)
+                .collect(Collectors.toList());
         boolean updated = dbInstrument.updateToLatestTemplateVersion();
         // the model sync above does not copy link-field allowed-relation-types whitelists, so an
         // existing instrument would otherwise keep its create-time whitelist after a template edit
         // (RSDEV-1200) — mirror the sample path and re-apply them here.
         boolean whitelistsChanged =
             syncLinkFieldWhitelistsFromTemplate(dbInstrument.getActiveFields());
+        linkFieldsBeforeUpdate.forEach(field -> softDeleteLinkOfDeletedLinkField(field, user));
         if (updated || whitelistsChanged) {
           saveDbInstrumentUpdate(dbInstrument, user);
         }

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -295,8 +295,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       String newFieldContent = apiField.getContent();
       InventoryEntityField inventoryEntityField = inventoryEntityFieldList.get(i);
 
-      if (inventoryEntityField instanceof InventoryLinkField) {
-        applyLinkFieldValueOnCreate((InventoryLinkField) inventoryEntityField, apiField, user);
+      if (inventoryEntityField instanceof InventoryLinkField linkField) {
+        applyLinkFieldValueOnCreate(linkField, apiField, user);
       } else if (inventoryEntityField.isOptionsStoringField()) {
         inventoryEntityField.setSelectedOptions(apiField.getSelectedOptions());
       } else if (inventoryEntityField == landingPage
@@ -702,8 +702,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
           identifiersHelper.createAssignRequestedIdentifiers(
               apiTemplate.getIdentifiers(), dbTemplate, user);
       contentChanged |= apiTemplate.applyChangesToDatabaseInstrument(dbTemplate, user);
-      // a template link field carries an editable default link of its own (RSDEV-1246), so the
-      // template goes through the same link write path as a concrete instrument
+      // a template link field carries a default link of its own (RSDEV-1246), so it goes through
+      // the same write path as a concrete instrument
       contentChanged |= applyLinkFieldValuesOnUpdate(apiTemplate, dbTemplate, user);
       assertDefaultLinksMatchWhitelists(dbTemplate.getActiveFields());
       contentChanged |= saveSharingACLForIncomingApiInvRec(dbTemplate, apiTemplate);
@@ -738,9 +738,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
         changed = true;
       }
       if (apiField.isDeleteFieldRequest()) {
-        // externalized, and an ApiRuntimeException so it maps to a 422 with the resolved bundle
-        // message; a raw IllegalArgumentException reached API clients as untranslated English.
-        // Same keys the sample counterpart uses.
+        // ApiRuntimeException so it maps to a resolved 422; a raw IllegalArgumentException
+        // reached clients as untranslated English. Same keys as the sample counterpart.
         if (apiField.getId() == null) {
           throw new ApiRuntimeException("errors.inventory.field.deleteRequestIdMissing");
         }
@@ -868,10 +867,9 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     try {
       dbInstrument = (Instrument) getIfExists(dbInstrument.getId());
       if (!dbTemplate.getVersion().equals(dbInstrument.getTemplateLinkedVersion())) {
-        // Snapshot the link fields before the sync: propagating a deleted template link-field marks
-        // the matching instrument field deleted in the model layer, which cannot soft-delete the
-        // field's InventoryLink. Reconcile those orphaned links once the sync has run, since
-        // getActiveFields() no longer returns them afterwards (RSDEV-1270).
+        // snapshot before the sync: it marks matching fields deleted in the model layer, which
+        // cannot soft-delete their InventoryLink, and getActiveFields() no longer returns them
+        // afterwards, so the orphans are reconciled from this list (RSDEV-1270)
         List<InventoryLinkField> linkFieldsBeforeUpdate =
             dbInstrument.getActiveFields().stream()
                 .filter(InventoryLinkField.class::isInstance)
@@ -898,23 +896,19 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   }
 
   /**
-   * Clears the link of any link field the template sync has just cloned onto this instrument, so a
-   * template's default link is stamped at creation only and never retro-applied (see the "Stamped"
-   * entry in {@code DevDocs/CONTEXT.md} and ADR-0006).
+   * Clears the link of any field the template sync has just cloned, so a default link is stamped at
+   * creation only and never retro-applied (ADR-0006).
    *
-   * <p>Needed because the two model-layer syncs differ: {@code
-   * Sample#updateToLatestTemplateVersion} calls {@code clearValue()} on each newly cloned field,
-   * which {@code InventoryLinkField} overrides to null its link, whereas {@code
-   * Instrument#updateToLatestTemplateVersion} calls {@code setFieldData(null)}, which link fields
-   * do not override. Without this an existing instrument would silently acquire a copy of the
-   * template's current default.
+   * <p>Compensates for a model-layer asymmetry: {@code Sample#updateToLatestTemplateVersion} calls
+   * {@code clearValue()}, which {@code InventoryLinkField} overrides to null its link, whereas
+   * {@code Instrument#updateToLatestTemplateVersion} calls {@code setFieldData(null)}, which it
+   * does not override.
    */
   void clearRetroStampedDefaultLinks(InstrumentEntity dbInstrument) {
     dbInstrument.getActiveFields().stream()
         .filter(InventoryLinkField.class::isInstance)
         .map(InventoryLinkField.class::cast)
-        // a field the sync has just cloned is exactly the one with no id yet, which is cheaper and
-        // more robust than comparing instance identity against a pre-sync snapshot
+        // a just-cloned field is exactly the one with no id yet
         .filter(field -> field.getId() == null)
         .forEach(InventoryLinkField::clearValue);
   }

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -338,8 +338,25 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
    * so the target is parsed/validated and the Envers revision captured. Mirrors the implementation
    * in {@link SampleApiManagerImpl}.
    */
+  /** Item semantics: see the four-argument overload. */
   boolean applyLinkFieldValue(
       InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    return applyLinkFieldValue(field, apiField, user, false);
+  }
+
+  /**
+   * @param omittedLinkPreservesExisting how to read a payload carrying no {@code link} key at all.
+   *     True for a <b>template</b> field, whose PUT accepts a partial field list, so a
+   *     whitelist-only edit must not destroy the default link. False for an <b>item</b> field,
+   *     whose field list always arrives complete, so an absent link means the user cleared it
+   *     (RSDEV-1131). An explicit {@code "link": null} clears in both cases. Mirrors {@link
+   *     SampleApiManagerImpl}.
+   */
+  boolean applyLinkFieldValue(
+      InventoryLinkField field,
+      ApiInventoryEntityField apiField,
+      User user,
+      boolean omittedLinkPreservesExisting) {
     ApiInventoryLink apiLink = apiField.getLink();
     String target = apiLink == null ? null : apiLink.getTargetGlobalId();
     InventoryLink existing = field.getLink();
@@ -347,8 +364,8 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       if (existing == null) {
         return false;
       }
-      if (!apiField.isLinkProvided()) {
-        // a partial update that never mentions the link: leave it alone rather than destroy it
+      if (omittedLinkPreservesExisting && !apiField.isLinkProvided()) {
+        // a partial template update that never mentions the link: leave it alone
         return false;
       }
       field.setLink(null);
@@ -404,7 +421,9 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
               .findFirst();
       if (dbFieldOpt.isPresent()) {
         rejectSelfLink(apiField.getLink(), dbInstrument);
-        changed |= applyLinkFieldValue((InventoryLinkField) dbFieldOpt.get(), apiField, user);
+        changed |=
+            applyLinkFieldValue(
+                (InventoryLinkField) dbFieldOpt.get(), apiField, user, dbInstrument.isTemplate());
       }
     }
     return changed;
@@ -422,7 +441,10 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
 
   private void rejectSelfLink(ApiInventoryLink apiLink, InstrumentEntity dbInstrument) {
     // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
-    // now reached while creating a template, which has no id yet (and so nothing to self-link to)
+    // now reached while creating a template, which has no id yet (and so nothing to self-link to).
+    // Returning early there is not a hole: the template is not in the database yet either, so
+    // InventoryLinkManager.createLink's target-exists-and-readable check rejects its own future
+    // Global ID before any link row is written. Same reasoning as SampleApiManagerImpl.
     if (apiLink == null || dbInstrument.getId() == null || dbInstrument.getOid() == null) {
       return;
     }
@@ -777,7 +799,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       // the same self-link rejection the edit path applies: adding a link field to an already-saved
       // template must not be a way in for a default that targets that very template
       rejectSelfLink(apiField.getLink(), dbTemplate);
-      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user, true);
     }
   }
 

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -347,6 +347,10 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       if (existing == null) {
         return false;
       }
+      if (!apiField.isLinkProvided()) {
+        // a partial update that never mentions the link: leave it alone rather than destroy it
+        return false;
+      }
       field.setLink(null);
       return true;
     }
@@ -417,7 +421,9 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   }
 
   private void rejectSelfLink(ApiInventoryLink apiLink, InstrumentEntity dbInstrument) {
-    if (apiLink == null || dbInstrument.getOid() == null) {
+    // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
+    // now reached while creating a template, which has no id yet (and so nothing to self-link to)
+    if (apiLink == null || dbInstrument.getId() == null || dbInstrument.getOid() == null) {
       return;
     }
     GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
@@ -750,7 +756,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     for (ApiInventoryEntityField apiField : post.getFields()) {
       InventoryEntityField toAdd =
           apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
-      applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
+      applyDefaultLinkOfNewTemplateField(toAdd, apiField, template, user);
       addNewFieldToInstrumentTemplate(template, toAdd);
     }
   }
@@ -763,8 +769,14 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
    * type, and for a link field whose payload carries no link.
    */
   private void applyDefaultLinkOfNewTemplateField(
-      InventoryEntityField toAdd, ApiInventoryEntityField apiField, User user) {
+      InventoryEntityField toAdd,
+      ApiInventoryEntityField apiField,
+      InstrumentEntity dbTemplate,
+      User user) {
     if (toAdd instanceof InventoryLinkField) {
+      // the same self-link rejection the edit path applies: adding a link field to an already-saved
+      // template must not be a way in for a default that targets that very template
+      rejectSelfLink(apiField.getLink(), dbTemplate);
       applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
     }
   }
@@ -842,25 +854,24 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       if (apiField.isNewFieldRequest()) {
         InventoryEntityField toAdd =
             apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
-        applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
+        applyDefaultLinkOfNewTemplateField(toAdd, apiField, dbTemplate, user);
         addNewFieldToInstrumentTemplate(dbTemplate, toAdd);
         changed = true;
       }
       if (apiField.isDeleteFieldRequest()) {
+        // externalized, and an ApiRuntimeException so it maps to a 422 with the resolved bundle
+        // message; a raw IllegalArgumentException reached API clients as untranslated English.
+        // Same keys the sample counterpart uses.
         if (apiField.getId() == null) {
-          throw new IllegalArgumentException(
-              "'id' property not provided "
-                  + "for a template field with 'deleteFieldRequest' flag");
+          throw new ApiRuntimeException("errors.inventory.field.deleteRequest.idMissing");
         }
         Optional<InventoryEntityField> dbFieldOpt =
             dbTemplate.getActiveFields().stream()
                 .filter(f -> apiField.getId().equals(f.getId()))
                 .findFirst();
         if (dbFieldOpt.isEmpty()) {
-          throw new IllegalArgumentException(
-              "Field id: "
-                  + apiField.getId()
-                  + " doesn't match id of any pre-existing template field");
+          throw new ApiRuntimeException(
+              "errors.inventory.field.deleteRequest.idUnknown", apiField.getId());
         }
         dbTemplate.deleteInstrumentField(dbFieldOpt.get(), apiField.isDeleteFieldOnSampleUpdate());
         softDeleteLinkOfDeletedLinkField(dbFieldOpt.get(), user);
@@ -993,6 +1004,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
         // (RSDEV-1200) — mirror the sample path and re-apply them here.
         boolean whitelistsChanged =
             syncLinkFieldWhitelistsFromTemplate(dbInstrument.getActiveFields());
+        clearRetroStampedDefaultLinks(dbInstrument, linkFieldsBeforeUpdate);
         linkFieldsBeforeUpdate.forEach(field -> softDeleteLinkOfDeletedLinkField(field, user));
         if (updated || whitelistsChanged) {
           saveDbInstrumentUpdate(dbInstrument, user);
@@ -1004,6 +1016,29 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       }
     }
     return getApiInstrumentById(instrumentId, user);
+  }
+
+  /**
+   * Clears the link of any link field the template sync has just cloned onto this instrument, so a
+   * template's default link is stamped at creation only and never retro-applied (see the "Stamped"
+   * entry in {@code DevDocs/CONTEXT.md} and ADR-0006).
+   *
+   * <p>Needed because the two model-layer syncs differ: {@code
+   * Sample#updateToLatestTemplateVersion} calls {@code clearValue()} on each newly cloned field,
+   * which {@code InventoryLinkField} overrides to null its link, whereas {@code
+   * Instrument#updateToLatestTemplateVersion} calls {@code setFieldData(null)}, which link fields
+   * do not override. Without this an existing instrument would silently acquire a copy of the
+   * template's current default.
+   *
+   * @param before the link fields active before the sync ran; anything not in it is newly cloned
+   */
+  private void clearRetroStampedDefaultLinks(
+      InstrumentEntity dbInstrument, List<InventoryLinkField> before) {
+    dbInstrument.getActiveFields().stream()
+        .filter(InventoryLinkField.class::isInstance)
+        .map(InventoryLinkField.class::cast)
+        .filter(field -> before.stream().noneMatch(seen -> seen == field))
+        .forEach(InventoryLinkField::clearValue);
   }
 
   @Override

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -12,7 +12,6 @@ import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
 import com.researchspace.api.v1.model.ApiInstrumentTemplateSearchResult;
 import com.researchspace.api.v1.model.ApiInventoryDOI;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
-import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
 import com.researchspace.core.util.ISearchResults;
@@ -35,16 +34,12 @@ import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.field.InventoryEntityField;
-import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.record.IActiveUserStrategy;
 import com.researchspace.service.MessageSourceUtils;
-import com.researchspace.service.inventory.DataCiteRelationType;
 import com.researchspace.service.inventory.InstrumentEntityApiManager;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.InventoryFieldNameUniquenessValidator;
-import com.researchspace.service.inventory.InventoryLinkManager;
-import com.researchspace.service.inventory.InventoryLinkValidator;
 import com.researchspace.service.inventory.InventoryMoveHelper;
 import com.researchspace.service.inventory.InventoryUrls;
 import com.researchspace.service.inventory.SampleApiManager;
@@ -53,7 +48,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -334,136 +328,18 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   }
 
   /**
-   * Applies a link value to a structured link field, going through the {@link InventoryLinkManager}
-   * so the target is parsed/validated and the Envers revision captured. Mirrors the implementation
-   * in {@link SampleApiManagerImpl}.
-   */
-  /** Item semantics: see the four-argument overload. */
-  boolean applyLinkFieldValue(
-      InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
-    return applyLinkFieldValue(field, apiField, user, false);
-  }
-
-  /**
-   * @param omittedLinkPreservesExisting how to read a payload carrying no {@code link} key at all.
-   *     True for a <b>template</b> field, whose PUT accepts a partial field list, so a
-   *     whitelist-only edit must not destroy the default link. False for an <b>item</b> field,
-   *     whose field list always arrives complete, so an absent link means the user cleared it
-   *     (RSDEV-1131). An explicit {@code "link": null} clears in both cases. Mirrors {@link
-   *     SampleApiManagerImpl}.
-   */
-  boolean applyLinkFieldValue(
-      InventoryLinkField field,
-      ApiInventoryEntityField apiField,
-      User user,
-      boolean omittedLinkPreservesExisting) {
-    ApiInventoryLink apiLink = apiField.getLink();
-    String target = apiLink == null ? null : apiLink.getTargetGlobalId();
-    InventoryLink existing = field.getLink();
-    if (target == null || target.trim().isEmpty()) {
-      if (existing == null) {
-        return false;
-      }
-      if (omittedLinkPreservesExisting && !apiField.isLinkProvided()) {
-        // a partial template update that never mentions the link: leave it alone
-        return false;
-      }
-      field.setLink(null);
-      return true;
-    }
-    Long effectivePin =
-        apiLink.derivedVersionPin() != null ? apiLink.derivedVersionPin() : apiLink.getVersionPin();
-    GlobalIdentifier incoming = parseTargetOrNull(target);
-    if (existing != null
-        && incoming != null
-        && incoming.getPrefix() == existing.getTargetPrefix()
-        && Objects.equals(incoming.getDbId(), existing.getTargetDbId())
-        && Objects.equals(effectivePin, existing.getVersionPin())
-        && Objects.equals(apiLink.getRelationType(), existing.getRelationType())) {
-      return false;
-    }
-    assertRelationAllowed(field, apiLink.getRelationType());
-    if (existing != null) {
-      field.setLink(inventoryLinkManager.updateLink(existing, apiLink, user));
-    } else {
-      field.setLink(inventoryLinkManager.createLink(apiLink, user));
-    }
-    return true;
-  }
-
-  /**
-   * Applies link values to an existing instrument's structured link fields (the update path). The
-   * DTO apply loop leaves link fields untouched because it cannot reach the service-layer {@link
-   * InventoryLinkManager}; this matches each modified link field by id and applies it here.
-   *
-   * <p>Takes an {@link ApiInstrumentEntity}/{@link InstrumentEntity}, not the concrete instrument
-   * pair: a template's link field carries an editable default link of its own (RSDEV-1246), so
-   * templates go through the same write path as instruments.
+   * Applies link values to an existing instrument's (or instrument template's) structured link
+   * fields. The shared implementation cannot read {@code isTemplate()} off {@link InventoryRecord},
+   * so this passes it in.
    */
   boolean applyLinkFieldValuesOnUpdate(
       ApiInstrumentEntity apiInstrument, InstrumentEntity dbInstrument, User user) {
-    if (apiInstrument.getFields() == null) {
-      return false;
-    }
-    boolean changed = false;
-    for (ApiInventoryEntityField apiField : apiInstrument.getFields()) {
-      if (apiField.isNewFieldRequest()
-          || apiField.isDeleteFieldRequest()
-          || apiField.getId() == null) {
-        continue;
-      }
-      Optional<InventoryEntityField> dbFieldOpt =
-          dbInstrument.getActiveFields().stream()
-              .filter(
-                  f ->
-                      f instanceof InventoryLinkField
-                          && Objects.equals(f.getId(), apiField.getId()))
-              .findFirst();
-      if (dbFieldOpt.isPresent()) {
-        rejectSelfLink(apiField.getLink(), dbInstrument);
-        changed |=
-            applyLinkFieldValue(
-                (InventoryLinkField) dbFieldOpt.get(), apiField, user, dbInstrument.isTemplate());
-      }
-    }
-    return changed;
-  }
-
-  private void assertRelationAllowed(InventoryLinkField field, String relationType) {
-    if (!DataCiteRelationType.isValid(relationType)) {
-      throw new ApiRuntimeException("errors.inventory.field.linkRelationTypeInvalid", relationType);
-    }
-    if (!isRelationPermitted(field, relationType)) {
-      throw new ApiRuntimeException(
-          "errors.inventory.field.linkRelationTypeNotPermitted", relationType, field.getName());
-    }
-  }
-
-  private void rejectSelfLink(ApiInventoryLink apiLink, InstrumentEntity dbInstrument) {
-    // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
-    // now reached while creating a template, which has no id yet (and so nothing to self-link to).
-    // Returning early there is not a hole: the template is not in the database yet either, so
-    // InventoryLinkManager.createLink's target-exists-and-readable check rejects its own future
-    // Global ID before any link row is written. Same reasoning as SampleApiManagerImpl.
-    if (apiLink == null || dbInstrument.getId() == null || dbInstrument.getOid() == null) {
-      return;
-    }
-    GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
-    if (target == null) {
-      return;
-    }
-    if (InventoryLinkValidator.isSelfLink(target, dbInstrument.getOid().toString())) {
-      throw new ApiRuntimeException(
-          "errors.inventory.field.link.selfLinkForbidden", apiLink.getTargetGlobalId());
-    }
-  }
-
-  private GlobalIdentifier parseTargetOrNull(String targetGlobalId) {
-    try {
-      return new GlobalIdentifier(targetGlobalId);
-    } catch (IllegalArgumentException | NullPointerException ex) {
-      return null;
-    }
+    return applyLinkFieldValuesOnUpdate(
+        apiInstrument.getFields(),
+        dbInstrument.getActiveFields(),
+        dbInstrument,
+        dbInstrument.isTemplate(),
+        user);
   }
 
   @Override
@@ -784,26 +660,6 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   }
 
   /**
-   * Applies a template link field's optional default link (RSDEV-1246). The stateless {@link
-   * ApiFieldToModelFieldFactory} sets only the allowed-relation-types whitelist, so the default has
-   * to be created here, through the same {@link InventoryLinkManager} write path an instrument's
-   * link uses. Mirrors the equivalent in {@link SampleApiManagerImpl}. No-op for any other field
-   * type, and for a link field whose payload carries no link.
-   */
-  private void applyDefaultLinkOfNewTemplateField(
-      InventoryEntityField toAdd,
-      ApiInventoryEntityField apiField,
-      InstrumentEntity dbTemplate,
-      User user) {
-    if (toAdd instanceof InventoryLinkField) {
-      // the same self-link rejection the edit path applies: adding a link field to an already-saved
-      // template must not be a way in for a default that targets that very template
-      rejectSelfLink(apiField.getLink(), dbTemplate);
-      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user, true);
-    }
-  }
-
-  /**
    * Adds a new {@link InventoryEntityField} to an {@link InstrumentTemplate}, mirroring the
    * behaviour of {@code Sample.addSampleField}: assigns a column index before the field is added to
    * the list so that {@code getActiveFields()}'s natural sort cannot trip over a null columnIndex.
@@ -885,7 +741,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
         // message; a raw IllegalArgumentException reached API clients as untranslated English.
         // Same keys the sample counterpart uses.
         if (apiField.getId() == null) {
-          throw new ApiRuntimeException("errors.inventory.field.deleteRequest.idMissing");
+          throw new ApiRuntimeException("errors.inventory.field.deleteRequestIdMissing");
         }
         Optional<InventoryEntityField> dbFieldOpt =
             dbTemplate.getActiveFields().stream()
@@ -893,7 +749,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
                 .findFirst();
         if (dbFieldOpt.isEmpty()) {
           throw new ApiRuntimeException(
-              "errors.inventory.field.deleteRequest.idUnknown", apiField.getId());
+              "errors.inventory.field.deleteRequestIdUnknown", apiField.getId());
         }
         dbTemplate.deleteInstrumentField(dbFieldOpt.get(), apiField.isDeleteFieldOnSampleUpdate());
         softDeleteLinkOfDeletedLinkField(dbFieldOpt.get(), user);

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -295,7 +295,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       InventoryEntityField inventoryEntityField = inventoryEntityFieldList.get(i);
 
       if (inventoryEntityField instanceof InventoryLinkField) {
-        applyLinkFieldValue((InventoryLinkField) inventoryEntityField, apiField, user);
+        applyLinkFieldValueOnCreate((InventoryLinkField) inventoryEntityField, apiField, user);
       } else if (inventoryEntityField.isOptionsStoringField()) {
         inventoryEntityField.setSelectedOptions(apiField.getSelectedOptions());
       } else if (inventoryEntityField == landingPage
@@ -882,7 +882,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
         // (RSDEV-1200) — mirror the sample path and re-apply them here.
         boolean whitelistsChanged =
             syncLinkFieldWhitelistsFromTemplate(dbInstrument.getActiveFields());
-        clearRetroStampedDefaultLinks(dbInstrument, linkFieldsBeforeUpdate);
+        clearRetroStampedDefaultLinks(dbInstrument);
         linkFieldsBeforeUpdate.forEach(field -> softDeleteLinkOfDeletedLinkField(field, user));
         if (updated || whitelistsChanged) {
           saveDbInstrumentUpdate(dbInstrument, user);
@@ -907,15 +907,14 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
    * Instrument#updateToLatestTemplateVersion} calls {@code setFieldData(null)}, which link fields
    * do not override. Without this an existing instrument would silently acquire a copy of the
    * template's current default.
-   *
-   * @param before the link fields active before the sync ran; anything not in it is newly cloned
    */
-  private void clearRetroStampedDefaultLinks(
-      InstrumentEntity dbInstrument, List<InventoryLinkField> before) {
+  void clearRetroStampedDefaultLinks(InstrumentEntity dbInstrument) {
     dbInstrument.getActiveFields().stream()
         .filter(InventoryLinkField.class::isInstance)
         .map(InventoryLinkField.class::cast)
-        .filter(field -> before.stream().noneMatch(seen -> seen == field))
+        // a field the sync has just cloned is exactly the one with no id yet, which is cheaper and
+        // more robust than comparing instance identity against a pre-sync snapshot
+        .filter(field -> field.getId() == null)
         .forEach(InventoryLinkField::clearValue);
   }
 

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
@@ -3,6 +3,7 @@ package com.researchspace.service.inventory.impl;
 import static com.researchspace.api.v1.model.ApiInventoryRecordInfo.tagDifferenceExists;
 
 import com.axiope.search.SearchUtils;
+import com.researchspace.api.v1.auth.ApiRuntimeException;
 import com.researchspace.api.v1.model.ApiBarcode;
 import com.researchspace.api.v1.model.ApiGroupBasicInfo;
 import com.researchspace.api.v1.model.ApiInventoryEditLock;
@@ -26,6 +27,7 @@ import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.MovableInventoryRecord;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.permissions.ACLElement;
 import com.researchspace.model.permissions.ConstraintBasedPermission;
@@ -42,6 +44,7 @@ import com.researchspace.service.inventory.ApiExtraFieldsHelper;
 import com.researchspace.service.inventory.ApiIdentifiersHelper;
 import com.researchspace.service.inventory.InventoryApiManager;
 import com.researchspace.service.inventory.InventoryFileApiManager;
+import com.researchspace.service.inventory.InventoryLinkManager;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -75,6 +78,7 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   protected @Autowired UserManager userManager;
   protected @Autowired ContainerDao containerDao;
   protected @Autowired InventoryPermissionUtils invPermissions;
+  protected @Autowired InventoryLinkManager inventoryLinkManager;
   private @Autowired InventoryEditLockTracker tracker;
   private @Autowired GroupDao groupDao;
   private @Autowired InventoryFileApiManager inventoryFileApiManager;
@@ -108,6 +112,61 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
       }
     }
     return changed;
+  }
+
+  /**
+   * Whether a link field's allowed-relation-types whitelist permits the given relation type. An
+   * empty (or absent) whitelist permits all of them.
+   */
+  static boolean isRelationPermitted(InventoryLinkField field, String relationType) {
+    String allowed = field.getAllowedRelationTypes();
+    if (allowed == null || allowed.trim().isEmpty()) {
+      return true;
+    }
+    return Arrays.asList(allowed.split("\\|")).contains(relationType);
+  }
+
+  /**
+   * Rejects a template edit that narrows a link field's allowed-relation-types whitelist so that
+   * the field's own default link (RSDEV-1246) would no longer be permitted. The per-link check in
+   * each manager's {@code assertRelationAllowed} only sees an incoming link, and an unchanged
+   * default is a no-op on that path, so a whitelist-only edit would otherwise leave the template
+   * holding a default its own field forbids. Failing the edit is preferable to silently dropping
+   * the default.
+   */
+  static void assertDefaultLinksMatchWhitelists(List<InventoryEntityField> templateFields) {
+    for (InventoryEntityField field : templateFields) {
+      if (field instanceof InventoryLinkField) {
+        InventoryLinkField linkField = (InventoryLinkField) field;
+        InventoryLink link = linkField.getLink();
+        if (link != null && !isRelationPermitted(linkField, link.getRelationType())) {
+          throw new ApiRuntimeException(
+              "errors.inventory.field.link.defaultRelationTypeNotPermitted",
+              link.getRelationType(),
+              linkField.getName());
+        }
+      }
+    }
+  }
+
+  /**
+   * Soft-deletes the {@link InventoryLink} backing a structured link field once that field has been
+   * soft-deleted, so the link row (and its Envers audit trail) stays in step with the field. The
+   * field's {@code deleted} flag is flipped in the model layer (a template link-field delete, or
+   * its propagation to records through {@code updateToLatestTemplateVersion}), which cannot reach
+   * the service-layer {@link InventoryLinkManager}; a soft-delete is also an ordinary update rather
+   * than a JPA remove, so the {@code cascade}/{@code orphanRemoval} on {@code
+   * InventoryLinkField#link} never fires. Without this the link row would linger with {@code
+   * deleted=false} after its field is gone (RSDEV-1270). No-op unless the field is a deleted {@link
+   * InventoryLinkField} whose link is still live.
+   */
+  void softDeleteLinkOfDeletedLinkField(InventoryEntityField field, User user) {
+    if (field instanceof InventoryLinkField && field.isDeleted()) {
+      InventoryLink link = ((InventoryLinkField) field).getLink();
+      if (link != null && !link.isDeleted()) {
+        inventoryLinkManager.deleteLink(link, user);
+      }
+    }
   }
 
   protected void updateOntologyOnUpdate(

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
@@ -8,6 +8,8 @@ import com.researchspace.api.v1.model.ApiBarcode;
 import com.researchspace.api.v1.model.ApiGroupBasicInfo;
 import com.researchspace.api.v1.model.ApiInventoryEditLock;
 import com.researchspace.api.v1.model.ApiInventoryEditLock.ApiInventoryEditLockStatus;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo.ApiGroupInfoWithSharedFlag;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
@@ -42,9 +44,11 @@ import com.researchspace.service.impl.DocumentTagManagerImpl;
 import com.researchspace.service.inventory.ApiBarcodesHelper;
 import com.researchspace.service.inventory.ApiExtraFieldsHelper;
 import com.researchspace.service.inventory.ApiIdentifiersHelper;
+import com.researchspace.service.inventory.DataCiteRelationType;
 import com.researchspace.service.inventory.InventoryApiManager;
 import com.researchspace.service.inventory.InventoryFileApiManager;
 import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.service.inventory.InventoryLinkValidator;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -166,6 +170,183 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
       if (link != null && !link.isDeleted()) {
         inventoryLinkManager.deleteLink(link, user);
       }
+    }
+  }
+
+  /**
+   * Applies a record's chosen link value to its structured link field, going through the {@link
+   * InventoryLinkManager} so the target is parsed/validated and the Envers revision captured (the
+   * same path used by extra-field links). An unchanged payload is a no-op (previously every save
+   * replaced the row, resetting its identity and creation date); a changed payload updates the
+   * field's existing InventoryLink row in place; clearing the value dereferences the row, which the
+   * field's {@code orphanRemoval} mapping hard-deletes at flush (an Envers DEL revision keeps the
+   * history in {@code InventoryLink_AUD}; a prior soft-delete write would be collapsed into that
+   * same DEL revision, so none is attempted). This differs deliberately from the extra-field delete
+   * path, where the FIELD itself is soft-deleted and its link row therefore survives soft-deleted
+   * alongside it. The chosen relation type must be permitted by the template field's
+   * allowed-relation-types whitelist (an empty whitelist permits all).
+   *
+   * <p>Item semantics: an omitted link clears. See the four-argument overload.
+   */
+  boolean applyLinkFieldValue(
+      InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    return applyLinkFieldValue(field, apiField, user, false);
+  }
+
+  /**
+   * @param omittedLinkPreservesExisting how to read a payload that carries no {@code link} key at
+   *     all. True for a <b>template</b> field, whose PUT accepts a partial field list: a
+   *     whitelist-only edit or a rename must not destroy the default link. False for an <b>item</b>
+   *     field, whose field list always arrives complete, so an absent link means the user cleared
+   *     it (RSDEV-1131, pinned by {@code
+   *     InstrumentEntityApiManagerTest.linkFieldValue_clearedWhenInstrumentUpdated}). An explicit
+   *     {@code "link": null} clears in both cases.
+   */
+  boolean applyLinkFieldValue(
+      InventoryLinkField field,
+      ApiInventoryEntityField apiField,
+      User user,
+      boolean omittedLinkPreservesExisting) {
+    ApiInventoryLink apiLink = apiField.getLink();
+    String target = apiLink == null ? null : apiLink.getTargetGlobalId();
+    InventoryLink existing = field.getLink();
+    if (target == null || target.trim().isEmpty()) {
+      if (existing == null) {
+        return false; // no link before, none requested now
+      }
+      if (omittedLinkPreservesExisting && !apiField.isLinkProvided()) {
+        // a partial template update that never mentions the link: leave it alone
+        return false;
+      }
+      field.setLink(null); // orphanRemoval hard-deletes the dereferenced row at flush
+      return true;
+    }
+    Long effectivePin =
+        apiLink.derivedVersionPin() != null ? apiLink.derivedVersionPin() : apiLink.getVersionPin();
+    // compare on the parsed base id, not the raw string: the stored row holds the
+    // unsuffixed id (the pin lives in versionPin), so a suffixed incoming id like
+    // "SA2v4" would otherwise never compare equal and every save would fire a
+    // spurious update (and Envers revision). Mirrors ApiExtraFieldsHelper.linkChanged.
+    GlobalIdentifier incoming = parseTargetOrNull(target);
+    if (existing != null
+        && incoming != null
+        && incoming.getPrefix() == existing.getTargetPrefix()
+        && Objects.equals(incoming.getDbId(), existing.getTargetDbId())
+        && Objects.equals(effectivePin, existing.getVersionPin())
+        && Objects.equals(apiLink.getRelationType(), existing.getRelationType())) {
+      return false; // unchanged
+    }
+    assertRelationAllowed(field, apiLink.getRelationType());
+    if (existing != null) {
+      field.setLink(inventoryLinkManager.updateLink(existing, apiLink, user));
+    } else {
+      field.setLink(inventoryLinkManager.createLink(apiLink, user));
+    }
+    return true;
+  }
+
+  /**
+   * Applies link values to an existing record's structured link fields (the update path). The DTO
+   * apply loop leaves link fields untouched because it cannot reach the service-layer {@link
+   * InventoryLinkManager}; this matches each modified link field by id and applies it here.
+   *
+   * <p>Templates go through this same path as items: a template's link field carries an editable
+   * default link of its own (RSDEV-1246). Callers pass the pieces rather than their own record
+   * type, because {@code isTemplate()} lives on the sample and instrument entities rather than on
+   * {@link InventoryRecord}.
+   */
+  boolean applyLinkFieldValuesOnUpdate(
+      List<ApiInventoryEntityField> apiFields,
+      List<InventoryEntityField> dbActiveFields,
+      InventoryRecord dbRecord,
+      boolean isTemplate,
+      User user) {
+    if (apiFields == null) {
+      return false;
+    }
+    boolean changed = false;
+    for (ApiInventoryEntityField apiField : apiFields) {
+      if (apiField.isNewFieldRequest()
+          || apiField.isDeleteFieldRequest()
+          || apiField.getId() == null) {
+        continue;
+      }
+      Optional<InventoryEntityField> dbFieldOpt =
+          dbActiveFields.stream()
+              .filter(
+                  f ->
+                      f instanceof InventoryLinkField
+                          && Objects.equals(f.getId(), apiField.getId()))
+              .findFirst();
+      if (dbFieldOpt.isPresent()) {
+        rejectSelfLink(apiField.getLink(), dbRecord);
+        changed |=
+            applyLinkFieldValue((InventoryLinkField) dbFieldOpt.get(), apiField, user, isTemplate);
+      }
+    }
+    return changed;
+  }
+
+  /**
+   * Applies a template link field's optional default link (RSDEV-1246). The stateless {@code
+   * ApiFieldToModelFieldFactory} sets only the allowed-relation-types whitelist, so the default has
+   * to be created here, through the same {@link InventoryLinkManager} write path an item's link
+   * uses: validated against the DataCite vocabulary and the field's own whitelist, with the Envers
+   * revision captured. Items created from the template are then stamped with a copy of it by {@code
+   * InventoryLinkField#shallowCopy()}, needing no further code. No-op for any other field type, and
+   * for a link field whose payload carries no link.
+   */
+  void applyDefaultLinkOfNewTemplateField(
+      InventoryEntityField toAdd,
+      ApiInventoryEntityField apiField,
+      InventoryRecord dbTemplate,
+      User user) {
+    if (toAdd instanceof InventoryLinkField) {
+      // the same self-link rejection the edit path applies: adding a link field to an already-saved
+      // template must not be a way in for a default that targets that very template
+      rejectSelfLink(apiField.getLink(), dbTemplate);
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user, true);
+    }
+  }
+
+  private void assertRelationAllowed(InventoryLinkField field, String relationType) {
+    // a chosen relation must be a real DataCite relation type, even when the whitelist is empty.
+    // ApiRuntimeException maps to a 422 with the resolved bundle message, where a raw
+    // IllegalArgumentException would surface as an unmapped 500.
+    if (!DataCiteRelationType.isValid(relationType)) {
+      throw new ApiRuntimeException("errors.inventory.field.linkRelationTypeInvalid", relationType);
+    }
+    if (!isRelationPermitted(field, relationType)) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.linkRelationTypeNotPermitted", relationType, field.getName());
+    }
+  }
+
+  private void rejectSelfLink(ApiInventoryLink apiLink, InventoryRecord dbRecord) {
+    // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
+    // reached while creating a template, which has no id yet (and so nothing to self-link to).
+    // Returning early there is not a hole: the template is not in the database yet either, so
+    // InventoryLinkManager.createLink's target-exists-and-readable check rejects its own future
+    // Global ID before any link row is written. Every path where a self-link IS reachable (a
+    // template or item that already exists) passes a saved record and so runs the check below.
+    if (apiLink == null || dbRecord.getId() == null || dbRecord.getOid() == null) {
+      return;
+    }
+    GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
+    if (target == null) {
+      return; // malformed/blank targets are handled by the manager / clear path
+    }
+    if (InventoryLinkValidator.isSelfLink(target, dbRecord.getOid().toString())) {
+      throw new ApiRuntimeException(
+          "errors.inventory.field.link.selfLinkForbidden", apiLink.getTargetGlobalId());
+    }
+  }
+
+  private GlobalIdentifier parseTargetOrNull(String targetGlobalId) {
+    try {
+      return new GlobalIdentifier(targetGlobalId);
+    } catch (IllegalArgumentException | NullPointerException ex) {
+      return null;
     }
   }
 

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
@@ -64,6 +64,7 @@ import java.util.Optional;
 import java.util.function.UnaryOperator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
@@ -124,23 +125,20 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
    */
   static boolean isRelationPermitted(InventoryLinkField field, String relationType) {
     String allowed = field.getAllowedRelationTypes();
-    if (allowed == null || allowed.trim().isEmpty()) {
+    if (StringUtils.isBlank(allowed)) {
       return true;
     }
     return Arrays.asList(allowed.split("\\|")).contains(relationType);
   }
 
   /**
-   * Rejects a template edit that narrows a link field's allowed-relation-types whitelist so that
-   * the field's own default link (RSDEV-1246) would no longer be permitted. The per-link check in
-   * {@code assertRelationAllowed} below only sees an incoming link, and an unchanged default is a
-   * no-op on that path, so a whitelist-only edit would otherwise leave the template holding a
-   * default its own field forbids. Failing the edit is preferable to silently dropping the default.
+   * Rejects a template edit that narrows a link field's whitelist past its own default link
+   * (RSDEV-1246). An unchanged default is a no-op on the per-link path, so a whitelist-only edit
+   * would otherwise slip through. Failing the edit beats silently dropping the default.
    */
   static void assertDefaultLinksMatchWhitelists(List<InventoryEntityField> templateFields) {
     for (InventoryEntityField field : templateFields) {
-      if (field instanceof InventoryLinkField) {
-        InventoryLinkField linkField = (InventoryLinkField) field;
+      if (field instanceof InventoryLinkField linkField) {
         InventoryLink link = linkField.getLink();
         if (link != null && !isRelationPermitted(linkField, link.getRelationType())) {
           throw new ApiRuntimeException(
@@ -153,54 +151,38 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   }
 
   /**
-   * Soft-deletes the {@link InventoryLink} backing a structured link field once that field has been
-   * soft-deleted, so the link row (and its Envers audit trail) stays in step with the field. The
-   * field's {@code deleted} flag is flipped in the model layer (a template link-field delete, or
-   * its propagation to records through {@code updateToLatestTemplateVersion}), which cannot reach
-   * the service-layer {@link InventoryLinkManager}; a soft-delete is also an ordinary update rather
-   * than a JPA remove, so the {@code cascade}/{@code orphanRemoval} on {@code
-   * InventoryLinkField#link} never fires. Without this the link row would linger with {@code
-   * deleted=false} after its field is gone (RSDEV-1270). No-op unless the field is a deleted {@link
-   * InventoryLinkField} whose link is still live.
+   * Soft-deletes the {@link InventoryLink} behind a soft-deleted link field, keeping the row and
+   * its Envers trail in step with the field (RSDEV-1270). Needed because the field's flag is
+   * flipped in the model layer, out of reach of {@link InventoryLinkManager}, and because a
+   * soft-delete is an UPDATE, so {@code orphanRemoval} never fires.
    */
   void softDeleteLinkOfDeletedLinkField(InventoryEntityField field, User user) {
-    if (field instanceof InventoryLinkField && field.isDeleted()) {
-      InventoryLink link = ((InventoryLinkField) field).getLink();
+    if (field instanceof InventoryLinkField linkField && field.isDeleted()) {
+      InventoryLink link = linkField.getLink();
       if (link != null && !link.isDeleted()) {
         inventoryLinkManager.deleteLink(link, user);
       }
     }
   }
 
-  /**
-   * Item semantics: an omitted link clears. Equivalent to the four-argument form with {@code
-   * omittedLinkPreservesExisting = false}.
-   */
+  /** Item semantics: an omitted link clears. */
   boolean applyLinkFieldValue(
       InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
     return applyLinkFieldValue(field, apiField, user, false);
   }
 
   /**
-   * Applies a record's chosen link value to its structured link field, going through the {@link
-   * InventoryLinkManager} so the target is parsed/validated and the Envers revision captured (the
-   * same path used by extra-field links). An unchanged payload is a no-op (previously every save
-   * replaced the row, resetting its identity and creation date); a changed payload updates the
-   * field's existing InventoryLink row in place; clearing the value dereferences the row, which the
-   * field's {@code orphanRemoval} mapping hard-deletes at flush (an Envers DEL revision keeps the
-   * history in {@code InventoryLink_AUD}; a prior soft-delete write would be collapsed into that
-   * same DEL revision, so none is attempted). This differs deliberately from the extra-field delete
-   * path, where the FIELD itself is soft-deleted and its link row therefore survives soft-deleted
-   * alongside it. The chosen relation type must be permitted by the template field's
-   * allowed-relation-types whitelist (an empty whitelist permits all).
+   * Applies a record's chosen link value to its link field through {@link InventoryLinkManager}, so
+   * the target is validated and the Envers revision captured. An unchanged payload is a no-op; a
+   * changed one updates the row in place; clearing dereferences it, which {@code orphanRemoval}
+   * hard-deletes at flush. This differs from the extra-field delete path, where the FIELD is
+   * soft-deleted and its row survives soft-deleted alongside it.
    *
-   * @param omittedLinkPreservesExisting how to read a payload that carries no {@code link} key at
-   *     all. True for a <b>template</b> field, whose PUT accepts a partial field list: a
-   *     whitelist-only edit or a rename must not destroy the default link. False for an <b>item</b>
-   *     field, whose field list always arrives complete, so an absent link means the user cleared
-   *     it (RSDEV-1131, pinned by {@code
-   *     InstrumentEntityApiManagerTest.linkFieldValue_clearedWhenInstrumentUpdated}). An explicit
-   *     {@code "link": null} clears in both cases.
+   * @param omittedLinkPreservesExisting how to read a payload carrying no {@code link} key. True
+   *     for a <b>template</b>, whose PUT accepts a partial field list, so a whitelist-only edit
+   *     must not destroy the default. False for an <b>item</b>, whose field list always arrives
+   *     complete, so absent means cleared (RSDEV-1131). An explicit {@code "link": null} clears in
+   *     both cases.
    */
   boolean applyLinkFieldValue(
       InventoryLinkField field,
@@ -210,7 +192,7 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
     ApiInventoryLink apiLink = apiField.getLink();
     String target = apiLink == null ? null : apiLink.getTargetGlobalId();
     InventoryLink existing = field.getLink();
-    if (target == null || target.trim().isEmpty()) {
+    if (StringUtils.isBlank(target)) {
       if (existing == null) {
         return false; // no link before, none requested now
       }
@@ -223,10 +205,8 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
     }
     Long effectivePin =
         apiLink.derivedVersionPin() != null ? apiLink.derivedVersionPin() : apiLink.getVersionPin();
-    // compare on the parsed base id, not the raw string: the stored row holds the
-    // unsuffixed id (the pin lives in versionPin), so a suffixed incoming id like
-    // "SA2v4" would otherwise never compare equal and every save would fire a
-    // spurious update (and Envers revision). Mirrors ApiExtraFieldsHelper.linkChanged.
+    // compare on the parsed base id: the row holds the unsuffixed id (the pin lives in versionPin),
+    // so a suffixed "SA2v4" would never compare equal and every save would fire a spurious update
     GlobalIdentifier incoming = parseTargetOrNull(target);
     if (existing != null
         && incoming != null
@@ -246,12 +226,10 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   }
 
   /**
-   * Applies a link value while creating a record from a template. The template's default link has
-   * already been stamped onto the new field by {@code InventoryLinkField#shallowCopy()}, so a
-   * payload that lists the fields but says nothing about the link must leave that stamp alone
-   * rather than wipe it before it is ever persisted (ADR-0006: bulk, API and UI creation behave
-   * identically, and the UI always sends the link key). An explicit {@code "link": null} still
-   * clears, which is how a caller declines the default.
+   * Create-from-template: {@code InventoryLinkField#shallowCopy()} has already stamped the
+   * template's default onto the new field, so a payload that says nothing about the link must leave
+   * it alone rather than wipe it before it is ever persisted (ADR-0006). An explicit {@code "link":
+   * null} still clears, which is how a caller declines the default.
    */
   boolean applyLinkFieldValueOnCreate(
       InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
@@ -259,14 +237,10 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   }
 
   /**
-   * Applies link values to an existing record's structured link fields (the update path). The DTO
-   * apply loop leaves link fields untouched because it cannot reach the service-layer {@link
-   * InventoryLinkManager}; this matches each modified link field by id and applies it here.
-   *
-   * <p>Templates go through this same path as items: a template's link field carries an editable
-   * default link of its own (RSDEV-1246). Callers pass the pieces rather than their own record
-   * type, because {@code isTemplate()} lives on the sample and instrument entities rather than on
-   * {@link InventoryRecord}.
+   * Applies link values to an existing record's link fields. The DTO apply loop skips them because
+   * it cannot reach {@link InventoryLinkManager}; this matches each by id and applies it here.
+   * Templates use the same path, carrying a default link of their own (RSDEV-1246). Callers pass
+   * the pieces because {@code isTemplate()} lives on the entities, not on {@link InventoryRecord}.
    */
   boolean applyLinkFieldValuesOnUpdate(
       List<ApiInventoryEntityField> apiFields,
@@ -301,31 +275,25 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   }
 
   /**
-   * Applies a template link field's optional default link (RSDEV-1246). The stateless {@code
-   * ApiFieldToModelFieldFactory} sets only the allowed-relation-types whitelist, so the default has
-   * to be created here, through the same {@link InventoryLinkManager} write path an item's link
-   * uses: validated against the DataCite vocabulary and the field's own whitelist, with the Envers
-   * revision captured. Items created from the template are then stamped with a copy of it by {@code
-   * InventoryLinkField#shallowCopy()}, needing no further code. No-op for any other field type, and
-   * for a link field whose payload carries no link.
+   * Creates a new template link field's optional default link (RSDEV-1246). {@code
+   * ApiFieldToModelFieldFactory} sets only the whitelist, so the default is written here through
+   * the same {@link InventoryLinkManager} path an item's link uses. Items are then stamped with a
+   * copy by {@code InventoryLinkField#shallowCopy()}. No-op for any other field type.
    */
   void applyDefaultLinkOfNewTemplateField(
       InventoryEntityField toAdd,
       ApiInventoryEntityField apiField,
       InventoryRecord dbTemplate,
       User user) {
-    if (toAdd instanceof InventoryLinkField) {
-      // the same self-link rejection the edit path applies: adding a link field to an already-saved
-      // template must not be a way in for a default that targets that very template
+    if (toAdd instanceof InventoryLinkField linkField) {
+      // adding a link field to a saved template must not smuggle in a default targeting it
       rejectSelfLink(apiField.getLink(), dbTemplate);
-      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user, true);
+      applyLinkFieldValue(linkField, apiField, user, true);
     }
   }
 
   private void assertRelationAllowed(InventoryLinkField field, String relationType) {
-    // a chosen relation must be a real DataCite relation type, even when the whitelist is empty.
-    // ApiRuntimeException maps to a 422 with the resolved bundle message, where a raw
-    // IllegalArgumentException would surface as an unmapped 500.
+    // ApiRuntimeException maps to a resolved 422; a raw IllegalArgumentException would be a 500
     if (!DataCiteRelationType.isValid(relationType)) {
       throw new ApiRuntimeException("errors.inventory.field.linkRelationTypeInvalid", relationType);
     }
@@ -336,12 +304,9 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   }
 
   private void rejectSelfLink(ApiInventoryLink apiLink, InventoryRecord dbRecord) {
-    // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
-    // reached while creating a template, which has no id yet (and so nothing to self-link to).
-    // Returning early there is not a hole: the template is not in the database yet either, so
-    // InventoryLinkManager.createLink's target-exists-and-readable check rejects its own future
-    // Global ID before any link row is written. Every path where a self-link IS reachable (a
-    // template or item that already exists) passes a saved record and so runs the check below.
+    // getId() first: getOid() throws on an unsaved record, and this is reached while creating a
+    // template. Not a hole: an unsaved template is not in the database either, so createLink's
+    // target-exists check rejects its own future Global ID before any row is written.
     if (apiLink == null || dbRecord.getId() == null || dbRecord.getOid() == null) {
       return;
     }
@@ -359,9 +324,8 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
     try {
       return new GlobalIdentifier(targetGlobalId);
     } catch (IllegalArgumentException | NullPointerException ex) {
-      // deliberately swallowed: a malformed or blank target is not an error here. The callers
-      // either treat it as "no target" (the clear path) or hand it to InventoryLinkManager, which
-      // rejects it with a resolved 422 rather than this raw parse failure.
+      // deliberately swallowed: a blank or malformed target is not an error here. Callers either
+      // treat it as "no target" or hand it to InventoryLinkManager, which returns a resolved 422.
       return null;
     }
   }

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryApiManagerImpl.java
@@ -82,7 +82,7 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   protected @Autowired UserManager userManager;
   protected @Autowired ContainerDao containerDao;
   protected @Autowired InventoryPermissionUtils invPermissions;
-  protected @Autowired InventoryLinkManager inventoryLinkManager;
+  private @Autowired InventoryLinkManager inventoryLinkManager;
   private @Autowired InventoryEditLockTracker tracker;
   private @Autowired GroupDao groupDao;
   private @Autowired InventoryFileApiManager inventoryFileApiManager;
@@ -133,10 +133,9 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   /**
    * Rejects a template edit that narrows a link field's allowed-relation-types whitelist so that
    * the field's own default link (RSDEV-1246) would no longer be permitted. The per-link check in
-   * each manager's {@code assertRelationAllowed} only sees an incoming link, and an unchanged
-   * default is a no-op on that path, so a whitelist-only edit would otherwise leave the template
-   * holding a default its own field forbids. Failing the edit is preferable to silently dropping
-   * the default.
+   * {@code assertRelationAllowed} below only sees an incoming link, and an unchanged default is a
+   * no-op on that path, so a whitelist-only edit would otherwise leave the template holding a
+   * default its own field forbids. Failing the edit is preferable to silently dropping the default.
    */
   static void assertDefaultLinksMatchWhitelists(List<InventoryEntityField> templateFields) {
     for (InventoryEntityField field : templateFields) {
@@ -147,7 +146,7 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
           throw new ApiRuntimeException(
               "errors.inventory.field.link.defaultRelationTypeNotPermitted",
               link.getRelationType(),
-              linkField.getName());
+              linkField.getName() == null ? "" : linkField.getName());
         }
       }
     }
@@ -174,6 +173,15 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
   }
 
   /**
+   * Item semantics: an omitted link clears. Equivalent to the four-argument form with {@code
+   * omittedLinkPreservesExisting = false}.
+   */
+  boolean applyLinkFieldValue(
+      InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    return applyLinkFieldValue(field, apiField, user, false);
+  }
+
+  /**
    * Applies a record's chosen link value to its structured link field, going through the {@link
    * InventoryLinkManager} so the target is parsed/validated and the Envers revision captured (the
    * same path used by extra-field links). An unchanged payload is a no-op (previously every save
@@ -186,14 +194,6 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
    * alongside it. The chosen relation type must be permitted by the template field's
    * allowed-relation-types whitelist (an empty whitelist permits all).
    *
-   * <p>Item semantics: an omitted link clears. See the four-argument overload.
-   */
-  boolean applyLinkFieldValue(
-      InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
-    return applyLinkFieldValue(field, apiField, user, false);
-  }
-
-  /**
    * @param omittedLinkPreservesExisting how to read a payload that carries no {@code link} key at
    *     all. True for a <b>template</b> field, whose PUT accepts a partial field list: a
    *     whitelist-only edit or a rename must not destroy the default link. False for an <b>item</b>
@@ -243,6 +243,19 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
       field.setLink(inventoryLinkManager.createLink(apiLink, user));
     }
     return true;
+  }
+
+  /**
+   * Applies a link value while creating a record from a template. The template's default link has
+   * already been stamped onto the new field by {@code InventoryLinkField#shallowCopy()}, so a
+   * payload that lists the fields but says nothing about the link must leave that stamp alone
+   * rather than wipe it before it is ever persisted (ADR-0006: bulk, API and UI creation behave
+   * identically, and the UI always sends the link key). An explicit {@code "link": null} still
+   * clears, which is how a caller declines the default.
+   */
+  boolean applyLinkFieldValueOnCreate(
+      InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    return applyLinkFieldValue(field, apiField, user, true);
   }
 
   /**
@@ -346,6 +359,9 @@ public abstract class InventoryApiManagerImpl<T extends InventoryRecord>
     try {
       return new GlobalIdentifier(targetGlobalId);
     } catch (IllegalArgumentException | NullPointerException ex) {
+      // deliberately swallowed: a malformed or blank target is not an error here. The callers
+      // either treat it as "no target" (the clear path) or hand it to InventoryLinkManager, which
+      // rejects it with a resolved 422 rather than this raw parse failure.
       return null;
     }
   }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -425,8 +425,26 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
    * alongside it. The chosen relation type must be permitted by the template field's
    * allowed-relation-types whitelist (an empty whitelist permits all).
    */
+  /** Item semantics: see the four-argument overload. */
   boolean applyLinkFieldValue(
       InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    return applyLinkFieldValue(field, apiField, user, false);
+  }
+
+  /**
+   * @param omittedLinkPreservesExisting how to read a payload that carries no {@code link} key at
+   *     all. True for a <b>template</b> field, whose PUT accepts a partial field list: a
+   *     whitelist-only edit or a rename must not destroy the default link. False for an <b>item</b>
+   *     field, whose field list always arrives complete, so an absent link means the user cleared
+   *     it (RSDEV-1131, pinned by {@code
+   *     InstrumentEntityApiManagerTest.linkFieldValue_clearedWhenInstrumentUpdated}). An explicit
+   *     {@code "link": null} clears in both cases.
+   */
+  boolean applyLinkFieldValue(
+      InventoryLinkField field,
+      ApiInventoryEntityField apiField,
+      User user,
+      boolean omittedLinkPreservesExisting) {
     ApiInventoryLink apiLink = apiField.getLink();
     String target = apiLink == null ? null : apiLink.getTargetGlobalId();
     InventoryLink existing = field.getLink();
@@ -434,8 +452,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       if (existing == null) {
         return false; // no link before, none requested now
       }
-      if (!apiField.isLinkProvided()) {
-        // a partial update that never mentions the link: leave it alone rather than destroy it
+      if (omittedLinkPreservesExisting && !apiField.isLinkProvided()) {
+        // a partial template update that never mentions the link: leave it alone
         return false;
       }
       field.setLink(null); // orphanRemoval hard-deletes the dereferenced row at flush
@@ -495,7 +513,9 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
               .findFirst();
       if (dbFieldOpt.isPresent()) {
         rejectSelfLink(apiField.getLink(), dbSample);
-        changed |= applyLinkFieldValue((InventoryLinkField) dbFieldOpt.get(), apiField, user);
+        changed |=
+            applyLinkFieldValue(
+                (InventoryLinkField) dbFieldOpt.get(), apiField, user, dbSample.isTemplate());
       }
     }
     return changed;
@@ -517,7 +537,11 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   private void rejectSelfLink(ApiInventoryLink apiLink, SampleEntity dbSample) {
     // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
-    // now reached while creating a template, which has no id yet (and so nothing to self-link to)
+    // now reached while creating a template, which has no id yet (and so nothing to self-link to).
+    // Returning early there is not a hole: the template is not in the database yet either, so
+    // InventoryLinkManager.createLink's target-exists-and-readable check rejects its own future
+    // Global ID before any link row is written. Every path where a self-link IS reachable (a
+    // template or item that already exists) passes a saved record and so runs the check below.
     if (apiLink == null || dbSample.getId() == null || dbSample.getOid() == null) {
       return;
     }
@@ -1086,7 +1110,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       // the same self-link rejection the edit path applies: adding a link field to an already-saved
       // template must not be a way in for a default that targets that very template
       rejectSelfLink(apiField.getLink(), dbTemplate);
-      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user, true);
     }
   }
 

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -58,7 +58,6 @@ import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -81,7 +80,6 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   private @Autowired InventoryMoveHelper inventoryMoveHelper;
   private @Autowired InventoryAuditApiManager inventoryAuditMgr;
   private @Autowired ApiFieldToModelFieldFactory apiFieldToModelFieldFactory;
-  private @Autowired InventoryLinkManager inventoryLinkManager;
 
   @Override
   public ApiSampleSearchResult getSamplesForUser(
@@ -467,9 +465,13 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
    * Applies link values to an existing sample's structured link fields (the update path). The DTO
    * apply loop leaves link fields untouched because it cannot reach the service-layer {@link
    * InventoryLinkManager}; this matches each modified link field by id and applies it here.
+   *
+   * <p>Takes a {@link SampleEntity}, not a {@link Sample}: a template's link field carries an
+   * editable default link of its own (RSDEV-1246), so templates go through the same write path as
+   * items rather than being skipped.
    */
-  private boolean applyLinkFieldValuesOnUpdate(
-      ApiSampleWithoutSubSamples apiSample, Sample dbSample, User user) {
+  boolean applyLinkFieldValuesOnUpdate(
+      ApiSampleWithoutSubSamples apiSample, SampleEntity dbSample, User user) {
     if (apiSample.getFields() == null) {
       return false;
     }
@@ -503,17 +505,13 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       throw new ApiRuntimeException(
           "errors.inventory.field.link.relationTypeInvalid", relationType);
     }
-    String allowed = field.getAllowedRelationTypes();
-    if (allowed == null || allowed.trim().isEmpty()) {
-      return; // empty whitelist = all relation types allowed
-    }
-    if (!Arrays.asList(allowed.split("\\|")).contains(relationType)) {
+    if (!isRelationPermitted(field, relationType)) {
       throw new ApiRuntimeException(
           "errors.inventory.field.link.relationTypeNotPermitted", relationType, field.getName());
     }
   }
 
-  private void rejectSelfLink(ApiInventoryLink apiLink, Sample dbSample) {
+  private void rejectSelfLink(ApiInventoryLink apiLink, SampleEntity dbSample) {
     if (apiLink == null || dbSample.getOid() == null) {
       return;
     }
@@ -532,26 +530,6 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       return new GlobalIdentifier(targetGlobalId);
     } catch (IllegalArgumentException | NullPointerException ex) {
       return null;
-    }
-  }
-
-  /**
-   * Soft-deletes the {@link InventoryLink} backing a structured link field once that field has been
-   * soft-deleted, so the link row (and its Envers audit trail) stays in step with the field. The
-   * field's {@code deleted} flag is flipped in the model layer (a template link-field delete, or
-   * its propagation to child samples through {@code Sample#updateToLatestTemplateVersion}), which
-   * cannot reach the service-layer {@link InventoryLinkManager}; a soft-delete is also an ordinary
-   * update rather than a JPA remove, so the {@code cascade}/{@code orphanRemoval} on {@code
-   * InventoryLinkField#link} never fires. Without this the link row would linger with {@code
-   * deleted=false} after its field is gone. No-op unless the field is a deleted {@link
-   * InventoryLinkField} whose link is still live.
-   */
-  void softDeleteLinkOfDeletedLinkField(InventoryEntityField field, User user) {
-    if (field instanceof InventoryLinkField && field.isDeleted()) {
-      InventoryLink link = ((InventoryLinkField) field).getLink();
-      if (link != null && !link.isDeleted()) {
-        inventoryLinkManager.deleteLink(link, user);
-      }
     }
   }
 
@@ -811,8 +789,9 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
         identifiersHelper.createAssignRequestedIdentifiers(
             apiSample.getIdentifiers(), dbSample, user);
     contentChanged |= apiSample.applyChangesToDatabaseSample(dbSample, user);
-    if (!dbSample.isTemplate()) {
-      contentChanged |= applyLinkFieldValuesOnUpdate(apiSample, (Sample) dbSample, user);
+    contentChanged |= applyLinkFieldValuesOnUpdate(apiSample, dbSample, user);
+    if (dbSample.isTemplate()) {
+      assertDefaultLinksMatchWhitelists(dbSample.getActiveFields());
     }
     contentChanged |= saveSharingACLForIncomingApiInvRec(dbSample, apiSample);
     contentChanged |= saveIncomingSampleImage(dbSample, apiSample, user);
@@ -1061,7 +1040,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     sampleTemplate.setDefaultUnitId(apiSample.getDefaultUnitId());
     setBasicFieldsFromNewIncomingApiInventoryRecord(sampleTemplate, apiSample, user);
     setSampleCoreProperties(apiSample, sampleTemplate);
-    createFields(apiSample, sampleTemplate);
+    createFields(apiSample, sampleTemplate, user);
 
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNames(sampleTemplate);
     SampleTemplate savedSampleTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
@@ -1073,12 +1052,29 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     return rc;
   }
 
-  private void createFields(ApiSampleTemplatePost apiSample, SampleTemplate sample) {
+  void createFields(ApiSampleTemplatePost apiSample, SampleTemplate sample, User user) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiSample.getFields(), null);
     for (ApiInventoryEntityField field : apiSample.getFields()) {
       InventoryEntityField toAdd = apiFieldToModelFieldFactory.apiInventoryFieldToModelField(field);
+      applyDefaultLinkOfNewTemplateField(toAdd, field, user);
       sample.addSampleField(toAdd);
+    }
+  }
+
+  /**
+   * Applies a template link field's optional default link (RSDEV-1246). The stateless {@link
+   * ApiFieldToModelFieldFactory} sets only the allowed-relation-types whitelist, so the default has
+   * to be created here, through the same {@link InventoryLinkManager} write path an item's link
+   * uses: validated against the DataCite vocabulary and the field's own whitelist, with the Envers
+   * revision captured. Items created from the template are then stamped with a copy of it by {@code
+   * InventoryLinkField#shallowCopy()}, needing no further code. No-op for any other field type, and
+   * for a link field whose payload carries no link.
+   */
+  private void applyDefaultLinkOfNewTemplateField(
+      InventoryEntityField toAdd, ApiInventoryEntityField apiField, User user) {
+    if (toAdd instanceof InventoryLinkField) {
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
     }
   }
 
@@ -1103,7 +1099,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     return (ApiSampleTemplate) getOutgoingApiSample(dbTemplate, user);
   }
 
-  private boolean createDeleteRequestedFieldsInDbSampleTemplate(
+  boolean createDeleteRequestedFieldsInDbSampleTemplate(
       ApiSampleWithoutSubSamples apiSample, SampleTemplate dbTemplate, User user) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiSample.getFields(), null);
@@ -1112,6 +1108,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       if (apiField.isNewFieldRequest()) {
         InventoryEntityField toAdd =
             apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
+        applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
         dbTemplate.addSampleField(toAdd);
         changed = true;
       }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -434,6 +434,10 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       if (existing == null) {
         return false; // no link before, none requested now
       }
+      if (!apiField.isLinkProvided()) {
+        // a partial update that never mentions the link: leave it alone rather than destroy it
+        return false;
+      }
       field.setLink(null); // orphanRemoval hard-deletes the dereferenced row at flush
       return true;
     }
@@ -512,7 +516,9 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   }
 
   private void rejectSelfLink(ApiInventoryLink apiLink, SampleEntity dbSample) {
-    if (apiLink == null || dbSample.getOid() == null) {
+    // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
+    // now reached while creating a template, which has no id yet (and so nothing to self-link to)
+    if (apiLink == null || dbSample.getId() == null || dbSample.getOid() == null) {
       return;
     }
     GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
@@ -1057,7 +1063,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
         apiSample.getFields(), null);
     for (ApiInventoryEntityField field : apiSample.getFields()) {
       InventoryEntityField toAdd = apiFieldToModelFieldFactory.apiInventoryFieldToModelField(field);
-      applyDefaultLinkOfNewTemplateField(toAdd, field, user);
+      applyDefaultLinkOfNewTemplateField(toAdd, field, sample, user);
       sample.addSampleField(toAdd);
     }
   }
@@ -1072,8 +1078,14 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
    * for a link field whose payload carries no link.
    */
   private void applyDefaultLinkOfNewTemplateField(
-      InventoryEntityField toAdd, ApiInventoryEntityField apiField, User user) {
+      InventoryEntityField toAdd,
+      ApiInventoryEntityField apiField,
+      SampleEntity dbTemplate,
+      User user) {
     if (toAdd instanceof InventoryLinkField) {
+      // the same self-link rejection the edit path applies: adding a link field to an already-saved
+      // template must not be a way in for a default that targets that very template
+      rejectSelfLink(apiField.getLink(), dbTemplate);
       applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
     }
   }
@@ -1108,7 +1120,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       if (apiField.isNewFieldRequest()) {
         InventoryEntityField toAdd =
             apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
-        applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
+        applyDefaultLinkOfNewTemplateField(toAdd, apiField, dbTemplate, user);
         dbTemplate.addSampleField(toAdd);
         changed = true;
       }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -434,6 +434,10 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       if (existing == null) {
         return false; // no link before, none requested now
       }
+      if (!apiField.isLinkProvided()) {
+        // a partial update that never mentions the link: leave it alone rather than destroy it
+        return false;
+      }
       field.setLink(null); // orphanRemoval hard-deletes the dereferenced row at flush
       return true;
     }
@@ -511,7 +515,9 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   }
 
   private void rejectSelfLink(ApiInventoryLink apiLink, SampleEntity dbSample) {
-    if (apiLink == null || dbSample.getOid() == null) {
+    // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
+    // now reached while creating a template, which has no id yet (and so nothing to self-link to)
+    if (apiLink == null || dbSample.getId() == null || dbSample.getOid() == null) {
       return;
     }
     GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
@@ -1056,7 +1062,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
         apiSample.getFields(), null);
     for (ApiInventoryEntityField field : apiSample.getFields()) {
       InventoryEntityField toAdd = apiFieldToModelFieldFactory.apiInventoryFieldToModelField(field);
-      applyDefaultLinkOfNewTemplateField(toAdd, field, user);
+      applyDefaultLinkOfNewTemplateField(toAdd, field, sample, user);
       sample.addSampleField(toAdd);
     }
   }
@@ -1071,8 +1077,14 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
    * for a link field whose payload carries no link.
    */
   private void applyDefaultLinkOfNewTemplateField(
-      InventoryEntityField toAdd, ApiInventoryEntityField apiField, User user) {
+      InventoryEntityField toAdd,
+      ApiInventoryEntityField apiField,
+      SampleEntity dbTemplate,
+      User user) {
     if (toAdd instanceof InventoryLinkField) {
+      // the same self-link rejection the edit path applies: adding a link field to an already-saved
+      // template must not be a way in for a default that targets that very template
+      rejectSelfLink(apiField.getLink(), dbTemplate);
       applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
     }
   }
@@ -1107,7 +1119,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       if (apiField.isNewFieldRequest()) {
         InventoryEntityField toAdd =
             apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
-        applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
+        applyDefaultLinkOfNewTemplateField(toAdd, apiField, dbTemplate, user);
         dbTemplate.addSampleField(toAdd);
         changed = true;
       }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -396,7 +396,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       InventoryEntityField inventoryEntityField = inventoryEntityFieldList.get(i);
 
       if (inventoryEntityField instanceof InventoryLinkField) {
-        applyLinkFieldValue((InventoryLinkField) inventoryEntityField, apiField, user);
+        applyLinkFieldValueOnCreate((InventoryLinkField) inventoryEntityField, apiField, user);
       } else if (inventoryEntityField.isOptionsStoringField()) {
         inventoryEntityField.setSelectedOptions(apiField.getSelectedOptions());
       } else {

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -58,7 +58,6 @@ import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -81,7 +80,6 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   private @Autowired InventoryMoveHelper inventoryMoveHelper;
   private @Autowired InventoryAuditApiManager inventoryAuditMgr;
   private @Autowired ApiFieldToModelFieldFactory apiFieldToModelFieldFactory;
-  private @Autowired InventoryLinkManager inventoryLinkManager;
 
   @Override
   public ApiSampleSearchResult getSamplesForUser(
@@ -467,9 +465,13 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
    * Applies link values to an existing sample's structured link fields (the update path). The DTO
    * apply loop leaves link fields untouched because it cannot reach the service-layer {@link
    * InventoryLinkManager}; this matches each modified link field by id and applies it here.
+   *
+   * <p>Takes a {@link SampleEntity}, not a {@link Sample}: a template's link field carries an
+   * editable default link of its own (RSDEV-1246), so templates go through the same write path as
+   * items rather than being skipped.
    */
-  private boolean applyLinkFieldValuesOnUpdate(
-      ApiSampleWithoutSubSamples apiSample, Sample dbSample, User user) {
+  boolean applyLinkFieldValuesOnUpdate(
+      ApiSampleWithoutSubSamples apiSample, SampleEntity dbSample, User user) {
     if (apiSample.getFields() == null) {
       return false;
     }
@@ -502,17 +504,13 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     if (!DataCiteRelationType.isValid(relationType)) {
       throw new ApiRuntimeException("errors.inventory.field.linkRelationTypeInvalid", relationType);
     }
-    String allowed = field.getAllowedRelationTypes();
-    if (allowed == null || allowed.trim().isEmpty()) {
-      return; // empty whitelist = all relation types allowed
-    }
-    if (!Arrays.asList(allowed.split("\\|")).contains(relationType)) {
+    if (!isRelationPermitted(field, relationType)) {
       throw new ApiRuntimeException(
           "errors.inventory.field.linkRelationTypeNotPermitted", relationType, field.getName());
     }
   }
 
-  private void rejectSelfLink(ApiInventoryLink apiLink, Sample dbSample) {
+  private void rejectSelfLink(ApiInventoryLink apiLink, SampleEntity dbSample) {
     if (apiLink == null || dbSample.getOid() == null) {
       return;
     }
@@ -531,26 +529,6 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       return new GlobalIdentifier(targetGlobalId);
     } catch (IllegalArgumentException | NullPointerException ex) {
       return null;
-    }
-  }
-
-  /**
-   * Soft-deletes the {@link InventoryLink} backing a structured link field once that field has been
-   * soft-deleted, so the link row (and its Envers audit trail) stays in step with the field. The
-   * field's {@code deleted} flag is flipped in the model layer (a template link-field delete, or
-   * its propagation to child samples through {@code Sample#updateToLatestTemplateVersion}), which
-   * cannot reach the service-layer {@link InventoryLinkManager}; a soft-delete is also an ordinary
-   * update rather than a JPA remove, so the {@code cascade}/{@code orphanRemoval} on {@code
-   * InventoryLinkField#link} never fires. Without this the link row would linger with {@code
-   * deleted=false} after its field is gone. No-op unless the field is a deleted {@link
-   * InventoryLinkField} whose link is still live.
-   */
-  void softDeleteLinkOfDeletedLinkField(InventoryEntityField field, User user) {
-    if (field instanceof InventoryLinkField && field.isDeleted()) {
-      InventoryLink link = ((InventoryLinkField) field).getLink();
-      if (link != null && !link.isDeleted()) {
-        inventoryLinkManager.deleteLink(link, user);
-      }
     }
   }
 
@@ -810,8 +788,9 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
         identifiersHelper.createAssignRequestedIdentifiers(
             apiSample.getIdentifiers(), dbSample, user);
     contentChanged |= apiSample.applyChangesToDatabaseSample(dbSample, user);
-    if (!dbSample.isTemplate()) {
-      contentChanged |= applyLinkFieldValuesOnUpdate(apiSample, (Sample) dbSample, user);
+    contentChanged |= applyLinkFieldValuesOnUpdate(apiSample, dbSample, user);
+    if (dbSample.isTemplate()) {
+      assertDefaultLinksMatchWhitelists(dbSample.getActiveFields());
     }
     contentChanged |= saveSharingACLForIncomingApiInvRec(dbSample, apiSample);
     contentChanged |= saveIncomingSampleImage(dbSample, apiSample, user);
@@ -1060,7 +1039,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     sampleTemplate.setDefaultUnitId(apiSample.getDefaultUnitId());
     setBasicFieldsFromNewIncomingApiInventoryRecord(sampleTemplate, apiSample, user);
     setSampleCoreProperties(apiSample, sampleTemplate);
-    createFields(apiSample, sampleTemplate);
+    createFields(apiSample, sampleTemplate, user);
 
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNames(sampleTemplate);
     SampleTemplate savedSampleTemplate = sampleTemplateDao.persistSampleTemplate(sampleTemplate);
@@ -1072,12 +1051,29 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     return rc;
   }
 
-  private void createFields(ApiSampleTemplatePost apiSample, SampleTemplate sample) {
+  void createFields(ApiSampleTemplatePost apiSample, SampleTemplate sample, User user) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiSample.getFields(), null);
     for (ApiInventoryEntityField field : apiSample.getFields()) {
       InventoryEntityField toAdd = apiFieldToModelFieldFactory.apiInventoryFieldToModelField(field);
+      applyDefaultLinkOfNewTemplateField(toAdd, field, user);
       sample.addSampleField(toAdd);
+    }
+  }
+
+  /**
+   * Applies a template link field's optional default link (RSDEV-1246). The stateless {@link
+   * ApiFieldToModelFieldFactory} sets only the allowed-relation-types whitelist, so the default has
+   * to be created here, through the same {@link InventoryLinkManager} write path an item's link
+   * uses: validated against the DataCite vocabulary and the field's own whitelist, with the Envers
+   * revision captured. Items created from the template are then stamped with a copy of it by {@code
+   * InventoryLinkField#shallowCopy()}, needing no further code. No-op for any other field type, and
+   * for a link field whose payload carries no link.
+   */
+  private void applyDefaultLinkOfNewTemplateField(
+      InventoryEntityField toAdd, ApiInventoryEntityField apiField, User user) {
+    if (toAdd instanceof InventoryLinkField) {
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
     }
   }
 
@@ -1102,7 +1098,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
     return (ApiSampleTemplate) getOutgoingApiSample(dbTemplate, user);
   }
 
-  private boolean createDeleteRequestedFieldsInDbSampleTemplate(
+  boolean createDeleteRequestedFieldsInDbSampleTemplate(
       ApiSampleWithoutSubSamples apiSample, SampleTemplate dbTemplate, User user) {
     InventoryFieldNameUniquenessValidator.assertNoDuplicateFieldNamesInRequest(
         apiSample.getFields(), null);
@@ -1111,6 +1107,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       if (apiField.isNewFieldRequest()) {
         InventoryEntityField toAdd =
             apiFieldToModelFieldFactory.apiInventoryFieldToModelField(apiField);
+        applyDefaultLinkOfNewTemplateField(toAdd, apiField, user);
         dbTemplate.addSampleField(toAdd);
         changed = true;
       }

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -425,8 +425,26 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
    * alongside it. The chosen relation type must be permitted by the template field's
    * allowed-relation-types whitelist (an empty whitelist permits all).
    */
+  /** Item semantics: see the four-argument overload. */
   boolean applyLinkFieldValue(
       InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
+    return applyLinkFieldValue(field, apiField, user, false);
+  }
+
+  /**
+   * @param omittedLinkPreservesExisting how to read a payload that carries no {@code link} key at
+   *     all. True for a <b>template</b> field, whose PUT accepts a partial field list: a
+   *     whitelist-only edit or a rename must not destroy the default link. False for an <b>item</b>
+   *     field, whose field list always arrives complete, so an absent link means the user cleared
+   *     it (RSDEV-1131, pinned by {@code
+   *     InstrumentEntityApiManagerTest.linkFieldValue_clearedWhenInstrumentUpdated}). An explicit
+   *     {@code "link": null} clears in both cases.
+   */
+  boolean applyLinkFieldValue(
+      InventoryLinkField field,
+      ApiInventoryEntityField apiField,
+      User user,
+      boolean omittedLinkPreservesExisting) {
     ApiInventoryLink apiLink = apiField.getLink();
     String target = apiLink == null ? null : apiLink.getTargetGlobalId();
     InventoryLink existing = field.getLink();
@@ -434,8 +452,8 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       if (existing == null) {
         return false; // no link before, none requested now
       }
-      if (!apiField.isLinkProvided()) {
-        // a partial update that never mentions the link: leave it alone rather than destroy it
+      if (omittedLinkPreservesExisting && !apiField.isLinkProvided()) {
+        // a partial template update that never mentions the link: leave it alone
         return false;
       }
       field.setLink(null); // orphanRemoval hard-deletes the dereferenced row at flush
@@ -495,7 +513,9 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
               .findFirst();
       if (dbFieldOpt.isPresent()) {
         rejectSelfLink(apiField.getLink(), dbSample);
-        changed |= applyLinkFieldValue((InventoryLinkField) dbFieldOpt.get(), apiField, user);
+        changed |=
+            applyLinkFieldValue(
+                (InventoryLinkField) dbFieldOpt.get(), apiField, user, dbSample.isTemplate());
       }
     }
     return changed;
@@ -516,7 +536,11 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
 
   private void rejectSelfLink(ApiInventoryLink apiLink, SampleEntity dbSample) {
     // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
-    // now reached while creating a template, which has no id yet (and so nothing to self-link to)
+    // now reached while creating a template, which has no id yet (and so nothing to self-link to).
+    // Returning early there is not a hole: the template is not in the database yet either, so
+    // InventoryLinkManager.createLink's target-exists-and-readable check rejects its own future
+    // Global ID before any link row is written. Every path where a self-link IS reachable (a
+    // template or item that already exists) passes a saved record and so runs the check below.
     if (apiLink == null || dbSample.getId() == null || dbSample.getOid() == null) {
       return;
     }
@@ -1085,7 +1109,7 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       // the same self-link rejection the edit path applies: adding a link field to an already-saved
       // template must not be a way in for a default that targets that very template
       rejectSelfLink(apiField.getLink(), dbTemplate);
-      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user);
+      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user, true);
     }
   }
 

--- a/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/SampleApiManagerImpl.java
@@ -4,7 +4,6 @@ import com.axiope.search.InventorySearchConfig.InventorySearchDeletedOption;
 import com.researchspace.api.v1.auth.ApiRuntimeException;
 import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
-import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
 import com.researchspace.api.v1.model.ApiSample;
@@ -25,7 +24,6 @@ import com.researchspace.dao.SampleDao;
 import com.researchspace.dao.SampleTemplateDao;
 import com.researchspace.model.PaginationCriteria;
 import com.researchspace.model.User;
-import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.events.InventoryAccessEvent;
 import com.researchspace.model.events.InventoryCreationEvent;
 import com.researchspace.model.events.InventoryDeleteEvent;
@@ -43,14 +41,10 @@ import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.InventoryEntityField;
-import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.record.IActiveUserStrategy;
-import com.researchspace.service.inventory.DataCiteRelationType;
 import com.researchspace.service.inventory.InventoryAuditApiManager;
 import com.researchspace.service.inventory.InventoryFieldNameUniquenessValidator;
-import com.researchspace.service.inventory.InventoryLinkManager;
-import com.researchspace.service.inventory.InventoryLinkValidator;
 import com.researchspace.service.inventory.InventoryMoveHelper;
 import com.researchspace.service.inventory.SampleApiManager;
 import com.researchspace.service.inventory.SubSampleApiManager;
@@ -60,7 +54,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -413,153 +406,14 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
   }
 
   /**
-   * Applies a sample's chosen link value to its structured link field, going through the {@link
-   * InventoryLinkManager} so the target is parsed/validated and the Envers revision captured (the
-   * same path used by extra-field links). An unchanged payload is a no-op (previously every save
-   * replaced the row, resetting its identity and creation date); a changed payload updates the
-   * field's existing InventoryLink row in place; clearing the value dereferences the row, which the
-   * field's {@code orphanRemoval} mapping hard-deletes at flush (an Envers DEL revision keeps the
-   * history in {@code InventoryLink_AUD}; a prior soft-delete write would be collapsed into that
-   * same DEL revision, so none is attempted). This differs deliberately from the extra-field delete
-   * path, where the FIELD itself is soft-deleted and its link row therefore survives soft-deleted
-   * alongside it. The chosen relation type must be permitted by the template field's
-   * allowed-relation-types whitelist (an empty whitelist permits all).
-   */
-  /** Item semantics: see the four-argument overload. */
-  boolean applyLinkFieldValue(
-      InventoryLinkField field, ApiInventoryEntityField apiField, User user) {
-    return applyLinkFieldValue(field, apiField, user, false);
-  }
-
-  /**
-   * @param omittedLinkPreservesExisting how to read a payload that carries no {@code link} key at
-   *     all. True for a <b>template</b> field, whose PUT accepts a partial field list: a
-   *     whitelist-only edit or a rename must not destroy the default link. False for an <b>item</b>
-   *     field, whose field list always arrives complete, so an absent link means the user cleared
-   *     it (RSDEV-1131, pinned by {@code
-   *     InstrumentEntityApiManagerTest.linkFieldValue_clearedWhenInstrumentUpdated}). An explicit
-   *     {@code "link": null} clears in both cases.
-   */
-  boolean applyLinkFieldValue(
-      InventoryLinkField field,
-      ApiInventoryEntityField apiField,
-      User user,
-      boolean omittedLinkPreservesExisting) {
-    ApiInventoryLink apiLink = apiField.getLink();
-    String target = apiLink == null ? null : apiLink.getTargetGlobalId();
-    InventoryLink existing = field.getLink();
-    if (target == null || target.trim().isEmpty()) {
-      if (existing == null) {
-        return false; // no link before, none requested now
-      }
-      if (omittedLinkPreservesExisting && !apiField.isLinkProvided()) {
-        // a partial template update that never mentions the link: leave it alone
-        return false;
-      }
-      field.setLink(null); // orphanRemoval hard-deletes the dereferenced row at flush
-      return true;
-    }
-    Long effectivePin =
-        apiLink.derivedVersionPin() != null ? apiLink.derivedVersionPin() : apiLink.getVersionPin();
-    // compare on the parsed base id, not the raw string: the stored row holds the
-    // unsuffixed id (the pin lives in versionPin), so a suffixed incoming id like
-    // "SA2v4" would otherwise never compare equal and every save would fire a
-    // spurious update (and Envers revision). Mirrors ApiExtraFieldsHelper.linkChanged.
-    GlobalIdentifier incoming = parseTargetOrNull(target);
-    if (existing != null
-        && incoming != null
-        && incoming.getPrefix() == existing.getTargetPrefix()
-        && Objects.equals(incoming.getDbId(), existing.getTargetDbId())
-        && Objects.equals(effectivePin, existing.getVersionPin())
-        && Objects.equals(apiLink.getRelationType(), existing.getRelationType())) {
-      return false; // unchanged
-    }
-    assertRelationAllowed(field, apiLink.getRelationType());
-    if (existing != null) {
-      field.setLink(inventoryLinkManager.updateLink(existing, apiLink, user));
-    } else {
-      field.setLink(inventoryLinkManager.createLink(apiLink, user));
-    }
-    return true;
-  }
-
-  /**
-   * Applies link values to an existing sample's structured link fields (the update path). The DTO
-   * apply loop leaves link fields untouched because it cannot reach the service-layer {@link
-   * InventoryLinkManager}; this matches each modified link field by id and applies it here.
-   *
-   * <p>Takes a {@link SampleEntity}, not a {@link Sample}: a template's link field carries an
-   * editable default link of its own (RSDEV-1246), so templates go through the same write path as
-   * items rather than being skipped.
+   * Applies link values to an existing sample's (or sample template's) structured link fields. The
+   * shared implementation cannot read {@code isTemplate()} off {@link InventoryRecord}, so this
+   * passes it in.
    */
   boolean applyLinkFieldValuesOnUpdate(
       ApiSampleWithoutSubSamples apiSample, SampleEntity dbSample, User user) {
-    if (apiSample.getFields() == null) {
-      return false;
-    }
-    boolean changed = false;
-    for (ApiInventoryEntityField apiField : apiSample.getFields()) {
-      if (apiField.isNewFieldRequest()
-          || apiField.isDeleteFieldRequest()
-          || apiField.getId() == null) {
-        continue;
-      }
-      Optional<InventoryEntityField> dbFieldOpt =
-          dbSample.getActiveFields().stream()
-              .filter(
-                  f ->
-                      f instanceof InventoryLinkField
-                          && Objects.equals(f.getId(), apiField.getId()))
-              .findFirst();
-      if (dbFieldOpt.isPresent()) {
-        rejectSelfLink(apiField.getLink(), dbSample);
-        changed |=
-            applyLinkFieldValue(
-                (InventoryLinkField) dbFieldOpt.get(), apiField, user, dbSample.isTemplate());
-      }
-    }
-    return changed;
-  }
-
-  private void assertRelationAllowed(InventoryLinkField field, String relationType) {
-    // a chosen relation must be a real DataCite relation type, even when the whitelist is empty.
-    // ApiRuntimeException maps to a 422 with the resolved bundle message, where a raw
-    // IllegalArgumentException would surface as an unmapped 500.
-    if (!DataCiteRelationType.isValid(relationType)) {
-      throw new ApiRuntimeException("errors.inventory.field.linkRelationTypeInvalid", relationType);
-    }
-    if (!isRelationPermitted(field, relationType)) {
-      throw new ApiRuntimeException(
-          "errors.inventory.field.linkRelationTypeNotPermitted", relationType, field.getName());
-    }
-  }
-
-  private void rejectSelfLink(ApiInventoryLink apiLink, SampleEntity dbSample) {
-    // getId() first: getOid() throws rather than returning null on an unsaved record, and this is
-    // now reached while creating a template, which has no id yet (and so nothing to self-link to).
-    // Returning early there is not a hole: the template is not in the database yet either, so
-    // InventoryLinkManager.createLink's target-exists-and-readable check rejects its own future
-    // Global ID before any link row is written. Every path where a self-link IS reachable (a
-    // template or item that already exists) passes a saved record and so runs the check below.
-    if (apiLink == null || dbSample.getId() == null || dbSample.getOid() == null) {
-      return;
-    }
-    GlobalIdentifier target = parseTargetOrNull(apiLink.getTargetGlobalId());
-    if (target == null) {
-      return; // malformed/blank targets are handled by the manager / clear path
-    }
-    if (InventoryLinkValidator.isSelfLink(target, dbSample.getOid().toString())) {
-      throw new ApiRuntimeException(
-          "errors.inventory.field.link.selfLinkForbidden", apiLink.getTargetGlobalId());
-    }
-  }
-
-  private GlobalIdentifier parseTargetOrNull(String targetGlobalId) {
-    try {
-      return new GlobalIdentifier(targetGlobalId);
-    } catch (IllegalArgumentException | NullPointerException ex) {
-      return null;
-    }
+    return applyLinkFieldValuesOnUpdate(
+        apiSample.getFields(), dbSample.getActiveFields(), dbSample, dbSample.isTemplate(), user);
   }
 
   private void publishAuditEventsForCreatedSample(User user, Sample savedSample) {
@@ -1088,28 +942,6 @@ public class SampleApiManagerImpl extends InventoryApiManagerImpl<SampleEntity>
       InventoryEntityField toAdd = apiFieldToModelFieldFactory.apiInventoryFieldToModelField(field);
       applyDefaultLinkOfNewTemplateField(toAdd, field, sample, user);
       sample.addSampleField(toAdd);
-    }
-  }
-
-  /**
-   * Applies a template link field's optional default link (RSDEV-1246). The stateless {@link
-   * ApiFieldToModelFieldFactory} sets only the allowed-relation-types whitelist, so the default has
-   * to be created here, through the same {@link InventoryLinkManager} write path an item's link
-   * uses: validated against the DataCite vocabulary and the field's own whitelist, with the Envers
-   * revision captured. Items created from the template are then stamped with a copy of it by {@code
-   * InventoryLinkField#shallowCopy()}, needing no further code. No-op for any other field type, and
-   * for a link field whose payload carries no link.
-   */
-  private void applyDefaultLinkOfNewTemplateField(
-      InventoryEntityField toAdd,
-      ApiInventoryEntityField apiField,
-      SampleEntity dbTemplate,
-      User user) {
-    if (toAdd instanceof InventoryLinkField) {
-      // the same self-link rejection the edit path applies: adding a link field to an already-saved
-      // template must not be a way in for a default that targets that very template
-      rejectSelfLink(apiField.getLink(), dbTemplate);
-      applyLinkFieldValue((InventoryLinkField) toAdd, apiField, user, true);
     }
   }
 

--- a/src/main/resources/bundles/inventory/inventory.properties
+++ b/src/main/resources/bundles/inventory/inventory.properties
@@ -60,6 +60,7 @@ errors.inventory.field.link.targetNotFound=Link target ''{0}'' could not be foun
 errors.inventory.field.link.selfLinkForbidden=An item cannot link to itself: ''{0}''.
 errors.inventory.field.link.relationTypeInvalid=Relation type ''{0}'' is not in the DataCite controlled vocabulary.
 errors.inventory.field.link.relationTypeNotPermitted=Relation type ''{0}'' is not permitted for field ''{1}''.
+errors.inventory.field.link.defaultRelationTypeNotPermitted=Field ''{1}'' has a default link using relation type ''{0}'', so that type cannot be removed from its allowed relationship types. Change or remove the default link first.
 errors.inventory.field.deleteRequest.idMissing=''id'' property not provided for a field with ''deleteFieldRequest'' flag.
 errors.inventory.field.deleteRequest.idUnknown=Field id {0} doesn''t match the id of any pre-existing field.
 errors.inventory.identifier.integration.not.enabled={0} integration is not enabled on this RSpace instance.

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
@@ -23,6 +23,12 @@ type LinkFieldValueArgs = {
   sourceGlobalId: string;
   disabled: boolean;
   onChange: () => void;
+  /**
+   * Whether to surface the field name above the editor and inside the committed card. True on an
+   * item, whose FormField label is hidden. False in the template editor, where the name is already
+   * entered in the Name field just above and repeating it here is noise.
+   */
+  showFieldName?: boolean;
 };
 
 /**
@@ -34,7 +40,13 @@ type LinkFieldValueArgs = {
  * committed on Apply, mirroring the extra-field Link editor. The editor body itself is the shared
  * {@link LinkEditor}.
  */
-function LinkFieldValue({ field, sourceGlobalId, disabled, onChange }: LinkFieldValueArgs): React.ReactNode {
+function LinkFieldValue({
+  field,
+  sourceGlobalId,
+  disabled,
+  onChange,
+  showFieldName = true,
+}: LinkFieldValueArgs): React.ReactNode {
   const { t } = useTranslation("inventory");
   const committedRelationType = field.link?.relationType ?? "";
   const committedTargetGlobalId = field.link?.targetGlobalId ?? "";
@@ -160,7 +172,7 @@ function LinkFieldValue({ field, sourceGlobalId, disabled, onChange }: LinkField
             />
           </Box>
         )}
-        <LinkField name={field.name} link={committedLink} editable={!disabled} />
+        <LinkField name={showFieldName ? field.name : ""} link={committedLink} editable={!disabled} />
       </Box>
     );
   }
@@ -178,7 +190,7 @@ function LinkFieldValue({ field, sourceGlobalId, disabled, onChange }: LinkField
   return (
     <Box>
       {/* The FormField label is hidden, so surface the field name here. */}
-      {field.name && (
+      {showFieldName && field.name && (
         <Typography variant="subtitle1" component="span" sx={{ fontWeight: 700 }}>
           {field.name}
         </Typography>

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
@@ -22,7 +22,9 @@ type LinkFieldValueArgs = {
   /** The Global ID of the sample owning this field, used to forbid self-links. */
   sourceGlobalId: string;
   disabled: boolean;
-  onChange: () => void;
+  /** Notifies the owning form that the committed link changed. Omit where there is nothing to tell:
+   * the template editor tracks error state on its Name field only. */
+  onChange?: () => void;
   /**
    * Whether to surface the field name above the editor and inside the committed card. True on an
    * item, whose FormField label is hidden. False in the template editor, where the name is already
@@ -101,8 +103,14 @@ function LinkFieldValue({
   // left-open editor must not keep the field flagged: that would block save with an "Apply or
   // discard" message the user has no way to act on. A record Save happens while still editable
   // (`disabled` is false), so gating on `!disabled` does not weaken the guard.
+  // The cleanup matters: the template editor unmounts this component when the field is marked for
+  // deletion (Template/Fields/CustomField swaps in the delete notice), and record validation walks
+  // every field including deleted ones. Without it, opening the editor on a link field and then
+  // removing that field leaves the flag set and blocks Save with an "Apply or discard" message the
+  // user has no editor left to act on.
   useEffect(() => {
     field.setLinkEditInProgress(!disabled && (changed || (editing && hasLink)));
+    return () => field.setLinkEditInProgress(false);
   }, [changed, editing, hasLink, disabled, field]);
 
   const relationOptions =
@@ -117,8 +125,7 @@ function LinkFieldValue({
   // a stageable value is either fully cleared (removing the link) or a complete, valid link
   const canApply = changed && !checkingTarget && !targetExistenceError && (bothEmpty || (bothSet && targetValidity.ok));
 
-  const validationMessage =
-    changed && !bothEmpty && !bothSet ? "Select both a relationship type and a target before applying." : "";
+  const validationMessage = changed && !bothEmpty && !bothSet ? t("sample.fields.linkFieldValue.bothRequired") : "";
 
   const apply = async (): Promise<void> => {
     const nextLink: FieldLink | null = bothEmpty
@@ -135,14 +142,14 @@ function LinkFieldValue({
       const exists = await checkLinkTargetExists(nextLink.targetGlobalId);
       setCheckingTarget(false);
       if (!exists) {
-        setTargetExistenceError(`${nextLink.targetGlobalId} does not exist, or you do not have permission to view it.`);
+        setTargetExistenceError(t("fields.extraFields.link.targetNotFound", { globalId: nextLink.targetGlobalId }));
         return;
       }
     }
     field.setAttributesDirty({ link: nextLink });
     field.setLinkEditInProgress(false);
     setEditing(false);
-    onChange();
+    onChange?.();
   };
 
   const discard = (): void => {
@@ -200,13 +207,13 @@ function LinkFieldValue({
         onRelationTypeChange={(value) => setStagedRelationType(value)}
         relationOptions={relationOptions}
         relationFreeSolo={false}
-        relationLabel="Relationship type"
+        relationLabel={t("fields.extraFields.fields.relationType")}
         targetGlobalId={stagedTargetGlobalId}
         onTargetChange={(globalId) => setStagedTarget(globalId)}
         targetError={Boolean(targetExistenceError) || !targetValidity.ok}
         targetHelperText={
           targetExistenceError ??
-          (!targetValidity.ok ? targetValidity.reason : "Paste a Global ID, or use the Browse buttons above.")
+          (!targetValidity.ok ? targetValidity.reason : t("fields.extraFields.link.targetHelper"))
         }
         validationMessage={validationMessage}
         versionPin={stagedVersionPin}

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
@@ -23,6 +23,12 @@ type LinkFieldValueArgs = {
   sourceGlobalId: string;
   disabled: boolean;
   onChange: () => void;
+  /**
+   * Whether to surface the field name above the editor and inside the committed card. True on an
+   * item, whose FormField label is hidden. False in the template editor, where the name is already
+   * entered in the Name field just above and repeating it here is noise.
+   */
+  showFieldName?: boolean;
 };
 
 /**
@@ -34,7 +40,13 @@ type LinkFieldValueArgs = {
  * committed on Apply, mirroring the extra-field Link editor. The editor body itself is the shared
  * {@link LinkEditor}.
  */
-function LinkFieldValue({ field, sourceGlobalId, disabled, onChange }: LinkFieldValueArgs): React.ReactNode {
+function LinkFieldValue({
+  field,
+  sourceGlobalId,
+  disabled,
+  onChange,
+  showFieldName = true,
+}: LinkFieldValueArgs): React.ReactNode {
   const { t } = useTranslation("inventory");
   const committedRelationType = field.link?.relationType ?? "";
   const committedTargetGlobalId = field.link?.targetGlobalId ?? "";
@@ -164,7 +176,7 @@ function LinkFieldValue({ field, sourceGlobalId, disabled, onChange }: LinkField
             />
           </Box>
         )}
-        <LinkField name={field.name} link={committedLink} editable={!disabled} />
+        <LinkField name={showFieldName ? field.name : ""} link={committedLink} editable={!disabled} />
       </Box>
     );
   }
@@ -182,7 +194,7 @@ function LinkFieldValue({ field, sourceGlobalId, disabled, onChange }: LinkField
   return (
     <Box>
       {/* The FormField label is hidden, so surface the field name here. */}
-      {field.name && (
+      {showFieldName && field.name && (
         <Typography variant="subtitle1" component="span" sx={{ fontWeight: 700 }}>
           {field.name}
         </Typography>

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
@@ -22,7 +22,9 @@ type LinkFieldValueArgs = {
   /** The Global ID of the sample owning this field, used to forbid self-links. */
   sourceGlobalId: string;
   disabled: boolean;
-  onChange: () => void;
+  /** Notifies the owning form that the committed link changed. Omit where there is nothing to tell:
+   * the template editor tracks error state on its Name field only. */
+  onChange?: () => void;
   /**
    * Whether to surface the field name above the editor and inside the committed card. True on an
    * item, whose FormField label is hidden. False in the template editor, where the name is already
@@ -101,8 +103,14 @@ function LinkFieldValue({
   // left-open editor must not keep the field flagged: that would block save with an "Apply or
   // discard" message the user has no way to act on. A record Save happens while still editable
   // (`disabled` is false), so gating on `!disabled` does not weaken the guard.
+  // The cleanup matters: the template editor unmounts this component when the field is marked for
+  // deletion (Template/Fields/CustomField swaps in the delete notice), and record validation walks
+  // every field including deleted ones. Without it, opening the editor on a link field and then
+  // removing that field leaves the flag set and blocks Save with an "Apply or discard" message the
+  // user has no editor left to act on.
   useEffect(() => {
     field.setLinkEditInProgress(!disabled && (changed || (editing && hasLink)));
+    return () => field.setLinkEditInProgress(false);
   }, [changed, editing, hasLink, disabled, field]);
 
   const relationOptions =
@@ -146,7 +154,7 @@ function LinkFieldValue({
     field.setAttributesDirty({ link: nextLink });
     field.setLinkEditInProgress(false);
     setEditing(false);
-    onChange();
+    onChange?.();
   };
 
   const discard = (): void => {

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
@@ -37,6 +37,8 @@ type LinkFieldValueArgs = {
    * record. Left unset on an item, where "Target" is right.
    */
   targetHeading?: string;
+  /** Passed through to {@link LinkEditor}; see its docblock. */
+  nestHeadings?: boolean;
 };
 
 /**
@@ -55,6 +57,7 @@ function LinkFieldValue({
   onChange,
   showFieldName = true,
   targetHeading,
+  nestHeadings,
 }: LinkFieldValueArgs): React.ReactNode {
   const { t } = useTranslation("inventory");
   const committedRelationType = field.link?.relationType ?? "";
@@ -117,8 +120,11 @@ function LinkFieldValue({
   // user has no editor left to act on.
   useEffect(() => {
     field.setLinkEditInProgress(!disabled && (changed || (editing && hasLink)));
-    return () => field.setLinkEditInProgress(false);
   }, [changed, editing, hasLink, disabled, field]);
+  // Separate from the effect above on purpose. React runs a cleanup before every re-run, not only
+  // on unmount, so keeping it there wrote false and then the real value on every dependency
+  // change: two MobX actions, and an observable transiently wrong in between.
+  useEffect(() => () => field.setLinkEditInProgress(false), [field]);
 
   const relationOptions =
     field.allowedRelationTypes.length > 0 ? field.allowedRelationTypes : [...DATACITE_RELATION_TYPES];
@@ -221,6 +227,7 @@ function LinkFieldValue({
         relationFreeSolo={false}
         relationLabel={t("fields.extraFields.fields.relationType")}
         targetHeading={targetHeading}
+        nestHeadings={nestHeadings}
         targetGlobalId={stagedTargetGlobalId}
         onTargetChange={(globalId) => setStagedTarget(globalId)}
         targetError={Boolean(targetExistenceError) || !targetValidity.ok}

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
@@ -26,16 +26,11 @@ type LinkFieldValueArgs = {
    * the template editor tracks error state on its Name field only. */
   onChange?: () => void;
   /**
-   * Whether to surface the field name above the editor and inside the committed card. True on an
-   * item, whose FormField label is hidden. False in the template editor, where the name is already
-   * entered in the Name field just above and repeating it here is noise.
+   * Whether to surface the field name above the editor and in the committed card. False in the
+   * template editor, where the Name field just above already carries it.
    */
   showFieldName?: boolean;
-  /**
-   * Overrides the editor's "Target" group heading. The template editor passes "Default link target",
-   * since inside the Default link section the target being chosen belongs to the default, not to the
-   * record. Left unset on an item, where "Target" is right.
-   */
+  /** Overrides the editor's "Target" group heading; the template editor names the default's. */
   targetHeading?: string;
   /** Passed through to {@link LinkEditor}; see its docblock. */
   nestHeadings?: boolean;
@@ -106,24 +101,16 @@ function LinkFieldValue({
     stagedTargetGlobalId !== committedTargetGlobalId ||
     stagedVersionPin !== committedVersionPin;
 
-  // Block record Save while the link editor is open or holds unapplied changes; the
-  // `hasLink` guard keeps an empty optional field saveable. A dedicated flag, not
-  // field.error (see Field.linkEditInProgress), so an open editor reads as in-progress.
-  // In view mode (`disabled`) the editor - and its Apply/Discard buttons - is never shown, so a
-  // left-open editor must not keep the field flagged: that would block save with an "Apply or
-  // discard" message the user has no way to act on. A record Save happens while still editable
-  // (`disabled` is false), so gating on `!disabled` does not weaken the guard.
-  // The cleanup matters: the template editor unmounts this component when the field is marked for
-  // deletion (Template/Fields/CustomField swaps in the delete notice), and record validation walks
-  // every field including deleted ones. Without it, opening the editor on a link field and then
-  // removing that field leaves the flag set and blocks Save with an "Apply or discard" message the
-  // user has no editor left to act on.
+  // Block record Save while the editor is open or holds unapplied changes; the `hasLink` guard
+  // keeps an empty optional field saveable. A dedicated flag, not field.error, so an open editor
+  // reads as in-progress. Gated on `!disabled` because in view mode there are no Apply/Discard
+  // buttons to act on, and a record Save happens while still editable.
   useEffect(() => {
     field.setLinkEditInProgress(!disabled && (changed || (editing && hasLink)));
   }, [changed, editing, hasLink, disabled, field]);
-  // Separate from the effect above on purpose. React runs a cleanup before every re-run, not only
-  // on unmount, so keeping it there wrote false and then the real value on every dependency
-  // change: two MobX actions, and an observable transiently wrong in between.
+  // Separate from the effect above on purpose: React runs a cleanup before every re-run, not only
+  // on unmount, so keeping it there wrote false then the real value on every dependency change.
+  // Clears the flag when the template editor unmounts a field marked for deletion.
   useEffect(() => () => field.setLinkEditInProgress(false), [field]);
 
   const relationOptions =

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/LinkFieldValue.tsx
@@ -31,6 +31,12 @@ type LinkFieldValueArgs = {
    * entered in the Name field just above and repeating it here is noise.
    */
   showFieldName?: boolean;
+  /**
+   * Overrides the editor's "Target" group heading. The template editor passes "Default link target",
+   * since inside the Default link section the target being chosen belongs to the default, not to the
+   * record. Left unset on an item, where "Target" is right.
+   */
+  targetHeading?: string;
 };
 
 /**
@@ -48,6 +54,7 @@ function LinkFieldValue({
   disabled,
   onChange,
   showFieldName = true,
+  targetHeading,
 }: LinkFieldValueArgs): React.ReactNode {
   const { t } = useTranslation("inventory");
   const committedRelationType = field.link?.relationType ?? "";
@@ -213,6 +220,7 @@ function LinkFieldValue({
         relationOptions={relationOptions}
         relationFreeSolo={false}
         relationLabel={t("fields.extraFields.fields.relationType")}
+        targetHeading={targetHeading}
         targetGlobalId={stagedTargetGlobalId}
         onTargetChange={(globalId) => setStagedTarget(globalId)}
         targetError={Boolean(targetExistenceError) || !targetValidity.ok}

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
@@ -94,6 +94,19 @@ beforeEach(() => {
 });
 
 describe("LinkFieldValue", () => {
+  it("surfaces the field name on an item, whose FormField label is hidden", () => {
+    // the template editor opts out with showFieldName={false} (its Name field is right above); an
+    // item has no other label, so the default must keep showing it
+    renderField({
+      field: linkField(),
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    expect(screen.getByText("Related items")).toBeInTheDocument();
+  });
+
   it("constrains the relationship type options to the field's allowed set", async () => {
     const user = userEvent.setup();
     renderField({

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
@@ -488,7 +488,9 @@ describe("LinkFieldValue", () => {
     await user.click(screen.getByRole("button", { name: "inventory:sample.fields.linkFieldValue.applyLabel" }));
 
     expect(
-      await screen.findByText("SS9999 does not exist, or you do not have permission to view it."),
+      // the message is now the shared catalog key (cimode resolves it to ns:key, so the
+      // interpolated globalId is not part of the rendered text)
+      await screen.findByText("inventory:fields.extraFields.link.targetNotFound"),
     ).toBeInTheDocument();
     expect(setAttributesDirty).not.toHaveBeenCalled();
   });

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
@@ -248,6 +248,57 @@ describe("LinkFieldValue", () => {
     expect(setAttributesDirty).not.toHaveBeenCalled();
   });
 
+  it("clears the edit-in-progress flag on unmount, so a deleted field cannot block save", async () => {
+    // The template editor unmounts this component when the field is marked for deletion (CustomField
+    // swaps in the delete notice), while record validation still walks deleted fields. Without the
+    // cleanup, opening the editor and then removing the field left Save blocked by an "Apply or
+    // discard" message with no editor left to act on.
+    const user = userEvent.setup();
+    const setLinkEditInProgress = vi.fn();
+    const field = linkField({
+      link: { relationType: "References", targetGlobalId: "SA20", versionPin: null },
+      setLinkEditInProgress,
+    });
+    const { unmount } = renderField({
+      field,
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    await user.click(screen.getByRole("button", { name: "inventory:fields.link.linkField.editLink" }));
+    expect(setLinkEditInProgress).toHaveBeenLastCalledWith(true);
+
+    unmount();
+
+    expect(setLinkEditInProgress).toHaveBeenLastCalledWith(false);
+  });
+
+  it("commits an Apply when no onChange listener is supplied", async () => {
+    // DefaultValueField is the only caller that omits onChange. Dropping the optional-call guard
+    // would throw a TypeError on every template default-link Apply, and nothing else catches it.
+    const user = userEvent.setup();
+    const setAttributesDirty = vi.fn();
+    const field = linkField({
+      link: { relationType: "References", targetGlobalId: "SA20", versionPin: null },
+      setAttributesDirty,
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LinkFieldValue field={field} sourceGlobalId="ST1" disabled={false} />
+      </ThemeProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "inventory:fields.link.linkField.editLink" }));
+    await user.click(screen.getByRole("button", { name: "Open" }));
+    await user.click(screen.getByRole("option", { name: "IsDerivedFrom" }));
+    await user.click(screen.getByRole("button", { name: "inventory:sample.fields.linkFieldValue.applyLabel" }));
+
+    expect(setAttributesDirty).toHaveBeenCalledWith({
+      link: { relationType: "IsDerivedFrom", targetGlobalId: "SA20", versionPin: null },
+    });
+  });
+
   it("flags the field model while link edits are unapplied so record save is blocked", async () => {
     const user = userEvent.setup();
     const setLinkEditInProgress = vi.fn();

--- a/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Sample/Fields/TemplateFields/__tests__/LinkFieldValue.test.tsx
@@ -113,6 +113,19 @@ beforeEach(() => {
 });
 
 describe("LinkFieldValue", () => {
+  it("surfaces the field name on an item, whose FormField label is hidden", () => {
+    // the template editor opts out with showFieldName={false} (its Name field is right above); an
+    // item has no other label, so the default must keep showing it
+    renderField({
+      field: linkField(),
+      sourceGlobalId: "SA1",
+      disabled: false,
+      onChange: () => {},
+    });
+
+    expect(screen.getByText("Related items")).toBeInTheDocument();
+  });
+
   it("constrains the relationship type options to the field's allowed set", async () => {
     const user = userEvent.setup();
     renderField({

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -47,58 +47,62 @@ function DefaultValueField({ field, editing }: DefaultValueFieldArgs): React.Rea
    * rejection, target-existence check and Apply/Discard guard all come for free.
    */
   if (field.type === "link") {
+    // siblings, not nested: InputWrapper renders a labelled fieldset, so nesting would make the
+    // default-link controls announce as part of the "Allowed relationship types" group
     return (
-      <InputWrapper
-        label={t("fields.templateFields.defaultValue.allowedRelationshipTypes")}
-        explanation={t("fields.templateFields.defaultValue.allowedRelationshipTypesExplanation")}
-      >
-        <Autocomplete
-          multiple
-          disabled={!editing}
-          options={[...DATACITE_RELATION_TYPES]}
-          value={field.allowedRelationTypes}
-          // already-chosen types are greyed out rather than toggled off; they
-          // are removed via their chip's delete icon instead
-          getOptionDisabled={(option) => field.allowedRelationTypes.includes(option)}
-          onChange={(_event, value) => field.setAttributesDirty({ allowedRelationTypes: value })}
-          renderInput={(params) => {
-            const { slotProps, ...textFieldProps } = params;
-            return (
-              <MuiTextField
-                {...textFieldProps}
-                variant="standard"
-                placeholder={
-                  field.allowedRelationTypes.length === 0
-                    ? t("fields.templateFields.defaultValue.allRelationshipTypes")
-                    : ""
-                }
-                slotProps={{
-                  ...slotProps,
-                  htmlInput: {
-                    ...slotProps.htmlInput,
-                    "aria-label": t("fields.templateFields.defaultValue.allowedRelationshipTypes"),
-                  },
-                }}
-              />
-            );
-          }}
-        />
-        <Box sx={{ mt: 2 }}>
-          <InputWrapper
-            label={t("fields.templateFields.defaultValue.defaultLink")}
-            explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
-          >
-            <LinkFieldValue
-              field={field}
-              sourceGlobalId={field.owner.globalId ?? ""}
-              disabled={!editing}
-              onChange={() => {}}
-              // the name is already entered in the Name field above
-              showFieldName={false}
-            />
-          </InputWrapper>
-        </Box>
-      </InputWrapper>
+      <>
+        <InputWrapper
+          label={t("fields.templateFields.defaultValue.allowedRelationshipTypes")}
+          explanation={t("fields.templateFields.defaultValue.allowedRelationshipTypesExplanation")}
+        >
+          <Autocomplete
+            multiple
+            disabled={!editing}
+            options={[...DATACITE_RELATION_TYPES]}
+            value={field.allowedRelationTypes}
+            // already-chosen types are greyed out rather than toggled off; they
+            // are removed via their chip's delete icon instead
+            getOptionDisabled={(option) => field.allowedRelationTypes.includes(option)}
+            onChange={(_event, value) => field.setAttributesDirty({ allowedRelationTypes: value })}
+            renderInput={(params) => {
+              const { slotProps, ...textFieldProps } = params;
+              return (
+                <MuiTextField
+                  {...textFieldProps}
+                  variant="standard"
+                  placeholder={
+                    field.allowedRelationTypes.length === 0
+                      ? t("fields.templateFields.defaultValue.allRelationshipTypes")
+                      : ""
+                  }
+                  slotProps={{
+                    ...slotProps,
+                    htmlInput: {
+                      ...slotProps.htmlInput,
+                      "aria-label": t("fields.templateFields.defaultValue.allowedRelationshipTypes"),
+                    },
+                  }}
+                />
+              );
+            }}
+          />
+        </InputWrapper>
+        <InputWrapper
+          label={t("fields.templateFields.defaultValue.defaultLink")}
+          explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
+        >
+          <LinkFieldValue
+            field={field}
+            // on an unsaved template this is "", which leaves the client-side self-link check inert.
+            // Harmless: a template with no Global ID has nothing to self-link to yet, and the server
+            // rejects it either way once the template exists.
+            sourceGlobalId={field.owner.globalId ?? ""}
+            disabled={!editing}
+            // the name is already entered in the Name field above
+            showFieldName={false}
+          />
+        </InputWrapper>
+      </>
     );
   }
 

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -15,6 +15,7 @@ import { hasOptions } from "../../../stores/models/FieldTypes";
 import { match } from "../../../util/Util";
 import { DATACITE_RELATION_TYPES } from "../../components/Fields/Link/dataciteRelationTypes";
 import CustomField from "../../components/Inputs/CustomField";
+import LinkFieldValue from "../../Sample/Fields/TemplateFields/LinkFieldValue";
 
 type DefaultValueFieldArgs = {
   field: FieldModel;
@@ -39,9 +40,11 @@ function DefaultValueField({ field, editing }: DefaultValueFieldArgs): React.Rea
   const key = React.useMemo(() => field.id ?? crypto.randomUUID(), [field.id]);
 
   /*
-   * Link template fields don't store a "default value" in the usual sense; instead the template
-   * defines which DataCite relationship types samples may use. An empty whitelist means all
-   * relationship types are allowed.
+   * A Link template field's "default value" has two parts: the whitelist of DataCite relationship
+   * types items created from this template may use (an empty whitelist means all of them), and an
+   * optional default link that is stamped onto those items (RSDEV-1246). The default is edited with
+   * the same LinkFieldValue editor an item's own link uses, so the relation options, self-link
+   * rejection, target-existence check and Apply/Discard guard all come for free.
    */
   if (field.type === "link") {
     return (
@@ -80,6 +83,19 @@ function DefaultValueField({ field, editing }: DefaultValueFieldArgs): React.Rea
             );
           }}
         />
+        <Box sx={{ mt: 2 }}>
+          <InputWrapper
+            label={t("fields.templateFields.defaultValue.defaultLink")}
+            explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
+          >
+            <LinkFieldValue
+              field={field}
+              sourceGlobalId={field.owner.globalId ?? ""}
+              disabled={!editing}
+              onChange={() => {}}
+            />
+          </InputWrapper>
+        </Box>
       </InputWrapper>
     );
   }

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -93,6 +93,8 @@ function DefaultValueField({ field, editing }: DefaultValueFieldArgs): React.Rea
               sourceGlobalId={field.owner.globalId ?? ""}
               disabled={!editing}
               onChange={() => {}}
+              // the name is already entered in the Name field above
+              showFieldName={false}
             />
           </InputWrapper>
         </Box>

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -15,6 +15,7 @@ import { hasOptions } from "../../../stores/models/FieldTypes";
 import { match } from "../../../util/Util";
 import { DATACITE_RELATION_TYPES } from "../../components/Fields/Link/dataciteRelationTypes";
 import CustomField from "../../components/Inputs/CustomField";
+import LinkFieldValue from "../../Sample/Fields/TemplateFields/LinkFieldValue";
 
 type DefaultValueFieldArgs = {
   field: FieldModel;
@@ -40,9 +41,11 @@ function DefaultValueField({ field, editing, recordTypeName = "sample" }: Defaul
   const key = React.useMemo(() => field.id ?? crypto.randomUUID(), [field.id]);
 
   /*
-   * Link template fields don't store a "default value" in the usual sense; instead the template
-   * defines which DataCite relationship types samples may use. An empty whitelist means all
-   * relationship types are allowed.
+   * A Link template field's "default value" has two parts: the whitelist of DataCite relationship
+   * types items created from this template may use (an empty whitelist means all of them), and an
+   * optional default link that is stamped onto those items (RSDEV-1246). The default is edited with
+   * the same LinkFieldValue editor an item's own link uses, so the relation options, self-link
+   * rejection, target-existence check and Apply/Discard guard all come for free.
    */
   if (field.type === "link") {
     return (
@@ -85,6 +88,19 @@ function DefaultValueField({ field, editing, recordTypeName = "sample" }: Defaul
             );
           }}
         />
+        <Box sx={{ mt: 2 }}>
+          <InputWrapper
+            label={t("fields.templateFields.defaultValue.defaultLink")}
+            explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
+          >
+            <LinkFieldValue
+              field={field}
+              sourceGlobalId={field.owner.globalId ?? ""}
+              disabled={!editing}
+              onChange={() => {}}
+            />
+          </InputWrapper>
+        </Box>
       </InputWrapper>
     );
   }

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -92,21 +92,36 @@ function DefaultValueField({ field, editing, recordTypeName = "sample" }: Defaul
             }}
           />
         </InputWrapper>
-        <InputWrapper
-          label={t("fields.templateFields.defaultValue.defaultLink")}
-          explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
+        {/* The default link is a whole sub-form (heading, explanation, target group, relationship
+          type, version), so without a boundary it reads as a continuation of the allowed-types
+          control above it. The border and inset give it one. */}
+        <Box
+          data-test-id="DefaultLinkSection"
+          sx={(theme) => ({
+            mt: 2,
+            p: 2,
+            border: `1px solid ${theme.palette.divider}`,
+            borderRadius: 1,
+          })}
         >
-          <LinkFieldValue
-            field={field}
-            // on an unsaved template this is "", which leaves the client-side self-link check inert.
-            // Harmless: a template with no Global ID has nothing to self-link to yet, and the server
-            // rejects it either way once the template exists.
-            sourceGlobalId={field.owner.globalId ?? ""}
-            disabled={!editing}
-            // the name is already entered in the Name field above
-            showFieldName={false}
-          />
-        </InputWrapper>
+          <InputWrapper
+            label={t("fields.templateFields.defaultValue.defaultLink")}
+            explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
+          >
+            <LinkFieldValue
+              field={field}
+              // on an unsaved template this is "", which leaves the client-side self-link check
+              // inert. Harmless: a template with no Global ID has nothing to self-link to yet, and
+              // the server rejects it either way once the template exists.
+              sourceGlobalId={field.owner.globalId ?? ""}
+              disabled={!editing}
+              // the name is already entered in the Name field above
+              showFieldName={false}
+              // inside this section "Target" alone would be ambiguous against the item's own link
+              targetHeading={t("fields.templateFields.defaultValue.defaultLinkTarget")}
+            />
+          </InputWrapper>
+        </Box>
       </>
     );
   }

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -2,6 +2,7 @@ import AddIcon from "@mui/icons-material/Add";
 import Autocomplete from "@mui/material/Autocomplete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Paper from "@mui/material/Paper";
 import MuiTextField from "@mui/material/TextField";
 import { observer } from "mobx-react-lite";
 import React from "react";
@@ -41,11 +42,9 @@ function DefaultValueField({ field, editing, recordTypeName = "sample" }: Defaul
   const key = React.useMemo(() => field.id ?? crypto.randomUUID(), [field.id]);
 
   /*
-   * A Link template field's "default value" has two parts: the whitelist of DataCite relationship
-   * types items created from this template may use (an empty whitelist means all of them), and an
-   * optional default link that is stamped onto those items (RSDEV-1246). The default is edited with
-   * the same LinkFieldValue editor an item's own link uses, so the relation options, self-link
-   * rejection, target-existence check and Apply/Discard guard all come for free.
+   * A Link template field's "default value" is two things: the whitelist of relationship types
+   * items may use (empty means all), and an optional default link stamped onto those items
+   * (RSDEV-1246). The default reuses the item's own LinkFieldValue editor.
    */
   if (field.type === "link") {
     // siblings, not nested: InputWrapper renders a labelled fieldset, so nesting would make the
@@ -92,39 +91,28 @@ function DefaultValueField({ field, editing, recordTypeName = "sample" }: Defaul
             }}
           />
         </InputWrapper>
-        {/* The default link is a whole sub-form (heading, explanation, target group, relationship
-          type, version), so without a boundary it reads as a continuation of the allowed-types
-          control above it. The border and inset give it one. */}
-        <Box
-          data-test-id="DefaultLinkSection"
-          sx={(theme) => ({
-            mt: 2,
-            p: 2,
-            border: `1px solid ${theme.palette.divider}`,
-            borderRadius: 1,
-          })}
-        >
+        {/* a whole sub-form, so without a boundary it reads as a continuation of the
+          allowed-types control above it */}
+        <Paper variant="outlined" data-test-id="DefaultLinkSection" sx={{ mt: 2, p: 2 }}>
           <InputWrapper
             label={t("fields.templateFields.defaultValue.defaultLink")}
             explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
           >
             <LinkFieldValue
               field={field}
-              // on an unsaved template this is "", which leaves the client-side self-link check
-              // inert. Harmless: a template with no Global ID has nothing to self-link to yet, and
-              // the server rejects it either way once the template exists.
+              // "" on an unsaved template, leaving the client-side self-link check inert; harmless,
+              // since a template with no Global ID has nothing to self-link to yet
               sourceGlobalId={field.owner.globalId ?? ""}
               disabled={!editing}
               // the name is already entered in the Name field above
               showFieldName={false}
               // inside this section "Target" alone would be ambiguous against the item's own link
               targetHeading={t("fields.templateFields.defaultValue.defaultLinkTarget")}
-              // InputWrapper renders the "Default Link (optional)" heading above, so these
-              // groups really are one level below it
+              // InputWrapper renders the heading above, so these groups sit one level below
               nestHeadings
             />
           </InputWrapper>
-        </Box>
+        </Paper>
       </>
     );
   }

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -98,6 +98,8 @@ function DefaultValueField({ field, editing, recordTypeName = "sample" }: Defaul
               sourceGlobalId={field.owner.globalId ?? ""}
               disabled={!editing}
               onChange={() => {}}
+              // the name is already entered in the Name field above
+              showFieldName={false}
             />
           </InputWrapper>
         </Box>

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -119,6 +119,9 @@ function DefaultValueField({ field, editing, recordTypeName = "sample" }: Defaul
               showFieldName={false}
               // inside this section "Target" alone would be ambiguous against the item's own link
               targetHeading={t("fields.templateFields.defaultValue.defaultLinkTarget")}
+              // InputWrapper renders the "Default Link (optional)" heading above, so these
+              // groups really are one level below it
+              nestHeadings
             />
           </InputWrapper>
         </Box>

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/DefaultValueField.tsx
@@ -48,62 +48,66 @@ function DefaultValueField({ field, editing, recordTypeName = "sample" }: Defaul
    * rejection, target-existence check and Apply/Discard guard all come for free.
    */
   if (field.type === "link") {
+    // siblings, not nested: InputWrapper renders a labelled fieldset, so nesting would make the
+    // default-link controls announce as part of the "Allowed relationship types" group
     return (
-      <InputWrapper
-        label={t("fields.templateFields.defaultValue.allowedRelationshipTypes")}
-        explanation={t(
-          recordTypeName === "instrument"
-            ? "fields.templateFields.defaultValue.allowedRelationshipTypesExplanationInstrument"
-            : "fields.templateFields.defaultValue.allowedRelationshipTypesExplanation",
-        )}
-      >
-        <Autocomplete
-          multiple
-          disabled={!editing}
-          options={[...DATACITE_RELATION_TYPES]}
-          value={field.allowedRelationTypes}
-          // already-chosen types are greyed out rather than toggled off; they
-          // are removed via their chip's delete icon instead
-          getOptionDisabled={(option) => field.allowedRelationTypes.includes(option)}
-          onChange={(_event, value) => field.setAttributesDirty({ allowedRelationTypes: value })}
-          renderInput={(params) => {
-            const { slotProps, ...textFieldProps } = params;
-            return (
-              <MuiTextField
-                {...textFieldProps}
-                variant="standard"
-                placeholder={
-                  field.allowedRelationTypes.length === 0
-                    ? t("fields.templateFields.defaultValue.allRelationshipTypes")
-                    : ""
-                }
-                slotProps={{
-                  ...slotProps,
-                  htmlInput: {
-                    ...slotProps.htmlInput,
-                    "aria-label": t("fields.templateFields.defaultValue.allowedRelationshipTypes"),
-                  },
-                }}
-              />
-            );
-          }}
-        />
-        <Box sx={{ mt: 2 }}>
-          <InputWrapper
-            label={t("fields.templateFields.defaultValue.defaultLink")}
-            explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
-          >
-            <LinkFieldValue
-              field={field}
-              sourceGlobalId={field.owner.globalId ?? ""}
-              disabled={!editing}
-              onChange={() => {}}
-              // the name is already entered in the Name field above
-              showFieldName={false}
-            />
-          </InputWrapper>
-        </Box>
-      </InputWrapper>
+      <>
+        <InputWrapper
+          label={t("fields.templateFields.defaultValue.allowedRelationshipTypes")}
+          explanation={t(
+            recordTypeName === "instrument"
+              ? "fields.templateFields.defaultValue.allowedRelationshipTypesExplanationInstrument"
+              : "fields.templateFields.defaultValue.allowedRelationshipTypesExplanation",
+          )}
+        >
+          <Autocomplete
+            multiple
+            disabled={!editing}
+            options={[...DATACITE_RELATION_TYPES]}
+            value={field.allowedRelationTypes}
+            // already-chosen types are greyed out rather than toggled off; they
+            // are removed via their chip's delete icon instead
+            getOptionDisabled={(option) => field.allowedRelationTypes.includes(option)}
+            onChange={(_event, value) => field.setAttributesDirty({ allowedRelationTypes: value })}
+            renderInput={(params) => {
+              const { slotProps, ...textFieldProps } = params;
+              return (
+                <MuiTextField
+                  {...textFieldProps}
+                  variant="standard"
+                  placeholder={
+                    field.allowedRelationTypes.length === 0
+                      ? t("fields.templateFields.defaultValue.allRelationshipTypes")
+                      : ""
+                  }
+                  slotProps={{
+                    ...slotProps,
+                    htmlInput: {
+                      ...slotProps.htmlInput,
+                      "aria-label": t("fields.templateFields.defaultValue.allowedRelationshipTypes"),
+                    },
+                  }}
+                />
+              );
+            }}
+          />
+        </InputWrapper>
+        <InputWrapper
+          label={t("fields.templateFields.defaultValue.defaultLink")}
+          explanation={t("fields.templateFields.defaultValue.defaultLinkExplanation")}
+        >
+          <LinkFieldValue
+            field={field}
+            // on an unsaved template this is "", which leaves the client-side self-link check inert.
+            // Harmless: a template with no Global ID has nothing to self-link to yet, and the server
+            // rejects it either way once the template exists.
+            sourceGlobalId={field.owner.globalId ?? ""}
+            disabled={!editing}
+            // the name is already entered in the Name field above
+            showFieldName={false}
+          />
+        </InputWrapper>
+      </>
     );
   }
 

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
@@ -77,7 +77,7 @@ describe("DefaultValueField", () => {
         </ThemeProvider>,
       );
 
-      await user.click(screen.getByRole("combobox", { name: "Relationship type" }));
+      await user.click(screen.getByRole("combobox", { name: "inventory:fields.extraFields.fields.relationType" }));
       expect(await screen.findByRole("option", { name: "IsCitedBy" })).toBeInTheDocument();
       expect(screen.queryByRole("option", { name: "Cites" })).not.toBeInTheDocument();
     });
@@ -142,7 +142,9 @@ describe("DefaultValueField", () => {
         </ThemeProvider>,
       );
 
-      expect(screen.queryByRole("combobox", { name: "Relationship type" })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("combobox", { name: "inventory:fields.extraFields.fields.relationType" }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
@@ -98,6 +98,41 @@ describe("DefaultValueField", () => {
       expect(screen.getByText("SA2")).toBeInTheDocument();
     });
 
+    it("does not repeat the field name under the Default link heading", () => {
+      // the name is already entered in the Name field above; repeating it here is noise
+      const field = makeMockField({
+        type: "link",
+        name: "Related items",
+        allowedRelationTypes: ["IsCitedBy"],
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      expect(screen.queryByText("Related items")).not.toBeInTheDocument();
+    });
+
+    it("does not repeat the field name inside a committed default link card", () => {
+      const field = makeMockField({
+        type: "link",
+        name: "Related items",
+        allowedRelationTypes: ["IsCitedBy"],
+        link: { relationType: "IsCitedBy", targetGlobalId: "SA2", versionPin: null },
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByText("SA2")).toBeInTheDocument();
+      expect(screen.queryByText("Related items")).not.toBeInTheDocument();
+    });
+
     it("renders no default link editor for a non-link field", () => {
       const field = makeMockField({ type: "string", content: "hello" });
 

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
@@ -7,7 +7,10 @@ import { makeMockField } from "../../../../stores/models/__tests__/FieldModel/mo
 import materialTheme from "../../../../theme";
 import DefaultValueField from "../DefaultValueField";
 
-vi.mock("../../../../common/InvApiService", () => ({ default: {} }));
+// the default-link editor resolves its target summary through InvApiService
+vi.mock("../../../../common/InvApiService", () => ({
+  default: { get: vi.fn(() => new Promise(() => {})) },
+}));
 
 describe("DefaultValueField", () => {
   describe("link fields' allowed relationship types", () => {
@@ -57,6 +60,54 @@ describe("DefaultValueField", () => {
 
       await user.click(unchosen);
       expect(field.allowedRelationTypes).toEqual(["IsCitedBy", "Cites"]);
+    });
+  });
+
+  describe("link fields' default link", () => {
+    it("offers a default link editor whose relation options are constrained to the whitelist", async () => {
+      const user = userEvent.setup();
+      const field = makeMockField({
+        type: "link",
+        allowedRelationTypes: ["IsCitedBy"],
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      await user.click(screen.getByRole("combobox", { name: "Relationship type" }));
+      expect(await screen.findByRole("option", { name: "IsCitedBy" })).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "Cites" })).not.toBeInTheDocument();
+    });
+
+    it("shows the committed default link for an existing template field", () => {
+      const field = makeMockField({
+        type: "link",
+        allowedRelationTypes: ["IsCitedBy"],
+        link: { relationType: "IsCitedBy", targetGlobalId: "SA2", versionPin: null },
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByText("SA2")).toBeInTheDocument();
+    });
+
+    it("renders no default link editor for a non-link field", () => {
+      const field = makeMockField({ type: "string", content: "hello" });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      expect(screen.queryByRole("combobox", { name: "Relationship type" })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
@@ -7,7 +7,10 @@ import { makeMockField } from "../../../../stores/models/__tests__/FieldModel/mo
 import materialTheme from "../../../../theme";
 import DefaultValueField from "../DefaultValueField";
 
-vi.mock("../../../../common/InvApiService", () => ({ default: {} }));
+// the default-link editor resolves its target summary through InvApiService
+vi.mock("../../../../common/InvApiService", () => ({
+  default: { get: vi.fn(() => new Promise(() => {})) },
+}));
 
 describe("DefaultValueField", () => {
   describe("link fields' allowed relationship types explanation text", () => {
@@ -93,6 +96,54 @@ describe("DefaultValueField", () => {
 
       await user.click(unchosen);
       expect(field.allowedRelationTypes).toEqual(["IsCitedBy", "Cites"]);
+    });
+  });
+
+  describe("link fields' default link", () => {
+    it("offers a default link editor whose relation options are constrained to the whitelist", async () => {
+      const user = userEvent.setup();
+      const field = makeMockField({
+        type: "link",
+        allowedRelationTypes: ["IsCitedBy"],
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      await user.click(screen.getByRole("combobox", { name: "Relationship type" }));
+      expect(await screen.findByRole("option", { name: "IsCitedBy" })).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "Cites" })).not.toBeInTheDocument();
+    });
+
+    it("shows the committed default link for an existing template field", () => {
+      const field = makeMockField({
+        type: "link",
+        allowedRelationTypes: ["IsCitedBy"],
+        link: { relationType: "IsCitedBy", targetGlobalId: "SA2", versionPin: null },
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByText("SA2")).toBeInTheDocument();
+    });
+
+    it("renders no default link editor for a non-link field", () => {
+      const field = makeMockField({ type: "string", content: "hello" });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      expect(screen.queryByRole("combobox", { name: "Relationship type" })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from "@mui/material/styles";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -182,5 +182,68 @@ describe("DefaultValueField", () => {
         screen.queryByRole("combobox", { name: "inventory:fields.extraFields.fields.relationType" }),
       ).not.toBeInTheDocument();
     });
+  });
+});
+
+describe("DefaultValueField default-link section", () => {
+  function renderLinkField() {
+    const field = makeMockField({ type: "link", allowedRelationTypes: ["IsCitedBy"] });
+    return render(
+      <ThemeProvider theme={materialTheme}>
+        <DefaultValueField field={field} editing />
+      </ThemeProvider>,
+    );
+  }
+
+  function section(container: HTMLElement): HTMLElement {
+    const found = container.querySelector<HTMLElement>('[data-test-id="DefaultLinkSection"]');
+    if (!found) throw new Error('no element with data-test-id="DefaultLinkSection"');
+    return found;
+  }
+
+  it("calls the target group 'Default link target' rather than the bare 'Target'", () => {
+    renderLinkField();
+
+    expect(
+      screen.getByRole("heading", { name: "inventory:fields.templateFields.defaultValue.defaultLinkTarget" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "inventory:fields.link.editor.target" })).not.toBeInTheDocument();
+  });
+
+  it("puts that subheading after the Default link heading and its explanation", () => {
+    renderLinkField();
+
+    const defaultLink = screen.getByRole("heading", {
+      name: "inventory:fields.templateFields.defaultValue.defaultLink",
+    });
+    const explanation = screen.getByText("inventory:fields.templateFields.defaultValue.defaultLinkExplanation");
+    const target = screen.getByRole("heading", {
+      name: "inventory:fields.templateFields.defaultValue.defaultLinkTarget",
+    });
+
+    expect(defaultLink.compareDocumentPosition(explanation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(explanation.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("delineates the whole default-link section, which holds the heading and the editor", () => {
+    const { container } = renderLinkField();
+
+    const delineated = section(container);
+    expect(
+      within(delineated).getByRole("heading", {
+        name: "inventory:fields.templateFields.defaultValue.defaultLink",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(delineated).getByRole("heading", {
+        name: "inventory:fields.templateFields.defaultValue.defaultLinkTarget",
+      }),
+    ).toBeInTheDocument();
+    // the allowed-types control belongs to the section above, not inside the delineated one
+    expect(
+      within(delineated).queryByRole("combobox", {
+        name: "inventory:fields.templateFields.defaultValue.allowedRelationshipTypes",
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
@@ -134,6 +134,41 @@ describe("DefaultValueField", () => {
       expect(screen.getByText("SA2")).toBeInTheDocument();
     });
 
+    it("does not repeat the field name under the Default link heading", () => {
+      // the name is already entered in the Name field above; repeating it here is noise
+      const field = makeMockField({
+        type: "link",
+        name: "Related items",
+        allowedRelationTypes: ["IsCitedBy"],
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      expect(screen.queryByText("Related items")).not.toBeInTheDocument();
+    });
+
+    it("does not repeat the field name inside a committed default link card", () => {
+      const field = makeMockField({
+        type: "link",
+        name: "Related items",
+        allowedRelationTypes: ["IsCitedBy"],
+        link: { relationType: "IsCitedBy", targetGlobalId: "SA2", versionPin: null },
+      });
+
+      render(
+        <ThemeProvider theme={materialTheme}>
+          <DefaultValueField field={field} editing />
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByText("SA2")).toBeInTheDocument();
+      expect(screen.queryByText("Related items")).not.toBeInTheDocument();
+    });
+
     it("renders no default link editor for a non-link field", () => {
       const field = makeMockField({ type: "string", content: "hello" });
 

--- a/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/Template/Fields/__tests__/DefaultValueField.test.tsx
@@ -113,7 +113,7 @@ describe("DefaultValueField", () => {
         </ThemeProvider>,
       );
 
-      await user.click(screen.getByRole("combobox", { name: "Relationship type" }));
+      await user.click(screen.getByRole("combobox", { name: "inventory:fields.extraFields.fields.relationType" }));
       expect(await screen.findByRole("option", { name: "IsCitedBy" })).toBeInTheDocument();
       expect(screen.queryByRole("option", { name: "Cites" })).not.toBeInTheDocument();
     });
@@ -178,7 +178,9 @@ describe("DefaultValueField", () => {
         </ThemeProvider>,
       );
 
-      expect(screen.queryByRole("combobox", { name: "Relationship type" })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("combobox", { name: "inventory:fields.extraFields.fields.relationType" }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
@@ -7,6 +7,7 @@ import FormHelperText from "@mui/material/FormHelperText";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 import type React from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -52,9 +53,11 @@ export interface LinkEditorProps {
 
 /**
  * The shared link-editor UI used by both the extra-field editor (UpdateField)
- * and the template-field editor (LinkFieldValue): the relation-type field, the
- * target chip + Browse Inventory/ELN buttons + Target Global ID field, the
- * version pill and version-pin control, and the three picker/version dialogs.
+ * and the template-field editor (LinkFieldValue), in three labelled groups:
+ * "Target" (the target chip, the Target Global ID field and the two Browse
+ * buttons, all on one wrapping row), then the relation-type field, then
+ * "Version" (the version pill and version-pin control). Plus the three
+ * picker/version dialogs.
  *
  * Controlled and presentational: it owns only the open-state of its three
  * dialogs and a neutral vertical layout. All staged values, validation, the
@@ -87,33 +90,15 @@ export default function LinkEditor({
 
   return (
     <Box>
-      <Autocomplete
-        freeSolo={relationFreeSolo}
-        options={relationOptions}
-        value={relationFreeSolo ? relationType : relationType === "" ? null : relationType}
-        onChange={relationFreeSolo ? undefined : (_event, value) => onRelationTypeChange(value ?? "")}
-        onInputChange={relationFreeSolo ? (_event, value) => onRelationTypeChange(value) : undefined}
-        renderInput={(params) => {
-          const { slotProps, ...textFieldProps } = params;
-          return (
-            <TextField
-              {...textFieldProps}
-              variant="standard"
-              label={relationLabel}
-              error={relationError}
-              helperText={relationHelperText}
-              slotProps={{
-                ...slotProps,
-                htmlInput: {
-                  ...slotProps.htmlInput,
-                  "aria-label": relationLabel,
-                },
-              }}
-            />
-          );
-        }}
-      />
-      <Stack direction="row" spacing={1} sx={{ mt: 1, flexWrap: "wrap", alignItems: "center" }}>
+      <Typography variant="subtitle1" component="h4" sx={{ fontWeight: 700 }}>
+        {t("fields.link.editor.target")}
+      </Typography>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{ mt: 0.5, flexWrap: "wrap", alignItems: "center" }}
+        data-test-id="LinkEditor-targetRow"
+      >
         {targetGlobalId
           ? (() => {
               const iconData = iconForGlobalId(targetGlobalId);
@@ -129,8 +114,11 @@ export default function LinkEditor({
                   // (spacing(0.5)). The selector is repeated to out-specify the
                   // theme's two-class `.MuiChip-deletable` rule. The cancel
                   // button just widens the chip.
+                  // flexShrink: 0 because the chip shares a flex row with the target field. A
+                  // shrunk chip clips its own delete icon (MuiChip-label is overflow: hidden), so
+                  // the X silently disappears rather than wrapping.
                   size="small"
-                  sx={{ "&.MuiChip-deletable": { pl: 0.5 } }}
+                  sx={{ flexShrink: 0, "&.MuiChip-deletable": { pl: 0.5 } }}
                   icon={iconData ? <RecordTypeIcon record={iconData} aria-hidden /> : undefined}
                   label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
                   onDelete={() => onTargetChange("", "")}
@@ -139,6 +127,19 @@ export default function LinkEditor({
               );
             })()
           : null}
+        <TextField
+          label={t("fields.link.editor.targetGlobalId")}
+          value={targetGlobalId}
+          onChange={(e) => onTargetChange(e.target.value, "")}
+          size="small"
+          variant="standard"
+          // a Global ID is short (about 20 characters at the very most, usually far fewer), so the
+          // field is sized to its content rather than flexing to fill the row
+          sx={{ width: "11em", flexShrink: 0 }}
+          helperText={targetHelperText}
+          error={targetError}
+          slotProps={{ htmlInput: { "aria-label": t("fields.link.editor.targetGlobalId") } }}
+        />
         <Button
           size="small"
           variant="outlined"
@@ -156,20 +157,39 @@ export default function LinkEditor({
           {t("fields.link.editor.browseEln")}
         </Button>
       </Stack>
-      <TextField
-        label={t("fields.link.editor.targetGlobalId")}
-        value={targetGlobalId}
-        onChange={(e) => onTargetChange(e.target.value, "")}
-        fullWidth
-        size="small"
-        variant="standard"
-        sx={{ mt: 1 }}
-        helperText={targetHelperText}
-        error={targetError}
-        slotProps={{ htmlInput: { "aria-label": t("fields.link.editor.targetGlobalId") } }}
-      />
       {validationMessage ? <FormHelperText error>{validationMessage}</FormHelperText> : null}
-      <Stack direction="row" spacing={1} sx={{ mt: 1, alignItems: "center" }}>
+      <Box sx={{ mt: 2 }}>
+        <Autocomplete
+          freeSolo={relationFreeSolo}
+          options={relationOptions}
+          value={relationFreeSolo ? relationType : relationType === "" ? null : relationType}
+          onChange={relationFreeSolo ? undefined : (_event, value) => onRelationTypeChange(value ?? "")}
+          onInputChange={relationFreeSolo ? (_event, value) => onRelationTypeChange(value) : undefined}
+          renderInput={(params) => {
+            const { slotProps, ...textFieldProps } = params;
+            return (
+              <TextField
+                {...textFieldProps}
+                variant="standard"
+                label={relationLabel}
+                error={relationError}
+                helperText={relationHelperText}
+                slotProps={{
+                  ...slotProps,
+                  htmlInput: {
+                    ...slotProps.htmlInput,
+                    "aria-label": relationLabel,
+                  },
+                }}
+              />
+            );
+          }}
+        />
+      </Box>
+      <Typography variant="subtitle1" component="h4" sx={{ mt: 2, fontWeight: 700 }}>
+        {t("fields.link.editor.version")}
+      </Typography>
+      <Stack direction="row" spacing={1} sx={{ mt: 0.5, alignItems: "center" }} data-test-id="LinkEditor-versionRow">
         <Chip
           size="small"
           variant="outlined"

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
@@ -7,10 +7,10 @@ import FormHelperText from "@mui/material/FormHelperText";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
-import Typography from "@mui/material/Typography";
 import type React from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Heading, HeadingContext } from "../../../../components/DynamicHeadingLevel";
 import RecordTypeIcon from "../../../../components/RecordTypeIcon";
 import ElnRecordPicker from "./ElnRecordPicker";
 import { iconForGlobalId } from "./iconForGlobalId";
@@ -89,157 +89,168 @@ export default function LinkEditor({
   const [versionDialogOpen, setVersionDialogOpen] = useState(false);
 
   return (
-    <Box>
-      <Typography variant="subtitle1" component="h4" sx={{ fontWeight: 700 }}>
-        {t("fields.link.editor.target")}
-      </Typography>
-      <Stack
-        direction="row"
-        spacing={1}
-        sx={{ mt: 0.5, flexWrap: "wrap", alignItems: "center" }}
-        data-test-id="LinkEditor-targetRow"
-      >
+    // The group headings descend from whatever level the caller's own label sits at, rather than
+    // being hardcoded: this component is mounted at two different depths (the extra-field editor and
+    // the template-field editor). The extra HeadingContext makes "Target"/"Version" children of the
+    // enclosing field label rather than its siblings.
+    <HeadingContext>
+      <Box>
+        <Heading variant="h6" sx={{ fontWeight: 700, fontSize: "1rem" }}>
+          {t("fields.link.editor.target")}
+        </Heading>
+        <Stack
+          direction="row"
+          spacing={1}
+          // useFlexGap so a wrapped line gets real vertical spacing; Stack's default
+          // sibling-margin implementation of `spacing` leaves wrapped lines touching
+          useFlexGap
+          sx={{ mt: 0.5, flexWrap: "wrap", alignItems: "flex-start" }}
+          data-test-id="LinkEditor-targetRow"
+        >
+          <TextField
+            label={t("fields.link.editor.targetGlobalId")}
+            value={targetGlobalId}
+            onChange={(e) => onTargetChange(e.target.value, "")}
+            size="small"
+            variant="standard"
+            // a Global ID is short (about 20 characters at the very most, usually far fewer), so the
+            // field is sized to its content rather than flexing to fill the row
+            sx={{ width: "11em", flexShrink: 0 }}
+            helperText={targetHelperText}
+            error={targetError}
+            slotProps={{ htmlInput: { "aria-label": t("fields.link.editor.targetGlobalId") } }}
+          />
+          <Button
+            size="small"
+            variant="outlined"
+            aria-label={t("fields.link.editor.browseInventory")}
+            onClick={() => setBrowserOpen(true)}
+          >
+            {t("fields.link.editor.browseInventory")}
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            aria-label={t("fields.link.editor.browseEln")}
+            onClick={() => setElnOpen(true)}
+          >
+            {t("fields.link.editor.browseEln")}
+          </Button>
+        </Stack>
+        {/* The selected target sits below the id field and pickers, not beside them: it is the
+          outcome of using them, and in the row it competed for width and had its delete icon
+          clipped (MuiChip-label is overflow: hidden, so a shrunk chip loses the X). */}
         {targetGlobalId
           ? (() => {
               const iconData = iconForGlobalId(targetGlobalId);
               return (
-                <Chip
-                  // Match the committed (non-edit) LinkField pill. size="small"
-                  // gives the same geometry; the pl restores the left padding
-                  // the accented theme strips from deletable chips
-                  // (`&.MuiChip-deletable { padding: 0 }`). Without it the type
-                  // icon — which gets no MuiChip-icon margin because
-                  // RecordTypeIcon wraps it in a tooltip — sits flush against
-                  // the left edge instead of the non-edit pill's 4px
-                  // (spacing(0.5)). The selector is repeated to out-specify the
-                  // theme's two-class `.MuiChip-deletable` rule. The cancel
-                  // button just widens the chip.
-                  // flexShrink: 0 because the chip shares a flex row with the target field. A
-                  // shrunk chip clips its own delete icon (MuiChip-label is overflow: hidden), so
-                  // the X silently disappears rather than wrapping.
-                  size="small"
-                  sx={{ flexShrink: 0, "&.MuiChip-deletable": { pl: 0.5 } }}
-                  icon={iconData ? <RecordTypeIcon record={iconData} aria-hidden /> : undefined}
-                  label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
-                  onDelete={() => onTargetChange("", "")}
-                  data-test-id="LinkTarget-globalId"
-                />
+                <Box sx={{ mt: 1 }}>
+                  <Chip
+                    // Match the committed (non-edit) LinkField pill. size="small"
+                    // gives the same geometry; the pl restores the left padding
+                    // the accented theme strips from deletable chips
+                    // (`&.MuiChip-deletable { padding: 0 }`). Without it the type
+                    // icon — which gets no MuiChip-icon margin because
+                    // RecordTypeIcon wraps it in a tooltip — sits flush against
+                    // the left edge instead of the non-edit pill's 4px
+                    // (spacing(0.5)). The selector is repeated to out-specify the
+                    // theme's two-class `.MuiChip-deletable` rule. The cancel
+                    // button just widens the chip.
+                    size="small"
+                    sx={{ "&.MuiChip-deletable": { pl: 0.5 } }}
+                    icon={iconData ? <RecordTypeIcon record={iconData} aria-hidden /> : undefined}
+                    label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
+                    onDelete={() => onTargetChange("", "")}
+                    data-test-id="LinkTarget-globalId"
+                  />
+                </Box>
               );
             })()
           : null}
-        <TextField
-          label={t("fields.link.editor.targetGlobalId")}
-          value={targetGlobalId}
-          onChange={(e) => onTargetChange(e.target.value, "")}
-          size="small"
-          variant="standard"
-          // a Global ID is short (about 20 characters at the very most, usually far fewer), so the
-          // field is sized to its content rather than flexing to fill the row
-          sx={{ width: "11em", flexShrink: 0 }}
-          helperText={targetHelperText}
-          error={targetError}
-          slotProps={{ htmlInput: { "aria-label": t("fields.link.editor.targetGlobalId") } }}
-        />
-        <Button
-          size="small"
-          variant="outlined"
-          aria-label={t("fields.link.editor.browseInventory")}
-          onClick={() => setBrowserOpen(true)}
-        >
-          {t("fields.link.editor.browseInventory")}
-        </Button>
-        <Button
-          size="small"
-          variant="outlined"
-          aria-label={t("fields.link.editor.browseEln")}
-          onClick={() => setElnOpen(true)}
-        >
-          {t("fields.link.editor.browseEln")}
-        </Button>
-      </Stack>
-      {validationMessage ? <FormHelperText error>{validationMessage}</FormHelperText> : null}
-      <Box sx={{ mt: 2 }}>
-        <Autocomplete
-          freeSolo={relationFreeSolo}
-          options={relationOptions}
-          value={relationFreeSolo ? relationType : relationType === "" ? null : relationType}
-          onChange={relationFreeSolo ? undefined : (_event, value) => onRelationTypeChange(value ?? "")}
-          onInputChange={relationFreeSolo ? (_event, value) => onRelationTypeChange(value) : undefined}
-          renderInput={(params) => {
-            const { slotProps, ...textFieldProps } = params;
-            return (
-              <TextField
-                {...textFieldProps}
-                variant="standard"
-                label={relationLabel}
-                error={relationError}
-                helperText={relationHelperText}
-                slotProps={{
-                  ...slotProps,
-                  htmlInput: {
-                    ...slotProps.htmlInput,
-                    "aria-label": relationLabel,
-                  },
-                }}
-              />
-            );
+        {validationMessage ? <FormHelperText error>{validationMessage}</FormHelperText> : null}
+        <Box sx={{ mt: 2 }}>
+          <Autocomplete
+            freeSolo={relationFreeSolo}
+            options={relationOptions}
+            value={relationFreeSolo ? relationType : relationType === "" ? null : relationType}
+            onChange={relationFreeSolo ? undefined : (_event, value) => onRelationTypeChange(value ?? "")}
+            onInputChange={relationFreeSolo ? (_event, value) => onRelationTypeChange(value) : undefined}
+            renderInput={(params) => {
+              const { slotProps, ...textFieldProps } = params;
+              return (
+                <TextField
+                  {...textFieldProps}
+                  variant="standard"
+                  label={relationLabel}
+                  error={relationError}
+                  helperText={relationHelperText}
+                  slotProps={{
+                    ...slotProps,
+                    htmlInput: {
+                      ...slotProps.htmlInput,
+                      "aria-label": relationLabel,
+                    },
+                  }}
+                />
+              );
+            }}
+          />
+        </Box>
+        <Heading variant="h6" sx={{ mt: 2, fontWeight: 700, fontSize: "1rem" }}>
+          {t("fields.link.editor.version")}
+        </Heading>
+        <Stack direction="row" spacing={1} sx={{ mt: 0.5, alignItems: "center" }} data-test-id="LinkEditor-versionRow">
+          <Chip
+            size="small"
+            variant="outlined"
+            label={
+              versionPin != null
+                ? t("fields.link.editor.pinnedVersion", { version: versionPin })
+                : t("fields.link.editor.latest")
+            }
+            data-test-id="LinkEditor-version"
+          />
+          <IconButton
+            size="small"
+            aria-label={
+              targetGlobalId
+                ? t("fields.link.editor.pinVersionFor", { globalId: targetGlobalId })
+                : t("fields.link.editor.pinVersion")
+            }
+            disabled={!canPinVersion}
+            onClick={() => setVersionDialogOpen(true)}
+          >
+            <HistoryIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+
+        <LinkTargetBrowser
+          open={browserOpen}
+          onCancel={() => setBrowserOpen(false)}
+          onPick={(target) => {
+            onTargetChange(target.globalId, target.name);
+            setBrowserOpen(false);
           }}
         />
-      </Box>
-      <Typography variant="subtitle1" component="h4" sx={{ mt: 2, fontWeight: 700 }}>
-        {t("fields.link.editor.version")}
-      </Typography>
-      <Stack direction="row" spacing={1} sx={{ mt: 0.5, alignItems: "center" }} data-test-id="LinkEditor-versionRow">
-        <Chip
-          size="small"
-          variant="outlined"
-          label={
-            versionPin != null
-              ? t("fields.link.editor.pinnedVersion", { version: versionPin })
-              : t("fields.link.editor.latest")
-          }
-          data-test-id="LinkEditor-version"
+        <ElnRecordPicker
+          open={elnOpen}
+          onCancel={() => setElnOpen(false)}
+          onPick={(target) => {
+            onTargetChange(target.globalId, target.name);
+            setElnOpen(false);
+          }}
         />
-        <IconButton
-          size="small"
-          aria-label={
-            targetGlobalId
-              ? t("fields.link.editor.pinVersionFor", { globalId: targetGlobalId })
-              : t("fields.link.editor.pinVersion")
-          }
-          disabled={!canPinVersion}
-          onClick={() => setVersionDialogOpen(true)}
-        >
-          <HistoryIcon fontSize="small" />
-        </IconButton>
-      </Stack>
-
-      <LinkTargetBrowser
-        open={browserOpen}
-        onCancel={() => setBrowserOpen(false)}
-        onPick={(target) => {
-          onTargetChange(target.globalId, target.name);
-          setBrowserOpen(false);
-        }}
-      />
-      <ElnRecordPicker
-        open={elnOpen}
-        onCancel={() => setElnOpen(false)}
-        onPick={(target) => {
-          onTargetChange(target.globalId, target.name);
-          setElnOpen(false);
-        }}
-      />
-      <VersionLockDialog
-        open={versionDialogOpen}
-        globalId={targetGlobalId}
-        currentVersionPin={versionPin}
-        onConfirm={(pin) => {
-          setVersionDialogOpen(false);
-          onVersionPinChange(pin);
-        }}
-        onCancel={() => setVersionDialogOpen(false)}
-      />
-    </Box>
+        <VersionLockDialog
+          open={versionDialogOpen}
+          globalId={targetGlobalId}
+          currentVersionPin={versionPin}
+          onConfirm={(pin) => {
+            setVersionDialogOpen(false);
+            onVersionPinChange(pin);
+          }}
+          onCancel={() => setVersionDialogOpen(false)}
+        />
+      </Box>
+    </HeadingContext>
   );
 }

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
@@ -38,6 +38,13 @@ export interface LinkEditorProps {
    * it, since there the target being chosen is the default's, not the record's own.
    */
   targetHeading?: string;
+  /**
+   * Whether the group headings descend one level below the caller's own. True only where the
+   * caller actually renders a heading immediately above (the template editor's InputWrapper, whose
+   * FormControl emits one). The item and extra-field editors render a plain <label> in edit mode,
+   * because FieldLabel only emits a Heading when disabled, so nesting there would skip a level.
+   */
+  nestHeadings?: boolean;
   /** Current target Global ID (controlled). */
   targetGlobalId: string;
   /** Optional display name shown in the target chip ("GID — name"). */
@@ -81,6 +88,7 @@ export default function LinkEditor({
   relationError,
   relationHelperText,
   targetHeading,
+  nestHeadings = false,
   targetGlobalId,
   targetName,
   onTargetChange,
@@ -98,167 +106,165 @@ export default function LinkEditor({
   const targetIcon = targetGlobalId ? iconForGlobalId(targetGlobalId) : null;
   const groupHeadingSx = { fontWeight: 700, fontSize: "1rem" } as const;
 
-  return (
-    // The group headings descend from whatever level the caller's own label sits at, rather than
-    // being hardcoded: this component is mounted at two different depths (the extra-field editor and
-    // the template-field editor). The extra HeadingContext makes "Target"/"Version" children of the
-    // enclosing field label rather than its siblings.
-    <HeadingContext>
-      <Box>
-        <Heading variant="h6" sx={groupHeadingSx}>
-          {targetHeading ?? t("fields.link.editor.target")}
-        </Heading>
-        <Stack
-          direction="row"
-          spacing={1}
-          // useFlexGap so a wrapped line gets real vertical spacing; Stack's default
-          // sibling-margin implementation of `spacing` leaves wrapped lines touching
-          useFlexGap
-          sx={{ mt: 0.5, flexWrap: "wrap", alignItems: "flex-start" }}
-          data-test-id="LinkEditor-targetRow"
+  // The group headings take their level from the ambient context rather than being hardcoded: this
+  // component is mounted at two different depths. Only nest where the caller really did render a
+  // heading above (see nestHeadings), or the levels skip.
+  const body = (
+    <Box>
+      <Heading variant="h6" sx={groupHeadingSx}>
+        {targetHeading ?? t("fields.link.editor.target")}
+      </Heading>
+      <Stack
+        direction="row"
+        spacing={1}
+        // useFlexGap so a wrapped line gets real vertical spacing; Stack's default
+        // sibling-margin implementation of `spacing` leaves wrapped lines touching
+        useFlexGap
+        sx={{ mt: 0.5, flexWrap: "wrap", alignItems: "flex-start" }}
+        data-test-id="LinkEditor-targetRow"
+      >
+        <TextField
+          // no floating label: variant="standard" stacks one above the input, which drops the
+          // input below the neighbouring Browse buttons. The group heading above names this
+          // control, the helper text says what to put in it, and aria-label keeps it announced.
+          placeholder={t("fields.link.editor.targetPlaceholder")}
+          value={targetGlobalId}
+          onChange={(e) => onTargetChange(e.target.value, "")}
+          size="small"
+          variant="standard"
+          // a Global ID is short (about 20 characters at the very most, usually far fewer), so the
+          // field is sized to its content rather than flexing to fill the row
+          sx={{ width: "11em", flexShrink: 0 }}
+          helperText={targetHelperText}
+          error={targetError}
+          slotProps={{ htmlInput: { "aria-label": t("fields.link.editor.targetGlobalId") } }}
+        />
+        <Button
+          size="small"
+          variant="outlined"
+          aria-label={t("fields.link.editor.browseInventory")}
+          onClick={() => setBrowserOpen(true)}
         >
-          <TextField
-            // no floating label: variant="standard" stacks one above the input, which drops the
-            // input below the neighbouring Browse buttons. The group heading above names this
-            // control, the helper text says what to put in it, and aria-label keeps it announced.
-            placeholder={t("fields.link.editor.targetPlaceholder")}
-            value={targetGlobalId}
-            onChange={(e) => onTargetChange(e.target.value, "")}
-            size="small"
-            variant="standard"
-            // a Global ID is short (about 20 characters at the very most, usually far fewer), so the
-            // field is sized to its content rather than flexing to fill the row
-            sx={{ width: "11em", flexShrink: 0 }}
-            helperText={targetHelperText}
-            error={targetError}
-            slotProps={{ htmlInput: { "aria-label": t("fields.link.editor.targetGlobalId") } }}
-          />
-          <Button
-            size="small"
-            variant="outlined"
-            aria-label={t("fields.link.editor.browseInventory")}
-            onClick={() => setBrowserOpen(true)}
-          >
-            {t("fields.link.editor.browseInventory")}
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            aria-label={t("fields.link.editor.browseEln")}
-            onClick={() => setElnOpen(true)}
-          >
-            {t("fields.link.editor.browseEln")}
-          </Button>
-        </Stack>
-        {/* The selected target sits below the id field and pickers, not beside them: it is the
+          {t("fields.link.editor.browseInventory")}
+        </Button>
+        <Button
+          size="small"
+          variant="outlined"
+          aria-label={t("fields.link.editor.browseEln")}
+          onClick={() => setElnOpen(true)}
+        >
+          {t("fields.link.editor.browseEln")}
+        </Button>
+      </Stack>
+      {/* The selected target sits below the id field and pickers, not beside them: it is the
           outcome of using them, and in the row it competed for width and had its delete icon
           clipped (MuiChip-label is overflow: hidden, so a shrunk chip loses the X). */}
-        {targetGlobalId ? (
-          <Box sx={{ mt: 1 }}>
-            <Chip
-              // Match the committed (non-edit) LinkField pill. size="small"
-              // gives the same geometry; the pl restores the left padding
-              // the accented theme strips from deletable chips
-              // (`&.MuiChip-deletable { padding: 0 }`). Without it the type
-              // icon — which gets no MuiChip-icon margin because
-              // RecordTypeIcon wraps it in a tooltip — sits flush against
-              // the left edge instead of the non-edit pill's 4px
-              // (spacing(0.5)). The selector is repeated to out-specify the
-              // theme's two-class `.MuiChip-deletable` rule. The cancel
-              // button just widens the chip.
-              size="small"
-              sx={{ "&.MuiChip-deletable": { pl: 0.5 } }}
-              icon={targetIcon ? <RecordTypeIcon record={targetIcon} aria-hidden /> : undefined}
-              label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
-              onDelete={() => onTargetChange("", "")}
-              data-test-id="LinkTarget-globalId"
-            />
-          </Box>
-        ) : null}
-        {validationMessage ? <FormHelperText error>{validationMessage}</FormHelperText> : null}
-        <Box sx={{ mt: 2 }}>
-          <Autocomplete
-            freeSolo={relationFreeSolo}
-            options={relationOptions}
-            value={relationFreeSolo ? relationType : relationType === "" ? null : relationType}
-            onChange={relationFreeSolo ? undefined : (_event, value) => onRelationTypeChange(value ?? "")}
-            onInputChange={relationFreeSolo ? (_event, value) => onRelationTypeChange(value) : undefined}
-            renderInput={(params) => {
-              const { slotProps, ...textFieldProps } = params;
-              return (
-                <TextField
-                  {...textFieldProps}
-                  variant="standard"
-                  label={relationLabel}
-                  error={relationError}
-                  helperText={relationHelperText}
-                  slotProps={{
-                    ...slotProps,
-                    htmlInput: {
-                      ...slotProps.htmlInput,
-                      "aria-label": relationLabel,
-                    },
-                  }}
-                />
-              );
-            }}
+      {targetGlobalId ? (
+        <Box sx={{ mt: 1 }}>
+          <Chip
+            // Match the committed (non-edit) LinkField pill. size="small"
+            // gives the same geometry; the pl restores the left padding
+            // the accented theme strips from deletable chips
+            // (`&.MuiChip-deletable { padding: 0 }`). Without it the type
+            // icon — which gets no MuiChip-icon margin because
+            // RecordTypeIcon wraps it in a tooltip — sits flush against
+            // the left edge instead of the non-edit pill's 4px
+            // (spacing(0.5)). The selector is repeated to out-specify the
+            // theme's two-class `.MuiChip-deletable` rule. The cancel
+            // button just widens the chip.
+            size="small"
+            sx={{ "&.MuiChip-deletable": { pl: 0.5 } }}
+            icon={targetIcon ? <RecordTypeIcon record={targetIcon} aria-hidden /> : undefined}
+            label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
+            onDelete={() => onTargetChange("", "")}
+            data-test-id="LinkTarget-globalId"
           />
         </Box>
-        <Heading variant="h6" sx={{ mt: 2, ...groupHeadingSx }}>
-          {t("fields.link.editor.version")}
-        </Heading>
-        <Stack direction="row" spacing={1} sx={{ mt: 0.5, alignItems: "center" }} data-test-id="LinkEditor-versionRow">
-          <Chip
-            size="small"
-            variant="outlined"
-            label={
-              versionPin != null
-                ? t("fields.link.editor.pinnedVersion", { version: versionPin })
-                : t("fields.link.editor.latest")
-            }
-            data-test-id="LinkEditor-version"
-          />
-          <IconButton
-            size="small"
-            aria-label={
-              targetGlobalId
-                ? t("fields.link.editor.pinVersionFor", { globalId: targetGlobalId })
-                : t("fields.link.editor.pinVersion")
-            }
-            disabled={!canPinVersion}
-            onClick={() => setVersionDialogOpen(true)}
-          >
-            <HistoryIcon fontSize="small" />
-          </IconButton>
-        </Stack>
-
-        <LinkTargetBrowser
-          open={browserOpen}
-          onCancel={() => setBrowserOpen(false)}
-          onPick={(target) => {
-            onTargetChange(target.globalId, target.name);
-            setBrowserOpen(false);
+      ) : null}
+      {validationMessage ? <FormHelperText error>{validationMessage}</FormHelperText> : null}
+      <Box sx={{ mt: 2 }}>
+        <Autocomplete
+          freeSolo={relationFreeSolo}
+          options={relationOptions}
+          value={relationFreeSolo ? relationType : relationType === "" ? null : relationType}
+          onChange={relationFreeSolo ? undefined : (_event, value) => onRelationTypeChange(value ?? "")}
+          onInputChange={relationFreeSolo ? (_event, value) => onRelationTypeChange(value) : undefined}
+          renderInput={(params) => {
+            const { slotProps, ...textFieldProps } = params;
+            return (
+              <TextField
+                {...textFieldProps}
+                variant="standard"
+                label={relationLabel}
+                error={relationError}
+                helperText={relationHelperText}
+                slotProps={{
+                  ...slotProps,
+                  htmlInput: {
+                    ...slotProps.htmlInput,
+                    "aria-label": relationLabel,
+                  },
+                }}
+              />
+            );
           }}
-        />
-        <ElnRecordPicker
-          open={elnOpen}
-          onCancel={() => setElnOpen(false)}
-          onPick={(target) => {
-            onTargetChange(target.globalId, target.name);
-            setElnOpen(false);
-          }}
-        />
-        <VersionLockDialog
-          open={versionDialogOpen}
-          globalId={targetGlobalId}
-          currentVersionPin={versionPin}
-          onConfirm={(pin) => {
-            setVersionDialogOpen(false);
-            onVersionPinChange(pin);
-          }}
-          onCancel={() => setVersionDialogOpen(false)}
         />
       </Box>
-    </HeadingContext>
+      <Heading variant="h6" sx={{ mt: 2, ...groupHeadingSx }}>
+        {t("fields.link.editor.version")}
+      </Heading>
+      <Stack direction="row" spacing={1} sx={{ mt: 0.5, alignItems: "center" }} data-test-id="LinkEditor-versionRow">
+        <Chip
+          size="small"
+          variant="outlined"
+          label={
+            versionPin != null
+              ? t("fields.link.editor.pinnedVersion", { version: versionPin })
+              : t("fields.link.editor.latest")
+          }
+          data-test-id="LinkEditor-version"
+        />
+        <IconButton
+          size="small"
+          aria-label={
+            targetGlobalId
+              ? t("fields.link.editor.pinVersionFor", { globalId: targetGlobalId })
+              : t("fields.link.editor.pinVersion")
+          }
+          disabled={!canPinVersion}
+          onClick={() => setVersionDialogOpen(true)}
+        >
+          <HistoryIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+
+      <LinkTargetBrowser
+        open={browserOpen}
+        onCancel={() => setBrowserOpen(false)}
+        onPick={(target) => {
+          onTargetChange(target.globalId, target.name);
+          setBrowserOpen(false);
+        }}
+      />
+      <ElnRecordPicker
+        open={elnOpen}
+        onCancel={() => setElnOpen(false)}
+        onPick={(target) => {
+          onTargetChange(target.globalId, target.name);
+          setElnOpen(false);
+        }}
+      />
+      <VersionLockDialog
+        open={versionDialogOpen}
+        globalId={targetGlobalId}
+        currentVersionPin={versionPin}
+        onConfirm={(pin) => {
+          setVersionDialogOpen(false);
+          onVersionPinChange(pin);
+        }}
+        onCancel={() => setVersionDialogOpen(false)}
+      />
+    </Box>
   );
+  return nestHeadings ? <HeadingContext>{body}</HeadingContext> : body;
 }

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
@@ -33,6 +33,11 @@ export interface LinkEditorProps {
   relationError?: boolean;
   relationHelperText?: string;
 
+  /**
+   * Heading for the target group. Defaults to "Target"; a template's default-link editor overrides
+   * it, since there the target being chosen is the default's, not the record's own.
+   */
+  targetHeading?: string;
   /** Current target Global ID (controlled). */
   targetGlobalId: string;
   /** Optional display name shown in the target chip ("GID — name"). */
@@ -54,10 +59,12 @@ export interface LinkEditorProps {
 /**
  * The shared link-editor UI used by both the extra-field editor (UpdateField)
  * and the template-field editor (LinkFieldValue), in three labelled groups:
- * "Target" (the target chip, the Target Global ID field and the two Browse
- * buttons, all on one wrapping row), then the relation-type field, then
- * "Version" (the version pill and version-pin control). Plus the three
- * picker/version dialogs.
+ * the target group (the Global ID field and the two Browse buttons on one
+ * wrapping row, with the selected target's chip beneath), then the
+ * relation-type field, then "Version" (the version pill and version-pin
+ * control). Plus the three picker/version dialogs. The target group is headed
+ * "Target" unless the caller renames it via `targetHeading`, which the
+ * template's default-link editor does.
  *
  * Controlled and presentational: it owns only the open-state of its three
  * dialogs and a neutral vertical layout. All staged values, validation, the
@@ -73,6 +80,7 @@ export default function LinkEditor({
   relationLabel,
   relationError,
   relationHelperText,
+  targetHeading,
   targetGlobalId,
   targetName,
   onTargetChange,
@@ -96,7 +104,7 @@ export default function LinkEditor({
     <HeadingContext>
       <Box>
         <Heading variant="h6" sx={{ fontWeight: 700, fontSize: "1rem" }}>
-          {t("fields.link.editor.target")}
+          {targetHeading ?? t("fields.link.editor.target")}
         </Heading>
         <Stack
           direction="row"
@@ -108,7 +116,10 @@ export default function LinkEditor({
           data-test-id="LinkEditor-targetRow"
         >
           <TextField
-            label={t("fields.link.editor.targetGlobalId")}
+            // no floating label: variant="standard" stacks one above the input, which drops the
+            // input below the neighbouring Browse buttons. The group heading above names this
+            // control, the helper text says what to put in it, and aria-label keeps it announced.
+            placeholder={t("fields.link.editor.targetPlaceholder")}
             value={targetGlobalId}
             onChange={(e) => onTargetChange(e.target.value, "")}
             size="small"

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
@@ -2,7 +2,7 @@ import HistoryIcon from "@mui/icons-material/History";
 import Autocomplete from "@mui/material/Autocomplete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Chip from "@mui/material/Chip";
+import Chip, { chipClasses } from "@mui/material/Chip";
 import FormHelperText from "@mui/material/FormHelperText";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
@@ -33,16 +33,12 @@ export interface LinkEditorProps {
   relationError?: boolean;
   relationHelperText?: string;
 
-  /**
-   * Heading for the target group. Defaults to "Target"; a template's default-link editor overrides
-   * it, since there the target being chosen is the default's, not the record's own.
-   */
+  /** Heading for the target group; defaults to "Target". */
   targetHeading?: string;
   /**
-   * Whether the group headings descend one level below the caller's own. True only where the
-   * caller actually renders a heading immediately above (the template editor's InputWrapper, whose
-   * FormControl emits one). The item and extra-field editors render a plain <label> in edit mode,
-   * because FieldLabel only emits a Heading when disabled, so nesting there would skip a level.
+   * Whether the group headings descend one level. True only where the caller really renders a
+   * heading above: the item and extra-field editors render a plain label in edit mode, so nesting
+   * there would skip a level.
    */
   nestHeadings?: boolean;
   /** Current target Global ID (controlled). */
@@ -64,20 +60,12 @@ export interface LinkEditorProps {
 }
 
 /**
- * The shared link-editor UI used by both the extra-field editor (UpdateField)
- * and the template-field editor (LinkFieldValue), in three labelled groups:
- * the target group (the Global ID field and the two Browse buttons on one
- * wrapping row, with the selected target's chip beneath), then the
- * relation-type field, then "Version" (the version pill and version-pin
- * control). Plus the three picker/version dialogs. The target group is headed
- * "Target" unless the caller renames it via `targetHeading`, which the
- * template's default-link editor does.
+ * The shared link-editor UI used by the extra-field editor (UpdateField) and the template-field
+ * editor (LinkFieldValue), in three groups: target (Global ID field, Browse buttons, selected chip),
+ * relation type, then version. Plus the three picker/version dialogs.
  *
- * Controlled and presentational: it owns only the open-state of its three
- * dialogs and a neutral vertical layout. All staged values, validation, the
- * commit buttons, and the commit logic stay with each caller, which differ
- * (constrained vs free-solo relations, a target name, Box vs Grid placement,
- * and different model-commit calls).
+ * Controlled and presentational: it owns only its dialogs' open-state and the layout. Staged
+ * values, validation and commit stay with each caller, which differ.
  */
 export default function LinkEditor({
   relationType,
@@ -106,9 +94,7 @@ export default function LinkEditor({
   const targetIcon = targetGlobalId ? iconForGlobalId(targetGlobalId) : null;
   const groupHeadingSx = { fontWeight: 700, fontSize: "1rem" } as const;
 
-  // The group headings take their level from the ambient context rather than being hardcoded: this
-  // component is mounted at two different depths. Only nest where the caller really did render a
-  // heading above (see nestHeadings), or the levels skip.
+  // headings take their level from the ambient context: this component mounts at two depths
   const body = (
     <Box>
       <Heading variant="h6" sx={groupHeadingSx}>
@@ -156,24 +142,15 @@ export default function LinkEditor({
           {t("fields.link.editor.browseEln")}
         </Button>
       </Stack>
-      {/* The selected target sits below the id field and pickers, not beside them: it is the
-          outcome of using them, and in the row it competed for width and had its delete icon
-          clipped (MuiChip-label is overflow: hidden, so a shrunk chip loses the X). */}
+      {/* Below the row, not in it: in the row the chip shrank, and a shrunk chip clips its own
+          delete icon. */}
       {targetGlobalId ? (
         <Box sx={{ mt: 1 }}>
           <Chip
-            // Match the committed (non-edit) LinkField pill. size="small"
-            // gives the same geometry; the pl restores the left padding
-            // the accented theme strips from deletable chips
-            // (`&.MuiChip-deletable { padding: 0 }`). Without it the type
-            // icon — which gets no MuiChip-icon margin because
-            // RecordTypeIcon wraps it in a tooltip — sits flush against
-            // the left edge instead of the non-edit pill's 4px
-            // (spacing(0.5)). The selector is repeated to out-specify the
-            // theme's two-class `.MuiChip-deletable` rule. The cancel
-            // button just widens the chip.
+            // the accented theme zeroes padding on deletable chips; restore the non-edit
+            // pill's 4px so the type icon is not flush against the edge
             size="small"
-            sx={{ "&.MuiChip-deletable": { pl: 0.5 } }}
+            sx={{ [`&.${chipClasses.deletable}`]: { pl: 0.5 } }}
             icon={targetIcon ? <RecordTypeIcon record={targetIcon} aria-hidden /> : undefined}
             label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
             onDelete={() => onTargetChange("", "")}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkEditor.tsx
@@ -95,6 +95,8 @@ export default function LinkEditor({
   const [browserOpen, setBrowserOpen] = useState(false);
   const [elnOpen, setElnOpen] = useState(false);
   const [versionDialogOpen, setVersionDialogOpen] = useState(false);
+  const targetIcon = targetGlobalId ? iconForGlobalId(targetGlobalId) : null;
+  const groupHeadingSx = { fontWeight: 700, fontSize: "1rem" } as const;
 
   return (
     // The group headings descend from whatever level the caller's own label sits at, rather than
@@ -103,7 +105,7 @@ export default function LinkEditor({
     // enclosing field label rather than its siblings.
     <HeadingContext>
       <Box>
-        <Heading variant="h6" sx={{ fontWeight: 700, fontSize: "1rem" }}>
+        <Heading variant="h6" sx={groupHeadingSx}>
           {targetHeading ?? t("fields.link.editor.target")}
         </Heading>
         <Stack
@@ -151,33 +153,28 @@ export default function LinkEditor({
         {/* The selected target sits below the id field and pickers, not beside them: it is the
           outcome of using them, and in the row it competed for width and had its delete icon
           clipped (MuiChip-label is overflow: hidden, so a shrunk chip loses the X). */}
-        {targetGlobalId
-          ? (() => {
-              const iconData = iconForGlobalId(targetGlobalId);
-              return (
-                <Box sx={{ mt: 1 }}>
-                  <Chip
-                    // Match the committed (non-edit) LinkField pill. size="small"
-                    // gives the same geometry; the pl restores the left padding
-                    // the accented theme strips from deletable chips
-                    // (`&.MuiChip-deletable { padding: 0 }`). Without it the type
-                    // icon — which gets no MuiChip-icon margin because
-                    // RecordTypeIcon wraps it in a tooltip — sits flush against
-                    // the left edge instead of the non-edit pill's 4px
-                    // (spacing(0.5)). The selector is repeated to out-specify the
-                    // theme's two-class `.MuiChip-deletable` rule. The cancel
-                    // button just widens the chip.
-                    size="small"
-                    sx={{ "&.MuiChip-deletable": { pl: 0.5 } }}
-                    icon={iconData ? <RecordTypeIcon record={iconData} aria-hidden /> : undefined}
-                    label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
-                    onDelete={() => onTargetChange("", "")}
-                    data-test-id="LinkTarget-globalId"
-                  />
-                </Box>
-              );
-            })()
-          : null}
+        {targetGlobalId ? (
+          <Box sx={{ mt: 1 }}>
+            <Chip
+              // Match the committed (non-edit) LinkField pill. size="small"
+              // gives the same geometry; the pl restores the left padding
+              // the accented theme strips from deletable chips
+              // (`&.MuiChip-deletable { padding: 0 }`). Without it the type
+              // icon — which gets no MuiChip-icon margin because
+              // RecordTypeIcon wraps it in a tooltip — sits flush against
+              // the left edge instead of the non-edit pill's 4px
+              // (spacing(0.5)). The selector is repeated to out-specify the
+              // theme's two-class `.MuiChip-deletable` rule. The cancel
+              // button just widens the chip.
+              size="small"
+              sx={{ "&.MuiChip-deletable": { pl: 0.5 } }}
+              icon={targetIcon ? <RecordTypeIcon record={targetIcon} aria-hidden /> : undefined}
+              label={targetName ? `${targetGlobalId} — ${targetName}` : targetGlobalId}
+              onDelete={() => onTargetChange("", "")}
+              data-test-id="LinkTarget-globalId"
+            />
+          </Box>
+        ) : null}
         {validationMessage ? <FormHelperText error>{validationMessage}</FormHelperText> : null}
         <Box sx={{ mt: 2 }}>
           <Autocomplete
@@ -207,7 +204,7 @@ export default function LinkEditor({
             }}
           />
         </Box>
-        <Heading variant="h6" sx={{ mt: 2, fontWeight: 700, fontSize: "1rem" }}>
+        <Heading variant="h6" sx={{ mt: 2, ...groupHeadingSx }}>
           {t("fields.link.editor.version")}
         </Heading>
         <Stack direction="row" spacing={1} sx={{ mt: 0.5, alignItems: "center" }} data-test-id="LinkEditor-versionRow">

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkField.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/LinkField.tsx
@@ -89,7 +89,10 @@ export default function LinkField(props: LinkFieldProps): React.ReactElement {
 
   const openHref = openHrefForLink(props.link, targetIsInventory);
   return (
-    <Card variant="outlined" aria-label={props.name ? `Link field ${props.name}` : "Link field"}>
+    <Card
+      variant="outlined"
+      aria-label={props.name ? t("fields.link.field.namedLabel", { name: props.name }) : t("fields.link.field.label")}
+    >
       <CardContent sx={{ "&:last-child": { pb: 2 } }}>
         <Box
           sx={{

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
@@ -82,11 +82,14 @@ describe("LinkEditor layout", () => {
     ).toBeInTheDocument();
   });
 
-  it("still shows the selected target chip alongside the target field", () => {
+  it("shows the selected target below the id field and pickers, not inside that row", () => {
     const { container } = renderEditor({ targetGlobalId: "SA42" });
 
     const targetRow = row(container, "LinkEditor-targetRow");
-    expect(targetRow.querySelector('[data-test-id="LinkTarget-globalId"]')).toBeInTheDocument();
+    const chip = container.querySelector<HTMLElement>('[data-test-id="LinkTarget-globalId"]');
+    expect(chip).toBeInTheDocument();
+    expect(targetRow.contains(chip)).toBe(false);
+    expect(targetRow.compareDocumentPosition(chip as HTMLElement) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("keeps the chip's delete affordance, which clears the target", async () => {
@@ -98,9 +101,6 @@ describe("LinkEditor layout", () => {
     const deleteIcon = chip?.querySelector<HTMLElement>(".MuiChip-deleteIcon");
     expect(deleteIcon).toBeInTheDocument();
 
-    // the chip must not shrink away in the flex row: a squashed chip clips its own delete icon
-    expect(window.getComputedStyle(chip as HTMLElement).flexShrink).toBe("0");
-
     await user.click(deleteIcon as HTMLElement);
     expect(onTargetChange).toHaveBeenCalledWith("", "");
   });
@@ -108,8 +108,10 @@ describe("LinkEditor layout", () => {
   it("keeps the target field narrow, since a Global ID is short", () => {
     const { container } = renderEditor();
 
-    const field = container.querySelector<HTMLElement>(".MuiTextField-root");
-    // a Global ID tops out around 20 characters, so the field is sized rather than greedy
-    expect(window.getComputedStyle(field as HTMLElement).flexGrow).not.toBe("1");
+    const field = within(row(container, "LinkEditor-targetRow"))
+      .getByRole("textbox", { name: "inventory:fields.link.editor.targetGlobalId" })
+      .closest<HTMLElement>(".MuiTextField-root");
+    // a Global ID tops out around 20 characters, so the field is sized rather than filling the row
+    expect(window.getComputedStyle(field as HTMLElement).width).toBe("11em");
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
@@ -1,0 +1,115 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import materialTheme from "../../../../../theme";
+import LinkEditor, { type LinkEditorProps } from "../LinkEditor";
+
+// the three picker dialogs are closed in every case here and fetch on open; stub them out so the
+// layout assertions below are about the editor's own structure
+vi.mock("../LinkTargetBrowser", () => ({ default: () => null }));
+vi.mock("../ElnRecordPicker", () => ({ default: () => null }));
+vi.mock("../VersionLockDialog", () => ({ default: () => null }));
+
+function renderEditor(overrides: Partial<LinkEditorProps> = {}) {
+  const props: LinkEditorProps = {
+    relationType: "",
+    onRelationTypeChange: vi.fn(),
+    relationOptions: ["References", "IsDerivedFrom"],
+    relationFreeSolo: false,
+    relationLabel: "Relationship type",
+    targetGlobalId: "",
+    onTargetChange: vi.fn(),
+    targetError: false,
+    targetHelperText: "",
+    versionPin: null,
+    onVersionPinChange: vi.fn(),
+    canPinVersion: false,
+    ...overrides,
+  };
+  return render(
+    <ThemeProvider theme={materialTheme}>
+      <LinkEditor {...props} />
+    </ThemeProvider>,
+  );
+}
+
+// this repo tags elements with `data-test-id`, which is not testing-library's default
+// `testIdAttribute`; the sibling LinkField tests reach them by selector, so these do too
+function row(container: HTMLElement, testId: string): HTMLElement {
+  const found = container.querySelector<HTMLElement>(`[data-test-id="${testId}"]`);
+  if (!found) throw new Error(`no element with data-test-id="${testId}"`);
+  return found;
+}
+
+describe("LinkEditor layout", () => {
+  it("groups the target field and both browse buttons on one row under a Target heading", () => {
+    const { container } = renderEditor();
+
+    expect(screen.getByRole("heading", { name: "inventory:fields.link.editor.target" })).toBeInTheDocument();
+
+    const targetRow = row(container, "LinkEditor-targetRow");
+    expect(
+      within(targetRow).getByRole("textbox", { name: "inventory:fields.link.editor.targetGlobalId" }),
+    ).toBeInTheDocument();
+    expect(
+      within(targetRow).getByRole("button", { name: "inventory:fields.link.editor.browseInventory" }),
+    ).toBeInTheDocument();
+    expect(
+      within(targetRow).getByRole("button", { name: "inventory:fields.link.editor.browseEln" }),
+    ).toBeInTheDocument();
+  });
+
+  it("puts the relationship type below the target group", () => {
+    const { container } = renderEditor();
+
+    const targetRow = row(container, "LinkEditor-targetRow");
+    const relation = screen.getByRole("combobox", { name: "Relationship type" });
+
+    expect(targetRow.compareDocumentPosition(relation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("gives the version pill and its clock a Version heading", () => {
+    const { container } = renderEditor();
+
+    expect(screen.getByRole("heading", { name: "inventory:fields.link.editor.version" })).toBeInTheDocument();
+
+    const versionRow = row(container, "LinkEditor-versionRow");
+    expect(versionRow.querySelector('[data-test-id="LinkEditor-version"]')).toBeInTheDocument();
+    expect(
+      within(versionRow).getByRole("button", { name: "inventory:fields.link.editor.pinVersion" }),
+    ).toBeInTheDocument();
+  });
+
+  it("still shows the selected target chip alongside the target field", () => {
+    const { container } = renderEditor({ targetGlobalId: "SA42" });
+
+    const targetRow = row(container, "LinkEditor-targetRow");
+    expect(targetRow.querySelector('[data-test-id="LinkTarget-globalId"]')).toBeInTheDocument();
+  });
+
+  it("keeps the chip's delete affordance, which clears the target", async () => {
+    const user = userEvent.setup();
+    const onTargetChange = vi.fn();
+    const { container } = renderEditor({ targetGlobalId: "SA42", onTargetChange });
+
+    const chip = container.querySelector<HTMLElement>('[data-test-id="LinkTarget-globalId"]');
+    const deleteIcon = chip?.querySelector<HTMLElement>(".MuiChip-deleteIcon");
+    expect(deleteIcon).toBeInTheDocument();
+
+    // the chip must not shrink away in the flex row: a squashed chip clips its own delete icon
+    expect(window.getComputedStyle(chip as HTMLElement).flexShrink).toBe("0");
+
+    await user.click(deleteIcon as HTMLElement);
+    expect(onTargetChange).toHaveBeenCalledWith("", "");
+  });
+
+  it("keeps the target field narrow, since a Global ID is short", () => {
+    const { container } = renderEditor();
+
+    const field = container.querySelector<HTMLElement>(".MuiTextField-root");
+    // a Global ID tops out around 20 characters, so the field is sized rather than greedy
+    expect(window.getComputedStyle(field as HTMLElement).flexGrow).not.toBe("1");
+  });
+});

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-
+import { HeadingContext } from "@/components/DynamicHeadingLevel";
 import materialTheme from "../../../../../theme";
 import LinkEditor, { type LinkEditorProps } from "../LinkEditor";
 
@@ -148,5 +148,49 @@ describe("LinkEditor target row alignment", () => {
       name: "inventory:fields.link.editor.targetGlobalId",
     });
     expect(input).toHaveAttribute("placeholder", "inventory:fields.link.editor.targetPlaceholder");
+  });
+});
+
+describe("LinkEditor heading level", () => {
+  function renderAtLevel(props: Partial<LinkEditorProps>, level: 1 | 2 | 3 | 4 | 5 | 6) {
+    return render(
+      <ThemeProvider theme={materialTheme}>
+        <HeadingContext level={level}>
+          <LinkEditor
+            relationType=""
+            onRelationTypeChange={vi.fn()}
+            relationOptions={[]}
+            relationFreeSolo={false}
+            relationLabel="Relationship type"
+            targetGlobalId=""
+            onTargetChange={vi.fn()}
+            targetError={false}
+            targetHelperText=""
+            versionPin={null}
+            onVersionPinChange={vi.fn()}
+            canPinVersion={false}
+            {...props}
+          />
+        </HeadingContext>
+      </ThemeProvider>,
+    );
+  }
+
+  it("renders its group headings at the ambient level, not one deeper", () => {
+    // The item and extra-field callers render no heading of their own in edit mode: FieldLabel
+    // only emits a Heading when disabled, so nesting a level here would skip one (h3 panel title
+    // straight to h5) and axe's heading-order rule would flag it.
+    renderAtLevel({}, 4);
+
+    expect(screen.getByRole("heading", { name: "inventory:fields.link.editor.target" }).tagName).toBe("H4");
+    expect(screen.getByRole("heading", { name: "inventory:fields.link.editor.version" }).tagName).toBe("H4");
+  });
+
+  it("descends one level when the caller already renders a heading above", () => {
+    // the template editor wraps this in an InputWrapper whose FormControl does render a Heading
+    // ("Default Link (optional)"), so there the groups genuinely are subheadings of it
+    renderAtLevel({ nestHeadings: true, targetHeading: "Default link target" }, 4);
+
+    expect(screen.getByRole("heading", { name: "Default link target" }).tagName).toBe("H5");
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
@@ -1,4 +1,6 @@
+import { chipClasses } from "@mui/material/Chip";
 import { ThemeProvider } from "@mui/material/styles";
+import { textFieldClasses } from "@mui/material/TextField";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -98,7 +100,7 @@ describe("LinkEditor layout", () => {
     const { container } = renderEditor({ targetGlobalId: "SA42", onTargetChange });
 
     const chip = container.querySelector<HTMLElement>('[data-test-id="LinkTarget-globalId"]');
-    const deleteIcon = chip?.querySelector<HTMLElement>(".MuiChip-deleteIcon");
+    const deleteIcon = chip?.querySelector<HTMLElement>(`.${chipClasses.deleteIcon}`);
     expect(deleteIcon).toBeInTheDocument();
 
     await user.click(deleteIcon as HTMLElement);
@@ -110,7 +112,7 @@ describe("LinkEditor layout", () => {
 
     const field = within(row(container, "LinkEditor-targetRow"))
       .getByRole("textbox", { name: "inventory:fields.link.editor.targetGlobalId" })
-      .closest<HTMLElement>(".MuiTextField-root");
+      .closest<HTMLElement>(`.${textFieldClasses.root}`);
     // a Global ID tops out around 20 characters, so the field is sized rather than filling the row
     expect(window.getComputedStyle(field as HTMLElement).width).toBe("11em");
   });

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/LinkEditor.test.tsx
@@ -115,3 +115,38 @@ describe("LinkEditor layout", () => {
     expect(window.getComputedStyle(field as HTMLElement).width).toBe("11em");
   });
 });
+
+describe("LinkEditor target heading", () => {
+  it("labels the target group 'Target' by default", () => {
+    renderEditor();
+
+    expect(screen.getByRole("heading", { name: "inventory:fields.link.editor.target" })).toBeInTheDocument();
+  });
+
+  it("lets the caller name the target group, so a template can call it a default link target", () => {
+    // the same editor serves an item's own link, an extra-field link and a template's default; only
+    // the template's copy is a "default link target"
+    renderEditor({ targetHeading: "Default link target" });
+
+    expect(screen.getByRole("heading", { name: "Default link target" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "inventory:fields.link.editor.target" })).not.toBeInTheDocument();
+  });
+});
+
+describe("LinkEditor target row alignment", () => {
+  it("gives the target field no floating label, so its input line starts level with the buttons", () => {
+    // jsdom has no layout, so this asserts the structural cause rather than the pixels: a
+    // variant="standard" TextField with a label stacks the label above the input, dropping the
+    // input ~16px below the neighbouring buttons. Without one they share a top edge. The group
+    // heading and the helper text carry the naming instead.
+    const { container } = renderEditor();
+
+    const targetRow = row(container, "LinkEditor-targetRow");
+    expect(targetRow.querySelector("label")).toBeNull();
+
+    const input = within(targetRow).getByRole("textbox", {
+      name: "inventory:fields.link.editor.targetGlobalId",
+    });
+    expect(input).toHaveAttribute("placeholder", "inventory:fields.link.editor.targetPlaceholder");
+  });
+});

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -909,7 +909,9 @@
         "pinnedVersion": "Pinned to v{version}",
         "pinVersion": "Pin version",
         "pinVersionFor": "Pin version for {globalId}",
-        "targetGlobalId": "Target Global ID"
+        "target": "Target",
+        "targetGlobalId": "Target Global ID",
+        "version": "Version"
       },
       "elnFolderBrowser": {
         "failedToLoadContents": "Failed to load contents",

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -1099,6 +1099,8 @@
         "allowedRelationshipTypes": "Allowed relationship types",
         "allowedRelationshipTypesExplanation": "The DataCite relationship types that links may use on samples created from this template. Leave empty to allow all relationship types.",
         "allRelationshipTypes": "All relationship types",
+        "defaultLink": "Default link",
+        "defaultLinkExplanation": "An optional link applied to every item created from this template. Its relationship type must be one of the allowed types above. Items can change or remove it afterwards.",
         "none": "None"
       },
       "move": {

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -628,7 +628,7 @@
       },
       "link": {
         "relationHelper": "Pick a DataCite relation type",
-        "targetHelper": "Paste a Global ID, or use the Browse buttons above.",
+        "targetHelper": "Paste a Global ID, or Browse",
         "targetNotFound": "{globalId} does not exist, or you do not have permission to view it."
       },
       "maxCharacters": "Must be no more than {max} characters.",
@@ -1838,6 +1838,7 @@
       "linkFieldValue": {
         "apply": "Apply",
         "applyLabel": "Apply link",
+        "bothRequired": "Select both a relationship type and a target before applying.",
         "discard": "Discard",
         "discardLabel": "Discard link changes",
         "none": "None"

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -940,6 +940,7 @@
         "pinVersionFor": "Pin version for {globalId}",
         "target": "Target",
         "targetGlobalId": "Target Global ID",
+        "targetPlaceholder": "e.g. SA123",
         "version": "Version"
       },
       "elnFolderBrowser": {
@@ -1131,8 +1132,9 @@
         "allowedRelationshipTypesExplanation": "The DataCite relationship types that links may use on samples created from this template. Leave empty to allow all relationship types.",
         "allowedRelationshipTypesExplanationInstrument": "The DataCite relationship types that links may use on instruments created from this template. Leave empty to allow all relationship types.",
         "allRelationshipTypes": "All relationship types",
-        "defaultLink": "Default link",
+        "defaultLink": "Default Link (optional)",
         "defaultLinkExplanation": "An optional link applied to every item created from this template. Its relationship type must be one of the allowed types above. Items can change or remove it afterwards.",
+        "defaultLinkTarget": "Default link target",
         "none": "None"
       },
       "move": {

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -959,6 +959,10 @@
         "title": "Browse ELN",
         "workspaceTreeLabel": "Workspace tree"
       },
+      "field": {
+        "label": "Link field",
+        "namedLabel": "Link field {name}"
+      },
       "gallerySections": {
         "labels": {
           "caption": "Caption",
@@ -1880,7 +1884,6 @@
       "linkFieldValue": {
         "apply": "Apply",
         "applyLabel": "Apply link",
-        "bothRequired": "Select both a relationship type and a target before applying.",
         "discard": "Discard",
         "discardLabel": "Discard link changes",
         "none": "None",

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -656,7 +656,7 @@
       },
       "link": {
         "relationHelper": "Pick a DataCite relation type",
-        "targetHelper": "Paste a Global ID, or use the Browse buttons above.",
+        "targetHelper": "Paste a Global ID, or Browse",
         "targetNotFound": "{globalId} does not exist, or you do not have permission to view it."
       },
       "maxCharacters": "Must be no more than {max} characters.",
@@ -1878,6 +1878,7 @@
       "linkFieldValue": {
         "apply": "Apply",
         "applyLabel": "Apply link",
+        "bothRequired": "Select both a relationship type and a target before applying.",
         "discard": "Discard",
         "discardLabel": "Discard link changes",
         "none": "None",

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -938,7 +938,9 @@
         "pinnedVersion": "Pinned to v{version}",
         "pinVersion": "Pin version",
         "pinVersionFor": "Pin version for {globalId}",
-        "targetGlobalId": "Target Global ID"
+        "target": "Target",
+        "targetGlobalId": "Target Global ID",
+        "version": "Version"
       },
       "elnFolderBrowser": {
         "failedToLoadContents": "Failed to load contents",

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -1129,6 +1129,8 @@
         "allowedRelationshipTypesExplanation": "The DataCite relationship types that links may use on samples created from this template. Leave empty to allow all relationship types.",
         "allowedRelationshipTypesExplanationInstrument": "The DataCite relationship types that links may use on instruments created from this template. Leave empty to allow all relationship types.",
         "allRelationshipTypes": "All relationship types",
+        "defaultLink": "Default link",
+        "defaultLinkExplanation": "An optional link applied to every item created from this template. Its relationship type must be one of the allowed types above. Items can change or remove it afterwards.",
         "none": "None"
       },
       "move": {

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
@@ -53,6 +53,7 @@
         "deleteRequestIdUnknown": "Field id {0} doesn''t match the id of any pre-existing field.",
         "duplicateName": "Field name ''{0}'' is duplicated. Field names on a record must be unique.",
         "link": {
+          "defaultRelationTypeNotPermitted": "Field ''{1}'' has a default link using relation type ''{0}'', so that type cannot be removed from its allowed relationship types. Change or remove the default link first.",
           "selfLinkForbidden": "An item cannot link to itself: ''{0}''."
         },
         "linkRelationTypeInvalid": "Relation type ''{0}'' is not in the DataCite controlled vocabulary.",

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
@@ -49,7 +49,7 @@
         "unexportableUsers": "Cannot export data of users [{0}] - users not found, or no permission"
       },
       "field": {
-        "deleteRequestIdMissing": "''id'' property not provided for a field with ''deleteFieldRequest'' flag.",
+        "deleteRequestIdMissing": "'id' property not provided for a field with 'deleteFieldRequest' flag.",
         "deleteRequestIdUnknown": "Field id {0} doesn''t match the id of any pre-existing field.",
         "duplicateName": "Field name ''{0}'' is duplicated. Field names on a record must be unique.",
         "link": {

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -3392,6 +3392,8 @@ export default interface Resources {
           "allowedRelationshipTypes": "Allowed relationship types",
           "allowedRelationshipTypesExplanation": "The DataCite relationship types that links may use on samples created from this template. Leave empty to allow all relationship types.",
           "allowedRelationshipTypesExplanationInstrument": "The DataCite relationship types that links may use on instruments created from this template. Leave empty to allow all relationship types.",
+          "defaultLink": "Default link",
+          "defaultLinkExplanation": "An optional link applied to every item created from this template. Its relationship type must be one of the allowed types above. Items can change or remove it afterwards.",
           "none": "None"
         },
         "move": {

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -6738,6 +6738,7 @@ export default interface Resources {
           "deleteRequestIdUnknown": "Field id {0} doesn''t match the id of any pre-existing field.",
           "duplicateName": "Field name ''{0}'' is duplicated. Field names on a record must be unique.",
           "link": {
+            "defaultRelationTypeNotPermitted": "Field ''{1}'' has a default link using relation type ''{0}'', so that type cannot be removed from its allowed relationship types. Change or remove the default link first.",
             "selfLinkForbidden": "An item cannot link to itself: ''{0}''."
           },
           "linkRelationTypeInvalid": "Relation type ''{0}'' is not in the DataCite controlled vocabulary.",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -3222,6 +3222,10 @@ export default interface Resources {
           "title": "Browse ELN",
           "workspaceTreeLabel": "Workspace tree"
         },
+        "field": {
+          "label": "Link field",
+          "namedLabel": "Link field {name}"
+        },
         "gallerySections": {
           "labels": {
             "caption": "Caption",
@@ -4143,7 +4147,6 @@ export default interface Resources {
         "linkFieldValue": {
           "apply": "Apply",
           "applyLabel": "Apply link",
-          "bothRequired": "Select both a relationship type and a target before applying.",
           "discard": "Discard",
           "discardLabel": "Discard link changes",
           "none": "None",
@@ -6736,7 +6739,7 @@ export default interface Resources {
           "unexportableUsers": "Cannot export data of users [{0}] - users not found, or no permission"
         },
         "field": {
-          "deleteRequestIdMissing": "''id'' property not provided for a field with ''deleteFieldRequest'' flag.",
+          "deleteRequestIdMissing": "'id' property not provided for a field with 'deleteFieldRequest' flag.",
           "deleteRequestIdUnknown": "Field id {0} doesn''t match the id of any pre-existing field.",
           "duplicateName": "Field name ''{0}'' is duplicated. Field names on a record must be unique.",
           "link": {

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -3201,7 +3201,9 @@ export default interface Resources {
           "pinVersion": "Pin version",
           "pinVersionFor": "Pin version for {globalId}",
           "pinnedVersion": "Pinned to v{version}",
-          "targetGlobalId": "Target Global ID"
+          "target": "Target",
+          "targetGlobalId": "Target Global ID",
+          "version": "Version"
         },
         "elnFolderBrowser": {
           "failedToLoadContents": "Failed to load contents",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -3314,6 +3314,8 @@ export default interface Resources {
           "allRelationshipTypes": "All relationship types",
           "allowedRelationshipTypes": "Allowed relationship types",
           "allowedRelationshipTypesExplanation": "The DataCite relationship types that links may use on samples created from this template. Leave empty to allow all relationship types.",
+          "defaultLink": "Default link",
+          "defaultLinkExplanation": "An optional link applied to every item created from this template. Its relationship type must be one of the allowed types above. Items can change or remove it afterwards.",
           "none": "None"
         },
         "move": {

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -2843,7 +2843,7 @@ export default interface Resources {
         },
         "link": {
           "relationHelper": "Pick a DataCite relation type",
-          "targetHelper": "Paste a Global ID, or use the Browse buttons above.",
+          "targetHelper": "Paste a Global ID, or Browse",
           "targetNotFound": "{globalId} does not exist, or you do not have permission to view it."
         },
         "maxCharacters": "Must be no more than {max} characters.",
@@ -4053,6 +4053,7 @@ export default interface Resources {
         "linkFieldValue": {
           "apply": "Apply",
           "applyLabel": "Apply link",
+          "bothRequired": "Select both a relationship type and a target before applying.",
           "discard": "Discard",
           "discardLabel": "Discard link changes",
           "none": "None"

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -3124,7 +3124,9 @@ export default interface Resources {
           "pinVersion": "Pin version",
           "pinVersionFor": "Pin version for {globalId}",
           "pinnedVersion": "Pinned to v{version}",
-          "targetGlobalId": "Target Global ID"
+          "target": "Target",
+          "targetGlobalId": "Target Global ID",
+          "version": "Version"
         },
         "elnFolderBrowser": {
           "failedToLoadContents": "Failed to load contents",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -2919,7 +2919,7 @@ export default interface Resources {
         },
         "link": {
           "relationHelper": "Pick a DataCite relation type",
-          "targetHelper": "Paste a Global ID, or use the Browse buttons above.",
+          "targetHelper": "Paste a Global ID, or Browse",
           "targetNotFound": "{globalId} does not exist, or you do not have permission to view it."
         },
         "maxCharacters": "Must be no more than {max} characters.",
@@ -4141,6 +4141,7 @@ export default interface Resources {
         "linkFieldValue": {
           "apply": "Apply",
           "applyLabel": "Apply link",
+          "bothRequired": "Select both a relationship type and a target before applying.",
           "discard": "Discard",
           "discardLabel": "Discard link changes",
           "none": "None",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -3203,6 +3203,7 @@ export default interface Resources {
           "pinnedVersion": "Pinned to v{version}",
           "target": "Target",
           "targetGlobalId": "Target Global ID",
+          "targetPlaceholder": "e.g. SA123",
           "version": "Version"
         },
         "elnFolderBrowser": {
@@ -3394,8 +3395,9 @@ export default interface Resources {
           "allowedRelationshipTypes": "Allowed relationship types",
           "allowedRelationshipTypesExplanation": "The DataCite relationship types that links may use on samples created from this template. Leave empty to allow all relationship types.",
           "allowedRelationshipTypesExplanationInstrument": "The DataCite relationship types that links may use on instruments created from this template. Leave empty to allow all relationship types.",
-          "defaultLink": "Default link",
+          "defaultLink": "Default Link (optional)",
           "defaultLinkExplanation": "An optional link applied to every item created from this template. Its relationship type must be one of the allowed types above. Items can change or remove it afterwards.",
+          "defaultLinkTarget": "Default link target",
           "none": "None"
         },
         "move": {

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplateDefaultLinkMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplateDefaultLinkMVCIT.java
@@ -87,8 +87,8 @@ public class InstrumentTemplateDefaultLinkMVCIT extends API_MVC_InventoryTestBas
                 apiKey, "/instrumentTemplates/" + template.getId(), anyUser, deleteJson))
         .andExpect(status().isOk());
 
-    InventoryLink row = inventoryLinkDao.get(linkRowId);
-    assertTrue(row.isDeleted(), "the default link row must be soft-deleted with its field");
+    assertTrue(
+        linkRowIsDeleted(linkRowId), "the default link row must be soft-deleted with its field");
   }
 
   @Test
@@ -126,9 +126,9 @@ public class InstrumentTemplateDefaultLinkMVCIT extends API_MVC_InventoryTestBas
         synced.getFields().stream().anyMatch(f -> ApiFieldType.LINK.equals(f.getType())),
         "the propagated delete should remove the link field from the instrument");
 
-    InventoryLink row = inventoryLinkDao.get(instrumentLinkRowId);
     assertTrue(
-        row.isDeleted(), "the instrument's orphaned link row must be soft-deleted by the sync");
+        linkRowIsDeleted(instrumentLinkRowId),
+        "the instrument's orphaned link row must be soft-deleted by the sync");
   }
 
   @Test
@@ -155,11 +155,23 @@ public class InstrumentTemplateDefaultLinkMVCIT extends API_MVC_InventoryTestBas
         .andExpect(status().isUnprocessableEntity());
   }
 
-  /** The InventoryLink row id behind a link field, read straight from the DAO. */
-  private Long linkRowIdOfField(Long fieldId) {
-    InventoryLinkField field = (InventoryLinkField) inventoryEntityFieldDao.get(fieldId);
-    assertNotNull(field.getLink(), "the field should hold a link before it is deleted");
-    return field.getLink().getId();
+  /**
+   * The InventoryLink row id behind a link field, read straight from the DAO. This base runs real
+   * transactions per request rather than wrapping the test method in one, so a direct DAO call
+   * needs its own transaction or Hibernate has no session to bind to.
+   */
+  private Long linkRowIdOfField(Long fieldId) throws Exception {
+    return doInTransaction(
+        () -> {
+          InventoryLinkField field = (InventoryLinkField) inventoryEntityFieldDao.get(fieldId);
+          assertNotNull(field.getLink(), "the field should hold a link before it is deleted");
+          return field.getLink().getId();
+        });
+  }
+
+  /** Same reason as {@link #linkRowIdOfField}: the row read needs its own transaction. */
+  private boolean linkRowIsDeleted(Long linkRowId) throws Exception {
+    return doInTransaction(() -> inventoryLinkDao.get(linkRowId).isDeleted());
   }
 
   private ApiInstrumentTemplate createTemplateWithDefaultLink(String targetGlobalId)

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplateDefaultLinkMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentTemplateDefaultLinkMVCIT.java
@@ -1,0 +1,193 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.dao.InventoryEntityFieldDao;
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.service.inventory.InstrumentEntityApiManager;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage for an instrument template's <b>default link</b> (RSDEV-1246) and for the
+ * link-row reconciliation the instrument manager was missing (RSDEV-1270).
+ *
+ * <p>The RSDEV-1270 cases fail on {@code main} at the {@code deleted=true} assertion. The symptom
+ * is invisible in the UI, because both referencing-items queries filter on the field's {@code
+ * deleted} flag, so the assertion has to reach the {@link InventoryLink} row directly.
+ *
+ * <p>Authored as part of the feature; not run automatically (extends a real-transaction MVC base).
+ */
+@WebAppConfiguration
+public class InstrumentTemplateDefaultLinkMVCIT extends API_MVC_InventoryTestBase {
+
+  private @Autowired InstrumentEntityApiManager instrumentApiManager;
+  private @Autowired InventoryLinkDao inventoryLinkDao;
+  private @Autowired InventoryEntityFieldDao inventoryEntityFieldDao;
+
+  private User anyUser;
+  private String apiKey;
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+    anyUser = createInitAndLoginAnyUser();
+    apiKey = createNewApiKeyForUser(anyUser);
+  }
+
+  @Test
+  public void defaultLinkIsStampedOntoInstrumentsCreatedFromTheTemplate() throws Exception {
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+    ApiInstrumentTemplate template = createTemplateWithDefaultLink(target.getGlobalId());
+
+    ApiInventoryEntityField templateLinkField = findLinkField(template.getFields());
+    assertNotNull(templateLinkField.getLink(), "the template should hold its default link");
+    assertEquals(target.getGlobalId(), templateLinkField.getLink().getTargetGlobalId());
+
+    ApiInstrument apiInstrument = new ApiInstrument();
+    apiInstrument.setName("instrument with a stamped default");
+    apiInstrument.setTemplateId(template.getId());
+    ApiInstrument created = instrumentApiManager.createNewApiInstrument(apiInstrument, anyUser);
+
+    ApiInventoryEntityField instrumentLinkField = findLinkField(created.getFields());
+    assertNotNull(instrumentLinkField.getLink(), "the instrument should arrive with the default");
+    assertEquals(target.getGlobalId(), instrumentLinkField.getLink().getTargetGlobalId());
+    assertEquals("References", instrumentLinkField.getLink().getRelationType());
+  }
+
+  @Test
+  public void deletingATemplateLinkFieldSoftDeletesItsDefaultLinkRow() throws Exception {
+    // RSDEV-1270, template side: deleting the field is a soft delete (an UPDATE, not a JPA remove),
+    // so cascade/orphanRemoval never fires and the row has to be soft-deleted at the service layer.
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+    ApiInstrumentTemplate template = createTemplateWithDefaultLink(target.getGlobalId());
+    Long linkFieldId = findLinkField(template.getFields()).getId();
+    Long linkRowId = linkRowIdOfField(linkFieldId);
+
+    String deleteJson = "{\"fields\":[{\"id\":" + linkFieldId + ",\"deleteFieldRequest\":true}]}";
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(
+                apiKey, "/instrumentTemplates/" + template.getId(), anyUser, deleteJson))
+        .andExpect(status().isOk());
+
+    InventoryLink row = inventoryLinkDao.get(linkRowId);
+    assertTrue(row.isDeleted(), "the default link row must be soft-deleted with its field");
+  }
+
+  @Test
+  public void propagatingATemplateFieldDeletionSoftDeletesTheInstrumentsLinkRow() throws Exception {
+    // RSDEV-1270, propagation side: this is the case already broken on main. A concrete
+    // instrument's
+    // link field does hold a link, and updateInstrumentToLatestTemplateVersion marked the field
+    // deleted without touching the row.
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+    ApiInstrumentTemplate template = createTemplateWithDefaultLink(target.getGlobalId());
+    Long templateLinkFieldId = findLinkField(template.getFields()).getId();
+
+    ApiInstrument apiInstrument = new ApiInstrument();
+    apiInstrument.setName("instrument whose link field is about to go");
+    apiInstrument.setTemplateId(template.getId());
+    ApiInstrument created = instrumentApiManager.createNewApiInstrument(apiInstrument, anyUser);
+    Long instrumentLinkFieldId = findLinkField(created.getFields()).getId();
+    Long instrumentLinkRowId = linkRowIdOfField(instrumentLinkFieldId);
+
+    // delete the template field with "update all", bumping the template version
+    String deleteJson =
+        "{\"fields\":[{\"id\":"
+            + templateLinkFieldId
+            + ",\"deleteFieldRequest\":true,\"deleteFieldOnSampleUpdate\":true}]}";
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(
+                apiKey, "/instrumentTemplates/" + template.getId(), anyUser, deleteJson))
+        .andExpect(status().isOk());
+
+    instrumentApiManager.updateInstrumentToLatestTemplateVersion(created.getId(), anyUser);
+
+    ApiInstrument synced = instrumentApiManager.getApiInstrumentById(created.getId(), anyUser);
+    assertFalse(
+        synced.getFields().stream().anyMatch(f -> ApiFieldType.LINK.equals(f.getType())),
+        "the propagated delete should remove the link field from the instrument");
+
+    InventoryLink row = inventoryLinkDao.get(instrumentLinkRowId);
+    assertTrue(
+        row.isDeleted(), "the instrument's orphaned link row must be soft-deleted by the sync");
+  }
+
+  @Test
+  public void narrowingTheWhitelistPastTheDefaultIsRejected() throws Exception {
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+    ApiInstrumentTemplate template = createTemplateWithDefaultLink(target.getGlobalId());
+    Long linkFieldId = findLinkField(template.getFields()).getId();
+
+    String updateJson =
+        "{\"fields\":[{"
+            + "\"id\":"
+            + linkFieldId
+            + ","
+            + "\"type\":\"link\","
+            + "\"allowedRelationTypes\":[\"IsCitedBy\"],"
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + target.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(
+                apiKey, "/instrumentTemplates/" + template.getId(), anyUser, updateJson))
+        .andExpect(status().isUnprocessableEntity());
+  }
+
+  /** The InventoryLink row id behind a link field, read straight from the DAO. */
+  private Long linkRowIdOfField(Long fieldId) {
+    InventoryLinkField field = (InventoryLinkField) inventoryEntityFieldDao.get(fieldId);
+    assertNotNull(field.getLink(), "the field should hold a link before it is deleted");
+    return field.getLink().getId();
+  }
+
+  private ApiInstrumentTemplate createTemplateWithDefaultLink(String targetGlobalId)
+      throws Exception {
+    String templateJson =
+        "{\"name\":\"instrument template with a default link\","
+            + "\"fields\":[{"
+            + "\"name\":\"Related items\","
+            + "\"type\":\"link\","
+            + "\"allowedRelationTypes\":[\"References\",\"IsDerivedFrom\"],"
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + targetGlobalId
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(
+                    apiKey, "/instrumentTemplates", anyUser, templateJson))
+            .andExpect(status().isCreated())
+            .andReturn();
+    return getFromJsonResponseBody(result, ApiInstrumentTemplate.class);
+  }
+
+  private ApiInventoryEntityField findLinkField(List<ApiInventoryEntityField> fields) {
+    return fields.stream()
+        .filter(f -> ApiFieldType.LINK.equals(f.getType()))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplateDefaultLinkMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplateDefaultLinkMVCIT.java
@@ -1,0 +1,271 @@
+package com.researchspace.api.v1.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
+import com.researchspace.api.v1.model.ApiSample;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.units.RSUnitDef;
+import com.researchspace.service.inventory.SampleApiManager;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage for a Sample template's <b>default link</b> (RSDEV-1246): a template Link
+ * field may carry a complete relation-type-and-target pair, stored in the same {@code link_id} an
+ * item's link uses, which is stamped onto every item created from that template as that item's own
+ * editable link.
+ *
+ * <p>Authored as part of the feature; not run automatically (extends a real-transaction MVC base).
+ */
+@WebAppConfiguration
+public class SampleTemplateDefaultLinkMVCIT extends API_MVC_InventoryTestBase {
+
+  private @Autowired SampleApiManager sampleApiManager;
+
+  private User anyUser;
+  private String apiKey;
+
+  @Before
+  public void setup() throws Exception {
+    super.setUp();
+    anyUser = createInitAndLoginAnyUser();
+    apiKey = createNewApiKeyForUser(anyUser);
+  }
+
+  @Test
+  public void defaultLinkIsStampedOntoItemsAsTheirOwnRow() throws Exception {
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+    ApiSampleWithFullSubSamples otherTarget = createBasicSampleForUser(anyUser);
+    ApiSampleTemplate savedTemplate = createTemplateWithDefaultLink(target.getGlobalId());
+
+    ApiInventoryEntityField templateLinkField = findLinkField(savedTemplate.getFields());
+    assertNotNull(templateLinkField.getLink(), "the template should hold its default link");
+    assertEquals(target.getGlobalId(), templateLinkField.getLink().getTargetGlobalId());
+    assertEquals("References", templateLinkField.getLink().getRelationType());
+
+    ApiSample item = createSampleFromTemplate(savedTemplate, "item with a stamped default");
+    ApiInventoryEntityField itemLinkField = findLinkField(item.getFields());
+    assertNotNull(itemLinkField.getLink(), "the item should arrive with the default already set");
+    assertEquals(target.getGlobalId(), itemLinkField.getLink().getTargetGlobalId());
+    assertEquals("References", itemLinkField.getLink().getRelationType());
+
+    // the item owns its stamped copy: retargeting the item must not reach back into the template.
+    // This is what proves shallowCopy() produced a distinct row rather than sharing the template's.
+    String itemUpdateJson =
+        "{\"fields\":[{"
+            + "\"id\":"
+            + itemLinkField.getId()
+            + ","
+            + "\"type\":\"link\","
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + otherTarget.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(
+                apiKey, "/samples/" + item.getId(), anyUser, itemUpdateJson))
+        .andExpect(status().isOk());
+
+    ApiSampleTemplate reloadedTemplate =
+        sampleApiManager.getApiSampleTemplateById(savedTemplate.getId(), anyUser);
+    assertEquals(
+        target.getGlobalId(),
+        findLinkField(reloadedTemplate.getFields()).getLink().getTargetGlobalId(),
+        "retargeting the item must leave the template's default alone");
+  }
+
+  @Test
+  public void defaultLinkWithADeletedTargetIsStillStamped() throws Exception {
+    // ADR-0006: the default is stamped verbatim. A target deleted after the template was authored
+    // must not stop items being created, and must not silently drop the link.
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+    ApiSampleTemplate savedTemplate = createTemplateWithDefaultLink(target.getGlobalId());
+
+    sampleApiManager.markSampleAsDeleted(target.getId(), false, anyUser);
+
+    ApiSample item = createSampleFromTemplate(savedTemplate, "item created after target deletion");
+    ApiInventoryEntityField itemLinkField = findLinkField(item.getFields());
+    assertNotNull(itemLinkField.getLink(), "a deleted target is still stamped verbatim");
+    assertEquals(target.getGlobalId(), itemLinkField.getLink().getTargetGlobalId());
+  }
+
+  @Test
+  public void editingTheTemplatesDefaultLeavesExistingItemsUnchanged() throws Exception {
+    ApiSampleWithFullSubSamples firstTarget = createBasicSampleForUser(anyUser);
+    ApiSampleWithFullSubSamples secondTarget = createBasicSampleForUser(anyUser);
+    ApiSampleTemplate savedTemplate = createTemplateWithDefaultLink(firstTarget.getGlobalId());
+    Long templateLinkFieldId = findLinkField(savedTemplate.getFields()).getId();
+
+    ApiSample item = createSampleFromTemplate(savedTemplate, "item stamped before the edit");
+
+    // retarget the template's default (bumps the template version)
+    String updateJson =
+        "{\"fields\":[{"
+            + "\"id\":"
+            + templateLinkFieldId
+            + ","
+            + "\"type\":\"link\","
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + secondTarget.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPutWithJSONBody(
+                    apiKey, "/sampleTemplates/" + savedTemplate.getId(), anyUser, updateJson))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiSampleTemplate updatedTemplate = getFromJsonResponseBody(result, ApiSampleTemplate.class);
+    assertEquals(
+        secondTarget.getGlobalId(),
+        findLinkField(updatedTemplate.getFields()).getLink().getTargetGlobalId(),
+        "the template's default should be retargeted");
+
+    // the already-created item keeps the target it was stamped with: defaults are never
+    // retro-applied, and updateToLatestTemplateVersion clears newly-cloned fields
+    ApiSample reloadedItem = sampleApiManager.getApiSampleById(item.getId(), anyUser);
+    assertEquals(
+        firstTarget.getGlobalId(),
+        findLinkField(reloadedItem.getFields()).getLink().getTargetGlobalId());
+
+    sampleApiManager.updateSampleToLatestTemplateVersion(item.getId(), anyUser);
+    ApiSample syncedItem = sampleApiManager.getApiSampleById(item.getId(), anyUser);
+    assertEquals(
+        firstTarget.getGlobalId(),
+        findLinkField(syncedItem.getFields()).getLink().getTargetGlobalId(),
+        "syncing to a newer template version must not re-stamp the item");
+  }
+
+  @Test
+  public void templateHoldingADefaultAppearsInItsTargetsReferencingItems() throws Exception {
+    // ADR-0006 decision 3: templates are not filtered out of referencingItems. Seeing the template
+    // listed is wanted, because it shows new items will keep being created pointing at that record.
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+    ApiSampleTemplate savedTemplate = createTemplateWithDefaultLink(target.getGlobalId());
+
+    MvcResult refs =
+        mockMvc
+            .perform(
+                createBuilderForGet(
+                    API_VERSION.ONE, apiKey, "/referencingItems/" + target.getGlobalId(), anyUser))
+            .andExpect(status().isOk())
+            .andReturn();
+    ApiInventoryReferencingItems body =
+        getFromJsonResponseBody(refs, ApiInventoryReferencingItems.class);
+    assertTrue(
+        body.getReferencingItems().stream()
+            .anyMatch(r -> savedTemplate.getGlobalId().equals(r.getSourceGlobalId())),
+        "the template holding the default link should be listed as a referencing item");
+  }
+
+  @Test
+  public void narrowingTheWhitelistPastTheDefaultIsRejected() throws Exception {
+    ApiSampleWithFullSubSamples target = createBasicSampleForUser(anyUser);
+    ApiSampleTemplate savedTemplate = createTemplateWithDefaultLink(target.getGlobalId());
+    Long templateLinkFieldId = findLinkField(savedTemplate.getFields()).getId();
+
+    // the default uses "References"; removing it from the whitelist would orphan the default, so
+    // the edit must fail rather than silently drop it
+    String updateJson =
+        "{\"fields\":[{"
+            + "\"id\":"
+            + templateLinkFieldId
+            + ","
+            + "\"type\":\"link\","
+            + "\"allowedRelationTypes\":[\"IsCitedBy\"],"
+            + "\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+            + target.getGlobalId()
+            + "\",\"versionPin\":null}"
+            + "}]}";
+    mockMvc
+        .perform(
+            createBuilderForPutWithJSONBody(
+                apiKey, "/sampleTemplates/" + savedTemplate.getId(), anyUser, updateJson))
+        .andExpect(status().isUnprocessableEntity());
+  }
+
+  @Test
+  public void aTemplateWithNoDefaultStillCreatesItemsWithAnEmptyLinkField() throws Exception {
+    // the default is optional: a whitelist-only template behaves exactly as it did before
+    // RSDEV-1246
+    ApiSampleTemplate savedTemplate = createTemplateWithDefaultLink(null);
+    assertNull(findLinkField(savedTemplate.getFields()).getLink());
+
+    ApiSample item = createSampleFromTemplate(savedTemplate, "item with no default");
+    ApiInventoryEntityField itemLinkField = findLinkField(item.getFields());
+    assertNotNull(itemLinkField, "the item should still inherit the link field itself");
+    assertNull(itemLinkField.getLink(), "with no default the item's link starts unset");
+  }
+
+  private ApiSample createSampleFromTemplate(ApiSampleTemplate template, String name) {
+    ApiSampleWithFullSubSamples apiSample = new ApiSampleWithFullSubSamples(name);
+    apiSample.setTemplateId(template.getId());
+    ApiSampleWithFullSubSamples created = sampleApiManager.createNewApiSample(apiSample, anyUser);
+    return sampleApiManager.getApiSampleById(created.getId(), anyUser);
+  }
+
+  /** Creates a template with one Link field; {@code targetGlobalId} null means "no default". */
+  private ApiSampleTemplate createTemplateWithDefaultLink(String targetGlobalId) throws Exception {
+    ApiSampleTemplatePost templatePost = new ApiSampleTemplatePost();
+    templatePost.setName("template with a default link");
+    templatePost.setDefaultUnitId(RSUnitDef.GRAM.getId());
+    templatePost.setSampleSource(SampleSource.LAB_CREATED);
+    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
+    linkField.setName("Related items");
+    linkField.setType(ApiFieldType.LINK);
+    linkField.setAllowedRelationTypes(List.of("References", "IsDerivedFrom"));
+    templatePost.setFields(List.of(linkField));
+
+    String linkJson =
+        targetGlobalId == null
+            ? ""
+            : ",\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\""
+                + targetGlobalId
+                + "\",\"versionPin\":null}";
+    String templateJson =
+        "{\"name\":\"template with a default link\","
+            + "\"defaultUnitId\":"
+            + RSUnitDef.GRAM.getId()
+            + ","
+            + "\"sampleSource\":\"LAB_CREATED\","
+            + "\"fields\":[{"
+            + "\"name\":\"Related items\","
+            + "\"type\":\"link\","
+            + "\"allowedRelationTypes\":[\"References\",\"IsDerivedFrom\"]"
+            + linkJson
+            + "}]}";
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                createBuilderForPostWithJSONBody(apiKey, "/sampleTemplates", anyUser, templateJson))
+            // the sampleTemplates POST returns 201 Created (see SampleTemplatesApiControllerMVCIT)
+            .andExpect(status().is2xxSuccessful())
+            .andReturn();
+    return getFromJsonResponseBody(result, ApiSampleTemplate.class);
+  }
+
+  private ApiInventoryEntityField findLinkField(List<ApiInventoryEntityField> fields) {
+    return fields.stream()
+        .filter(f -> ApiFieldType.LINK.equals(f.getType()))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/src/test/java/com/researchspace/api/v1/controller/SampleTemplateDefaultLinkMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/SampleTemplateDefaultLinkMVCIT.java
@@ -11,10 +11,8 @@ import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryReferencingItems;
 import com.researchspace.api.v1.model.ApiSample;
 import com.researchspace.api.v1.model.ApiSampleTemplate;
-import com.researchspace.api.v1.model.ApiSampleTemplatePost;
 import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
 import com.researchspace.model.User;
-import com.researchspace.model.inventory.SampleSource;
 import com.researchspace.model.units.RSUnitDef;
 import com.researchspace.service.inventory.SampleApiManager;
 import java.util.List;
@@ -223,16 +221,8 @@ public class SampleTemplateDefaultLinkMVCIT extends API_MVC_InventoryTestBase {
 
   /** Creates a template with one Link field; {@code targetGlobalId} null means "no default". */
   private ApiSampleTemplate createTemplateWithDefaultLink(String targetGlobalId) throws Exception {
-    ApiSampleTemplatePost templatePost = new ApiSampleTemplatePost();
-    templatePost.setName("template with a default link");
-    templatePost.setDefaultUnitId(RSUnitDef.GRAM.getId());
-    templatePost.setSampleSource(SampleSource.LAB_CREATED);
-    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
-    linkField.setName("Related items");
-    linkField.setType(ApiFieldType.LINK);
-    linkField.setAllowedRelationTypes(List.of("References", "IsDerivedFrom"));
-    templatePost.setFields(List.of(linkField));
-
+    // hand-written JSON rather than the typed DTO, so the "link" key can be omitted entirely
+    // (the DTO cannot express absent-vs-null, which is the distinction under test elsewhere)
     String linkJson =
         targetGlobalId == null
             ? ""

--- a/src/test/java/com/researchspace/api/v1/model/ApiInventoryEntityFieldLinkContentTest.java
+++ b/src/test/java/com/researchspace/api/v1/model/ApiInventoryEntityFieldLinkContentTest.java
@@ -3,8 +3,10 @@ package com.researchspace.api.v1.model;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.inventory.field.InventoryTextField;
@@ -100,5 +102,49 @@ class ApiInventoryEntityFieldLinkContentTest {
 
     assertTrue(apiField.applyChangesToDatabaseField(dbField, null));
     assertEquals("updated text", dbField.getData());
+  }
+
+  /*
+   * Telling an absent "link" key apart from an explicit "link": null is what stops a partial
+   * template PUT destroying that field's default link (RSDEV-1246). The whole mechanism rests on
+   * Jackson routing deserialization through the hand-written setLink, so these read real JSON
+   * rather than calling the setter directly: a change to Jackson visibility, an added @JsonSetter,
+   * or Lombok regaining the setter would silently reinstate the bug with every other test green.
+   */
+  private static ApiInventoryEntityField parse(String json) throws Exception {
+    return new ObjectMapper().readValue(json, ApiInventoryEntityField.class);
+  }
+
+  @Test
+  void aPayloadWithNoLinkKeyLeavesLinkUnprovided() throws Exception {
+    ApiInventoryEntityField field = parse("{\"id\":1,\"allowedRelationTypes\":[\"IsCitedBy\"]}");
+
+    assertFalse(field.isLinkProvided());
+    assertNull(field.getLink());
+  }
+
+  @Test
+  void anExplicitNullLinkCountsAsProvided() throws Exception {
+    ApiInventoryEntityField field = parse("{\"id\":1,\"link\":null}");
+
+    assertTrue(field.isLinkProvided(), "an explicit null is the client asking to clear the link");
+    assertNull(field.getLink());
+  }
+
+  @Test
+  void aPopulatedLinkCountsAsProvided() throws Exception {
+    ApiInventoryEntityField field =
+        parse("{\"id\":1,\"link\":{\"relationType\":\"References\",\"targetGlobalId\":\"SA2\"}}");
+
+    assertTrue(field.isLinkProvided());
+    assertEquals("SA2", field.getLink().getTargetGlobalId());
+  }
+
+  @Test
+  void aClientCannotForgeTheProvidedFlag() throws Exception {
+    // @JsonIgnore removes the whole logical property, so linkProvided is not client-settable
+    ApiInventoryEntityField field = parse("{\"id\":1,\"linkProvided\":true}");
+
+    assertFalse(field.isLinkProvided());
   }
 }

--- a/src/test/java/com/researchspace/service/JsonMessageSourceTest.java
+++ b/src/test/java/com/researchspace/service/JsonMessageSourceTest.java
@@ -77,6 +77,15 @@ class JsonMessageSourceTest {
         () -> SOURCE.getMessage("no.such.key.exists.anywhere", null, EN_US));
   }
 
+  @Test
+  void zeroArgumentMessagesShipTheirApostrophesUnescaped() {
+    // getMessageInternal returns the raw pattern when args are empty, so an ICU-escaped '' in a
+    // message no call site ever formats reaches the user as two apostrophes.
+    assertMessage(
+        "'id' property not provided for a field with 'deleteFieldRequest' flag.",
+        "errors.inventory.field.deleteRequestIdMissing");
+  }
+
   private static void assertMessage(String expected, String key, Object... arguments) {
     assertEquals(expected, SOURCE.getMessage(key, arguments, EN_US));
   }

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -13,14 +13,20 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.service.inventory.InventoryLinkManager;
 import com.researchspace.testutils.TestFactory;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,6 +55,9 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
   void setUp() {
     manager = new InstrumentEntityApiManagerImpl();
     ReflectionTestUtils.setField(manager, "inventoryLinkManager", inventoryLinkManager);
+    // the real factory is stateless, so the template-create path is exercised end to end
+    ReflectionTestUtils.setField(
+        manager, "apiFieldToModelFieldFactory", new ApiFieldToModelFieldFactory());
     user = TestFactory.createAnyUser("any");
     dbLink = new InventoryLink();
     dbLink.setRelationType("References");
@@ -194,5 +203,89 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
     assertTrue(changed);
     assertSame(created, dbField.getLink());
     verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+  }
+
+  @Test
+  void deletingAnInstrumentLinkFieldSoftDeletesItsLink() {
+    // RSDEV-1270: the instrument manager had no equivalent of the sample manager's reconciliation,
+    // so a deleted link field left its InventoryLink row with deleted=false
+    dbField.setDeleted(true);
+
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verify(inventoryLinkManager).deleteLink(dbLink, user);
+  }
+
+  @Test
+  void aDeletedInstrumentLinkFieldWhoseLinkIsAlreadyDeletedIsLeftAlone() {
+    dbLink.setDeleted(true);
+    dbField.setDeleted(true);
+
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aLiveInstrumentLinkFieldKeepsItsLink() {
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aNewInstrumentTemplateLinkFieldIsCreatedWithItsDefaultLink() {
+    // RSDEV-1246: mirrors the sample template create path
+    ApiInstrumentTemplatePost post = new ApiInstrumentTemplatePost();
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setName("default related sample");
+    post.setFields(List.of(apiField));
+    InventoryLink created = new InventoryLink();
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    InstrumentTemplate dbTemplate = new InstrumentTemplate();
+    manager.addFieldsToNewInstrumentTemplate(post, dbTemplate, user);
+
+    InventoryLinkField added = (InventoryLinkField) dbTemplate.getActiveFields().get(0);
+    assertSame(created, added.getLink());
+  }
+
+  @Test
+  void aLinkFieldAddedToAnExistingInstrumentTemplateIsCreatedWithItsDefaultLink() {
+    ApiInstrumentTemplate apiTemplate = new ApiInstrumentTemplate();
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setName("default related sample");
+    apiField.setNewFieldRequest(true);
+    apiTemplate.setFields(List.of(apiField));
+    InventoryLink created = new InventoryLink();
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    InstrumentTemplate dbTemplate = new InstrumentTemplate();
+    assertTrue(
+        manager.createDeleteRequestedFieldsInDbInstrumentTemplate(apiTemplate, dbTemplate, user));
+
+    InventoryLinkField added = (InventoryLinkField) dbTemplate.getActiveFields().get(0);
+    assertSame(created, added.getLink());
+  }
+
+  @Test
+  void editingAnInstrumentTemplatesDefaultLinkUpdatesItsRowInPlace() {
+    ApiInstrumentTemplate apiTemplate = new ApiInstrumentTemplate();
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "References", null);
+    apiField.setId(7L);
+    apiTemplate.setFields(List.of(apiField));
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    InstrumentTemplate dbTemplate = new InstrumentTemplate();
+    dbTemplate.setId(1L);
+    dbField.setId(7L);
+    dbField.setInventoryRecord(dbTemplate);
+    dbTemplate.getFields().add(dbField);
+    dbTemplate.refreshActiveFieldsAndColumnIndex();
+
+    assertTrue(manager.applyLinkFieldValuesOnUpdate(apiTemplate, dbTemplate, user));
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
   }
 }

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -140,14 +140,39 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
   @Test
   void clearingTheValueDereferencesTheRowForOrphanRemoval() {
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
-    // an explicit null, not mere absence: absence now means "no change" (see the sample
-    // counterpart)
     apiField.setLink(null);
 
     boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
 
     assertTrue(changed);
     assertNull(dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void anItemUpdateThatOmitsTheLinkEntirelyStillClearsIt() {
+    // RSDEV-1131 semantics, which InstrumentEntityApiManagerTest.linkFieldValue_clearedWhenInstrume
+    // ntUpdated pins: an instrument's field list arrives complete, so a link field carrying no link
+    // at all means the user cleared it. Only a TEMPLATE's field list can be partial.
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    assertNull(dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aTemplatePutThatOmitsTheLinkKeepsTheDefault() {
+    // the whitelist-only template edit: {"fields":[{"id":N,"allowedRelationTypes":[...]}]}. Absence
+    // there cannot mean "clear", or a legitimate partial edit would destroy the default link.
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user, true);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
     verifyNoInteractions(inventoryLinkManager);
   }
 

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -140,6 +140,9 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
   @Test
   void clearingTheValueDereferencesTheRowForOrphanRemoval() {
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    // an explicit null, not mere absence: absence now means "no change" (see the sample
+    // counterpart)
+    apiField.setLink(null);
 
     boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
 

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -16,7 +16,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
 import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
 import com.researchspace.api.v1.model.ApiInventoryDOI;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryLink;
@@ -96,6 +100,9 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
     ReflectionTestUtils.setField(manager, "extraFieldHelper", extraFieldHelper);
     ReflectionTestUtils.setField(manager, "inventoryMoveHelper", inventoryMoveHelper);
     ReflectionTestUtils.setField(manager, "messages", messages);
+    // the real factory is stateless, so the template-create path is exercised end to end
+    ReflectionTestUtils.setField(
+        manager, "apiFieldToModelFieldFactory", new ApiFieldToModelFieldFactory());
     user = TestFactory.createAnyUser("any");
     dbLink = new InventoryLink();
     dbLink.setRelationType("References");
@@ -727,5 +734,89 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
     assertFalse(changed);
     assertEquals(otherPage, landingPageFieldData(instrument));
+  }
+
+  @Test
+  void deletingAnInstrumentLinkFieldSoftDeletesItsLink() {
+    // RSDEV-1270: the instrument manager had no equivalent of the sample manager's reconciliation,
+    // so a deleted link field left its InventoryLink row with deleted=false
+    dbField.setDeleted(true);
+
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verify(inventoryLinkManager).deleteLink(dbLink, user);
+  }
+
+  @Test
+  void aDeletedInstrumentLinkFieldWhoseLinkIsAlreadyDeletedIsLeftAlone() {
+    dbLink.setDeleted(true);
+    dbField.setDeleted(true);
+
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aLiveInstrumentLinkFieldKeepsItsLink() {
+    manager.softDeleteLinkOfDeletedLinkField(dbField, user);
+
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aNewInstrumentTemplateLinkFieldIsCreatedWithItsDefaultLink() {
+    // RSDEV-1246: mirrors the sample template create path
+    ApiInstrumentTemplatePost post = new ApiInstrumentTemplatePost();
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setName("default related sample");
+    post.setFields(List.of(apiField));
+    InventoryLink created = new InventoryLink();
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    InstrumentTemplate dbTemplate = new InstrumentTemplate();
+    manager.addFieldsToNewInstrumentTemplate(post, dbTemplate, user);
+
+    InventoryLinkField added = (InventoryLinkField) dbTemplate.getActiveFields().get(0);
+    assertSame(created, added.getLink());
+  }
+
+  @Test
+  void aLinkFieldAddedToAnExistingInstrumentTemplateIsCreatedWithItsDefaultLink() {
+    ApiInstrumentTemplate apiTemplate = new ApiInstrumentTemplate();
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setName("default related sample");
+    apiField.setNewFieldRequest(true);
+    apiTemplate.setFields(List.of(apiField));
+    InventoryLink created = new InventoryLink();
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    InstrumentTemplate dbTemplate = new InstrumentTemplate();
+    assertTrue(
+        manager.createDeleteRequestedFieldsInDbInstrumentTemplate(apiTemplate, dbTemplate, user));
+
+    InventoryLinkField added = (InventoryLinkField) dbTemplate.getActiveFields().get(0);
+    assertSame(created, added.getLink());
+  }
+
+  @Test
+  void editingAnInstrumentTemplatesDefaultLinkUpdatesItsRowInPlace() {
+    ApiInstrumentTemplate apiTemplate = new ApiInstrumentTemplate();
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "References", null);
+    apiField.setId(7L);
+    apiTemplate.setFields(List.of(apiField));
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    InstrumentTemplate dbTemplate = new InstrumentTemplate();
+    dbTemplate.setId(1L);
+    dbField.setId(7L);
+    dbField.setInventoryRecord(dbTemplate);
+    dbTemplate.getFields().add(dbField);
+    dbTemplate.refreshActiveFieldsAndColumnIndex();
+
+    assertTrue(manager.applyLinkFieldValuesOnUpdate(apiTemplate, dbTemplate, user));
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
   }
 }

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -65,9 +65,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 /**
  * Unit tests for the link-field persistence logic in {@link InstrumentEntityApiManagerImpl}.
  *
- * <p>The {@code applyLinkFieldValue} method is the creation/update hot-path for structured
- * link-type template fields on instruments. It mirrors the equivalent in {@link
- * SampleApiManagerImpl}; these tests guard against independent drift or regression.
+ * <p>{@code applyLinkFieldValue} now lives once on {@link InventoryApiManagerImpl}, so these cases
+ * exercise it through the instrument manager: what is instrument-specific is the {@code isTemplate}
+ * wiring of the update wrapper, the template-create path, and {@code
+ * clearRetroStampedDefaultLinks}.
  */
 @ExtendWith(MockitoExtension.class)
 class InstrumentEntityApiManagerImplLinkFieldTest {
@@ -195,6 +196,20 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
     assertTrue(changed);
     assertNull(dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aCreatePayloadThatOmitsTheLinkKeepsTheStampedDefault() {
+    // as the sample counterpart: the template's default is already stamped on the field by
+    // shallowCopy() before the create payload is applied, and an unmentioned link must not wipe it
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setContent("");
+
+    boolean changed = manager.applyLinkFieldValueOnCreate(dbField, apiField, user);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
     verifyNoInteractions(inventoryLinkManager);
   }
 
@@ -798,14 +813,63 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
                 manager.createDeleteRequestedFieldsInDbInstrumentTemplate(
                     apiTemplate, new InstrumentTemplate(), user));
 
+    assertEquals("errors.inventory.field.deleteRequestIdMissing", missingId.getErrorCode());
+    assertEquals("errors.inventory.field.deleteRequestIdUnknown", unknownId.getErrorCode());
+    assertResolves(missingId.getErrorCode(), unknownId.getErrorCode());
+  }
+
+  @Test
+  void everyErrorCodeTheLinkPathsThrowResolves() {
+    // Same failure mode as above, for the codes reached from the shared link write path. They are
+    // bare string literals, so a renamed catalogue key compiles, lints and passes i18n:lint, and
+    // shows up only as an unresolved message against a live server.
+    assertResolves(
+        "errors.inventory.field.link.defaultRelationTypeNotPermitted",
+        "errors.inventory.field.link.selfLinkForbidden",
+        "errors.inventory.field.linkRelationTypeInvalid",
+        "errors.inventory.field.linkRelationTypeNotPermitted",
+        "errors.inventory.field.linkTargetNotFound",
+        "errors.inventory.field.linkTargetKindUnsupported");
+  }
+
+  private static void assertResolves(String... errorCodes) {
     JsonMessageSource messages = new JsonMessageSource();
     Locale enUs = Locale.forLanguageTag("en-US");
-    assertDoesNotThrow(
-        () -> messages.getMessage(missingId.getErrorCode(), new Object[] {1L}, enUs),
-        () -> missingId.getErrorCode() + " resolves to no message");
-    assertDoesNotThrow(
-        () -> messages.getMessage(unknownId.getErrorCode(), new Object[] {1L}, enUs),
-        () -> unknownId.getErrorCode() + " resolves to no message");
+    for (String code : errorCodes) {
+      assertDoesNotThrow(
+          () -> messages.getMessage(code, new Object[] {"a", "b"}, enUs),
+          () -> code + " is thrown by a link path but resolves to no message");
+    }
+  }
+
+  @Test
+  void aLinkFieldTheTemplateSyncJustClonedHasItsDefaultCleared() {
+    // A template's default is stamped at creation only, never retro-applied (ADR-0006, and the
+    // "Stamped" entry in CONTEXT.md). This is instrument-only compensation: Sample's
+    // updateToLatestTemplateVersion calls clearValue(), which InventoryLinkField overrides to null
+    // its link, while Instrument's calls setFieldData(null), which link fields do not override.
+    Instrument dbInstrument = new Instrument();
+
+    InventoryLinkField existingField = new InventoryLinkField();
+    existingField.setName("already here");
+    existingField.setId(11L);
+    existingField.setColumnIndex(1);
+    InventoryLink keptLink = new InventoryLink();
+    existingField.setLink(keptLink);
+
+    InventoryLinkField clonedField = new InventoryLinkField();
+    clonedField.setName("just arrived from the template");
+    clonedField.setColumnIndex(2);
+    clonedField.setLink(new InventoryLink());
+
+    dbInstrument.getFields().add(existingField);
+    dbInstrument.getFields().add(clonedField);
+    dbInstrument.refreshActiveFieldsAndColumnIndex();
+
+    manager.clearRetroStampedDefaultLinks(dbInstrument);
+
+    assertNull(clonedField.getLink(), "a newly cloned field must not inherit the current default");
+    assertSame(keptLink, existingField.getLink(), "an existing field's own link is untouched");
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -185,14 +185,39 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
   @Test
   void clearingTheValueDereferencesTheRowForOrphanRemoval() {
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
-    // an explicit null, not mere absence: absence now means "no change" (see the sample
-    // counterpart)
     apiField.setLink(null);
 
     boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
 
     assertTrue(changed);
     assertNull(dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void anItemUpdateThatOmitsTheLinkEntirelyStillClearsIt() {
+    // RSDEV-1131 semantics, which InstrumentEntityApiManagerTest.linkFieldValue_clearedWhenInstrume
+    // ntUpdated pins: an instrument's field list arrives complete, so a link field carrying no link
+    // at all means the user cleared it. Only a TEMPLATE's field list can be partial.
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    assertNull(dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void aTemplatePutThatOmitsTheLinkKeepsTheDefault() {
+    // the whitelist-only template edit: {"fields":[{"id":N,"allowedRelationTypes":[...]}]}. Absence
+    // there cannot mean "clear", or a legitimate partial edit would destroy the default link.
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user, true);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
     verifyNoInteractions(inventoryLinkManager);
   }
 

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -42,7 +42,6 @@ import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.inventory.field.InventoryStringField;
 import com.researchspace.model.inventory.field.InventoryUriField;
 import com.researchspace.model.record.RecordFactory;
-import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.JsonMessageSource;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.UserManager;

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -185,6 +185,9 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
   @Test
   void clearingTheValueDereferencesTheRowForOrphanRemoval() {
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    // an explicit null, not mere absence: absence now means "no change" (see the sample
+    // counterpart)
+    apiField.setLink(null);
 
     boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
 

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -1,5 +1,6 @@
 package com.researchspace.service.inventory.impl;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -41,6 +42,8 @@ import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.inventory.field.InventoryStringField;
 import com.researchspace.model.inventory.field.InventoryUriField;
 import com.researchspace.model.record.RecordFactory;
+import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.JsonMessageSource;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.UserManager;
 import com.researchspace.service.inventory.ApiExtraFieldsHelper;
@@ -49,6 +52,7 @@ import com.researchspace.service.inventory.InventoryMoveHelper;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
 import com.researchspace.testutils.TestFactory;
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -762,6 +766,46 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
     assertFalse(changed);
     assertEquals(otherPage, landingPageFieldData(instrument));
+  }
+
+  @Test
+  void theTemplateFieldDeleteErrorsResolveToRealMessages() {
+    // ApiRuntimeException carries a bare string literal, so a code that no longer matches the
+    // catalogue compiles, passes every lint and fails only against a live server. A rebase across
+    // the JSON-catalogue migration left both of these pointing at renamed keys. Taking the code
+    // from the production path, rather than restating it, is what makes this a guard.
+    ApiInstrumentTemplate apiTemplate = new ApiInstrumentTemplate();
+    ApiInventoryEntityField deleteWithoutId = new ApiInventoryEntityField();
+    deleteWithoutId.setDeleteFieldRequest(true);
+    apiTemplate.setFields(List.of(deleteWithoutId));
+
+    ApiRuntimeException missingId =
+        assertThrows(
+            ApiRuntimeException.class,
+            () ->
+                manager.createDeleteRequestedFieldsInDbInstrumentTemplate(
+                    apiTemplate, new InstrumentTemplate(), user));
+
+    ApiInventoryEntityField deleteUnknownId = new ApiInventoryEntityField();
+    deleteUnknownId.setDeleteFieldRequest(true);
+    deleteUnknownId.setId(404L);
+    apiTemplate.setFields(List.of(deleteUnknownId));
+
+    ApiRuntimeException unknownId =
+        assertThrows(
+            ApiRuntimeException.class,
+            () ->
+                manager.createDeleteRequestedFieldsInDbInstrumentTemplate(
+                    apiTemplate, new InstrumentTemplate(), user));
+
+    JsonMessageSource messages = new JsonMessageSource();
+    Locale enUs = Locale.forLanguageTag("en-US");
+    assertDoesNotThrow(
+        () -> messages.getMessage(missingId.getErrorCode(), new Object[] {1L}, enUs),
+        () -> missingId.getErrorCode() + " resolves to no message");
+    assertDoesNotThrow(
+        () -> messages.getMessage(unknownId.getErrorCode(), new Object[] {1L}, enUs),
+        () -> unknownId.getErrorCode() + " resolves to no message");
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -64,9 +64,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 /**
  * Unit tests for the link-field persistence logic in {@link InstrumentEntityApiManagerImpl}.
  *
- * <p>{@code applyLinkFieldValue} now lives once on {@link InventoryApiManagerImpl}, so these cases
- * exercise it through the instrument manager: what is instrument-specific is the {@code isTemplate}
- * wiring of the update wrapper, the template-create path, and {@code
+ * <p>{@code applyLinkFieldValue} lives once on {@link InventoryApiManagerImpl}; what is
+ * instrument-specific is the {@code isTemplate} wiring, the template-create path, and {@code
  * clearRetroStampedDefaultLinks}.
  */
 @ExtendWith(MockitoExtension.class)
@@ -214,9 +213,8 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
   @Test
   void anItemUpdateThatOmitsTheLinkEntirelyStillClearsIt() {
-    // RSDEV-1131 semantics, which InstrumentEntityApiManagerTest.linkFieldValue_clearedWhenInstrume
-    // ntUpdated pins: an instrument's field list arrives complete, so a link field carrying no link
-    // at all means the user cleared it. Only a TEMPLATE's field list can be partial.
+    // RSDEV-1131 semantics: an instrument's field list arrives complete, so a link field carrying
+    // no link means the user cleared it. Only a TEMPLATE's field list can be partial.
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
 
     boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
@@ -228,8 +226,8 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
   @Test
   void aTemplatePutThatOmitsTheLinkKeepsTheDefault() {
-    // the whitelist-only template edit: {"fields":[{"id":N,"allowedRelationTypes":[...]}]}. Absence
-    // there cannot mean "clear", or a legitimate partial edit would destroy the default link.
+    // the whitelist-only template edit: absence there cannot mean "clear", or a legitimate partial
+    // edit would destroy the default link
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
 
     boolean changed = manager.applyLinkFieldValue(dbField, apiField, user, true);
@@ -785,9 +783,8 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
   @Test
   void theTemplateFieldDeleteErrorsResolveToRealMessages() {
     // ApiRuntimeException carries a bare string literal, so a code that no longer matches the
-    // catalogue compiles, passes every lint and fails only against a live server. A rebase across
-    // the JSON-catalogue migration left both of these pointing at renamed keys. Taking the code
-    // from the production path, rather than restating it, is what makes this a guard.
+    // catalogue compiles, lints clean and fails only against a live server. Taking the code from
+    // the production path, rather than restating it, is what makes this a guard.
     ApiInstrumentTemplate apiTemplate = new ApiInstrumentTemplate();
     ApiInventoryEntityField deleteWithoutId = new ApiInventoryEntityField();
     deleteWithoutId.setDeleteFieldRequest(true);
@@ -819,9 +816,7 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
   @Test
   void everyErrorCodeTheLinkPathsThrowResolves() {
-    // Same failure mode as above, for the codes reached from the shared link write path. They are
-    // bare string literals, so a renamed catalogue key compiles, lints and passes i18n:lint, and
-    // shows up only as an unresolved message against a live server.
+    // same failure mode as above, for the codes reached from the shared link write path
     assertResolves(
         "errors.inventory.field.link.defaultRelationTypeNotPermitted",
         "errors.inventory.field.link.selfLinkForbidden",
@@ -843,10 +838,9 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
   @Test
   void aLinkFieldTheTemplateSyncJustClonedHasItsDefaultCleared() {
-    // A template's default is stamped at creation only, never retro-applied (ADR-0006, and the
-    // "Stamped" entry in CONTEXT.md). This is instrument-only compensation: Sample's
-    // updateToLatestTemplateVersion calls clearValue(), which InventoryLinkField overrides to null
-    // its link, while Instrument's calls setFieldData(null), which link fields do not override.
+    // Stamped at creation only, never retro-applied (ADR-0006). Instrument-only compensation:
+    // Sample's updateToLatestTemplateVersion calls clearValue(), which InventoryLinkField overrides
+    // to null its link, while Instrument's calls setFieldData(null), which it does not override.
     Instrument dbInstrument = new Instrument();
 
     InventoryLinkField existingField = new InventoryLinkField();

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
@@ -152,10 +152,12 @@ class SampleApiManagerImplLinkFieldTest {
   @Test
   void clearingTheValueDereferencesTheRowForOrphanRemoval() {
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
-    // no link payload at all: the field's value is being cleared. The field's
+    // an explicit null link: the field's value is being cleared. (Absence is a different thing and
+    // now means "no change" - see aPayloadThatNeverMentionsTheLinkLeavesItAlone.) The field's
     // orphanRemoval mapping hard-deletes the dereferenced row at flush (with a
     // DEL revision in InventoryLink_AUD); an extra soft-delete write would be
     // collapsed away by Envers and is deliberately not attempted.
+    apiField.setLink(null);
     boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
 
     assertTrue(changed);
@@ -197,6 +199,35 @@ class SampleApiManagerImplLinkFieldTest {
     when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
 
     assertTrue(manager.applyLinkFieldValue(dbField, apiField, user));
+  }
+
+  @Test
+  void aPayloadThatNeverMentionsTheLinkLeavesItAlone() {
+    // A partial update must not destroy the link. This is the request the whitelist-conflict error
+    // tells the user to make (narrow the allowed types, no link key), and also a plain field
+    // rename.
+    // Treating absent as "clear" hard-deleted the row AND left assertDefaultLinksMatchWhitelists
+    // seeing link == null, so the guard passed and the 422 never fired.
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setAllowedRelationTypes(List.of("IsCitedBy"));
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void anExplicitNullLinkStillClearsIt() {
+    // the editor's "remove the link" path sends link: null explicitly, and must keep working
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setLink(null);
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    assertNull(dbField.getLink());
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -11,10 +12,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiFieldToModelFieldFactory;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleTemplatePost;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.inventory.field.InventoryLinkField;
@@ -56,6 +63,9 @@ class SampleApiManagerImplLinkFieldTest {
     manager = new SampleApiManagerImpl();
     // the manager is field-autowired in production; wire the mock in directly
     ReflectionTestUtils.setField(manager, "inventoryLinkManager", inventoryLinkManager);
+    // the real factory is stateless, so the template-create path is exercised end to end
+    ReflectionTestUtils.setField(
+        manager, "apiFieldToModelFieldFactory", new ApiFieldToModelFieldFactory());
     user = TestFactory.createAnyUser("any");
     dbLink = new InventoryLink();
     dbLink.setRelationType("References");
@@ -268,6 +278,116 @@ class SampleApiManagerImplLinkFieldTest {
     List<InventoryEntityField> sampleFields = List.of(textField, orphanLinkField);
     assertFalse(InventoryApiManagerImpl.syncLinkFieldWhitelistsFromTemplate(sampleFields));
     assertEquals("References", orphanLinkField.getAllowedRelationTypes());
+  }
+
+  @Test
+  void aNewTemplateLinkFieldIsCreatedWithItsDefaultLink() {
+    // RSDEV-1246: a template's Link field may carry a default link, stored in the same link_id an
+    // item's link uses so that shallowCopy() stamps it onto items with no extra copy code. The
+    // stateless factory only sets the whitelist, so the manager must apply the default through
+    // InventoryLinkManager (which validates the target and captures the Envers revision).
+    ApiSampleTemplatePost apiTemplate = new ApiSampleTemplatePost();
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setName("default related sample");
+    apiTemplate.setFields(List.of(apiField));
+    InventoryLink created = new InventoryLink();
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    SampleTemplate dbTemplate = new SampleTemplate();
+    manager.createFields(apiTemplate, dbTemplate, user);
+
+    InventoryLinkField added = (InventoryLinkField) dbTemplate.getActiveFields().get(0);
+    assertSame(created, added.getLink());
+  }
+
+  @Test
+  void aLinkFieldAddedToAnExistingTemplateIsCreatedWithItsDefaultLink() {
+    // the second create path: a new-field-request on an existing template must stamp the default
+    // too, otherwise a default set when the field is added is silently dropped
+    ApiSampleTemplate apiTemplate = new ApiSampleTemplate();
+    ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
+    apiField.setType(ApiFieldType.LINK);
+    apiField.setName("default related sample");
+    apiField.setNewFieldRequest(true);
+    apiTemplate.setFields(List.of(apiField));
+    InventoryLink created = new InventoryLink();
+    when(inventoryLinkManager.createLink(apiField.getLink(), user)).thenReturn(created);
+
+    SampleTemplate dbTemplate = new SampleTemplate();
+    assertTrue(
+        manager.createDeleteRequestedFieldsInDbSampleTemplate(apiTemplate, dbTemplate, user));
+
+    InventoryLinkField added = (InventoryLinkField) dbTemplate.getActiveFields().get(0);
+    assertSame(created, added.getLink());
+  }
+
+  @Test
+  void editingATemplatesDefaultLinkUpdatesItsRowInPlace() {
+    // updateDbSample used to skip the link write path for templates, so a template's default was
+    // read back on GET but never written on PUT. Templates now go through the same path as items.
+    ApiSampleTemplate apiTemplate = new ApiSampleTemplate();
+    ApiInventoryEntityField apiField = apiLinkField("SA3", "References", null);
+    apiField.setId(7L);
+    apiTemplate.setFields(List.of(apiField));
+    when(inventoryLinkManager.updateLink(dbLink, apiField.getLink(), user)).thenReturn(dbLink);
+
+    SampleTemplate dbTemplate = new SampleTemplate();
+    dbTemplate.setId(1L);
+    dbField.setId(7L);
+    dbTemplate.addSampleField(dbField);
+
+    assertTrue(manager.applyLinkFieldValuesOnUpdate(apiTemplate, dbTemplate, user));
+    verify(inventoryLinkManager).updateLink(dbLink, apiField.getLink(), user);
+  }
+
+  @Test
+  void aTemplateCannotDefaultToItself() {
+    ApiSampleTemplate apiTemplate = new ApiSampleTemplate();
+    ApiInventoryEntityField apiField = apiLinkField("IT1", "References", null);
+    apiField.setId(7L);
+    apiTemplate.setFields(List.of(apiField));
+
+    SampleTemplate dbTemplate = new SampleTemplate();
+    dbTemplate.setId(1L);
+    dbField.setId(7L);
+    dbTemplate.addSampleField(dbField);
+
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class,
+            () -> manager.applyLinkFieldValuesOnUpdate(apiTemplate, dbTemplate, user));
+    assertEquals("errors.inventory.field.link.selfLinkForbidden", ex.getErrorCode());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void narrowingTheWhitelistPastTheFieldsOwnDefaultIsRejected() {
+    // an unchanged default is a no-op on the per-link path, so a whitelist-only edit would
+    // otherwise leave the template holding a default its own field forbids
+    dbField.setAllowedRelationTypes("IsPartOf");
+
+    ApiRuntimeException ex =
+        assertThrows(
+            ApiRuntimeException.class,
+            () -> InventoryApiManagerImpl.assertDefaultLinksMatchWhitelists(List.of(dbField)));
+    assertEquals("errors.inventory.field.link.defaultRelationTypeNotPermitted", ex.getErrorCode());
+  }
+
+  @Test
+  void aDefaultLinkStillInsideTheWhitelistIsAccepted() {
+    dbField.setAllowedRelationTypes("References|IsPartOf");
+
+    InventoryApiManagerImpl.assertDefaultLinksMatchWhitelists(List.of(dbField));
+  }
+
+  @Test
+  void aLinkFieldWithNoDefaultIsUnaffectedByAnyWhitelist() {
+    dbField.setLink(null);
+    dbField.setAllowedRelationTypes("IsPartOf");
+
+    InventoryApiManagerImpl.assertDefaultLinksMatchWhitelists(
+        List.of(dbField, new InventoryTextField("notes")));
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
@@ -202,19 +202,34 @@ class SampleApiManagerImplLinkFieldTest {
   }
 
   @Test
-  void aPayloadThatNeverMentionsTheLinkLeavesItAlone() {
-    // A partial update must not destroy the link. This is the request the whitelist-conflict error
-    // tells the user to make (narrow the allowed types, no link key), and also a plain field
-    // rename.
-    // Treating absent as "clear" hard-deleted the row AND left assertDefaultLinksMatchWhitelists
-    // seeing link == null, so the guard passed and the 422 never fired.
+  void aTemplatePayloadThatNeverMentionsTheLinkLeavesItAlone() {
+    // A partial TEMPLATE update must not destroy the default link. This is the request the
+    // whitelist-conflict error tells the user to make (narrow the allowed types, no link key), and
+    // also a plain field rename. Treating absent as "clear" hard-deleted the row AND left
+    // assertDefaultLinksMatchWhitelists seeing link == null, so the guard passed and the 422 never
+    // fired.
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
     apiField.setAllowedRelationTypes(List.of("IsCitedBy"));
 
-    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user, true);
 
     assertFalse(changed);
     assertSame(dbLink, dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
+  void anItemPayloadThatNeverMentionsTheLinkStillClearsIt() {
+    // The item contract is the opposite way round, and predates this work (RSDEV-1131): an item's
+    // field list arrives complete, so a link field with no link at all means the user cleared it.
+    // Only a template's field list can legitimately be partial, so only a template can read absence
+    // as "no change".
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+
+    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
+
+    assertTrue(changed);
+    assertNull(dbField.getLink());
     verifyNoInteractions(inventoryLinkManager);
   }
 

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
@@ -153,7 +153,8 @@ class SampleApiManagerImplLinkFieldTest {
   void clearingTheValueDereferencesTheRowForOrphanRemoval() {
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
     // an explicit null link: the field's value is being cleared. (Absence is a different thing and
-    // now means "no change" - see aPayloadThatNeverMentionsTheLinkLeavesItAlone.) The field's
+    // now means "no change" for a template - see
+    // aTemplatePayloadThatNeverMentionsTheLinkLeavesItAlone.) The field's
     // orphanRemoval mapping hard-deletes the dereferenced row at flush (with a
     // DEL revision in InventoryLink_AUD); an extra soft-delete write would be
     // collapsed away by Envers and is deliberately not attempted.
@@ -219,6 +220,22 @@ class SampleApiManagerImplLinkFieldTest {
   }
 
   @Test
+  void aCreatePayloadThatOmitsTheLinkKeepsTheStampedDefault() {
+    // Creating an item from a template stamps the template's default onto the new field before the
+    // request's own field values are applied. A create payload that lists the fields but says
+    // nothing about the link must not wipe that stamp before it is ever persisted: ADR-0006 says
+    // bulk, API and UI creation behave identically, and the UI always sends the link key.
+    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
+    apiField.setContent("");
+
+    boolean changed = manager.applyLinkFieldValueOnCreate(dbField, apiField, user);
+
+    assertFalse(changed);
+    assertSame(dbLink, dbField.getLink());
+    verifyNoInteractions(inventoryLinkManager);
+  }
+
+  @Test
   void anItemPayloadThatNeverMentionsTheLinkStillClearsIt() {
     // The item contract is the opposite way round, and predates this work (RSDEV-1131): an item's
     // field list arrives complete, so a link field with no link at all means the user cleared it.
@@ -231,18 +248,6 @@ class SampleApiManagerImplLinkFieldTest {
     assertTrue(changed);
     assertNull(dbField.getLink());
     verifyNoInteractions(inventoryLinkManager);
-  }
-
-  @Test
-  void anExplicitNullLinkStillClearsIt() {
-    // the editor's "remove the link" path sends link: null explicitly, and must keep working
-    ApiInventoryEntityField apiField = new ApiInventoryEntityField();
-    apiField.setLink(null);
-
-    boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
-
-    assertTrue(changed);
-    assertNull(dbField.getLink());
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/SampleApiManagerImplLinkFieldTest.java
@@ -152,9 +152,8 @@ class SampleApiManagerImplLinkFieldTest {
   @Test
   void clearingTheValueDereferencesTheRowForOrphanRemoval() {
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
-    // an explicit null link: the field's value is being cleared. (Absence is a different thing and
-    // now means "no change" for a template - see
-    // aTemplatePayloadThatNeverMentionsTheLinkLeavesItAlone.) The field's
+    // an explicit null link clears the value; absence is a different thing for a template. The
+    // field's
     // orphanRemoval mapping hard-deletes the dereferenced row at flush (with a
     // DEL revision in InventoryLink_AUD); an extra soft-delete write would be
     // collapsed away by Envers and is deliberately not attempted.
@@ -204,11 +203,9 @@ class SampleApiManagerImplLinkFieldTest {
 
   @Test
   void aTemplatePayloadThatNeverMentionsTheLinkLeavesItAlone() {
-    // A partial TEMPLATE update must not destroy the default link. This is the request the
-    // whitelist-conflict error tells the user to make (narrow the allowed types, no link key), and
-    // also a plain field rename. Treating absent as "clear" hard-deleted the row AND left
-    // assertDefaultLinksMatchWhitelists seeing link == null, so the guard passed and the 422 never
-    // fired.
+    // A partial TEMPLATE update must not destroy the default link: this is the very request the
+    // whitelist-conflict error tells the user to make. Treating absent as "clear" hard-deleted the
+    // row and left the guard seeing link == null, so the 422 never fired.
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
     apiField.setAllowedRelationTypes(List.of("IsCitedBy"));
 
@@ -221,10 +218,8 @@ class SampleApiManagerImplLinkFieldTest {
 
   @Test
   void aCreatePayloadThatOmitsTheLinkKeepsTheStampedDefault() {
-    // Creating an item from a template stamps the template's default onto the new field before the
-    // request's own field values are applied. A create payload that lists the fields but says
-    // nothing about the link must not wipe that stamp before it is ever persisted: ADR-0006 says
-    // bulk, API and UI creation behave identically, and the UI always sends the link key.
+    // The default is stamped onto the new field before the request's own values are applied, so a
+    // create payload that says nothing about the link must not wipe it (ADR-0006).
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
     apiField.setContent("");
 
@@ -237,10 +232,9 @@ class SampleApiManagerImplLinkFieldTest {
 
   @Test
   void anItemPayloadThatNeverMentionsTheLinkStillClearsIt() {
-    // The item contract is the opposite way round, and predates this work (RSDEV-1131): an item's
-    // field list arrives complete, so a link field with no link at all means the user cleared it.
-    // Only a template's field list can legitimately be partial, so only a template can read absence
-    // as "no change".
+    // The item contract is the opposite, and predates this work (RSDEV-1131): an item's field list
+    // arrives complete, so absence means cleared. Only a template's list can legitimately be
+    // partial.
     ApiInventoryEntityField apiField = new ApiInventoryEntityField();
 
     boolean changed = manager.applyLinkFieldValue(dbField, apiField, user);
@@ -333,10 +327,9 @@ class SampleApiManagerImplLinkFieldTest {
 
   @Test
   void aNewTemplateLinkFieldIsCreatedWithItsDefaultLink() {
-    // RSDEV-1246: a template's Link field may carry a default link, stored in the same link_id an
-    // item's link uses so that shallowCopy() stamps it onto items with no extra copy code. The
-    // stateless factory only sets the whitelist, so the manager must apply the default through
-    // InventoryLinkManager (which validates the target and captures the Envers revision).
+    // RSDEV-1246: a template Link field may carry a default, stored in the same link_id an item's
+    // link uses so shallowCopy() stamps it on for free. The stateless factory sets only the
+    // whitelist, so the manager applies the default through InventoryLinkManager.
     ApiSampleTemplatePost apiTemplate = new ApiSampleTemplatePost();
     ApiInventoryEntityField apiField = apiLinkField("SA2", "References", null);
     apiField.setType(ApiFieldType.LINK);


### PR DESCRIPTION
## What

Template Link fields can now carry a **default link**. Every item created from that template gets it as the item's own ordinary, editable link. Follow-on from RSDEV-1131, where a template Link field could declare only a name and a set of allowed relationship types.

Two things ride along:

- **RSDEV-1270 fix.** The instrument manager now soft deletes the `InventoryLink` row when a link field is deleted. It did this in neither of the two places the sample manager does.
- **Link editor UI.** The shared editor is regrouped into Target / Relationship type / Version. Cosmetic, no functional change, and it applies to all three callers: item link fields, extra-field links, and the new template default.

Glossary terms: `DevDocs/CONTEXT.md`. Storage decision: `DevDocs/adr/0006-template-default-link-is-whole-or-nothing.md`.

## Why the backend is small

No schema change, no new API field, no new copy code. `InventoryEntityField.link_id` and `ApiInventoryEntityField.link` already exist on the single table and DTO shared by template fields and item fields (`changeLog-rsdev-1131.xml` changeSet 5). `link_id` was simply never populated on template rows, deliberately, in three places. Items are stamped by the existing `InventoryLinkField.shallowCopy()` chain, so bulk, API and UI creation behave identically down one code path.

Most of the diff on the two managers is therefore removal. Every link helper both of them had a copy of moved up to `InventoryApiManagerImpl`: `applyLinkFieldValue`, `applyLinkFieldValuesOnUpdate`, `applyLinkFieldValueOnCreate`, `softDeleteLinkOfDeletedLinkField`, `isRelationPermitted`, `rejectSelfLink`, `assertRelationAllowed`, `parseTargetOrNull`, joining `syncLinkFieldWhitelistsFromTemplate` (RSDEV-1200). Each manager keeps a one-line typed delegate. That step alone is **net −116 lines** across the three files; the whole feature leaves them at net +62.

## Decisions

1. **Whole or nothing.** A default is a relation type *and* a target, stored as an ordinary `InventoryLink` on the template field's existing `link_id`. Half a default is not supported: `InventoryLink`'s four identifying columns are all `NOT NULL`, and relaxing them pushes a null branch into every consumer forever. ADR-0006 records the two rejected alternatives.
2. **Stamped verbatim.** A default whose target has since been deleted, or which the creating user cannot read, is copied onto the item unchanged. The alternative makes one template produce different items for different users.
3. **Templates appear in "referenced by".** A template holding a default shows up in its target's referencing-items list. Wanted: it shows that new items will keep being created pointing at that record.

Two consequences fall out rather than being decided: defaults are **never retro-applied**, and **version pins are allowed and stay pinned**, because `InventoryLink.shallowCopy()` already carries `version_pin` and `target_revision_id`.

## Validation

Reusing the item write path brings the DataCite vocabulary check, GlobalID parse, allowed-target-kind, existence-and-readability, whitelist and self-link checks across to templates unchanged. Two things are new:

- **Whitelist conflict**, 422 `errors.inventory.field.link.defaultRelationTypeNotPermitted`. Narrowing a field's allowed relationship types past its own default is rejected instead of silently dropping the default. Needed because an unchanged default is a no-op on the per-link path, so a whitelist-only edit would otherwise slip through.
- **`linkProvided` on `ApiInventoryEntityField`.** An absent `link` key is now distinguishable from an explicit `"link": null`. Without it, absent meant clear, so a template PUT naming only `allowedRelationTypes`, which is exactly the request the error above asks the user to make, destroyed that field's default link and then passed the whitelist guard because the guard saw a null link. Item payloads keep RSDEV-1131 semantics: their field list arrives complete, so absent still clears. The flag is `@JsonIgnore` and excluded from equals/toString, and the outgoing constructor assigns the field rather than the setter so serialization cannot forge it.

## RSDEV-1270

Deleting an inventory field is a **soft** delete: an UPDATE, not a JPA remove, so the `cascade`/`orphanRemoval` on `InventoryLinkField.link` never fires and the link row must be soft deleted explicitly at the service layer.

- *Already broken on `main`.* Concrete instrument link fields do hold links, so a template field deletion propagating through `updateInstrumentToLatestTemplateVersion` orphaned that instrument's link row.
- *Would have been widened here.* Once instrument templates carry defaults, deleting a template field orphans the template's own row too.

Harm was latent: both referencing-items queries filter `f.deleted = false`, and user deletion hard deletes orphans by join. What broke was the invariant "a live `InventoryLink` belongs to a live field", plus an `InventoryLink_AUD` trail that never recorded the delete. Ordering matters: the snapshot is taken **before** the template sync, because `getActiveFields()` no longer returns the newly deleted fields afterwards.

## Frontend

The template editor reuses the item editor (`LinkFieldValue`) wholesale, so relation constraint, self-link rejection, target-existence checking, version pinning and the Apply-or-discard save guard all carry over for free. `LinkFieldValue` gains three optional props: `showFieldName` (false in the template, where the name is already entered in the Name field directly above), `targetHeading`, and `nestHeadings`.

Shared `LinkEditor` layout, applying to all three callers:

```
Target
  [Target Global ID]  [Browse Inventory]  [Browse ELN]
  (SA42 chip, with delete)
Relationship type ____
Version
  (Latest)  (clock)
```

- The Global ID field moved up onto the Browse buttons' row, sized to content (`11em`), with a placeholder instead of a floating label so it aligns with the buttons rather than sitting below them.
- The selected-target chip moved beneath that row. In the row it competed for width, and `MuiChip-label` is `overflow: hidden`, so a shrunk chip lost its own delete X. There is a regression test for this.
- Target and Version gained headings, rendered through `DynamicHeadingLevel` so they take the correct level at both of the depths this component mounts at.
- The template's default-link block is boxed and headed "Default Link (optional)", with its target group headed "Default link target" so it is not confused with an item's own link.

Each control keeps its own `aria-label`, so screen-reader naming is unchanged.

## Tests

- **27 new backend unit cases** across `SampleApiManagerImplLinkFieldTest`, `InstrumentEntityApiManagerImplLinkFieldTest`, `ApiInventoryEntityFieldLinkContentTest` and `JsonMessageSourceTest`.
- **22 new frontend cases**: a new `LinkEditor.test.tsx` (11), plus `DefaultValueField.test.tsx` (8) and `LinkFieldValue.test.tsx` (3).

Green: `mvn test -Dfast=true` 2699, `pnpm test` 420 files / 2458, plus `pnpm tsc`, `pnpm lint`, `pnpm run i18n:lint`, `mvn spotless:check`.

**Not run:** `SampleTemplateDefaultLinkMVCIT` (6) and `InstrumentTemplateDefaultLinkMVCIT` (4) are written and compile but have never been executed, following the repo convention for real-transaction MVC bases. They need a reviewer with a DB. The two RSDEV-1270 cases in the instrument one should **fail on `main`** at the `deleted=true` assertion, worth confirming, since the orphaned row is invisible through the API and the assertions therefore reach it via the DAO.

## Out of scope

Archive export/import does not carry `InventoryLink` at all, so a default link does not survive export. Pre-existing gap, unchanged here.

Known follow-up for a separate ticket: in `rspace-core-model`, `Instrument#updateToLatestTemplateVersion` calls `setFieldData(null)` where `Sample` calls `clearValue()`, and `InventoryLinkField` overrides only the latter. That asymmetry is why the instrument path needs `clearRetroStampedDefaultLinks` here to compensate. Fixing it upstream would delete those ~20 lines, but it needs a JitPack build and a version bump, so it does not belong in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
