### PR TITLE
RSDEV-1276: Spring 6 minor version bump to 6.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>javax.cache</groupId>
         <artifactId>cache-api</artifactId>
         <version>${javax.cache.version}</version>
@@ -793,12 +800,6 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-audit</artifactId>
       <version>1.0.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
@@ -1598,10 +1599,6 @@
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-core-util</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1631,10 +1628,6 @@
         <exclusion>
           <groupId>com.google.j2objc</groupId>
           <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1780,10 +1773,6 @@
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-core-util</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1795,10 +1784,6 @@
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-repository-spi</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1809,10 +1794,6 @@
         <exclusion>
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-repository-spi</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1873,12 +1854,6 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>fieldmark-java-client</artifactId>
       <version>4.0.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
@@ -1893,22 +1868,12 @@
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-core-util</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>argos-java-client</artifactId>
       <version>1.0.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
@@ -1918,10 +1883,6 @@
         <exclusion>
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rda-dmp-common-standard</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1960,12 +1921,6 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>datacite-java-client</artifactId>
       <version>1.0.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
@@ -1979,10 +1934,6 @@
         <exclusion>
           <groupId>jakarta.el</groupId>
           <artifactId>jakarta.el-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -2002,10 +1953,6 @@
         <exclusion>
           <groupId>io.github.resilience4j</groupId>
           <artifactId>resilience4j-all</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -2163,10 +2110,6 @@
         <exclusion>
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-core-util</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
     <!-- temporary JitPack commit pin of the Spring 6.2.19 bump; replace with 3.0.1 once released -->
-    <version>1b7f2b3e3c</version>
+    <version>dbda5e7fd9</version>
   </parent>
 
   <repositories>
@@ -47,13 +47,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-framework-bom</artifactId>
-        <version>${spring.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>javax.cache</groupId>
         <artifactId>cache-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,7 @@
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
-    <!-- temporary JitPack commit pin of the Spring 6.2.19 bump; replace with 3.0.1 once released -->
-    <version>dbda5e7fd9</version>
+    <version>3.0.1</version>
   </parent>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
-    <version>3.0.0</version>
+    <!-- temporary JitPack commit pin of the Spring 6.2.19 bump; replace with 3.0.1 once released -->
+    <version>1b7f2b3e3c</version>
   </parent>
 
   <repositories>
@@ -792,6 +793,12 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-audit</artifactId>
       <version>1.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
@@ -1591,6 +1598,10 @@
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-core-util</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1620,6 +1631,10 @@
         <exclusion>
           <groupId>com.google.j2objc</groupId>
           <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1765,6 +1780,10 @@
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-core-util</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1776,6 +1795,10 @@
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-repository-spi</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1786,6 +1809,10 @@
         <exclusion>
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-repository-spi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1846,6 +1873,12 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>fieldmark-java-client</artifactId>
       <version>4.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
@@ -1860,12 +1893,22 @@
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-core-util</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>argos-java-client</artifactId>
       <version>1.0.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
@@ -1875,6 +1918,10 @@
         <exclusion>
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rda-dmp-common-standard</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1913,6 +1960,12 @@
       <groupId>com.github.rspace-os</groupId>
       <artifactId>datacite-java-client</artifactId>
       <version>1.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
@@ -1926,6 +1979,10 @@
         <exclusion>
           <groupId>jakarta.el</groupId>
           <artifactId>jakarta.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1945,6 +2002,10 @@
         <exclusion>
           <groupId>io.github.resilience4j</groupId>
           <artifactId>resilience4j-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -2102,6 +2163,10 @@
         <exclusion>
           <groupId>com.github.rspace-os</groupId>
           <artifactId>rspace-core-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
## Description

- Bumps Spring Framework from 6.2.15 to 6.2.19 via rspace-parent 3.0.1 ([rspace-os/rspace-parent#11](https://github.com/rspace-os/rspace-parent/pull/11)), which also imports `spring-framework-bom` so all Spring artifacts, including sibling libraries' transitives, converge on `spring.version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)