### PR TITLE
PRT-1121: show a single, reliable notification when creating a notebook in a shared group folder

### DIFF
--- a/src/main/webapp/scripts/pages/coreEditor.js
+++ b/src/main/webapp/scripts/pages/coreEditor.js
@@ -2145,11 +2145,16 @@ window.addEventListener("ReactToolbarMounted", () => {
   });
 });
 
+// Confirm the automatic share after the server redirects here with
+// ?sharedWithGroup=<group> on creating a document or notebook in a shared group folder.
 $(document).ready(function () {
   const searchParams = new URLSearchParams(window.location.search);
   if (searchParams.has("sharedWithGroup")) {
+    const messageKey = isDocumentEditor
+      ? "legacyjs.workspace.coreEditor.sharedWithGroup"
+      : "legacyjs.workspace.coreEditor.notebookSharedWithGroup";
     RS.confirm(
-      RS.msg("legacyjs.workspace.coreEditor.sharedWithGroup", RS.escapeHtml(searchParams.get("sharedWithGroup"))),
+      RS.msg(messageKey, RS.escapeHtml(searchParams.get("sharedWithGroup"))),
       "success",
       "infinite"
     );

--- a/src/main/webapp/scripts/pages/journal.js
+++ b/src/main/webapp/scripts/pages/journal.js
@@ -790,19 +790,4 @@ function journal($, extensions = default_extensions) {
   $(window).on('resize', function(e) {
     repositionEntryNavButtons();
   });
-
-  // When a notebook is created directly in a shared group folder the server
-  // redirects here with ?sharedWithGroup=<group>. Mirror the document editor
-  // (coreEditor.js) and confirm the automatic share to the user, since the
-  // notebook editor does not load coreEditor.js.
-  $(document).ready(function() {
-    const searchParams = new URLSearchParams(window.location.search);
-    if (searchParams.has("sharedWithGroup")) {
-      RS.confirm(
-        RS.msg("legacyjs.workspace.journal.sharedWithGroup", RS.escapeHtml(searchParams.get("sharedWithGroup"))),
-        "success",
-        "infinite"
-      );
-    }
-  });
 };

--- a/src/main/webapp/ui/src/components/ToastMessage.tsx
+++ b/src/main/webapp/ui/src/components/ToastMessage.tsx
@@ -42,6 +42,20 @@ type ToastMessageProps = Pick<ToastConfig, "callback" | "id" | "open" | "variant
 
 type CloseHandler = (event?: React.SyntheticEvent<unknown> | Event, reason?: SnackbarCloseReason) => void;
 
+/*
+ * Snackbars only starts listening in a useEffect, after React commits, so toasts
+ * dispatched earlier (e.g. from jQuery document-ready handlers) would be lost.
+ * Module scripts run before DOMContentLoaded, so this buffer catches them;
+ * Snackbars drains it on mount.
+ */
+const preMountToasts: Array<Event> = [];
+const bufferPreMountToast = (event: Event) => {
+  preMountToasts.push(event);
+};
+document.addEventListener("show-toast-message", bufferPreMountToast);
+
+let nextToastId = 0;
+
 type MySnackbarContentWrapperProps = {
   message: string;
   onClose: CloseHandler;
@@ -81,7 +95,7 @@ export default function Snackbars() {
       const e = event as CustomEvent<ToastEventDetail>;
       if (isMountedRef.current) {
         const config: ToastConfig = {
-          id: Date.now(),
+          id: nextToastId++,
           message: e.detail.message,
           variant: e.detail.variant || "notice", // success/warning/error/notice
           duration: e.detail.duration || 4000,
@@ -93,11 +107,14 @@ export default function Snackbars() {
       }
     };
 
+    document.removeEventListener("show-toast-message", bufferPreMountToast);
     document.addEventListener("show-toast-message", handleShowToastMessage);
+    preMountToasts.splice(0).forEach(handleShowToastMessage);
 
     return () => {
       isMountedRef.current = false;
       document.removeEventListener("show-toast-message", handleShowToastMessage);
+      document.addEventListener("show-toast-message", bufferPreMountToast);
     };
   }, [addToast]);
 

--- a/src/main/webapp/ui/src/components/__tests__/ToastMessage.test.tsx
+++ b/src/main/webapp/ui/src/components/__tests__/ToastMessage.test.tsx
@@ -1,0 +1,30 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import Snackbars from "../ToastMessage";
+
+const dispatchToast = (message: string) => {
+  document.dispatchEvent(
+    new CustomEvent("show-toast-message", {
+      detail: { message, variant: "success", infinite: true },
+    }),
+  );
+};
+
+describe("Snackbars", () => {
+  test("shows a toast dispatched after mount", async () => {
+    render(<Snackbars />);
+    act(() => {
+      dispatchToast("post-mount toast");
+    });
+    expect(await screen.findByText("post-mount toast")).toBeInTheDocument();
+  });
+
+  test("shows toasts dispatched before mount", async () => {
+    // legacy scripts can dispatch from document-ready, before the listener mounts
+    dispatchToast("pre-mount toast 1");
+    dispatchToast("pre-mount toast 2");
+    render(<Snackbars />);
+    expect(await screen.findByText("pre-mount toast 1")).toBeInTheDocument();
+    expect(screen.getByText("pre-mount toast 2")).toBeInTheDocument();
+  });
+});

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.legacyJs.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.legacyJs.json
@@ -733,6 +733,7 @@
         "imageDetails": "Image details",
         "linkAtServer": "at {0}",
         "markushNotSupported": "RSpace doesn't currently support the generation of Markush or R-Group structure images, your file is stored in the gallery but cannot be inserted into a document",
+        "notebookSharedWithGroup": "<b>This notebook has been automatically shared with edit rights with all members of {0}. It remains available in your own workspace.</b><br />To amend the permissions, visit the <a href=\"/record/share/manage\">Shared Documents</a> page.",
         "okButton": "OK",
         "ontologiesEnforcedMessage": "Ontologies are enforced, tag values must come from ontology files shared with a group",
         "pleaseEnterName": "Please enter a name",
@@ -916,8 +917,7 @@
         "noMoreRecordsInDirection": "No more records in this direction.",
         "noParentRecordId": "No parent record ID was set, journal view cannot be rendered",
         "noResultsFound": "No results were found",
-        "searchFailed": "Search failed: {0}",
-        "sharedWithGroup": "<b>This notebook has been automatically shared with edit rights with all members of {0}. It remains available in your own workspace.</b><br />To amend the permissions, visit the <a href=\"/record/share/manage\">Shared Documents</a> page."
+        "searchFailed": "Search failed: {0}"
       },
       "main": {
         "cancelButton": "Cancel",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -7640,6 +7640,7 @@ export default interface Resources {
           "imageDetails": "Image details",
           "linkAtServer": "at {0}",
           "markushNotSupported": "RSpace doesn't currently support the generation of Markush or R-Group structure images, your file is stored in the gallery but cannot be inserted into a document",
+          "notebookSharedWithGroup": "<b>This notebook has been automatically shared with edit rights with all members of {0}. It remains available in your own workspace.</b><br />To amend the permissions, visit the <a href=\"/record/share/manage\">Shared Documents</a> page.",
           "okButton": "OK",
           "ontologiesEnforcedMessage": "Ontologies are enforced, tag values must come from ontology files shared with a group",
           "pleaseEnterName": "Please enter a name",
@@ -7823,8 +7824,7 @@ export default interface Resources {
           "noMoreRecordsInDirection": "No more records in this direction.",
           "noParentRecordId": "No parent record ID was set, journal view cannot be rendered",
           "noResultsFound": "No results were found",
-          "searchFailed": "Search failed: {0}",
-          "sharedWithGroup": "<b>This notebook has been automatically shared with edit rights with all members of {0}. It remains available in your own workspace.</b><br />To amend the permissions, visit the <a href=\"/record/share/manage\">Shared Documents</a> page."
+          "searchFailed": "Search failed: {0}"
         },
         "main": {
           "cancelButton": "Cancel",


### PR DESCRIPTION
## Description ##
Fixes the follow-up on [PRT-1121](https://researchspace.atlassian.net/browse/PRT-1121): after #976, creating a notebook directly in a shared group folder showed multiple notifications instead of one. Rather than patching around #976, this reverts it and fixes the two underlying problems.

- **Duplicate toasts:** #976 assumed the notebook editor page does not load coreEditor.js. It always has, so coreEditor.js's existing `sharedWithGroup` block fired alongside the new journal.js copy. The copy is reverted and coreEditor.js is now the single consumer of the redirect param, picking document or notebook wording via the existing `isDocumentEditor` flag. The notebook string moves to the `coreEditor` catalogue namespace.

- **Missing toasts (the original report):** toasts dispatched at document-ready raced the React snackbar host, whose listener is only added in a `useEffect` after React commits, so early dispatches were silently lost depending on load timing. The host now registers a module-scope buffering listener (module scripts run before DOMContentLoaded) and drains it on mount, which fixes every early dispatcher, not just this flow. Toast ids switch from `Date.now()` to a counter so same-millisecond toasts cannot share a React key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
