### PR TITLE
PRT-1131: fix integration issues found during e2e mock testing

### DIFF
--- a/src/main/java/com/researchspace/webapp/integrations/clustermarket/ClustermarketOAuthService.java
+++ b/src/main/java/com/researchspace/webapp/integrations/clustermarket/ClustermarketOAuthService.java
@@ -112,7 +112,7 @@ public class ClustermarketOAuthService {
     String redirectUri = properties.getServerUrl() + "/apps/clustermarket/redirect_uri";
     kv.put("redirect_uri", redirectUri);
     ResponseEntity<AccessToken> accessToken = getAccessToken(kv);
-    log.info("Got access token {}", accessToken);
+    log.info("Received Clustermarket access token for user {}", subject.getUsername());
     UserConnection conn = new UserConnection();
     conn.setDisplayName("RSpace Clustermarket access token");
     conn.setId(
@@ -131,9 +131,6 @@ public class ClustermarketOAuthService {
         new HttpEntity<>(kv, getApiHeaders());
     log.info(
         "Sending access token request to: " + clustermarketWebUrl + CLUSTERMARKET_ACCESS_TOKEN_URL);
-    for (String key : kv.keySet()) {
-      log.info("Access token request had key " + key + " with value: " + kv.get(key));
-    }
     ResponseEntity<AccessToken> accessToken =
         restTemplate.exchange(
             clustermarketWebUrl + CLUSTERMARKET_ACCESS_TOKEN_URL,

--- a/src/main/java/com/researchspace/webapp/integrations/dryad/DryadOAuthController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/dryad/DryadOAuthController.java
@@ -102,10 +102,8 @@ public class DryadOAuthController extends BaseOAuth2Controller {
     try {
       ResponseEntity<DryadAccessToken> response =
           restTemplate.postForEntity(baseUrl + "/oauth/token", entity, DryadAccessToken.class);
-      log.debug("Response: {}", response.getBody());
       log.debug("Response status: {}", response.getStatusCode());
       DryadAccessToken accessToken = response.getBody();
-      log.debug("Got access token: " + accessToken.getAccessToken());
       UserConnection conn = new UserConnection();
       String accessTokenStr = accessToken.getAccessToken();
       conn.setAccessToken(accessTokenStr);
@@ -117,7 +115,6 @@ public class DryadOAuthController extends BaseOAuth2Controller {
       // This is null for now as dryad doesn't currently provide a proper OAuth flow to refresh the
       // token.
       conn.setRefreshToken(null);
-      log.debug("Plain text access token is {}", accessTokenStr);
       userConnectionManager.save(conn);
 
     } catch (HttpStatusCodeException e) {

--- a/src/main/java/com/researchspace/webapp/integrations/egnyte/EgnyteController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/egnyte/EgnyteController.java
@@ -42,14 +42,15 @@ public class EgnyteController {
   @GetMapping("/egnyteSessionToken")
   @ResponseBody
   public String getEgnyteTokenFromSession(HttpSession session) {
-    log.info("requesting egnyte token, which is: " + session.getAttribute(SESSION_EGNYTE_TOKEN));
+    log.info("Egnyte session token requested");
     return (String) session.getAttribute(SESSION_EGNYTE_TOKEN);
   }
 
+  @IgnoreInLoggingInterceptor(ignoreRequestParams = {"token"})
   @PostMapping("/egnyteSessionToken")
   @ResponseBody
   public String saveEgnyteTokenToSession(@RequestParam("token") String token, HttpSession session) {
-    log.info("saving egnyte token: " + token);
+    log.info("Saving Egnyte token to session");
     session.setAttribute(SESSION_EGNYTE_TOKEN, token);
     return "OK";
   }

--- a/src/main/java/com/researchspace/webapp/integrations/figshare/FigshareOAuthController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/figshare/FigshareOAuthController.java
@@ -120,7 +120,7 @@ public class FigshareOAuthController extends BaseOAuth2Controller {
     try {
       ResponseEntity<FigshareOAuthController.AccessToken> accessToken =
           getAccessToken(authorizationCode);
-      log.info("Got access token {}", accessToken);
+      log.info("Received Figshare access token for user {}", subject.getUsername());
       UserConnection conn = new UserConnection();
       AccessToken token = accessToken.getBody();
       String accessTokenStr = token.getAccessToken();
@@ -131,7 +131,6 @@ public class FigshareOAuthController extends BaseOAuth2Controller {
       conn.setId(new UserConnectionId(subject.getUsername(), FIGSHARE_APP_NAME, id + ""));
       conn.setRank(1);
       conn.setRefreshToken(token.getRefreshToken());
-      log.info("Plain text access token is {}", accessTokenStr);
       userConnectionManager.save(conn);
       ConnectionResultPage.addConnectionAttributes(
           model, APP_DISPLAY_NAME, CONNECTION_CHANNEL, CONNECTION_TYPE);

--- a/src/main/java/com/researchspace/webapp/integrations/github/GitHubController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/github/GitHubController.java
@@ -1,18 +1,22 @@
 package com.researchspace.webapp.integrations.github;
 
+import static com.researchspace.session.SessionAttributeUtils.getSessionAttribute;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.researchspace.model.User;
 import com.researchspace.model.dto.IntegrationInfo;
 import com.researchspace.model.field.ErrorList;
-import com.researchspace.service.IntegrationsHandler;
-import com.researchspace.service.MessageSourceUtils;
-import com.researchspace.service.UserManager;
+import com.researchspace.session.SessionAttributeUtils;
 import com.researchspace.webapp.controller.AjaxReturnObject;
+import com.researchspace.webapp.integrations.helper.BaseOAuth2Controller;
 import com.researchspace.webapp.integrations.helper.ConnectionResultPage;
 import com.researchspace.webapp.integrations.helper.OauthAuthorizationError;
 import com.researchspace.webapp.integrations.helper.OauthAuthorizationError.OauthAuthorizationErrorBuilder;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -24,7 +28,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -47,7 +50,7 @@ import org.springframework.web.client.RestTemplate;
 @Controller
 @RequestMapping("/github")
 @Slf4j
-public class GitHubController {
+public class GitHubController extends BaseOAuth2Controller {
 
   protected static final String GITHUB_VIEW_NAME = "connect/github/gitHubTreeView";
 
@@ -65,10 +68,6 @@ public class GitHubController {
 
   @Value("${github.secret}")
   private String clientSecret;
-
-  private @Autowired IntegrationsHandler integrationsHandler;
-  private @Autowired UserManager userManager;
-  private @Autowired MessageSourceUtils messages;
 
   private RestTemplate restTemplate;
 
@@ -201,7 +200,18 @@ public class GitHubController {
   @GetMapping("/oauthUrl")
   @ResponseBody
   public AjaxReturnObject<String> oauthUrl() {
-    var url = githubAuthorizeUrl + "?scope=repo,user&client_id=" + this.clientId;
+    String redirectUri =
+        URLEncoder.encode(
+            properties.getServerUrl() + "/github/redirect_uri", StandardCharsets.UTF_8);
+    String state = generateState();
+    var url =
+        githubAuthorizeUrl
+            + "?scope=repo,user&client_id="
+            + this.clientId
+            + "&redirect_uri="
+            + redirectUri
+            + "&state="
+            + state;
     return new AjaxReturnObject<>(url, null);
   }
 
@@ -219,7 +229,31 @@ public class GitHubController {
 
   @GetMapping("/redirect_uri")
   public String onAuthorization(
-      @RequestParam Map<String, String> params, Model model, Principal principal) {
+      @RequestParam Map<String, String> params,
+      Model model,
+      Principal principal,
+      HttpServletRequest request) {
+    try {
+      // oauthUrl() always issues a state param, so a callback with no cached state is a forged or
+      // replayed request. verifyStateParameter only compares when a cached state exists (it passes
+      // when there is none), so require its presence here to keep the CSRF check fail-closed.
+      if (getSessionAttribute(SessionAttributeUtils.RS_OAUTH_STATE) == null) {
+        throw new IllegalStateException(getText("connect.authorizationError.stateMismatch"));
+      }
+      verifyStateParameter(request);
+    } catch (IllegalStateException e) {
+      log.error("GitHub OAuth state mismatch", e);
+      OauthAuthorizationError error =
+          getAuthorizationBuilder()
+              .errorMsg(
+                  messages.getMessage("apps.oauth.errors.connection", new Object[] {"GitHub"}))
+              .errorDetails(e.getMessage())
+              .build();
+      ConnectionResultPage.addError(
+          model, "GitHub", "rspace.apps.github.connection", "GITHUB_CONNECTED", error);
+      return ConnectionResultPage.VIEW;
+    }
+
     String authorizationCode = params.get("code");
     String accessToken;
     try {

--- a/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIO_OAuthController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/protocolsio/ProtocolsIO_OAuthController.java
@@ -126,7 +126,7 @@ public class ProtocolsIO_OAuthController extends BaseOAuth2Controller {
     String authorizationCode = params.get("code");
     try {
       ResponseEntity<AccessToken> accessToken = getAccessToken(authorizationCode);
-      log.info("Got access token {}", accessToken);
+      log.info("Received Protocols.io access token for user {}", subject.getUsername());
       UserConnection conn = new UserConnection();
       conn.setAccessToken(accessToken.getBody().getAccessToken());
       conn.setExpireTime(getExpireTime(accessToken));

--- a/src/main/java/com/researchspace/webapp/integrations/slack/SlackController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/slack/SlackController.java
@@ -1,5 +1,7 @@
 package com.researchspace.webapp.integrations.slack;
 
+import static com.researchspace.session.SessionAttributeUtils.getSessionAttribute;
+
 import com.researchspace.analytics.service.AnalyticsEvent;
 import com.researchspace.analytics.service.AnalyticsManager;
 import com.researchspace.core.util.ISearchResults;
@@ -9,16 +11,17 @@ import com.researchspace.model.record.BaseRecord;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.ChatBotFunctionalityHandler;
 import com.researchspace.service.UserAppConfigManager;
+import com.researchspace.session.SessionAttributeUtils;
 import com.researchspace.slack.SlackAttachment;
 import com.researchspace.slack.SlackAuthToken;
 import com.researchspace.slack.SlackMessage;
 import com.researchspace.slack.SlackUser;
 import com.researchspace.webapp.controller.AjaxReturnObject;
-import com.researchspace.webapp.controller.BaseController;
+import com.researchspace.webapp.integrations.helper.BaseOAuth2Controller;
 import com.researchspace.webapp.integrations.helper.ConnectionResultPage;
 import com.researchspace.webapp.integrations.helper.OauthAuthorizationError;
 import com.researchspace.webapp.integrations.helper.OauthAuthorizationError.OauthAuthorizationErrorBuilder;
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -49,7 +52,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /** Class responsible for handling connection between RSpace and Slack */
 @Controller
 @RequestMapping("/slack")
-public class SlackController extends BaseController {
+public class SlackController extends BaseOAuth2Controller {
   private static final String USER_ID = "user_id";
   private static final String TEAM_ID = "team_id";
   private static final String SAVE_CONVO_ERROR_GENERIC_MSG =
@@ -101,12 +104,15 @@ public class SlackController extends BaseController {
   @GetMapping("/oauthUrl")
   @ResponseBody
   public AjaxReturnObject<String> oauthUrl() {
+    String state = generateState();
     var url =
         slackOauthAuthorizeUrl
             + "?scope=incoming-webhook,commands,channels:history,users:read,files:read,groups:history,im:history,mpim:history&client_id="
             + this.clientId
             + "&redirect_uri="
-            + encodedRedirectUri();
+            + encodedRedirectUri()
+            + "&state="
+            + state;
     return new AjaxReturnObject<>(url, null);
   }
 
@@ -121,9 +127,25 @@ public class SlackController extends BaseController {
 
   @GetMapping("/redirect_uri")
   public String handleSlackRedirect(
-      @RequestParam Map<String, String> params, Model model, HttpSession session) {
+      @RequestParam Map<String, String> params, Model model, HttpServletRequest request) {
     ConnectionResultPage.addConnectionAttributes(
         model, APP_DISPLAY_NAME, CONNECTION_CHANNEL, CONNECTION_TYPE);
+
+    try {
+      if (getSessionAttribute(SessionAttributeUtils.RS_OAUTH_STATE) == null) {
+        throw new IllegalStateException(getText("connect.authorizationError.stateMismatch"));
+      }
+      verifyStateParameter(request);
+    } catch (IllegalStateException e) {
+      log.warn("Slack OAuth state mismatch");
+      OauthAuthorizationError error =
+          getAuthErrorBuilder()
+              .errorMsg(getText("apps.oauth.errors.connection", new Object[] {APP_DISPLAY_NAME}))
+              .errorDetails(e.getMessage())
+              .build();
+      model.addAttribute("connectionError", ConnectionResultPage.buildErrorMessage(error));
+      return CONNECTED_VIEW;
+    }
 
     if (params.containsKey("error")) {
       OauthAuthorizationError error =

--- a/src/main/java/com/researchspace/webapp/integrations/slack/SlackController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/slack/SlackController.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.List;
@@ -103,8 +104,19 @@ public class SlackController extends BaseController {
     var url =
         slackOauthAuthorizeUrl
             + "?scope=incoming-webhook,commands,channels:history,users:read,files:read,groups:history,im:history,mpim:history&client_id="
-            + this.clientId;
+            + this.clientId
+            + "&redirect_uri="
+            + encodedRedirectUri();
     return new AjaxReturnObject<>(url, null);
+  }
+
+  /**
+   * Slack's oauth.access rejects the token exchange with {@code bad_redirect_uri} unless it is
+   * given the same redirect_uri that was sent to the authorize endpoint, so both callers build it
+   * here.
+   */
+  private String encodedRedirectUri() {
+    return URLEncoder.encode(props.getServerUrl() + "/slack/redirect_uri", StandardCharsets.UTF_8);
   }
 
   @GetMapping("/redirect_uri")
@@ -132,7 +144,9 @@ public class SlackController extends BaseController {
               + "&client_secret="
               + clientSecret
               + "&code="
-              + authorizationCode;
+              + authorizationCode
+              + "&redirect_uri="
+              + encodedRedirectUri();
       String content = IOUtils.toString(new URL(slackUrl), StandardCharsets.UTF_8);
       model.addAttribute("connectionResponse", content);
       log.info("slack response retrieved fine");

--- a/src/main/webapp/WEB-INF/pages/connect/connected.jsp
+++ b/src/main/webapp/WEB-INF/pages/connect/connected.jsp
@@ -16,20 +16,25 @@
     connectionResponse raw response payload (e.g. Slack OAuth JSON)
 
   Values are emitted as HTML-escaped data-* attributes (not interpolated into the
-  script) so provider-supplied error text cannot break out of the JS context.
+  script) so provider-supplied error text cannot break out of the JS context. The
+  escaping happens once, globally, via the EscapeXmlELResolver registered in
+  web.xml, which escapes every ${...} that resolves to a String. Do NOT wrap these
+  in <c:out>: that escapes an already-escaped value, so a " becomes &amp;#034; and
+  the browser decodes only one layer, corrupting JSON payloads such as Slack's
+  OAuth response.
 --%>
 <head>
   <spring:message code="connect.connected.defaultTitle" var="connectedDefaultTitle"/>
-  <title><c:out value="${appName}" default="${connectedDefaultTitle}"/></title>
+  <title>${empty appName ? connectedDefaultTitle : appName}</title>
 </head>
 <body>
 <div id="rs-connection-result"
-     data-channel="<c:out value='${connectionChannel}'/>"
-     data-type="<c:out value='${connectionType}'/>"
-     data-alias="<c:out value='${connectionAlias}'/>"
-     data-token="<c:out value='${connectionToken}'/>"
-     data-error="<c:out value='${connectionError}'/>"
-     data-response="<c:out value='${connectionResponse}'/>"></div>
+     data-channel="${connectionChannel}"
+     data-type="${connectionType}"
+     data-alias="${connectionAlias}"
+     data-token="${connectionToken}"
+     data-error="${connectionError}"
+     data-response="${connectionResponse}"></div>
 <p><spring:message code="connect.connected.closeWindowNotice"/></p>
 <script>
   window.addEventListener("load", () => {

--- a/src/main/webapp/WEB-INF/pages/connect/github/gitHubTreeView.jsp
+++ b/src/main/webapp/WEB-INF/pages/connect/github/gitHubTreeView.jsp
@@ -2,10 +2,10 @@
 
 <ul class="jqueryFileTree" style="display: none;">
 	<c:if test="${not empty error}">
-		<div><c:out value="${error}"></c:out></div>
+		<div>${error}</div>
 	</c:if>
 	<c:forEach items="${treeNodes}" var="node">
-		  <li class=${node.folder ? "directory collapsed" : "file"}>
+		  <li class="${node.folder ? 'directory collapsed' : 'file'}">
             <a href="#" data-name="${node.path}" rel="${node.repository}#${node.sha}#${node.fullPath}/" >${node.path}</a>
           </li>
 	</c:forEach>

--- a/src/main/webapp/scripts/externalTinymcePlugins/egnyte/script.js
+++ b/src/main/webapp/scripts/externalTinymcePlugins/egnyte/script.js
@@ -37,6 +37,21 @@ function initEgnyteDialog() {
 	});
 }
 
+var EGNYTE_OAUTH_STATE_KEY = 'egnyteOAuthState';
+
+// Random nonce sent as the OAuth `state` param and checked when the token comes
+// back, so a token can only be accepted for a flow this browser started (guards
+// against an attacker pasting a dialog.html#access_token=... URL to a victim).
+function generateEgnyteOAuthState() {
+	var bytes = new Uint8Array(16);
+	window.crypto.getRandomValues(bytes);
+	var state = Array.from(bytes, function (b) {
+		return b.toString(16).padStart(2, '0');
+	}).join('');
+	sessionStorage.setItem(EGNYTE_OAUTH_STATE_KEY, state);
+	return state;
+}
+
 function openAuthorizationDialogForEgnyte(onSuccess, egnyteDomain) {
 
 	var jqxhr = $.get('/deploymentproperties/ajax/property', { name: 'egnyte.client.id' });
@@ -45,9 +60,15 @@ function openAuthorizationDialogForEgnyte(onSuccess, egnyteDomain) {
 			alert(RS.msg("legacyjs.tinymce.egnyte.configMissing"));
 			return;
 		}
-		var authUrl = egnyteDomain + "/puboauth/token?client_id=" + egnyteClientId
-			+ "&redirect_uri=https://" + window.location.host + "/scripts/externalTinymcePlugins/egnyte/dialog.html"
-			+ "&scope=Egnyte.filesystem Egnyte.link&response_type=token";
+		var redirectUri = "https://" + window.location.host
+			+ "/scripts/externalTinymcePlugins/egnyte/dialog.html";
+		var state = generateEgnyteOAuthState();
+		var authUrl = egnyteDomain + "/puboauth/token"
+			+ "?client_id=" + encodeURIComponent(egnyteClientId)
+			+ "&redirect_uri=" + encodeURIComponent(redirectUri)
+			+ "&scope=" + encodeURIComponent("Egnyte.filesystem Egnyte.link")
+			+ "&response_type=token"
+			+ "&state=" + encodeURIComponent(state);
 
 		window.location = authUrl;
 	});
@@ -106,8 +127,18 @@ var insertSimpleEgnyteLink = function (egnyteDomain, egnyteElem) {
 $(document).ready(function () {
 	var hash = window.location.hash;
 
-	if (hash && hash.startsWith('#access_token=')) {
-		egnyteToken = hash.substring('#access_token='.length, hash.indexOf('&'));
+	if (hash && hash.indexOf('access_token=') !== -1) {
+		var fragment = new URLSearchParams(hash.substring(1));
+		var returnedToken = fragment.get('access_token');
+		var returnedState = fragment.get('state');
+		var expectedState = sessionStorage.getItem(EGNYTE_OAUTH_STATE_KEY);
+		sessionStorage.removeItem(EGNYTE_OAUTH_STATE_KEY);
+
+		if (!expectedState || returnedState !== expectedState) {
+			alert(RS.msg("legacyjs.tinymce.egnyte.authError"));
+			return;
+		}
+		egnyteToken = returnedToken;
 		$.post('/egnyte/egnyteSessionToken', { token: egnyteToken });
 	}
 

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.legacyJs.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.legacyJs.json
@@ -560,6 +560,7 @@
         "message": "Please confirm that you wish to cancel - the changes you made won't be saved."
       },
       "egnyte": {
+        "authError": "Egnyte authorization could not be verified. Please try connecting to Egnyte again.",
         "configMissing": "Egnyte is not configured properly on this RSpace instance. Please contact your System Admin",
         "domainMissing": "Egnyte Domain URL is not set, please go to Apps page and set it up."
       },

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -7485,6 +7485,7 @@ export default interface Resources {
           "message": "Please confirm that you wish to cancel - the changes you made won't be saved."
         },
         "egnyte": {
+          "authError": "Egnyte authorization could not be verified. Please try connecting to Egnyte again.",
           "configMissing": "Egnyte is not configured properly on this RSpace instance. Please contact your System Admin",
           "domainMissing": "Egnyte Domain URL is not set, please go to Apps page and set it up."
         },

--- a/src/test/java/com/researchspace/webapp/integrations/github/GitHubControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/github/GitHubControllerMVCIT.java
@@ -2,6 +2,8 @@ package com.researchspace.webapp.integrations.github;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
@@ -15,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.researchspace.Constants;
 import com.researchspace.model.User;
 import com.researchspace.service.IntegrationsHandler;
+import com.researchspace.session.SessionAttributeUtils;
 import com.researchspace.webapp.controller.MVCTestBase;
 import com.researchspace.webapp.integrations.github.GitHubController.TreeNode;
 import java.util.HashMap;
@@ -70,6 +73,9 @@ public class GitHubControllerMVCIT extends MVCTestBase {
     initUsers(user);
     logoutAndLoginAs(user);
 
+    String state = "test-oauth-state";
+    SessionAttributeUtils.setSessionAttribute(SessionAttributeUtils.RS_OAUTH_STATE, state);
+
     String authorizationCode = RandomStringUtils.randomAlphabetic(20);
 
     server
@@ -99,11 +105,34 @@ public class GitHubControllerMVCIT extends MVCTestBase {
             .perform(
                 get("/github/redirect_uri")
                     .param("code", authorizationCode)
+                    .param("state", state)
                     .principal(user::getUsername))
             .andExpect(status().isOk())
             .andExpect(view().name("connect/connected"))
             .andReturn();
     assertThat(result.getModelAndView().getModel().get("connectionToken"), is(GITHUB_ACCESS_TOKEN));
+  }
+
+  @Test
+  public void testAuthorizationRejectedWhenNoStateEstablished() throws Exception {
+    User user = createAndSaveUser(getRandomAlphabeticString("user"), Constants.USER_ROLE);
+    initUsers(user);
+    logoutAndLoginAs(user);
+
+    // No RS_OAUTH_STATE seeded, so the CSRF check must fail closed and never exchange the code.
+    MvcResult result =
+        this.mockMvc
+            .perform(
+                get("/github/redirect_uri")
+                    .param("code", RandomStringUtils.randomAlphabetic(20))
+                    .param("state", "forged-state")
+                    .principal(user::getUsername))
+            .andExpect(status().isOk())
+            .andExpect(view().name("connect/connected"))
+            .andReturn();
+    assertNull(result.getModelAndView().getModel().get("connectionToken"));
+    assertNotNull(result.getModelAndView().getModel().get("connectionError"));
+    server.verify();
   }
 
   private void addExampleRepositories(User user) {

--- a/src/test/java/com/researchspace/webapp/integrations/slack/SlackControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/slack/SlackControllerMVCIT.java
@@ -1,0 +1,84 @@
+package com.researchspace.webapp.integrations.slack;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.researchspace.Constants;
+import com.researchspace.model.User;
+import com.researchspace.session.SessionAttributeUtils;
+import com.researchspace.webapp.controller.MVCTestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@WebAppConfiguration
+public class SlackControllerMVCIT extends MVCTestBase {
+
+  private static final String CALLBACK_URL = "/slack/redirect_uri";
+  private static final String CONNECTED_VIEW = "connect/connected";
+  private static final String STATE_MISMATCH = "state' parameter is missing or doesn't match";
+
+  @Autowired private SlackController slackController;
+  private User user;
+
+  @Before
+  public void setUp() throws Exception {
+    mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    user = createAndSaveUser(getRandomAlphabeticString("user"), Constants.USER_ROLE);
+    initUsers(user);
+    logoutAndLoginAs(user);
+    SessionAttributeUtils.removeSessionAttribute(SessionAttributeUtils.RS_OAUTH_STATE);
+  }
+
+  @Test
+  public void callbackAcceptsMatchingState() throws Exception {
+    String oauthUrl = slackController.oauthUrl().getData();
+    String state =
+        UriComponentsBuilder.fromUriString(oauthUrl).build().getQueryParams().getFirst("state");
+    assertNotNull(state);
+
+    mockMvc
+        .perform(
+            get(CALLBACK_URL)
+                .param("error", "access_denied")
+                .param("state", state)
+                .principal(user::getUsername))
+        .andExpect(status().isOk())
+        .andExpect(view().name(CONNECTED_VIEW))
+        .andExpect(model().attribute("connectionError", containsString("access_denied")))
+        .andExpect(model().attribute("connectionError", not(containsString(STATE_MISMATCH))));
+  }
+
+  @Test
+  public void callbackRejectsMismatchedState() throws Exception {
+    SessionAttributeUtils.setSessionAttribute(
+        SessionAttributeUtils.RS_OAUTH_STATE, "expected-state");
+
+    mockMvc
+        .perform(
+            get(CALLBACK_URL)
+                .param("error", "access_denied")
+                .param("state", "forged-state")
+                .principal(user::getUsername))
+        .andExpect(status().isOk())
+        .andExpect(view().name(CONNECTED_VIEW))
+        .andExpect(model().attribute("connectionError", containsString(STATE_MISMATCH)));
+  }
+
+  @Test
+  public void callbackRejectsMissingState() throws Exception {
+    mockMvc
+        .perform(get(CALLBACK_URL).param("error", "access_denied").principal(user::getUsername))
+        .andExpect(status().isOk())
+        .andExpect(view().name(CONNECTED_VIEW))
+        .andExpect(model().attribute("connectionError", containsString(STATE_MISMATCH)));
+  }
+}


### PR DESCRIPTION
## Description

Fixes a batch of OAuth integration issues found while building the e2e integration test mocks (PRT-1131), plus a credential-logging cleanup across the OAuth controllers.

**Slack** — send `redirect_uri` on both the authorize URL and the token exchange (Slack rejects the exchange with `bad_redirect_uri` when the two differ; this caused channel connection to fail), and generate and verify a fail-closed OAuth `state` on the connect flow.

**GitHub** — send `redirect_uri` and a secure random `state` on the authorize URL, and verify `state` fail-closed on the callback. Now extends `BaseOAuth2Controller` to reuse the shared state helpers.

**Egnyte** — add an OAuth `state` nonce to block token injection via the URL fragment, `encodeURIComponent` the authorize params, and stop logging the token.

**Shared OAuth result page (`connected.jsp`)** — drop the redundant `<c:out>` wrappers. The global `EscapeXmlELResolver` already escapes every `${...}`, so wrapping again double-escaped every payload; that is what broke Slack channel save (double-escaped JSON failed `JSON.parse`).

**Credential logging** — stop logging access token in the Figshare, Protocols.io, Clustermarket and Dryad OAuth logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

