### PR TITLE
Don't allow committing deployment.properties / .env files

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Seed dev deployment.properties
         run: |
-          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+          cp -f src/main/resources/deployments/dev/deployment.properties.example \
             src/main/resources/deployments/dev/deployment.properties
 
       - name: Run unit + Spring tests with coverage
@@ -190,7 +190,7 @@ jobs:
 
       - name: Seed dev deployment.properties
         run: |
-          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+          cp -f src/main/resources/deployments/dev/deployment.properties.example \
             src/main/resources/deployments/dev/deployment.properties
 
       - name: Run integration tests with coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,6 +81,11 @@ jobs:
           rm -rf $RS_FILE_BASE
           mkdir -p $RS_FILE_BASE
 
+      - name: Seed dev deployment.properties
+        run: |
+          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+            src/main/resources/deployments/dev/deployment.properties
+
       - name: Run unit + Spring tests with coverage
         # The jacoco `report` goal is bound to `verify`, which `mvn test` never
         # reaches, so invoke it explicitly to emit target/site/jacoco/jacoco.xml.
@@ -182,6 +187,11 @@ jobs:
         run: |
           rm -rf $RS_FILE_BASE
           mkdir -p $RS_FILE_BASE
+
+      - name: Seed dev deployment.properties
+        run: |
+          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+            src/main/resources/deployments/dev/deployment.properties
 
       - name: Run integration tests with coverage
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
       - run: corepack enable
       - name: Seed dev deployment.properties
         run: |
-          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+          cp -f src/main/resources/deployments/dev/deployment.properties.example \
             src/main/resources/deployments/dev/deployment.properties
 
       - name: Package WAR (frontend + backend)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,11 @@ jobs:
         with:
           node-version: 24
       - run: corepack enable
+      - name: Seed dev deployment.properties
+        run: |
+          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+            src/main/resources/deployments/dev/deployment.properties
+
       - name: Package WAR (frontend + backend)
         run: ./mvnw clean package -DgenerateReactDist -DskipTests -Djava-version=${{ matrix.java-version }} -Djava-vendor=${{ inputs.java_vendor }} -Dtimestamp=${{ github.run_id }}
       - name: Upload WAR

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -102,6 +102,11 @@ jobs:
           rm -rf $RS_FILE_BASE
           mkdir -p $RS_FILE_BASE
 
+      - name: Seed dev deployment.properties
+        run: |
+          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+            src/main/resources/deployments/dev/deployment.properties
+
       - name: Run fast tests
         run: |
           # ponytail: forkCount=2 is conservative; raise it / isolate RS_FILE_BASE per fork (${surefire.forkNumber}) if file-collision flakiness appears
@@ -616,6 +621,11 @@ jobs:
           rm -rf $RS_FILE_BASE
           mkdir -p $RS_FILE_BASE
 
+      - name: Seed dev deployment.properties
+        run: |
+          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+            src/main/resources/deployments/dev/deployment.properties
+
       - name: Run Spring tests
         run: |
           ./mvnw clean test -Denvironment=drop-recreate-db \
@@ -703,6 +713,11 @@ jobs:
           rm -rf $RS_FILE_BASE
           mkdir -p $RS_FILE_BASE
 
+      - name: Seed dev deployment.properties
+        run: |
+          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+            src/main/resources/deployments/dev/deployment.properties
+
       - name: Run integration tests
         run: |
           ./mvnw clean integration-test -DskipUnitTests=true -Denvironment=drop-recreate-db \
@@ -773,6 +788,11 @@ jobs:
         run: |
           rm -rf $RS_FILE_BASE
           mkdir -p $RS_FILE_BASE
+
+      - name: Seed dev deployment.properties
+        run: |
+          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+            src/main/resources/deployments/dev/deployment.properties
 
       - name: Build project
         run: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Seed dev deployment.properties
         run: |
-          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+          cp -f src/main/resources/deployments/dev/deployment.properties.example \
             src/main/resources/deployments/dev/deployment.properties
 
       - name: Run fast tests
@@ -623,7 +623,7 @@ jobs:
 
       - name: Seed dev deployment.properties
         run: |
-          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+          cp -f src/main/resources/deployments/dev/deployment.properties.example \
             src/main/resources/deployments/dev/deployment.properties
 
       - name: Run Spring tests
@@ -715,7 +715,7 @@ jobs:
 
       - name: Seed dev deployment.properties
         run: |
