### PR TITLE
Don't run Java tests if no JS files change, don't run Vitest tests if no TS files change

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,6 +27,10 @@ on:
         type: string
         default: 'temurin'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -57,9 +61,13 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - '.github/workflows/**'
             java:
               - 'src/main/java/**'
               - 'src/test/java/**'
+              - 'src/main/resources/**'
+              - 'src/test/resources/**'
+              - 'src/main/webapp/WEB-INF/**'
               - 'pom.xml'
 
   fast-junit-tests:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -74,7 +74,6 @@ jobs:
         java-version: [17]
     if: |
       (github.event_name == 'push' && github.ref_name == 'main') ||
-      github.event_name == 'pull_request' ||
       inputs.fast_java_tests ||
       needs.changed-files.outputs.java == 'true'
     steps:
@@ -223,7 +222,6 @@ jobs:
         shard: [1, 2]
     if: |
       (github.event_name == 'push' && github.ref_name == 'main') ||
-      github.event_name == 'pull_request' ||
       inputs.frontend_tests ||
       needs.changed-files.outputs.frontend == 'true'
     steps:
@@ -294,7 +292,6 @@ jobs:
       !cancelled() &&
       (
         (github.event_name == 'push' && github.ref_name == 'main') ||
-        github.event_name == 'pull_request' ||
         inputs.frontend_tests ||
         needs.changed-files.outputs.frontend == 'true'
       )
@@ -352,7 +349,6 @@ jobs:
         browser: [ chromium, firefox, webkit ]
     if: |
       (github.event_name == 'push' && github.ref_name == 'main') ||
-      github.event_name == 'pull_request' ||
       inputs.frontend_tests ||
       needs.changed-files.outputs.frontend == 'true'
     steps:


### PR DESCRIPTION
## Description ##
Stops the overzealous test running behaviour if the PR does not touch related paths.