### PR TITLE
Remove unnecessary Grid container constraining width of export dialog

### DIFF
--- a/src/main/webapp/ui/src/Export/WordExport.tsx
+++ b/src/main/webapp/ui/src/Export/WordExport.tsx
@@ -54,40 +54,38 @@ export default function WordExport({
           data-test-id="word-title"
         />
       </Grid>
-      <Grid container>
-        <Grid size={5}>
-          <InputLabel htmlFor={pageSizeId}>{t("export.format.word.pageFormatLabel")}</InputLabel>
-          <Select
-            variant="standard"
-            fullWidth
-            value={pageSize}
-            onChange={({ target: { value } }) => updateExportDetails("pageSize", value)}
-            inputProps={{ id: pageSizeId }}
-            data-test-id="word-size"
-          >
-            <MenuItem value={"A4"} data-test-id="word-size-a4">
-              {t("export.format.word.pageSize.a4")}
-            </MenuItem>
-            <MenuItem value={"LETTER"} data-test-id="word-size-letter">
-              {t("export.format.word.pageSize.letter")}
-            </MenuItem>
-          </Select>
-          {pageSize !== defaultPageSize && (
-            <FormControlLabel
-              control={
-                <Checkbox
-                  onChange={({ target: { checked } }) => {
-                    updateExportDetails("setPageSizeAsDefault", checked);
-                  }}
-                  color="primary"
-                  checked={setPageSizeAsDefault}
-                  data-test-id="set-size-default"
-                />
-              }
-              label={t("export.format.word.setDefault", { pageSize })}
-            />
-          )}
-        </Grid>
+      <Grid size={5}>
+        <InputLabel htmlFor={pageSizeId}>{t("export.format.word.pageFormatLabel")}</InputLabel>
+        <Select
+          variant="standard"
+          fullWidth
+          value={pageSize}
+          onChange={({ target: { value } }) => updateExportDetails("pageSize", value)}
+          inputProps={{ id: pageSizeId }}
+          data-test-id="word-size"
+        >
+          <MenuItem value={"A4"} data-test-id="word-size-a4">
+            {t("export.format.word.pageSize.a4")}
+          </MenuItem>
+          <MenuItem value={"LETTER"} data-test-id="word-size-letter">
+            {t("export.format.word.pageSize.letter")}
+          </MenuItem>
+        </Select>
+        {pageSize !== defaultPageSize && (
+          <FormControlLabel
+            control={
+              <Checkbox
+                onChange={({ target: { checked } }) => {
+                  updateExportDetails("setPageSizeAsDefault", checked);
+                }}
+                color="primary"
+                checked={setPageSizeAsDefault}
+                data-test-id="set-size-default"
+              />
+            }
+            label={t("export.format.word.setDefault", { pageSize })}
+          />
+        )}
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
## Description ##
Remove unnecessary Grid container constraining width of export dialog, so that options are now visible again.

Fixes [PRT-1137](https://researchspace.atlassian.net/browse/PRT-1137)
