### PR TITLE
Disable Scalar telemetry explicitly

### DIFF
--- a/src/main/webapp/ui/src/modules/api/components/ApiDocsPage.test.tsx
+++ b/src/main/webapp/ui/src/modules/api/components/ApiDocsPage.test.tsx
@@ -82,6 +82,10 @@ describe("createApiDocsConfiguration", () => {
     expect(config.mcp?.disabled).toBe(true);
   });
 
+  test("disables Scalar telemetry", () => {
+    expect(config.telemetry).toBe(false);
+  });
+
   test("disables the Ask AI agent on every source", () => {
     for (const source of config.sources ?? []) {
       expect(source.agent?.disabled).toBe(true);

--- a/src/main/webapp/ui/src/modules/api/components/ApiDocsPage.tsx
+++ b/src/main/webapp/ui/src/modules/api/components/ApiDocsPage.tsx
@@ -86,6 +86,8 @@ export function createApiDocsConfiguration(baseUrl: string): Partial<ApiReferenc
     hideClientButton: true,
     // Hide the "Generate MCP server" button.
     mcp: { disabled: true },
+    // Explicitly opt out if Scalar's optional analytics plugin is ever loaded.
+    telemetry: false,
     // Do not pull fonts from fonts.scalar.com; RSpace installs may be air-gapped.
     withDefaultFonts: false,
     // Hide the "Powered by Scalar" attribution link (see HIDE_POWERED_BY_CSS).


### PR DESCRIPTION
## Description ##
We are not opting into Scalar's telemetry currently (as [the docs](https://scalar.com/products/api-references/configuration) make it clear), but adding another layer just in case.