### PR TITLE
PRT-1136 Fetch DMP integration states with one cached call in the Gallery Create menu

### DIFF
--- a/src/main/webapp/ui/src/eln/apps/useIntegrationsEndpoint.ts
+++ b/src/main/webapp/ui/src/eln/apps/useIntegrationsEndpoint.ts
@@ -1236,7 +1236,7 @@ const encodeIntegrationState = <I extends Integration>(integration: I, data: Int
   throw new Error(`encodeIntegrationState has not been implemented for integration ${integration}`);
 };
 
-const ONE_MINUTE_IN_MS = 60 * 60 * 1000;
+const ONE_MINUTE_IN_MS = 60 * 1000;
 
 /**
  * This is a custom hook that allows for react components to fetch the current

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.story.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.story.tsx
@@ -3,6 +3,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import MenuItem from "@mui/material/MenuItem";
 import { type Theme, ThemeProvider } from "@mui/material/styles";
 import StyledEngineProvider from "@mui/styled-engine/StyledEngineProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { BrowserRouter } from "react-router";
@@ -29,31 +30,35 @@ function GalleryTheme({ children }: { children: React.ReactNode }): React.ReactN
 }
 
 function SidebarStory({ folderId, path }: { folderId: Id; path: ReadonlyArray<GalleryFile> | null }): React.ReactNode {
+  // Fresh client per mount so query caches don't leak between tests
+  const [queryClient] = React.useState(() => new QueryClient());
   return (
     <React.StrictMode>
       <ErrorBoundary>
         <BrowserRouter>
           <GalleryTheme>
-            <Analytics>
-              <UiPreferences>
-                <DisableDragAndDropByDefault>
-                  <Alerts>
-                    <LandmarksProvider>
-                      <Sidebar
-                        selectedSection="Images"
-                        setSelectedSection={() => {}}
-                        drawerOpen={true}
-                        setDrawerOpen={() => {}}
-                        folderId={{ tag: "success", value: folderId }}
-                        path={path}
-                        refreshListing={() => Promise.resolve()}
-                        id="1"
-                      />
-                    </LandmarksProvider>
-                  </Alerts>
-                </DisableDragAndDropByDefault>
-              </UiPreferences>
-            </Analytics>
+            <QueryClientProvider client={queryClient}>
+              <Analytics>
+                <UiPreferences>
+                  <DisableDragAndDropByDefault>
+                    <Alerts>
+                      <LandmarksProvider>
+                        <Sidebar
+                          selectedSection="Images"
+                          setSelectedSection={() => {}}
+                          drawerOpen={true}
+                          setDrawerOpen={() => {}}
+                          folderId={{ tag: "success", value: folderId }}
+                          path={path}
+                          refreshListing={() => Promise.resolve()}
+                          id="1"
+                        />
+                      </LandmarksProvider>
+                    </Alerts>
+                  </DisableDragAndDropByDefault>
+                </UiPreferences>
+              </Analytics>
+            </QueryClientProvider>
           </GalleryTheme>
         </BrowserRouter>
       </ErrorBoundary>

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.story.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.story.tsx
@@ -29,18 +29,20 @@ function GalleryTheme({ children }: { children: React.ReactNode }): React.ReactN
   );
 }
 
+/**
+ * The one client these stories render with. Anything that renders them more
+ * than once must call `queryClient.clear()` between renders, or a cached
+ * response from the first will still be there for the second.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
 function SidebarStory({ folderId, path }: { folderId: Id; path: ReadonlyArray<GalleryFile> | null }): React.ReactNode {
-  // Fresh client per mount so query caches don't leak between tests
-  const [queryClient] = React.useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            retry: false,
-          },
-        },
-      }),
-  );
   return (
     <React.StrictMode>
       <ErrorBoundary>

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.story.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.story.tsx
@@ -31,7 +31,16 @@ function GalleryTheme({ children }: { children: React.ReactNode }): React.ReactN
 
 function SidebarStory({ folderId, path }: { folderId: Id; path: ReadonlyArray<GalleryFile> | null }): React.ReactNode {
   // Fresh client per mount so query caches don't leak between tests
-  const [queryClient] = React.useState(() => new QueryClient());
+  const [queryClient] = React.useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+          },
+        },
+      }),
+  );
   return (
     <React.StrictMode>
       <ErrorBoundary>

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.test.tsx
@@ -7,7 +7,7 @@ import MockAdapter from "axios-mock-adapter";
 import { expectAccessible } from "@/__tests__/accessibility";
 import axios from "@/common/axios";
 import allIntegrationsAreDisabled from "../../apps/__tests__/allIntegrationsAreDisabled.json";
-import { DefaultSidebar, S3_FILESTORE_ID, S3FilestoreSidebar } from "./Sidebar.story";
+import { DefaultSidebar, queryClient, S3_FILESTORE_ID, S3FilestoreSidebar } from "./Sidebar.story";
 
 const mockAxios = new MockAdapter(axios);
 
@@ -77,6 +77,7 @@ describe("Sidebar", () => {
   beforeEach(() => {
     mockAxios.reset();
     mockNetwork();
+    queryClient.clear();
   });
 
   afterEach(() => {

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.test.tsx
@@ -84,6 +84,29 @@ describe("Sidebar", () => {
     vi.clearAllMocks();
   });
 
+  test("Reopening the create menu reuses the cached integration states", async () => {
+    const user = userEvent.setup();
+    render(<DefaultSidebar />);
+
+    const allIntegrationsCalls = () => mockAxios.history.get.filter((req) => req.url?.includes("allIntegrations"));
+    const integrationInfoCalls = () => mockAxios.history.get.filter((req) => req.url?.includes("integrationInfo"));
+
+    await user.click(await screen.findByRole("button", { name: "common:actions.create" }));
+    await screen.findByRole("menuitem", { name: /dmpIntegrations.dmponline/ });
+    expect(allIntegrationsCalls()).toHaveLength(1);
+    expect(integrationInfoCalls()).toHaveLength(0);
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: /dmpIntegrations.dmponline/ })).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "common:actions.create" }));
+    await screen.findByRole("menuitem", { name: /dmpIntegrations.dmponline/ });
+    expect(allIntegrationsCalls()).toHaveLength(1);
+    expect(integrationInfoCalls()).toHaveLength(0);
+  });
+
   test("Should have no axe violations", async () => {
     const { baseElement } = render(<DefaultSidebar />);
 

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.test.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 import MockAdapter from "axios-mock-adapter";
 import { expectAccessible } from "@/__tests__/accessibility";
 import axios from "@/common/axios";
+import allIntegrationsAreDisabled from "../../apps/__tests__/allIntegrationsAreDisabled.json";
 import { DefaultSidebar, S3_FILESTORE_ID, S3FilestoreSidebar } from "./Sidebar.story";
 
 const mockAxios = new MockAdapter(axios);
@@ -41,51 +42,21 @@ function mockNetwork() {
     data: "my-bucket/test/",
   });
 
-  // DMP integration status lookups (DmpMenuSection)
-  const integrationInfo = (
-    name: string,
-    overrides: Partial<{
-      displayName: string;
-      available: boolean;
-      enabled: boolean;
-    }> = {},
-  ) => ({
-    data: {
-      name,
-      displayName: overrides.displayName ?? name,
-      available: overrides.available ?? false,
-      enabled: overrides.enabled ?? false,
-      oauthConnected: false,
-      options: {},
-    },
-    error: null,
-    success: true,
-    errorMsg: null,
-  });
-  mockAxios
-    .onGet("/integration/integrationInfo", { params: { name: "DMPTOOL" } })
-    .reply(200, integrationInfo("DMPTOOL", { displayName: "DMPtool", available: true }));
-  mockAxios.onGet("/integration/integrationInfo", { params: { name: "DMPONLINE" } }).reply(
-    200,
-    integrationInfo("DMPONLINE", {
-      displayName: "DMPonline",
-      available: true,
-      enabled: true,
-    }),
-  );
-  mockAxios
-    .onGet("/integration/integrationInfo", { params: { name: "ARGOS" } })
-    .reply(200, integrationInfo("ARGOS", { displayName: "Argos" }));
-  mockAxios
-    .onGet("/integration/integrationInfo", { params: { name: "DSW" } })
-    .reply(200, integrationInfo("DSW", { displayName: "DSW" }));
-
-  // DmpMenuSection also fetches the aggregated integration list; the component
-  // tolerates failures here, but stub it to keep the console clean.
+  // DmpMenuSection derives the DMP menu from /allIntegrations
   mockAxios.onGet("/integration/allIntegrations").reply(200, {
-    success: true,
-    data: { DSW: { options: {} } },
-    error: null,
+    ...allIntegrationsAreDisabled,
+    data: {
+      ...allIntegrationsAreDisabled.data,
+      DMPTOOL: {
+        ...allIntegrationsAreDisabled.data.DMPTOOL,
+        available: true,
+      },
+      DMPONLINE: {
+        ...allIntegrationsAreDisabled.data.DMPONLINE,
+        available: true,
+        enabled: true,
+      },
+    },
   });
 
   // AddFilestoreMenuItem fetches the configured filesystems on mount.

--- a/src/main/webapp/ui/src/eln/gallery/components/Sidebar.tsx
+++ b/src/main/webapp/ui/src/eln/gallery/components/Sidebar.tsx
@@ -14,12 +14,13 @@ import Divider from "@mui/material/Divider";
 import List from "@mui/material/List";
 import { paperClasses } from "@mui/material/Paper";
 import TextField from "@mui/material/TextField";
+import { useQuery } from "@tanstack/react-query";
 import { autorun } from "mobx";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import axios from "@/common/axios";
-import DSWAccentMenuItem, { type DswConfig } from "@/eln-dmp-integration/DSW/DSWAccentMenuItem";
+import DSWAccentMenuItem from "@/eln-dmp-integration/DSW/DSWAccentMenuItem";
 import AccentMenuItem from "../../../components/AccentMenuItem";
 import { Drawer } from "../../../components/DialogBoundary";
 import DrawerTab from "../../../components/DrawerTab";
@@ -30,16 +31,16 @@ import ArgosAccentMenuItem from "../../../eln-dmp-integration/Argos/ArgosAccentM
 import DMPAssistantAccentMenuItem from "../../../eln-dmp-integration/DMPAssistant/DMPAssistantAccentMenuItem";
 import DMPOnlineAccentMenuItem from "../../../eln-dmp-integration/DMPOnline/DMPOnlineAccentMenuItem";
 import DMPToolAccentMenuItem from "../../../eln-dmp-integration/DMPTool/DMPToolAccentMenuItem";
-import { useIntegrationIsAllowedAndEnabled } from "../../../hooks/api/integrationHelpers";
 import { useDeploymentProperty } from "../../../hooks/api/useDeploymentProperty";
 import useOauthToken from "../../../hooks/auth/useOauthToken";
 import useViewportDimensions from "../../../hooks/browser/useViewportDimensions";
 import useOneDimensionalRovingTabIndex from "../../../hooks/ui/useOneDimensionalRovingTabIndex";
 import AnalyticsContext from "../../../stores/contexts/Analytics";
+import * as ArrayUtils from "../../../util/ArrayUtils";
 import * as FetchingData from "../../../util/fetchingData";
 import * as Parsers from "../../../util/parsers";
 import Result from "../../../util/result";
-import type { FetchedState, Integration } from "../../apps/useIntegrationsEndpoint";
+import { useIntegrationsEndpoint } from "../../apps/useIntegrationsEndpoint";
 import { type GallerySection, gallerySectionIcon } from "../common";
 import { useGalleryActions } from "../useGalleryActions";
 import { asWritableS3Filestore, type GalleryFile, type Id, RemoteFile } from "../useGalleryListing";
@@ -345,14 +346,24 @@ type DmpMenuSectionArgs = {
   showDmpPanel: () => void;
 };
 const DmpMenuSection = ({ onDialogClose, showDmpPanel }: DmpMenuSectionArgs) => {
-  const [dswConnections, setDswConnections] = React.useState<null | DswConfig[]>(null);
-  const showArgos = FetchingData.getSuccessValue(useIntegrationIsAllowedAndEnabled("ARGOS")).orElse(false);
-  const showDmpAssistant = FetchingData.getSuccessValue(useIntegrationIsAllowedAndEnabled("DMPASSISTANT")).orElse(
-    false,
-  );
-  const showDmponline = FetchingData.getSuccessValue(useIntegrationIsAllowedAndEnabled("DMPONLINE")).orElse(false);
-  const showDmptool = FetchingData.getSuccessValue(useIntegrationIsAllowedAndEnabled("DMPTOOL")).orElse(false);
-  const showDsw = FetchingData.getSuccessValue(useIntegrationIsAllowedAndEnabled("DSW")).orElse(false);
+  /*
+   * One /allIntegrations call covers every DMP source. Cached because the
+   * menu remounts this component on every open.
+   */
+  const { allIntegrations } = useIntegrationsEndpoint();
+  const { data: integrationStates } = useQuery({
+    queryKey: ["integration", "allIntegrations"],
+    queryFn: () => allIntegrations(),
+    staleTime: 60_000,
+  });
+  const showArgos = integrationStates?.ARGOS.mode === "ENABLED";
+  const showDmpAssistant = integrationStates?.DMPASSISTANT.mode === "ENABLED";
+  const showDmponline = integrationStates?.DMPONLINE.mode === "ENABLED";
+  const showDmptool = integrationStates?.DMPTOOL.mode === "ENABLED";
+  const showDsw = integrationStates?.DSW.mode === "ENABLED";
+  const dswConnections = integrationStates
+    ? ArrayUtils.mapOptional((config) => config, integrationStates.DSW.credentials)
+    : [];
   React.useEffect(() => {
     /*
      * This is to maintain backwards compatibility with the old Gallery. It
@@ -363,39 +374,6 @@ const DmpMenuSection = ({ onDialogClose, showDmpPanel }: DmpMenuSectionArgs) => 
     // @ts-expect-error gallery is a global function
     window.gallery = showDmpPanel;
   }, [showDmpPanel]);
-  React.useEffect(() => {
-    void (async () => {
-      const ONE_MINUTE_IN_MS = 60 * 1000;
-      const api = axios.create({
-        baseURL: "/integration",
-        timeout: ONE_MINUTE_IN_MS,
-      });
-      try {
-        const states = await api.get<
-          | {
-              success: true;
-              data: { [integration in Integration]: FetchedState };
-              error: null;
-            }
-          | {
-              success: false;
-              data: null;
-              error: string;
-            }
-        >("allIntegrations");
-        if (states.data.success) {
-          const data = states.data.data;
-          const configs = Object.entries(data.DSW.options).map(([_optionsId, config]) => {
-            return config as DswConfig;
-          });
-          setDswConnections(configs);
-        }
-      } catch (e) {
-        console.error(e);
-        setDswConnections([]);
-      }
-    })();
-  }, []);
 
   const { t } = useTranslation("gallery");
   if (!showArgos && !showDmpAssistant && !showDmponline && !showDmptool && !showDsw) return null;
@@ -409,8 +387,8 @@ const DmpMenuSection = ({ onDialogClose, showDmpPanel }: DmpMenuSectionArgs) => 
       {showDmponline && <DMPOnlineAccentMenuItem onDialogClose={onDialogClose} />}
       {showDmptool && <DMPToolAccentMenuItem onDialogClose={onDialogClose} />}
       {showDsw &&
-        dswConnections?.map((connection, _index) => {
-          return <DSWAccentMenuItem onDialogClose={onDialogClose} connection={connection} />;
+        dswConnections.map((connection) => {
+          return <DSWAccentMenuItem key={connection.optionsId} onDialogClose={onDialogClose} connection={connection} />;
         })}
     </>
   );


### PR DESCRIPTION
## Description ##
Opening the Gallery's Create menu fetched each DMP source integration's state separately (5 GETs to `/integration/integrationInfo`) plus an unconditional `/integration/allIntegrations` call, and repeated them all on every open because the menu unmounts its items on close. `DmpMenuSection` now derives all of the DMP menu items, including DSW server connections, from a single React Query fetch of `allIntegrations`, cached for a minute. Roughly 12 requests on first open becomes 1; reopening within the cache window makes 0.

Also fixes `useIntegrationsEndpoint`'s mislabeled `ONE_MINUTE_IN_MS` constant, which was actually one hour, so all calls through that hook (Apps page included) now get the intended 60s timeout. And gives the DSW menu items proper React keys, dropping malformed DSW configs via the existing `decodeDsw` parser instead of casting them unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)