### PR TITLE
Fix pre-commit spotless hook silently skipping all files on Windows

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,10 @@ pre-commit:
     # Fail the commit if any staged Java file is not spotless-formatted.
     # spotlessFiles matches the absolute path via String#matches, so each
     # staged (repo-relative) path is prefixed with `.*` to anchor correctly.
+    # git reports forward slashes, but the absolute path spotless matches uses
+    # the OS separator (backslashes on Windows), so each `/` is turned into a
+    # `[/\\]` class; without this the pattern matches nothing on Windows and the
+    # check silently passes.
     # Guard against an empty list (drop blank lines) so we never fall back to
     # `-DspotlessFiles=".*"`, which would match every file in the repo.
     # -DspotlessStrict adds the CleanThat checks; scoped to staged files, so it
@@ -16,7 +20,7 @@ pre-commit:
       glob: "**/*.java"
       run: |
         spotless_files=$(printf '%s\n' {staged_files} \
-          | sed '/^$/d; s/[.[\](){}+^$|\\]/\\&/g; s#^#.*#' \
+          | sed '/^$/d; s/[.[\](){}+^$|\\]/\\&/g; s#/#[/\\\\]#g; s#^#.*#' \
           | paste -sd, -)
         if [ -n "$spotless_files" ]; then
           ./mvnw -q spotless:check -DspotlessStrict -DspotlessFiles="$spotless_files"


### PR DESCRIPTION
## Problem

The pre-commit `spotless` hook builds its `-DspotlessFiles` regex from the staged paths git reports, which use forward slashes. spotless matches that regex against each file's OS-native **absolute** path. On Windows that path uses backslashes (`...\src\main\java\...`), so a forward-slash pattern like `.*src/main/java/...` matches nothing. The result: on Windows the hook inspected zero files and the strict format check always passed, letting unformatted Java through. CI (Linux) uses forward slashes, so it correctly flagged the same files, producing a 'passes locally, fails on CI' gap.

## Fix

Turn each path separator in the generated pattern into a `[/\]` character class so it matches both separators. Forward-slash paths (Linux/macOS) still match because `/` remains in the class; backslash paths (Windows) now match too.

## Verification

On Windows, with a deliberately mis-formatted Java file staged: the old pattern passed (no files inspected); the new pattern fails the commit as expected. The class still matches forward-slash paths, so Linux/macOS behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)