-          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+          cp -f src/main/resources/deployments/dev/deployment.properties.example \
             src/main/resources/deployments/dev/deployment.properties
 
       - name: Run integration tests
@@ -791,7 +791,7 @@ jobs:
 
       - name: Seed dev deployment.properties
         run: |
-          cp -n src/main/resources/deployments/dev/deployment.properties.example \
+          cp -f src/main/resources/deployments/dev/deployment.properties.example \
             src/main/resources/deployments/dev/deployment.properties
 
       - name: Build project

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ src/main/webapp/ui/coverage
 /playwright-report/
 # Playwright MCP output (snapshots, console logs, screenshots from browser driving)
 .playwright-mcp/
+
+# Local dev deployment properties, copied from deployment.properties.example (see PropertyFiles.md)
+src/main/resources/deployments/dev/deployment.properties

--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -99,6 +99,11 @@ property that has a sensible production value live in
 `src/main/resources/deployments/defaultDeployment.properties`; only put dev-specific overrides and
 your own credentials in the copy.
 
+To add or change a property for the whole team, edit `deployment.properties.example` (and
+`defaultDeployment.properties` if it has a production value) and copy it down again. Your own
+`deployment.properties` is git-ignored and the pre-commit hook refuses to stage it, so a change
+made only there never reaches anyone else or CI.
+
 #### Sanity check
 
 As the 1st goal, you should be able to compile the java side of the code. 

--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -83,6 +83,22 @@ Current location of the codebase is https://github.com/rspace-os/rspace-web
 
 We recommend using a Git client to download and update the source code.
 
+#### Create your local deployment.properties
+
+`src/main/resources/deployments/dev/deployment.properties` holds your local settings and
+credentials, so it is gitignored. Spring will not start without it, so copy the checked-in
+template once after cloning:
+
+```bash
+cp src/main/resources/deployments/dev/deployment.properties.example \
+   src/main/resources/deployments/dev/deployment.properties
+```
+
+The Docker dev stack (`./docker/dev/rspace-dev up`) and CI do this for you. Defaults for every
+property that has a sensible production value live in
+`src/main/resources/deployments/defaultDeployment.properties`; only put dev-specific overrides and
+your own credentials in the copy.
+
 #### Sanity check
 
 As the 1st goal, you should be able to compile the java side of the code. 

--- a/DevDocs/DeveloperNotes/PropertyFiles.md
+++ b/DevDocs/DeveloperNotes/PropertyFiles.md
@@ -39,6 +39,22 @@ Property files can be loaded from the classpath, or from external files.
 To provide a uniform developer experience, property files  are located on the classpath in various subfolders of 
 `src/main/resources/deployments`
 
+`deployments/dev/deployment.properties` is **not** checked in — it holds local credentials. Copy it
+from the checked-in template before your first build; Spring fails to start if it is missing:
+
+```bash
+cp src/main/resources/deployments/dev/deployment.properties.example \
+   src/main/resources/deployments/dev/deployment.properties
+```
+
+`./docker/dev/rspace-dev`, the GitHub Actions workflows and the Jenkinsfile all run this copy
+automatically. Keep the `.example` template limited to dev-specific overrides and credential slots:
+anything with a sensible production value belongs in `defaultDeployment.properties`.
+
+If you already had a `deployment.properties` from before it was untracked, back it up before
+pulling: git deletes the file if you never edited it, and refuses to switch if you did. Restore
+your backup over the fresh copy afterwards.
+
 At build time, the placeholder `${propertyFileDirPlaceholder}/deployment.properties` in
 `applicationContext-resources.xml` is resolved by Maven
 using values defined in pom.xml. Typically, this will resolve ${propertyFileDirPlaceholder} to `classpath:deployments/dev`
@@ -66,6 +82,10 @@ may be variable between different deployment builds, and might need to
 be edited after installation (i.e., post-build)
 then add it to defaultDeployment.properties. Otherwise, add it to
 another property file. E.g., rs.properties.
+
+If the property also needs a different value locally, add the override to
+`deployments/dev/deployment.properties.example` (and to your own untracked copy) so other
+developers pick it up.
 
 For each deployment/subfolder, override if need be, if it is clear what
 value should be used by different deployments.

