### PR TITLE
RSDEV-1293 Date Picker for IGSN/PIDINST Dates Field Not Working

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MultipleInputHandler.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MultipleInputHandler.tsx
@@ -112,7 +112,6 @@ const MultipleInputHandler = ({ field, activeResult, editable }: MultipleInputAr
                   value={v.value}
                   disabled={false}
                   onChange={({ target: { value } }) => {
-                    console.log("MIH New Dates value: ", value);
                     if (value) handleUpdateValue(i, "value", value);
                   }}
                   disableWidthLimit

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MultipleInputHandler.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/MultipleInputHandler.tsx
@@ -4,6 +4,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
+import { format } from "date-fns";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react-lite";
 import type { ComponentType, ReactNode } from "react";
@@ -108,11 +109,13 @@ const MultipleInputHandler = ({ field, activeResult, editable }: MultipleInputAr
               {v.value instanceof Date ? (
                 <DateField
                   variant="outlined"
-                  value={v.value.toString()}
+                  value={v.value}
                   disabled={false}
                   onChange={({ target: { value } }) => {
+                    console.log("MIH New Dates value: ", value);
                     if (value) handleUpdateValue(i, "value", value);
                   }}
+                  disableWidthLimit
                   data-test-id={`IdentifierRecommendedField-${field.key}-${i}`}
                 />
               ) : (
@@ -198,7 +201,7 @@ const MultipleInputHandler = ({ field, activeResult, editable }: MultipleInputAr
             </FormControl>
           ) : (
             <>
-              <Grid>{v.value instanceof Date ? v.value.toISOString().split("T")[0] : String(v.value)}</Grid>
+              <Grid>{v.value instanceof Date ? format(v.value, "yyyy-MM-dd") : String(v.value)}</Grid>
               {
                 // @ts-expect-error - subFields accepts field.value[i]
                 subFields(field.value[i]).length > 0 &&

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/__tests__/MultipleInputHandler.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Identifiers/__tests__/MultipleInputHandler.test.tsx
@@ -1,0 +1,46 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import type { IdentifierField } from "../../../../../stores/definitions/Identifier";
+import type { InventoryRecord } from "../../../../../stores/definitions/InventoryRecord";
+import materialTheme from "../../../../../theme";
+import MultipleInputHandler from "../MultipleInputHandler";
+import "@/__tests__/__mocks__/matchMedia";
+
+const mockActiveResult = {
+  updateIdentifiers: vi.fn(),
+} as unknown as InventoryRecord;
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={materialTheme}>{children}</ThemeProvider>
+);
+
+const datesField = (dateValue: Date): IdentifierField => ({
+  key: "Dates",
+  value: [{ value: dateValue, type: "CREATED" }],
+  options: [{ value: "CREATED", label: "inventory:identifierModel.dateTypes.created" }],
+  selectLabelLabel: "inventory:fields.identifiers.dates.typeLabel",
+  handler: vi.fn(),
+});
+
+describe("MultipleInputHandler — Dates field", () => {
+  test("a Date value in editable mode does not show the Invalid Date error", () => {
+    const { container } = render(
+      <MultipleInputHandler field={datesField(new Date(2027, 4, 25))} activeResult={mockActiveResult} editable />,
+      { wrapper: Wrapper },
+    );
+    expect(container).not.toHaveTextContent("common:inputs.dateField.invalidDate");
+  });
+
+  test("in read-only mode a Date value is displayed as a yyyy-MM-dd string", () => {
+    render(
+      <MultipleInputHandler
+        field={datesField(new Date(2027, 4, 25))}
+        activeResult={mockActiveResult}
+        editable={false}
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByText("2027-05-25")).toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/IdentifierModel.tsx
+++ b/src/main/webapp/ui/src/stores/models/IdentifierModel.tsx
@@ -14,7 +14,7 @@
  *
  * ============================================================================
  */
-import { format } from "date-fns";
+import { format, isValid } from "date-fns";
 import { action, computed, makeObservable, observable, runInAction } from "mobx";
 import type React from "react";
 import i18n from "@/modules/common/i18n";
@@ -670,7 +670,7 @@ export default class IdentifierModel implements Identifier {
       alternateIdentifiers: this.alternateIdentifiers,
       dates: this.dates?.map((d) => ({
         ...d,
-        value: d.value instanceof Date ? format(d.value, "yyyy-MM-dd") : d.value,
+        value: d.value instanceof Date && isValid(d.value) ? format(d.value, "yyyy-MM-dd") : d.value,
       })),
       geoLocations: this.geoLocations?.map((g) => g.toJson()),
       editing: this.editing,

--- a/src/main/webapp/ui/src/stores/models/IdentifierModel.tsx
+++ b/src/main/webapp/ui/src/stores/models/IdentifierModel.tsx
@@ -14,6 +14,7 @@
  *
  * ============================================================================
  */
+import { format } from "date-fns";
 import { action, computed, makeObservable, observable, runInAction } from "mobx";
 import type React from "react";
 import i18n from "@/modules/common/i18n";
@@ -667,7 +668,10 @@ export default class IdentifierModel implements Identifier {
       subjects: this.subjects,
       descriptions: this.descriptions,
       alternateIdentifiers: this.alternateIdentifiers,
-      dates: this.dates,
+      dates: this.dates?.map((d) => ({
+        ...d,
+        value: d.value instanceof Date ? format(d.value, "yyyy-MM-dd") : d.value,
+      })),
       geoLocations: this.geoLocations?.map((g) => g.toJson()),
       editing: this.editing,
       customFieldsOnPublicPage: this.customFieldsOnPublicPage,

--- a/src/main/webapp/ui/src/stores/models/__tests__/IdentifierModel.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/IdentifierModel.test.ts
@@ -1,0 +1,35 @@
+import { runInAction } from "mobx";
+import { describe, expect, test } from "vitest";
+import { mockIGSNAttrs } from "../../../Inventory/components/Fields/Identifiers/__tests__/mocking";
+import IdentifierModel from "../IdentifierModel";
+
+describe("IdentifierModel.toJson() — Dates serialization", () => {
+  test("date values are plain yyyy-MM-dd strings, not Date objects or ISO timestamps", () => {
+    const model = new IdentifierModel({ ...mockIGSNAttrs(), dates: [{ value: "2027-05-25", type: "CREATED" }] }, "SA1");
+    const json = model.toJson() as { dates: Array<{ value: unknown }> };
+    expect(typeof json.dates[0].value).toBe("string");
+    expect(json.dates[0].value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test("serialized date matches local calendar date, not the UTC-shifted equivalent", () => {
+    /*
+     * new Date(year, monthIndex, day) creates midnight in LOCAL time.
+     * format() from date-fns also uses local time, so the round-trip must
+     * preserve the calendar date regardless of the host timezone offset.
+     * This guards against the prior bug where JSON.stringify serialised Date
+     * objects as UTC ISO strings, shifting the date back by the UTC offset.
+     */
+    const localMidnight = new Date(2027, 4, 25); // May 25 local midnight
+    const model = new IdentifierModel({ ...mockIGSNAttrs(), dates: [] }, "SA1");
+    runInAction(() => {
+      model.dates = [{ value: localMidnight, type: "CREATED" }];
+    });
+    const json = model.toJson() as { dates: Array<{ value: string }> };
+    const expectedLocalDateString = [
+      localMidnight.getFullYear(),
+      String(localMidnight.getMonth() + 1).padStart(2, "0"),
+      String(localMidnight.getDate()).padStart(2, "0"),
+    ].join("-");
+    expect(json.dates[0].value).toBe(expectedLocalDateString);
+  });
+});


### PR DESCRIPTION
## Description ##
- Resolves https://researchspace.atlassian.net/browse/RSDEV-1293

## Summary of changes from Claude ##

Three separate bugs were fixed across two files, plus tests were added to
  guard against regressions.

  ---
  Bug 1 — "Invalid Date" always shown (MultipleInputHandler.tsx)

  Cause: The editable DateField was receiving v.value.toString(), which produces
  a locale string like "Tue Aug 05 2026 00:00:00 GMT+0100". DateField's
  internal parser only accepts Date objects, ISO 8601 strings, or yyyy-MM-dd
  strings — so it always failed validation and showed "Invalid Date".

  Fix: Pass v.value (the Date object) directly instead of calling .toString() on
  it.

  ---
  Bug 2 — Date input box too narrow (MultipleInputHandler.tsx)

  Cause: DateField defaults to maxWidth: 10em, which doesn't leave enough room
  for the date text when using the outlined variant (which has more internal
  padding than standard).

  Fix: Added the disableWidthLimit prop to the DateField call, letting it fill
  the full width of its FormControl container.

  ---
  Bug 3 — Timezone offset corrupted the saved date (IdentifierModel.tsx + 
  MultipleInputHandler.tsx)

  Cause: Two places serialised dates using UTC time:
  - toJson() returned dates: this.dates with raw Date objects. When the HTTP
  request called JSON.stringify, each Date was serialised as a UTC ISO string
  (e.g. "2027-05-24T23:00:00.000Z"), shifting the date back by the local UTC
  offset.
  - The read-only display used v.value.toISOString().split("T")[0], which
  extracts the UTC date part for the same reason.

  Fix: Both sites now use format(d.value, "yyyy-MM-dd") from date-fns, which
  formats using local time. The backend receives a plain date string
  ("2027-05-25") with no time component or timezone ambiguity.

  ---
  Tests added

  File: Identifiers/__tests__/MultipleInputHandler.test.tsx
  Tests: "Invalid Date" does not appear when a Date value is passed; read-only
    mode displays the date as yyyy-MM-dd
  ────────────────────────────────────────
  File: stores/models/__tests__/IdentifierModel.test.ts
  Tests: toJson() produces a plain yyyy-MM-dd string (not a timestamp); the
    serialised value matches the local calendar date regardless of timezone