### PR TITLE
RSDEV-1261 Fix duplicated instrument keeps the original instrument's Landing page

### DIFF
--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -214,6 +214,26 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     return update.applyChangesToDatabaseField(blankLandingPage.get(), user);
   }
 
+  /**
+   * Blanks the Landing page field in {@code copy} when it contains the system-generated default URL
+   * for {@code source} — i.e. the URL RSpace would have auto-filled for the source record. A value
+   * the user typed on the source is left untouched.
+   */
+  private void clearSystemGeneratedLandingPage(Instrument source, Instrument copy) {
+    GlobalIdUrls.globalIdUrl(properties, source.getGlobalIdentifier())
+        .ifPresent(
+            sourceUrl ->
+                copy.getActiveFields().stream()
+                    .filter(f -> f.getType() == FieldType.URI)
+                    .filter(
+                        f ->
+                            f.getName() != null
+                                && LANDING_PAGE_FIELD_NAME.equalsIgnoreCase(f.getName().trim()))
+                    .filter(f -> sourceUrl.equals(f.getFieldData()))
+                    .findFirst()
+                    .ifPresent(f -> f.setFieldData(null)));
+  }
+
   private void setLocationForNewInstrument(
       ApiInstrument apiInstrument, Instrument instrumentToSave, User user) {
     inventoryMoveHelper.moveRecordToTargetParentAndLocation(
@@ -575,8 +595,13 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   public ApiInstrument duplicateInstrument(Long instrumentId, User user) {
     Instrument dbInstrument = assertUserCanReadInstrument(instrumentId, user);
     Instrument copy = (Instrument) dbInstrument.copy(user);
+    clearSystemGeneratedLandingPage(dbInstrument, copy);
     setWorkbenchAsParentForNewInstrument(copy, user);
     copy = instrumentDao.save(copy);
+    // Fill needs to be done after the save, as it needs the actual persisted id
+    if (fillBlankLandingPage(copy, user)) {
+      copy = instrumentDao.save(copy);
+    }
     publisher.publishEvent(new InventoryCreationEvent(copy, user));
     ApiInstrument result = new ApiInstrument(copy);
     populateOutgoingApiInstrumentEntity(result, copy, user);

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -228,6 +228,7 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
     Instrument instrument = new Instrument();
     instrument.setId(id);
     instrument.setName("Test Instrument");
+    instrument.setOwner(user);
     InventoryUriField lp = new InventoryUriField("Landing page");
     lp.setFieldData(landingPageData);
     addField(instrument, lp);
@@ -282,6 +283,7 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
     Instrument source = new Instrument();
     source.setId(1L);
     source.setName("Plain Instrument");
+    source.setOwner(user);
 
     when(properties.getServerUrl()).thenReturn(serverUrl);
     stubDuplicateInfrastructure(source);

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -15,17 +17,29 @@ import static org.mockito.Mockito.when;
 import com.researchspace.api.v1.auth.ApiRuntimeException;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.dao.ContainerDao;
+import com.researchspace.dao.InstrumentDao;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.field.FieldType;
+import com.researchspace.model.inventory.Container;
+import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.model.inventory.field.InventoryUriField;
+import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.UserManager;
 import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.service.inventory.InventoryPermissionUtils;
 import com.researchspace.testutils.TestFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -39,6 +53,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 class InstrumentEntityApiManagerImplLinkFieldTest {
 
   @Mock private InventoryLinkManager inventoryLinkManager;
+  @Mock private InstrumentDao instrumentDao;
+  @Mock private InventoryPermissionUtils invPermissions;
+  @Mock private ContainerDao containerDao;
+  @Mock private IPropertyHolder properties;
+  @Mock private ApplicationEventPublisher publisher;
+  @Mock private UserManager userManager;
   private InstrumentEntityApiManagerImpl manager;
 
   private User user;
@@ -49,6 +69,12 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
   void setUp() {
     manager = new InstrumentEntityApiManagerImpl();
     ReflectionTestUtils.setField(manager, "inventoryLinkManager", inventoryLinkManager);
+    ReflectionTestUtils.setField(manager, "instrumentDao", instrumentDao);
+    ReflectionTestUtils.setField(manager, "invPermissions", invPermissions);
+    ReflectionTestUtils.setField(manager, "containerDao", containerDao);
+    ReflectionTestUtils.setField(manager, "properties", properties);
+    ReflectionTestUtils.setField(manager, "publisher", publisher);
+    ReflectionTestUtils.setField(manager, "userManager", userManager);
     user = TestFactory.createAnyUser("any");
     dbLink = new InventoryLink();
     dbLink.setRelationType("References");
@@ -194,5 +220,103 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
     assertTrue(changed);
     assertSame(created, dbField.getLink());
     verify(inventoryLinkManager, never()).updateLink(any(), any(), any());
+  }
+
+  // --- duplicateInstrument / landing-page tests ---
+
+  private Instrument instrumentWithLandingPage(long id, String landingPageData) {
+    Instrument instrument = new Instrument();
+    instrument.setId(id);
+    instrument.setName("Test Instrument");
+    InventoryUriField lp = new InventoryUriField("Landing page");
+    lp.setFieldData(landingPageData);
+    addField(instrument, lp);
+    return instrument;
+  }
+
+  private void addField(Instrument instrument, InventoryEntityField field) {
+    field.setInventoryRecord(instrument);
+    field.setColumnIndex(instrument.getFields().size() + 1);
+    instrument.getFields().add(field);
+    instrument.refreshActiveFieldsAndColumnIndex();
+  }
+
+  private void stubDuplicateInfrastructure(Instrument source) {
+    when(instrumentDao.exists(source.getId())).thenReturn(true);
+    when(instrumentDao.get(source.getId())).thenReturn(source);
+    when(instrumentDao.save(any()))
+        .thenAnswer(
+            inv -> {
+              Instrument arg = inv.getArgument(0);
+              if (arg.getId() == null) {
+                arg.setId(source.getId() + 1);
+              }
+              return arg;
+            });
+    when(containerDao.getWorkbenchForUser(user)).thenReturn(mock(Container.class));
+  }
+
+  @Test
+  void duplicatingSystemGeneratedLandingPageGivesTheCopyItsOwnAddress() {
+    String serverUrl = "https://rspace.example.com";
+    // Source IN1 has the system-generated landing page for IN1
+    Instrument source = instrumentWithLandingPage(1L, serverUrl + "/globalId/IN1");
+
+    when(properties.getServerUrl()).thenReturn(serverUrl);
+    stubDuplicateInfrastructure(source);
+
+    manager.duplicateInstrument(1L, user);
+
+    // First save creates the copy (id=2); second save persists the filled landing page
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(2)).save(captor.capture());
+
+    String copyLandingPage = landingPageFieldData(captor.getAllValues().get(1));
+    assertEquals(serverUrl + "/globalId/IN2", copyLandingPage);
+  }
+
+  @Test
+  void duplicatingInstrumentWithNoLandingPageFieldChangesNothing() {
+    String serverUrl = "https://rspace.example.com";
+    // Source has no URI fields at all
+    Instrument source = new Instrument();
+    source.setId(1L);
+    source.setName("Plain Instrument");
+
+    when(properties.getServerUrl()).thenReturn(serverUrl);
+    stubDuplicateInfrastructure(source);
+
+    manager.duplicateInstrument(1L, user);
+
+    // fillBlankLandingPage found nothing to fill — only one save
+    verify(instrumentDao, times(1)).save(any());
+  }
+
+  @Test
+  void duplicatingUserTypedLandingPagePreservesTheValue() {
+    String serverUrl = "https://rspace.example.com";
+    String userTypedUrl = "https://external.lab.example.com/my-instrument";
+    // Source has a user-typed URL that does not match the system-generated form for IN1
+    Instrument source = instrumentWithLandingPage(1L, userTypedUrl);
+
+    when(properties.getServerUrl()).thenReturn(serverUrl);
+    stubDuplicateInfrastructure(source);
+
+    manager.duplicateInstrument(1L, user);
+
+    // Conservative check did not match → field still non-blank → only one save
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(1)).save(captor.capture());
+
+    assertEquals(userTypedUrl, landingPageFieldData(captor.getValue()));
+  }
+
+  private String landingPageFieldData(Instrument instrument) {
+    return instrument.getActiveFields().stream()
+        .filter(f -> f.getType() == FieldType.URI)
+        .filter(f -> "Landing page".equalsIgnoreCase(f.getName()))
+        .findFirst()
+        .map(InventoryEntityField::getFieldData)
+        .orElse(null);
   }
 }


### PR DESCRIPTION
## Description ##
- Resolves https://researchspace.atlassian.net/browse/RSDEV-1261
- Solution as per comments in that ticket.

Summary of changes by Claude:

  InstrumentEntityApiManagerImpl.java
  - duplicateInstrument: now calls clearSystemGeneratedLandingPage(dbInstrument,
  copy) before save, then calls fillBlankLandingPage(copy, user) after the
  first save (with a second save when it fills something, matching the 
  createInstrument pattern).
  - New private clearSystemGeneratedLandingPage(source, copy): uses
  GlobalIdUrls.globalIdUrl to build the source's expected default URL, then
  blanks the copy's Landing page field only if it matches -- preserving
  user-typed values.

  InstrumentEntityApiManagerImplLinkFieldTest.java
  - Three new tests covering the three cases from the ticket: system-generated
  URL gets replaced with the copy's own address, an instrument with no Landing
  page field is unaffected (one save only), and a user-typed URL survives
  unchanged. 
  - Added @Mock fields for instrumentDao, invPermissions, containerDao,
  properties, publisher, and userManager, injected in setUp() via
  ReflectionTestUtils.