### PR TITLE
Clean up Spring version management now the parent imports spring-framework-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,11 +140,6 @@
         <version>1.14.14</version>
       </dependency>
       <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-jdbc</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
         <groupId>javax.measure</groupId>
         <artifactId>unit-api</artifactId>
         <version>2.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -844,24 +844,6 @@
       <groupId>org.apache.velocity</groupId>
       <artifactId>spring-velocity-support</artifactId>
       <version>2.4.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-aop</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-beans</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity.tools</groupId>
@@ -967,28 +949,8 @@
       <version>5.2.1</version>
       <exclusions>
         <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-beans</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-tx</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.springframework.retry</groupId>
           <artifactId>spring-retry</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-aop</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.thoughtworks.xstream</groupId>
@@ -1002,14 +964,6 @@
       <version>5.2.1</version>
       <scope>test</scope>
       <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-test</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-jdbc</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
@@ -1664,31 +1618,11 @@
       <groupId>org.springframework.ldap</groupId>
       <artifactId>spring-ldap-core</artifactId>
       <version>2.3.4.RELEASE</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-tx</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-beans</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.retry</groupId>
       <artifactId>spring-retry</artifactId>
       <version>2.0.11</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
@@ -1851,18 +1785,6 @@
           <artifactId>commons-io</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-web</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.jayway.jsonpath</groupId>
           <artifactId>json-path</artifactId>
         </exclusion>
@@ -1921,18 +1843,6 @@
         <exclusion>
           <groupId>org.jetbrains</groupId>
           <artifactId>annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-web</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -935,7 +935,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.batch</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -940,7 +940,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>${spring.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -977,27 +976,22 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-orm</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context-support</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
@@ -2073,12 +2067,10 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-websocket</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-messaging</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>


### PR DESCRIPTION
## Description ##
Follow-up to #1001, which moved to rspace-parent 3.0.1 and its imported `spring-framework-bom`. With the BOM managing every `org.springframework` artifact, the now-redundant version plumbing in `pom.xml` can go:

- Removed the redundant `org.springframework` exclusions that only existed to force version convergence, as that's now handled by the parent BOM
- Dropped the explicit `<version>${spring.version}</version>` tags on the direct `org.springframework` dependencies; the BOM manages them.
- Removed the redundant spring-jdbc entry from rspace-web's own `dependencyManagement`.
- Declared spring-test with `<scope>test</scope>` instead of compile plus `<optional>true</optional>` for semantic correctness.

The `org.springframework.retry:spring-retry` exclusion on spring-batch-core is deliberately kept: spring-framework-bom does not manage spring-retry, so that exclusion still resolves a real convergence conflict with the directly pinned 2.0.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
