### PR TITLE
PRT-1143: rename "Linked Documents" to "Linked Items" on the Inventory info panel

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/LinkedItems.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/LinkedItems.tsx
@@ -64,15 +64,15 @@ function referencingItemsEndpoint(globalId: string): string | null {
 function ReferencingItemsTable({ items }: { items: ReferencingItem[] }): React.ReactElement {
   const { t } = useTranslation("inventory");
   return (
-    <Table size="small" aria-label={t("moreInfo.linkedDocuments.inventoryLinksTable")}>
+    <Table size="small" aria-label={t("moreInfo.linkedItems.inventoryLinksTable")}>
       <TableHead>
         <TableRow>
-          <TableCell>{t("moreInfo.linkedDocuments.columns.name")}</TableCell>
+          <TableCell>{t("moreInfo.linkedItems.columns.name")}</TableCell>
           <TableCell>{t("moreInfo.globalId")}</TableCell>
-          <TableCell>{t("moreInfo.linkedDocuments.columns.relation")}</TableCell>
+          <TableCell>{t("moreInfo.linkedItems.columns.relation")}</TableCell>
           {/* Which version of THIS item the linking item points at (not a version
               of the linking item itself). */}
-          <TableCell>{t("moreInfo.linkedDocuments.columns.linkedVersion")}</TableCell>
+          <TableCell>{t("moreInfo.linkedItems.columns.linkedVersion")}</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -87,9 +87,7 @@ function ReferencingItemsTable({ items }: { items: ReferencingItem[] }): React.R
               </a>
             </TableCell>
             <TableCell>{item.relationType}</TableCell>
-            <TableCell>
-              {item.versionPin != null ? `v${item.versionPin}` : t("moreInfo.linkedDocuments.latest")}
-            </TableCell>
+            <TableCell>{item.versionPin != null ? `v${item.versionPin}` : t("moreInfo.linkedItems.latest")}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -100,12 +98,12 @@ function ReferencingItemsTable({ items }: { items: ReferencingItem[] }): React.R
 function DocumentsTable({ documents }: { documents: RsSet<Document> }): React.ReactElement {
   const { t } = useTranslation("inventory");
   return (
-    <Table aria-label={t("moreInfo.linkedDocuments.documentsTable")}>
+    <Table aria-label={t("moreInfo.linkedItems.documentsTable")}>
       <TableHead>
         <TableRow>
-          <TableCell>{t("moreInfo.linkedDocuments.columns.name")}</TableCell>
+          <TableCell>{t("moreInfo.linkedItems.columns.name")}</TableCell>
           <TableCell>{t("moreInfo.globalId")}</TableCell>
-          <TableCell>{t("moreInfo.linkedDocuments.columns.owner")}</TableCell>
+          <TableCell>{t("moreInfo.linkedItems.columns.owner")}</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -144,33 +142,33 @@ function DialogContents({ state }: { state: State }): React.ReactNode {
       <>
         <Box>
           <Typography variant="subtitle1" gutterBottom>
-            {t("moreInfo.linkedDocuments.documentsTable")}
+            {t("moreInfo.linkedItems.documentsTable")}
           </Typography>
           {documents.size > 0 ? (
             <DocumentsTable documents={documents} />
           ) : (
-            <NoValue label={t("moreInfo.linkedDocuments.noDocuments")} />
+            <NoValue label={t("moreInfo.linkedItems.noDocuments")} />
           )}
         </Box>
         <Box sx={{ mt: 2 }}>
           <Typography variant="subtitle1" gutterBottom>
-            {t("moreInfo.linkedDocuments.inventoryLinksTable")}
+            {t("moreInfo.linkedItems.inventoryLinksTable")}
           </Typography>
           {referencingItems.length > 0 ? (
             <ReferencingItemsTable items={referencingItems} />
           ) : (
-            <NoValue label={t("moreInfo.linkedDocuments.noInventoryLinks")} />
+            <NoValue label={t("moreInfo.linkedItems.noInventoryLinks")} />
           )}
         </Box>
         {bothEmpty && (
           <>
             <Box sx={{ mt: 1 }}>
               <Typography variant="body1">
-                <TransRichText i18nKey="inventory:moreInfo.linkedDocumentsHelp.listOfMaterials" />
+                <TransRichText i18nKey="inventory:moreInfo.linkedItemsHelp.listOfMaterials" />
               </Typography>
             </Box>
             <Box sx={{ mt: 1 }}>
-              <Typography variant="body1">{t("moreInfo.linkedDocumentsHelp.linkField")}</Typography>
+              <Typography variant="body1">{t("moreInfo.linkedItemsHelp.linkField")}</Typography>
             </Box>
           </>
         )}
@@ -180,12 +178,12 @@ function DialogContents({ state }: { state: State }): React.ReactNode {
   return null;
 }
 
-type LinkedDocumentsArgs = {
+type LinkedItemsArgs = {
   globalId: GlobalId;
   factory: Factory | null;
 };
 
-function LinkedDocuments({ globalId, factory }: LinkedDocumentsArgs): React.ReactNode {
+function LinkedItems({ globalId, factory }: LinkedItemsArgs): React.ReactNode {
   const { t } = useTranslation(["inventory", "common"]);
   const [open, setOpen] = useState(false);
   const [state, setState] = useState<State>({ state: "init" });
@@ -240,7 +238,7 @@ function LinkedDocuments({ globalId, factory }: LinkedDocumentsArgs): React.Reac
   return (
     <Grid>
       <FormControl component="fieldset" style={{ alignItems: "flex-start" }}>
-        <FormLabel component="legend">{t("moreInfo.linkedDocuments.title")}</FormLabel>
+        <FormLabel component="legend">{t("moreInfo.linkedItems.title")}</FormLabel>
         <FormGroup>
           <Button
             variant="outlined"
@@ -250,10 +248,10 @@ function LinkedDocuments({ globalId, factory }: LinkedDocumentsArgs): React.Reac
             }}
             disabled={!factory}
           >
-            {t("moreInfo.linkedDocuments.show")}
+            {t("moreInfo.linkedItems.show")}
           </Button>
           <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="sm">
-            <DialogTitle>{t("moreInfo.linkedDocuments.title")}</DialogTitle>
+            <DialogTitle>{t("moreInfo.linkedItems.title")}</DialogTitle>
             <DialogContent>
               <DialogContents state={state} />
             </DialogContent>
@@ -267,4 +265,4 @@ function LinkedDocuments({ globalId, factory }: LinkedDocumentsArgs): React.Reac
   );
 }
 
-export default observer(LinkedDocuments);
+export default observer(LinkedItems);

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/SidebarBody.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/SidebarBody.tsx
@@ -10,7 +10,7 @@ import type { InventoryRecord } from "../../../stores/definitions/InventoryRecor
 import Date from "./Date";
 import GlobalId from "./GlobalId";
 import LatestTemplateActions from "./LatestTemplateActions";
-import LinkedDocuments from "./LinkedDocuments";
+import LinkedItems from "./LinkedItems";
 import VersionHistory from "./VersionHistory";
 
 type SidebarBodyArgs = {
@@ -29,7 +29,7 @@ function SidebarBody({ record, factory }: SidebarBodyArgs): React.ReactNode {
     <Stack
       spacing={2}
       // Give every action button (version history, update samples, linked
-      // documents) a shared minimum width so they line up, while still letting
+      // items) a shared minimum width so they line up, while still letting
       // a longer label grow past it. These are the only FormGroup-wrapped
       // buttons in the panel; the dialog Close buttons they render are portaled
       // out of this subtree.
@@ -45,10 +45,10 @@ function SidebarBody({ record, factory }: SidebarBodyArgs): React.ReactNode {
       <VersionHistory record={record} />
       <LatestTemplateActions record={record} />
       {/* templates cannot appear in a List of Materials, but they are valid
-          link targets, so the linked-documents dialog (which also lists the
+          link targets, so the linked-items dialog (which also lists the
           inventory items linking here) applies to them like every other type */}
       {(record.usableInLoM || record.recordType === "sampleTemplate" || record.recordType === "instrumentTemplate") &&
-        record.globalId && <LinkedDocuments globalId={record.globalId} factory={factory} />}
+        record.globalId && <LinkedItems globalId={record.globalId} factory={factory} />}
     </Stack>
   );
 }

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/MoreInfoLinkedItems.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/MoreInfoLinkedItems.test.tsx
@@ -10,14 +10,14 @@ import InvApiService from "../../../../common/InvApiService";
 import { mockFactory } from "../../../../stores/definitions/__tests__/Factory/mocking";
 import { newDocument } from "../../../../stores/models/Document";
 import materialTheme from "../../../../theme";
-import LinkedDocuments from "../LinkedDocuments";
+import LinkedItems from "../LinkedItems";
 
 vi.mock("../../../../common/InvApiService", () => ({
   default: {
     get: () => ({}),
   },
 }));
-describe("LinkedDocuments", () => {
+describe("LinkedItems", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -44,10 +44,10 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments factory={mockFactory()} globalId="IT5" />
+        <LinkedItems factory={mockFactory()} globalId="IT5" />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
 
     expect(await screen.findByText("A sample")).toBeVisible();
     expect(spy).toHaveBeenCalledWith("listOfMaterials/forInventoryItem/IT5");
@@ -79,10 +79,10 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments factory={mockFactory()} globalId="NT5" />
+        <LinkedItems factory={mockFactory()} globalId="NT5" />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
 
     expect(await screen.findByText("A sample")).toBeVisible();
     expect(spy).toHaveBeenCalledWith("listOfMaterials/forInventoryItem/NT5");
@@ -91,15 +91,15 @@ describe("LinkedDocuments", () => {
 
   test("Assert that correct API endpoint is called with Global ID", async () => {
     const spy = vi.spyOn(InvApiService, "get").mockImplementation(() => Promise.reject(new Error("An error")));
-    render(<LinkedDocuments factory={mockFactory()} globalId="IC1" />);
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    render(<LinkedItems factory={mockFactory()} globalId="IC1" />);
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     expect(await screen.findByText("An error")).toBeVisible();
     expect(spy).toHaveBeenCalledWith("listOfMaterials/forInventoryItem/IC1");
   });
   test("When there is an error loading the data, an alert should be shown.", async () => {
     vi.spyOn(InvApiService, "get").mockImplementation(() => Promise.reject(new Error("An error")));
-    render(<LinkedDocuments factory={mockFactory()} globalId="IC1" />);
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    render(<LinkedItems factory={mockFactory()} globalId="IC1" />);
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     expect(await screen.findByRole("alert")).toHaveTextContent("An error");
   });
   test("Two different documents should render as two table rows", async () => {
@@ -117,7 +117,7 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments
+        <LinkedItems
           factory={mockFactory({
             newDocument: (x) => newDocument(x),
           })}
@@ -125,17 +125,17 @@ describe("LinkedDocuments", () => {
         />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     expect(within(await screen.findByRole("table")).getAllByRole("row")).toHaveLength(3);
     expect(
       await findTableCell(screen.getByRole("table"), {
-        columnHeading: "inventory:moreInfo.linkedDocuments.columns.name",
+        columnHeading: "inventory:moreInfo.linkedItems.columns.name",
         rowIndex: 0,
       }),
     ).toHaveTextContent("Foo");
     expect(
       await findTableCell(screen.getByRole("table"), {
-        columnHeading: "inventory:moreInfo.linkedDocuments.columns.name",
+        columnHeading: "inventory:moreInfo.linkedItems.columns.name",
         rowIndex: 1,
       }),
     ).toHaveTextContent("Bar");
@@ -155,7 +155,7 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments
+        <LinkedItems
           factory={mockFactory({
             newDocument: (x) => newDocument(x),
           })}
@@ -163,13 +163,13 @@ describe("LinkedDocuments", () => {
         />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     const rows = within(await screen.findByRole("table")).getAllByRole("row");
 
     expect(rows).toHaveLength(2);
     expect(
       await findTableCell(screen.getByRole("table"), {
-        columnHeading: "inventory:moreInfo.linkedDocuments.columns.name",
+        columnHeading: "inventory:moreInfo.linkedItems.columns.name",
         rowIndex: 0,
       }),
     ).toHaveTextContent("Foo");
@@ -199,10 +199,10 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments factory={mockFactory()} globalId={globalId} />
+        <LinkedItems factory={mockFactory()} globalId={globalId} />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     await screen.findByRole("button", { name: "common:actions.close" });
     expect(spy).toHaveBeenCalledWith(expectedUrl);
   });
@@ -219,10 +219,10 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments factory={mockFactory()} globalId="ZZ1" />
+        <LinkedItems factory={mockFactory()} globalId="ZZ1" />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     await screen.findByRole("button", { name: "common:actions.close" });
     const calls = spy.mock.calls.map(([url]) => url);
     expect(calls.some((url) => typeof url === "string" && url.endsWith("/referencingItems"))).toBe(false);
@@ -240,11 +240,11 @@ describe("LinkedDocuments", () => {
     });
     await renderWithRealI18n(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments factory={mockFactory()} globalId="IC1" />
+        <LinkedItems factory={mockFactory()} globalId="IC1" />
       </ThemeProvider>,
       { resources: { common: commonEn, inventory: inventoryEn }, defaultNS: "inventory" },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Show Linked Documents" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show Linked Items" }));
     const listOfMaterialsLink = await screen.findByRole("link", { name: "List of Materials" });
     expect(listOfMaterialsLink).toHaveAttribute("href", expect.stringContaining("list-of-materials"));
     expect(
@@ -257,12 +257,12 @@ describe("LinkedDocuments", () => {
     const spy = vi.spyOn(InvApiService, "get").mockImplementation(() => {
       return Promise.reject(new Error("An error"));
     });
-    render(<LinkedDocuments factory={mockFactory()} globalId="IC1" />);
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    render(<LinkedItems factory={mockFactory()} globalId="IC1" />);
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     expect(await screen.findByRole("button", { name: "common:actions.close" })).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "common:actions.close" }));
-    await screen.findByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" });
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    await screen.findByRole("button", { name: "inventory:moreInfo.linkedItems.show" });
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     expect(await screen.findByText("An error")).toBeVisible();
     // 2 opens, each open triggers 2 calls (documents + referencing items)
     expect(spy).toHaveBeenCalledTimes(4);
@@ -289,10 +289,10 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments factory={mockFactory()} globalId="SA42" />
+        <LinkedItems factory={mockFactory()} globalId="SA42" />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     // wait for the dialog to settle
     await screen.findByRole("button", { name: "common:actions.close" });
     expect(spy).toHaveBeenCalledWith("samples/42/referencingItems");
@@ -338,10 +338,10 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments factory={mockFactory()} globalId="IC1" />
+        <LinkedItems factory={mockFactory()} globalId="IC1" />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     expect(await screen.findByText("Calibrator A")).toBeVisible();
     expect(screen.getByText("Box 5")).toBeVisible();
     expect(screen.getByText("IsCalibratedBy")).toBeVisible();
@@ -386,15 +386,15 @@ describe("LinkedDocuments", () => {
     });
     render(
       <ThemeProvider theme={materialTheme}>
-        <LinkedDocuments factory={mockFactory()} globalId="IC1" />
+        <LinkedItems factory={mockFactory()} globalId="IC1" />
       </ThemeProvider>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedDocuments.show" }));
+    fireEvent.click(screen.getByRole("button", { name: "inventory:moreInfo.linkedItems.show" }));
     // The source's Global ID is shown bare: the version pin is NOT a version of the source.
     expect(await screen.findByText("IC5")).toBeVisible();
     expect(screen.queryByText("IC5v3")).not.toBeInTheDocument();
     // Each row shows, separately, which version of THIS item the source links to.
     expect(screen.getByText("v3")).toBeVisible();
-    expect(screen.getByText("inventory:moreInfo.linkedDocuments.latest")).toBeVisible();
+    expect(screen.getByText("inventory:moreInfo.linkedItems.latest")).toBeVisible();
   });
 });

--- a/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/SidebarBody.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/MoreInfoSidebar/__tests__/SidebarBody.test.tsx
@@ -23,9 +23,9 @@ vi.mock("../LatestTemplateActions", () => ({
   default: () => <div data-testid="latest-template-actions" />,
 }));
 
-vi.mock("../LinkedDocuments", () => ({
+vi.mock("../LinkedItems", () => ({
   default: ({ globalId }: { globalId: string | null }) => (
-    <div data-testid="linked-documents" data-globalid={globalId ?? ""} />
+    <div data-testid="linked-items" data-globalid={globalId ?? ""} />
   ),
 }));
 
@@ -73,28 +73,28 @@ describe("SidebarBody", () => {
     );
   });
 
-  it("includes LinkedDocuments when the record is usable in a List of Materials and has a Global ID", () => {
+  it("includes LinkedItems when the record is usable in a List of Materials and has a Global ID", () => {
     render(
       <ThemeProvider theme={materialTheme}>
         <SidebarBody record={makeRecord() as never} factory={null} />
       </ThemeProvider>,
     );
-    expect(screen.getByTestId("linked-documents")).toHaveAttribute("data-globalid", "SA42");
+    expect(screen.getByTestId("linked-items")).toHaveAttribute("data-globalid", "SA42");
   });
 
-  it("omits LinkedDocuments when the record is not usable in a List of Materials", () => {
+  it("omits LinkedItems when the record is not usable in a List of Materials", () => {
     render(
       <ThemeProvider theme={materialTheme}>
         <SidebarBody record={makeRecord({ usableInLoM: false }) as never} factory={null} />
       </ThemeProvider>,
     );
-    expect(screen.queryByTestId("linked-documents")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("linked-items")).not.toBeInTheDocument();
   });
 
-  it("includes LinkedDocuments for a sample template", () => {
+  it("includes LinkedItems for a sample template", () => {
     // templates cannot appear in a List of Materials (usableInLoM is false),
     // but they are valid link targets, so "what links to this" applies and
-    // the Show Linked Documents button must be present like all other types
+    // the Show Linked Items button must be present like all other types
     render(
       <ThemeProvider theme={materialTheme}>
         <SidebarBody
@@ -109,10 +109,10 @@ describe("SidebarBody", () => {
         />
       </ThemeProvider>,
     );
-    expect(screen.getByTestId("linked-documents")).toHaveAttribute("data-globalid", "IT5");
+    expect(screen.getByTestId("linked-items")).toHaveAttribute("data-globalid", "IT5");
   });
 
-  it("includes LinkedDocuments for an instrument template", () => {
+  it("includes LinkedItems for an instrument template", () => {
     // like sample templates: not usable in a List of Materials, but a valid
     // link target, so the back-reference panel must render
     render(
@@ -129,15 +129,15 @@ describe("SidebarBody", () => {
         />
       </ThemeProvider>,
     );
-    expect(screen.getByTestId("linked-documents")).toHaveAttribute("data-globalid", "NT42");
+    expect(screen.getByTestId("linked-items")).toHaveAttribute("data-globalid", "NT42");
   });
 
-  it("omits LinkedDocuments when the record has no Global ID yet", () => {
+  it("omits LinkedItems when the record has no Global ID yet", () => {
     render(
       <ThemeProvider theme={materialTheme}>
         <SidebarBody record={makeRecord({ globalId: null }) as never} factory={null} />
       </ThemeProvider>,
     );
-    expect(screen.queryByTestId("linked-documents")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("linked-items")).not.toBeInTheDocument();
   });
 });

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/inventory.json
@@ -1589,7 +1589,7 @@
     "created": "Created",
     "globalId": "Global ID",
     "lastModified": "Last Modified",
-    "linkedDocuments": {
+    "linkedItems": {
       "columns": {
         "linkedVersion": "Linked version",
         "name": "Name",
@@ -1601,10 +1601,10 @@
       "latest": "Latest",
       "noDocuments": "No documents",
       "noInventoryLinks": "No inventory links",
-      "show": "Show Linked Documents",
-      "title": "Linked Documents"
+      "show": "Show Linked Items",
+      "title": "Linked Items"
     },
-    "linkedDocumentsHelp": {
+    "linkedItemsHelp": {
       "linkField": "Other Inventory items that link to this item through a Link custom field will also be listed here.",
       "listOfMaterials": "Adding this item to a document's <helpDocs docLink=\"listOfMaterials\">List of Materials</helpDocs> will add an entry for the document in this panel."
     },

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -3852,7 +3852,7 @@ export default interface Resources {
       "created": "Created",
       "globalId": "Global ID",
       "lastModified": "Last Modified",
-      "linkedDocuments": {
+      "linkedItems": {
         "columns": {
           "linkedVersion": "Linked version",
           "name": "Name",
@@ -3864,10 +3864,10 @@ export default interface Resources {
         "latest": "Latest",
         "noDocuments": "No documents",
         "noInventoryLinks": "No inventory links",
-        "show": "Show Linked Documents",
-        "title": "Linked Documents"
+        "show": "Show Linked Items",
+        "title": "Linked Items"
       },
-      "linkedDocumentsHelp": {
+      "linkedItemsHelp": {
         "linkField": "Other Inventory items that link to this item through a Link custom field will also be listed here.",
         "listOfMaterials": "Adding this item to a document's <helpDocs docLink=\"listOfMaterials\">List of Materials</helpDocs> will add an entry for the document in this panel."
       },


### PR DESCRIPTION
## Description ##

PRT-1143: renames the **Linked Documents** field on the Inventory item info panel to **Linked Items**, and its button to **Show Linked Items**.

Since RSDEV-1131 the dialog behind that button has listed both the ELN documents whose List of Materials references the item and the Inventory items linking to it through a Link field, so the old label named only half of its contents.

Frontend only, no behaviour change. The i18n key group is renamed to `moreInfo.linkedItems` and the component to `LinkedItems`; the table headings and help text inside the dialog already name what each table holds and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