--- a/DevDocs/DeveloperNotes/PropertyFiles.md
+++ b/DevDocs/DeveloperNotes/PropertyFiles.md
@@ -47,9 +47,10 @@ cp src/main/resources/deployments/dev/deployment.properties.example \
    src/main/resources/deployments/dev/deployment.properties
 ```
 
-`./docker/dev/rspace-dev`, the GitHub Actions workflows and the Jenkinsfile all run this copy
-automatically. Keep the `.example` template limited to dev-specific overrides and credential slots:
-anything with a sensible production value belongs in `defaultDeployment.properties`.
+`./docker/dev/rspace-dev` makes this copy automatically if you have no file yet, and CI overwrites
+it from the template on every run, so a change that lives only in your copy never reaches a build.
+Keep the `.example` template limited to dev-specific overrides and credential slots: anything with
+a sensible production value belongs in `defaultDeployment.properties`.
 
 If you already had a `deployment.properties` from before it was untracked, back it up before
 pulling: git deletes the file if you never edited it, and refuses to switch if you did. Restore
@@ -86,6 +87,13 @@ another property file. E.g., rs.properties.
 If the property also needs a different value locally, add the override to
 `deployments/dev/deployment.properties.example` (and to your own untracked copy) so other
 developers pick it up.
+
+**Editing your own `deployments/dev/deployment.properties` is never enough.** That file is
+git-ignored, so a property you add or change there exists only on your machine: colleagues,
+CI and the Docker dev stack all seed a fresh copy from
+`deployment.properties.example` and will never see it. The pre-commit hook blocks the file
+outright, so put the change in the template (and in `defaultDeployment.properties` when it has a
+sensible production value), then copy it down into your own file.
 
 For each deployment/subfolder, override if need be, if it is clear what
 value should be used by different deployments.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                 sh "rm -rf $RS_FILE_BASE"
                 sh "mkdir -p $RS_FILE_BASE"
                 echo "Workspace jenkins var is $WORKSPACE"
-                sh 'cp -n src/main/resources/deployments/dev/deployment.properties.example src/main/resources/deployments/dev/deployment.properties'
+                sh 'cp -f src/main/resources/deployments/dev/deployment.properties.example src/main/resources/deployments/dev/deployment.properties'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
                 sh "rm -rf $RS_FILE_BASE"
                 sh "mkdir -p $RS_FILE_BASE"
                 echo "Workspace jenkins var is $WORKSPACE"
+                sh 'cp -n src/main/resources/deployments/dev/deployment.properties.example src/main/resources/deployments/dev/deployment.properties'
             }
         }
 

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -32,6 +32,11 @@ fully isolated RSpace at the same time:
 Heavy, safe-to-share caches (the Maven `~/.m2` repository and the pnpm store)
 are reused across worktrees so you only download dependencies once.
 
+On first run `rspace-dev` also creates the git-ignored
+`src/main/resources/deployments/dev/deployment.properties` from the checked-in
+`deployment.properties.example`, since Spring will not start without it. Edit the copy to add your
+local credentials.
+
 ## Prerequisites
 
 - Docker Engine + Docker Compose v2 (Docker Desktop on macOS/Windows works).

--- a/docker/dev/rspace-dev
+++ b/docker/dev/rspace-dev
@@ -96,6 +96,17 @@ path_offset() {
   printf '%s' "$((sum % 200))"
 }
 
+# The dev property file is git-ignored (it holds local credentials) and Spring will not start
+# without it, so seed it from the checked-in template.
+ensure_deployment_properties() {
+  local dir="${RSPACE_SRC}/src/main/resources/deployments/dev"
+  if [ -f "${dir}/deployment.properties" ]; then
+    return 0
+  fi
+  cp "${dir}/deployment.properties.example" "${dir}/deployment.properties"
+  echo "rspace-dev: created ${dir}/deployment.properties from the .example template" >&2
+}
+
 ensure_env() {
   if [ -f "${ENV_FILE}" ]; then
     return 0
@@ -137,6 +148,7 @@ env_get() { grep -E "^$1=" "${ENV_FILE}" 2>/dev/null | head -n1 | cut -d= -f2-; 
 
 compose() {
   ensure_env
+  ensure_deployment_properties
   # Activate the optional chemistry profile when enabled in .env, so every
   # compose subcommand (up/down/ps/logs/...) consistently includes the service.
   local profiles=""

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,6 +5,23 @@ colors: false
 pre-commit:
   parallel: true
   commands:
+    # Refuse to commit local secret/config files. `.gitignore` already covers
+    # the known paths, but `git add -f` and new locations slip through, so match
+    # by filename instead: any `.env`/`.env.*` and any `deployment.properties`.
+    # Exempt the committed templates (`*.example`) and the checked-in defaults
+    # (`defaultDeployment.properties`). Escape hatch: `git commit --no-verify`.
+    secret-files:
+      run: |
+        blocked=$(printf '%s\n' {staged_files} \
+          | grep -iE '(^|/)(\.env(\..+)?|.*deployment\.properties)$' \
+          | grep -viE '\.example$|(^|/)defaultDeployment\.properties$' \
+          | sed 's/^/  /' || true)
+        if [ -n "$blocked" ]; then
+          echo "Refusing to commit local secret/config files:" >&2
+          echo "$blocked" >&2
+          echo "Unstage them (git restore --staged <file>), or use --no-verify if intentional." >&2
+          exit 1
+        fi
     # Fail the commit if any staged Java file is not spotless-formatted.
     # spotlessFiles matches the absolute path via String#matches, so each
     # staged (repo-relative) path is prefixed with `.*` to anchor correctly.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,18 +7,27 @@ pre-commit:
   commands:
     # Refuse to commit local secret/config files. `.gitignore` already covers
     # the known paths, but `git add -f` and new locations slip through, so match
-    # by filename instead: any `.env`/`.env.*` and any `deployment.properties`.
-    # Exempt the committed templates (`*.example`) and the checked-in defaults
-    # (`defaultDeployment.properties`). Escape hatch: `git commit --no-verify`.
+    # by filename instead: `.env`/`.env.*` and `deployment.properties` exactly.
+    # The name is anchored, so `defaultDeployment.properties` (the checked-in
+    # defaults) and `deployment.properties.example` (the dev template) do not
+    # match; `*.example` is excluded so `.env.example` stays committable.
+    # To add or change a property for everyone, edit the template
+    # `deployments/dev/deployment.properties.example`, and
+    # `deployments/defaultDeployment.properties` when the property has a
+    # sensible production value. Never your own `deployment.properties`: it is
+    # git-ignored, so nobody else would ever see the change.
+    # Escape hatch: `git commit --no-verify`.
     secret-files:
       run: |
         blocked=$(printf '%s\n' {staged_files} \
-          | grep -iE '(^|/)(\.env(\..+)?|.*deployment\.properties)$' \
-          | grep -viE '\.example$|(^|/)defaultDeployment\.properties$' \
+          | grep -iE '(^|/)(\.env(\..+)?|deployment\.properties)$' \
+          | grep -viE '\.example$' \
           | sed 's/^/  /' || true)
         if [ -n "$blocked" ]; then
           echo "Refusing to commit local secret/config files:" >&2
           echo "$blocked" >&2
+          echo "To share a property change, edit deployment.properties.example (and" >&2
+          echo "defaultDeployment.properties if it has a production value) instead." >&2
           echo "Unstage them (git restore --staged <file>), or use --no-verify if intentional." >&2
           exit 1
         fi

--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,8 @@
           placeholders resolve from deployment.properties at runtime. -->
         <excludes>
           <exclude>applicationContext-dao.xml</exclude>
+          <!-- seed template for the git-ignored deployment.properties; never packaged -->
+          <exclude>deployments/*/deployment.properties.example</exclude>
         </excludes>
       </resource>
 

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -183,10 +183,15 @@ rs.indexOnstartup=true
 onedrive.client.id=
 onedrive.redirect=
 egnyte.client.id=
+egnyte.internal.app.client.id=
 owncloud.url=
 owncloud.server.name=ownCloud
+owncloud.client.id=
+owncloud.secret=
 nextcloud.url=
 nextcloud.server.name=ownCloud
+nextcloud.client.id=
+nextcloud.secret=
 
 box.client.id=
 box.client.secret=
@@ -232,6 +237,7 @@ googledrive.client.id=
 
 slack.client.id=
 slack.secret=
+slack.verification.token=
 slack.oauth.authorize.url=https://slack.com/oauth/authorize
 slack.api.base.url=https://slack.com/api
 
@@ -249,10 +255,14 @@ user.signup.captcha.verify.url=https://www.google.com/recaptcha/api/siteverify
 
 ### 3rd party API endpoints
 ## GitHub integration
+github.client.id=
+github.secret=
 github.api.base.url=https://api.github.com
 github.oauth.access.token.url=https://github.com/login/oauth/access_token
 github.oauth.authorize.url=https://github.com/login/oauth/authorize
 ## ORCID integration
+orcid.client.id=
+orcid.client.secret=
 orcid.oauth.token.url=https://orcid.org/oauth/token
 ## PubChem chemical import
 pubchem.base.url=https://pubchem.ncbi.nlm.nih.gov
@@ -409,6 +419,8 @@ rs.hibernate.searchIndex.exclusiveIndex=true
 
 ## Enable Spring cache manager. Does not affect Hibernate 2nd level cache
 cache.apply=true
+## Optional per-cache heap override (max entries). Blank leaves the ehcache.xml value in place.
+cache.com.researchspace.model.UserGroup=
 ## RSPAC-1259 configure stack trace in error message:
 errorPage.showStackTrace=false
 
@@ -464,11 +476,15 @@ inventory.import.instrumentsLimit=500
 
 ## AWS configuration properties
 aws.s3.hasS3Access=false
+## Required when aws.s3.hasS3Access=true
+aws.s3.bucketName=
+aws.s3.archivePath=
+aws.s3.region=
 
 
 #Clustermarket is now rebranded as Calira.
-#clustermarket.client.id=
-#clustermarket.secret=
+clustermarket.client.id=
+clustermarket.secret=
 clustermarket.api.url=https://api.clustermarket.com/v1/
 clustermarket.web.url=https://app.clustermarket.com/
 
@@ -536,6 +552,14 @@ default.admin.password=admin1234
 default.sysadmin.password=sysWisc23!
 
 pyrat.server.config=
+
+## Left unset here so a production deployment never seeds users or creates developer groups.
+## Set them in ${propertyFileDir}/deployment.properties; see deployments/dev/deployment.properties.example.
+#rs.usergroup.initfile=deployments/dev/initUsers.csv
+#rs.dev.groupcreation=false
+## Signing secret, blank by default in PropertyHolder. Set a real value per deployment.
+#jwt.secret=
+
 deployment.description=Default deployment setup
 deployment.helpEmail=support@researchspace.com
 

--- a/src/main/resources/deployments/dev/deployment.properties.example
+++ b/src/main/resources/deployments/dev/deployment.properties.example
@@ -1,8 +1,16 @@
+# Template for the local dev property file. Copy it before your first build:
+#
+#   cp src/main/resources/deployments/dev/deployment.properties.example \
+#      src/main/resources/deployments/dev/deployment.properties
+#
+# The copy is git-ignored, so put your credentials there rather than here. Anything with a sensible
+# production value belongs in ../defaultDeployment.properties; this file holds only dev overrides
+# and the credential slots for opt-in real-connection tests.
+
 rs.customer.name=University of RSpace (Localhost)
 rs.customer.name.short=RSpace Local
 
 rs.usergroup.initfile=deployments/dev/initUsers.csv
-cache.com.researchspace.model.UserGroup=123
 email.enabled=false
 license.server.active=false
 
@@ -73,9 +81,6 @@ clustermarket.client.id=
 clustermarket.secret=
 clustermarket.api.url=https://api.clustermarket.dev/v1/
 clustermarket.web.url=https://app.clustermarket.dev/
-
-# Jove deployment props
-jove.api.access.enabled=true
 
 # omero
 #omero.api.url=https://demo.openmicroscopy.org/

--- a/src/main/resources/deployments/dev/deployment.properties.example
+++ b/src/main/resources/deployments/dev/deployment.properties.example
@@ -6,6 +6,10 @@
 # The copy is git-ignored, so put your credentials there rather than here. Anything with a sensible
 # production value belongs in ../defaultDeployment.properties; this file holds only dev overrides
 # and the credential slots for opt-in real-connection tests.
+#
+# To add or change a property for everyone, edit THIS file (and ../defaultDeployment.properties
+# where the property has a production value), then copy it down. A change made only in your own
+# git-ignored deployment.properties is invisible to colleagues and is overwritten in CI.
 
 rs.customer.name=University of RSpace (Localhost)
 rs.customer.name.short=RSpace Local


### PR DESCRIPTION
## Description ##
Don't allow committing deployment.properties / .env files, in order to avoid credentials leaking.