### PR TITLE
RSDEV-1307 Clear a manually entered Landing page on derived instruments

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,44 @@ resolved during design. This file is a glossary only — no implementation detai
   again. Instruments carrying no conforming field are untouched, and templates
   are never filled, since one instrument's address must not be stamped onto every
   instrument later created from that template.
+- **Identity-bound field** — a field whose value names exactly one concrete
+  Instrument, so deriving a new record from an existing one must not carry it
+  over. The Landing page is identity-bound. Three derivation paths enforce this
+  today: duplicating an instrument, duplicating a template, and creating an
+  instrument from a template all start the derived record's Landing page blank,
+  whether the source value was system-filled or typed by a user. On a concrete
+  instrument the blank is then an ordinary materialised default (filled with the
+  new record's own address, or left blank when no public server address is
+  configured — blank being the recoverable state); on a template it stays blank,
+  since templates are never filled. A value the user supplies directly *on the
+  new record itself* (e.g. typed into the creation form, or sent in the creation
+  request) is theirs and is kept: it is derivation that discards a landing page,
+  never user input. The one value that does *not* count as user input on the new
+  record is the source template's own Landing page echoed back unchanged in the
+  creation request, which is what a client posting a template's fields verbatim
+  sends; it is discarded like any other inherited value, so the guarantee is a
+  property of the service rather than of client cooperation. Because the rule
+  spans layers, the field is recognised by the same name-and-type test in the
+  service layer (`PidinstFields`, shared with the PIDINST mapping) and in the
+  Inventory UI (`InstrumentModel.tsx`), and those two must be changed together.
+  Both resolve a single field, so a record with two conforming fields has only
+  its first treated as identity-bound.
+  Three things are deliberately out of RSDEV-1307's scope. Syncing an instrument
+  to a newer template version keeps the instrument's existing Landing page
+  (correct — it is that instrument's own address) but a Landing page field newly
+  added by the sync stays blank until the next ordinary save, because that path
+  alone does not run the fill. Creating a *template from an instrument* copies
+  the instrument's Landing page into the new template only when the user
+  explicitly ticks that field in the create dialog (content is opt-in per field,
+  and defaults to off), which still leaves a reusable definition holding one
+  instrument's address. And records derived *before* this rule existed are not
+  backfilled: they keep their source's Landing page, and will not self-heal,
+  because the fill only ever writes into a blank field. A migration was not
+  written because a blanket update cannot distinguish an inherited value from
+  one the user legitimately typed.
+  Finally, the rule keys off the English display label "Landing page". If seeded
+  template field labels are ever localised, or a user names the field in another
+  language, every derivation path silently stops clearing it.
 - **Provider record page** — the registered record's own page on the issuing
   provider, distinct from a citable public URL: it exists from registration
   onwards and may require signing in to that provider, so it is never presented

--- a/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImpl.java
@@ -28,7 +28,6 @@ import com.researchspace.model.events.InventoryEditingEvent;
 import com.researchspace.model.events.InventoryMoveEvent;
 import com.researchspace.model.events.InventoryRestoreEvent;
 import com.researchspace.model.events.InventoryTransferEvent;
-import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InstrumentEntity;
@@ -69,13 +68,6 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     implements InstrumentEntityApiManager {
 
   public static final String INSTRUMENT_DEFAULT_NAME = "Generic Instrument";
-
-  /*
-   * Canonical spelling from the default PIDINST template; see CONTEXT.md ("PIDINST-mapped field").
-   * Matched the same way the PID mapping matches it, on trimmed case-insensitive name plus URI type,
-   * so an instrument shaped by that template is recognised however it was created.
-   */
-  private static final String LANDING_PAGE_FIELD_NAME = "Landing page";
 
   private @Autowired IPropertyHolder properties;
   private @Autowired InstrumentDao instrumentDao;
@@ -135,15 +127,23 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
         recordFactory.createInstrument(instrumentName, user, instrTemplate);
 
     setBasicFieldsFromNewIncomingApiInventoryRecord(instrumentToSave, apiInstrument, user);
+    String inheritedLandingPage = null;
     if (instrTemplate != null) {
       // might be null from incoming API request, but here we want to reference template icon id
       instrumentToSave.setIconId(instrTemplate.getIconId());
+      // read from the template itself, to recognise it if the request echoes it back below. The
+      // instrument's fields are deep copies, so the clear that follows cannot disturb this.
+      inheritedLandingPage =
+          landingPageField(instrTemplate).map(InventoryEntityField::getFieldData).orElse(null);
+      // must run before saveNewApiFieldsIntoInstrumentFields below: a landing page typed into
+      // the template must not travel onto the new instrument (RSDEV-1307)
+      clearLandingPage(instrumentToSave);
     }
     if (!apiInstrument.getFields().isEmpty()) {
       saveNewApiFieldsIntoInstrumentFields(
-          apiInstrument.getFields(), instrumentToSave.getActiveFields(), user);
+          apiInstrument.getFields(), instrumentToSave, inheritedLandingPage, user);
     } else {
-      assertDefaultFieldsValid(instrumentToSave.getActiveFields());
+      assertDefaultFieldsValid(instrumentToSave);
     }
     setLocationForNewInstrument(apiInstrument, instrumentToSave, user);
 
@@ -166,6 +166,10 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     return apiResultInstrument;
   }
 
+  private static Optional<InventoryEntityField> landingPageField(InstrumentEntity record) {
+    return PidinstFields.landingPage(record);
+  }
+
   /**
    * Gives an instrument shaped by the PIDINST template a landing page whenever the user leaves the
    * field empty, filling it with the instrument's own public RSpace address. A value the user typed
@@ -182,14 +186,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
       return false;
     }
     Optional<InventoryEntityField> blankLandingPage =
-        instrument.getActiveFields().stream()
-            .filter(field -> field.getType() == FieldType.URI)
-            .filter(
-                field ->
-                    field.getName() != null
-                        && LANDING_PAGE_FIELD_NAME.equalsIgnoreCase(field.getName().trim()))
-            .filter(field -> StringUtils.isBlank(field.getFieldData()))
-            .findFirst();
+        landingPageField(instrument).filter(field -> StringUtils.isBlank(field.getFieldData()));
     if (blankLandingPage.isEmpty()) {
       return false;
     }
@@ -215,23 +212,16 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   }
 
   /**
-   * Blanks the Landing page field in {@code copy} when it contains the system-generated default URL
-   * for {@code source} — i.e. the URL RSpace would have auto-filled for the source record. A value
-   * the user typed on the source is left untouched.
+   * Blanks the Landing page field of a record derived from another record — a duplicated
+   * instrument, a duplicated template, or an instrument created from a template. The landing page
+   * names exactly one physical instrument, so a derived record must never start out pointing at its
+   * source's page, whether the source value was system-generated or typed by a user (RSDEV-1307).
+   * On a concrete Instrument the blanked field is refilled with the record's own address by {@link
+   * #fillBlankLandingPage}; on an InstrumentTemplate it stays blank, since templates are never
+   * filled.
    */
-  private void clearSystemGeneratedLandingPage(Instrument source, Instrument copy) {
-    GlobalIdUrls.globalIdUrl(properties, source.getGlobalIdentifier())
-        .ifPresent(
-            sourceUrl ->
-                copy.getActiveFields().stream()
-                    .filter(f -> f.getType() == FieldType.URI)
-                    .filter(
-                        f ->
-                            f.getName() != null
-                                && LANDING_PAGE_FIELD_NAME.equalsIgnoreCase(f.getName().trim()))
-                    .filter(f -> sourceUrl.equals(f.getFieldData()))
-                    .findFirst()
-                    .ifPresent(f -> f.setFieldData(null)));
+  private static void clearLandingPage(InstrumentEntity derivedRecord) {
+    landingPageField(derivedRecord).ifPresent(InventoryEntityField::clearValue);
   }
 
   private void setLocationForNewInstrument(
@@ -249,25 +239,60 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
     setWorkbenchAsParentForNewInventoryRecord(workbench, instrument);
   }
 
-  private void assertDefaultFieldsValid(List<InventoryEntityField> activeFields) {
-    for (InventoryEntityField field : activeFields) {
+  /**
+   * Validates the defaults a new instrument inherited from its template. A blank Landing page is
+   * exempt: {@link #clearLandingPage} has just blanked the template-inherited value and {@link
+   * #fillBlankLandingPage} writes the instrument's own address immediately after the save, so at
+   * this point a blank is a materialised default in flight, not missing user input (RSDEV-1307).
+   *
+   * <p>The exemption is deliberately narrowed to a blank rather than to the field, so that a
+   * non-blank Landing page reaching here is still validated. No current path produces one, since
+   * {@link #clearLandingPage} runs first whenever there is a template, but the guard is what keeps
+   * that an implementation detail of the caller rather than a correctness requirement on it.
+   */
+  private void assertDefaultFieldsValid(Instrument instrument) {
+    InventoryEntityField landingPage = landingPageField(instrument).orElse(null);
+    for (InventoryEntityField field : instrument.getActiveFields()) {
+      if (field == landingPage && StringUtils.isBlank(field.getFieldData())) {
+        continue;
+      }
       field.assertFieldDataValid(field.getFieldData());
     }
   }
 
+  /**
+   * Writes the values of an incoming creation request onto the new instrument's template-derived
+   * fields, matched by position.
+   *
+   * <p>The Landing page is the one field whose incoming value is not always written through {@link
+   * InventoryEntityField#setFieldData}. Two incoming values mean "this instrument has no landing
+   * page of its own yet": a blank, which is what the creation UI posts after deliberately blanking
+   * the field, and {@code inheritedLandingPage}, the template's own value echoed back unchanged by
+   * a client that posted the template's fields verbatim. Neither is user input about this
+   * instrument, so both are applied with the validation-free {@link
+   * InventoryEntityField#clearValue()} and {@link #fillBlankLandingPage} writes the real value once
+   * the save has assigned an id. That keeps the RSDEV-1307 guarantee a property of the service
+   * rather than of client cooperation, and routing a blank through {@code setFieldData} would in
+   * any case fail the mandatory check on a template that marks the field mandatory. Any other
+   * non-blank Landing page is the user's own input for this record: it is kept and validated like
+   * every other value, so a malformed URI is still rejected.
+   */
   private void saveNewApiFieldsIntoInstrumentFields(
       List<ApiInventoryEntityField> apiFieldList,
-      List<InventoryEntityField> inventoryEntityFieldList,
+      Instrument instrumentToSave,
+      String inheritedLandingPage,
       User user) {
 
+    List<InventoryEntityField> inventoryEntityFieldList = instrumentToSave.getActiveFields();
     if (apiFieldList.size() != inventoryEntityFieldList.size()) {
       throw new IllegalArgumentException(
-          String.format(
-              "Number of incoming instrument fields [%d]"
-                  + " doesn't match number of template fields [%d]",
-              apiFieldList.size(), inventoryEntityFieldList.size()));
+          messages.getMessage(
+              "errors.inventory.instrument.fieldCountMismatch",
+              new Object[] {apiFieldList.size(), inventoryEntityFieldList.size()}));
     }
 
+    // resolved once and compared by reference, as assertDefaultFieldsValid does
+    InventoryEntityField landingPage = landingPageField(instrumentToSave).orElse(null);
     for (int i = 0; i < apiFieldList.size(); i++) {
       ApiInventoryEntityField apiField = apiFieldList.get(i);
       String newFieldContent = apiField.getContent();
@@ -277,10 +302,33 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
         applyLinkFieldValue((InventoryLinkField) inventoryEntityField, apiField, user);
       } else if (inventoryEntityField.isOptionsStoringField()) {
         inventoryEntityField.setSelectedOptions(apiField.getSelectedOptions());
+      } else if (inventoryEntityField == landingPage
+          && isNotThisInstrumentsOwnLandingPage(newFieldContent, inheritedLandingPage)) {
+        inventoryEntityField.clearValue();
       } else {
         inventoryEntityField.setFieldData(newFieldContent);
       }
     }
+  }
+
+  /**
+   * Whether an incoming Landing page value should be discarded rather than stored: either it is
+   * blank, or it is the value inherited from the template, echoed back unchanged. Compared on
+   * trimmed content so a client round-tripping the value cannot defeat the check with padding
+   * (RSDEV-1307).
+   *
+   * <p>This is hygiene, not a security boundary. Exact-match comparison is easily sidestepped with
+   * a trailing slash or a case change, and nothing needs it to be airtight: the Landing page is a
+   * freely editable URI, so a caller determined to store the template's address can simply PUT it
+   * after creation. The point is that the ordinary create-from-template flow cannot re-establish an
+   * inherited value by accident, not that it is impossible to do on purpose.
+   */
+  private static boolean isNotThisInstrumentsOwnLandingPage(
+      String incomingContent, String inheritedLandingPage) {
+    return StringUtils.isBlank(incomingContent)
+        || (StringUtils.isNotBlank(inheritedLandingPage)
+            && StringUtils.equals(
+                StringUtils.trim(inheritedLandingPage), StringUtils.trim(incomingContent)));
   }
 
   /**
@@ -595,7 +643,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   public ApiInstrument duplicateInstrument(Long instrumentId, User user) {
     Instrument dbInstrument = assertUserCanReadInstrument(instrumentId, user);
     Instrument copy = (Instrument) dbInstrument.copy(user);
-    clearSystemGeneratedLandingPage(dbInstrument, copy);
+    clearLandingPage(copy);
     setWorkbenchAsParentForNewInstrument(copy, user);
     copy = instrumentDao.save(copy);
     // Fill needs to be done after the save, as it needs the actual persisted id
@@ -889,6 +937,7 @@ public class InstrumentEntityApiManagerImpl extends InventoryApiManagerImpl<Inst
   public ApiInstrumentTemplate duplicateInstrumentTemplate(Long templateId, User user) {
     InstrumentTemplate dbTemplate = assertUserCanReadInstrumentTemplate(templateId, user);
     InstrumentTemplate copy = (InstrumentTemplate) dbTemplate.copy(user);
+    clearLandingPage(copy);
     copy = instrumentTemplateDao.save(copy);
     publisher.publishEvent(new InventoryCreationEvent(copy, user));
     ApiInstrumentTemplate result = new ApiInstrumentTemplate(copy);

--- a/src/main/java/com/researchspace/service/inventory/impl/PidinstFields.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/PidinstFields.java
@@ -1,0 +1,52 @@
+package com.researchspace.service.inventory.impl;
+
+import com.researchspace.model.field.FieldType;
+import com.researchspace.model.inventory.InstrumentEntity;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import java.util.Optional;
+
+/**
+ * Resolves the structured fields of an instrument that carry PIDINST meaning.
+ *
+ * <p>Shared deliberately, in the same spirit as {@link GlobalIdUrls}: an instrument's fields are
+ * matched by display name, so any two places that disagree about how a name is matched disagree
+ * about which field they are looking at. The service layer's landing-page rules and the PIDINST
+ * mapping both depend on picking the same field, so they resolve it here rather than each carrying
+ * their own copy of the predicate.
+ *
+ * <p>That leaves the Inventory UI's copy of the landing-page rule (see {@code InstrumentModel.tsx})
+ * as the only remaining duplicate, which nothing here can keep in step; a rename must be applied
+ * there by hand.
+ */
+final class PidinstFields {
+
+  /**
+   * Canonical spelling from the default PIDINST template; see CONTEXT.md ("PIDINST-mapped field").
+   */
+  static final String LANDING_PAGE = "Landing page";
+
+  private PidinstFields() {}
+
+  /**
+   * The record's field with the given canonical name and type, matched case-insensitively and
+   * ignoring surrounding whitespace, so a field is recognised however it was created.
+   *
+   * <p>Only active fields are considered, so a soft-deleted field is never treated as the mapped
+   * one.
+   */
+  static Optional<InventoryEntityField> mappedField(
+      InstrumentEntity record, String canonicalName, FieldType expectedType) {
+    return record.getActiveFields().stream()
+        .filter(f -> f.getType() == expectedType)
+        .filter(f -> f.getName() != null && canonicalName.equalsIgnoreCase(f.getName().trim()))
+        .findFirst();
+  }
+
+  /**
+   * The record's Landing page field. Shared by the fill, the clear and the PIDINST mapping so they
+   * can never act on different fields.
+   */
+  static Optional<InventoryEntityField> landingPage(InstrumentEntity record) {
+    return mappedField(record, LANDING_PAGE, FieldType.URI);
+  }
+}

--- a/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
@@ -46,7 +46,8 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
   private static final String FIELD_COMMISSIONED = "Commissioned";
   private static final String FIELD_DECOMMISSIONED = "Decommissioned";
   private static final String FIELD_MEASURED_QUANTITY = "Measured quantity";
-  private static final String FIELD_LANDING_PAGE = "Landing page";
+  // shared with the service layer's landing-page rules, which must resolve the same field
+  private static final String FIELD_LANDING_PAGE = PidinstFields.LANDING_PAGE;
   private static final String FIELD_ALTERNATE_IDENTIFIER = "Alternate Identifier";
 
   // PIDINST controlled values ("DeCommissioned" deliberately differs from the field name).
@@ -164,17 +165,9 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
     return measuredVariables;
   }
 
-  private Optional<InventoryEntityField> mappedField(
-      InstrumentEntity instrument, String canonicalName, FieldType expectedType) {
-    return instrument.getActiveFields().stream()
-        .filter(f -> f.getType() == expectedType)
-        .filter(f -> f.getName() != null && canonicalName.equalsIgnoreCase(f.getName().trim()))
-        .findFirst();
-  }
-
   private Optional<String> mappedFieldData(
       InstrumentEntity instrument, String canonicalName, FieldType expectedType) {
-    return mappedField(instrument, canonicalName, expectedType)
+    return PidinstFields.mappedField(instrument, canonicalName, expectedType)
         .map(InventoryEntityField::getFieldData)
         .filter(StringUtils::isNotBlank)
         .map(String::trim);

--- a/src/main/webapp/ui/biome.jsonc
+++ b/src/main/webapp/ui/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
@@ -105,6 +105,7 @@
       },
       "imageTooLarge": "Image cannot be larger than 10MB",
       "instrument": {
+        "fieldCountMismatch": "Number of incoming instrument fields [{0}] doesn''t match number of template fields [{1}]",
         "nameExists": "There is already an instrument named [{0}]",
         "notFound": "No instrument with id: {0}",
         "templateNotFound": "No instrument template with id: {0}",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -6787,6 +6787,7 @@ export default interface Resources {
           "unrecognizedFileType": "Unrecognized fileType: {0}"
         },
         "instrument": {
+          "fieldCountMismatch": "Number of incoming instrument fields [{0}] doesn''t match number of template fields [{1}]",
           "nameExists": "There is already an instrument named [{0}]",
           "notFound": "No instrument with id: {0}",
           "templateNotFound": "No instrument template with id: {0}",

--- a/src/main/webapp/ui/src/stores/models/InstrumentModel.tsx
+++ b/src/main/webapp/ui/src/stores/models/InstrumentModel.tsx
@@ -69,6 +69,21 @@ export type InstrumentAttrs = {
   _links: Array<_LINK>;
 } & Record<string, unknown>;
 
+/**
+ * The name of the field holding an instrument's public landing page. Matched case-insensitively
+ * and ignoring surrounding whitespace, together with the field's URI type.
+ *
+ * This rule is duplicated, not shared: the backend's copy lives in `PidinstFields` (Java), which
+ * the service layer and the PIDINST mapping both resolve through. Nothing detects a divergence
+ * between that copy and this one, so a rename must be applied to both in lock-step.
+ */
+export const LANDING_PAGE_FIELD_NAME = "Landing page";
+
+const LANDING_PAGE_FIELD_NAME_LOWERCASE = LANDING_PAGE_FIELD_NAME.toLowerCase();
+
+const isLandingPageField = (field: Field): boolean =>
+  field.type === "uri" && field.name?.trim().toLowerCase() === LANDING_PAGE_FIELD_NAME_LOWERCASE;
+
 const FIELDS = new Set([...RESULT_FIELDS].concat(["fields", "template"]));
 const defaultVisibleFields = new Set([...FIELDS, ...defaultVisibleResultFields]);
 const defaultEditableFields = new Set<string>();
@@ -105,7 +120,9 @@ export default class InstrumentModel
 
   constructor(factory: Factory, params: InstrumentAttrs) {
     super(factory, params);
-    makeObservable(this, {
+    // the explicit key list is what lets a private member be annotated (MobX types the plain
+    // overload against the public shape only)
+    makeObservable<this, "blankLandingPageField">(this, {
       parentContainers: observable,
       immediateParentContainer: observable,
       createOptionsParametersState: observable,
@@ -115,6 +132,7 @@ export default class InstrumentModel
       templateVersion: observable,
       setTemplate: action,
       overrideFields: action,
+      blankLandingPageField: action,
       paramsForBackend: override,
       populateFromJson: override,
       updateFieldsState: override,
@@ -307,6 +325,32 @@ export default class InstrumentModel
     });
   }
 
+  /**
+   * Blanks the Landing page field of an instrument whose fields were just copied from a template.
+   * The landing page names exactly one physical instrument, so a record derived from another record
+   * must never start out pointing at its source's page (RSDEV-1307). The backend clears it on
+   * creation and then fills it with the new instrument's own address; blanking it here keeps the
+   * form showing what will actually be saved. Anything the user types into the creation form
+   * afterwards is their own input and is left alone.
+   *
+   * Only the first matching field is blanked, mirroring the backend, which resolves a single
+   * Landing page and refills only that one. Blanking a second match would leave it permanently
+   * empty, since nothing would ever fill it.
+   *
+   * Note that this deliberately blanks a field the template may mark mandatory. That is safe only
+   * because instrument structured fields are not validated client-side: `InventoryBaseRecord`
+   * validates `extraFields` only, and `FieldModel`'s mandatory branch reads
+   * `owner.enforceMandatoryFields`, which `InstrumentModel` does not define. If either changes,
+   * this needs revisiting — the backend routes the same case around `setFieldData` for exactly
+   * this reason.
+   */
+  private blankLandingPageField(): void {
+    const landingPage = this.fields.find(isLandingPageField);
+    if (landingPage) {
+      (landingPage as FieldModel).setAttributes({ content: "" });
+    }
+  }
+
   async setTemplate(template: InstrumentTemplateModel | null): Promise<void> {
     if (template) await template.fetchAdditionalInfo();
 
@@ -323,6 +367,7 @@ export default class InstrumentModel
 
     if (!this.id) {
       this.overrideFields(template.fields);
+      this.blankLandingPageField();
       const userAddedFields = this.extraFields.filter((ef) => !ef.fromTemplate);
       const templateFields = template.extraFields
         .filter((ef) => !ef.deleteFieldRequest)

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/overrideFields.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/overrideFields.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import FieldModel from "../../FieldModel";
+import { LANDING_PAGE_FIELD_NAME } from "../../InstrumentModel";
 import { fieldAttrs } from "../FieldModel/mocking";
 import { makeMockInstrument } from "./mocking";
 
@@ -119,6 +120,23 @@ describe("InstrumentModel.overrideFields", () => {
     instrument.overrideFields([source]);
     const fm = instrument.fields[0] as FieldModel;
     expect(fm.allowedRelationTypes).toEqual(["IsDerivedFrom", "IsPartOf"]);
+  });
+
+  test("copies content verbatim, including a URI field named Landing page", () => {
+    // Blanking a derived record's landing page (RSDEV-1307) belongs to setTemplate's
+    // new-instrument path, not here: overrideFields is a plain verbatim copy.
+    const instrument = makeMockInstrument();
+    const source = new FieldModel(
+      fieldAttrs({
+        type: "uri",
+        name: LANDING_PAGE_FIELD_NAME,
+        content: "https://lab.example.org/original",
+        columnIndex: 1,
+      }),
+      instrument,
+    );
+    instrument.overrideFields([source]);
+    expect(instrument.fields[0].content).toBe("https://lab.example.org/original");
   });
 
   test("preserves radio field options", () => {

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/paramsForBackend.landingPage.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/paramsForBackend.landingPage.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, vi } from "vitest";
+import { LANDING_PAGE_FIELD_NAME } from "../../InstrumentModel";
+import { makeMockInstrumentTemplate } from "../InstrumentTemplateModel/mocking";
+import { makeMockInstrument } from "./mocking";
+
+vi.mock("../../../../common/InvApiService", () => ({ default: { query: vi.fn(), get: vi.fn() } }));
+vi.mock("../../../../stores/stores/getRootStore", () => ({
+  default: () => ({
+    trackingStore: { trackEvent: vi.fn() },
+    uiStore: {
+      addAlert: vi.fn(),
+      setPageNavigationConfirmation: vi.fn(),
+      setDirty: vi.fn(),
+    },
+  }),
+}));
+
+const templateWithLandingPage = () => {
+  const template = makeMockInstrumentTemplate({
+    fields: [
+      {
+        id: 1,
+        globalId: "IF1",
+        name: LANDING_PAGE_FIELD_NAME,
+        type: "uri",
+        content: "https://lab.example.org/original",
+        selectedOptions: null,
+        definition: null,
+        columnIndex: 1,
+        attachment: null,
+        mandatory: true,
+      },
+      {
+        id: 2,
+        globalId: "IF2",
+        name: "Manufacturer",
+        type: "text",
+        content: "Acme Instruments",
+        selectedOptions: null,
+        definition: null,
+        columnIndex: 2,
+        attachment: null,
+        mandatory: false,
+      },
+    ],
+  });
+  vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+  return template;
+};
+
+/*
+ * The request shape this describes is the contract the backend relies on: because the creation form
+ * always sends `fields`, a blanked Landing page reaches
+ * `InstrumentEntityApiManagerImpl.saveNewApiFieldsIntoInstrumentFields`, which must treat the blank
+ * as "fill this for me" rather than as a missing mandatory value (RSDEV-1307).
+ */
+describe("InstrumentModel.paramsForBackend for an instrument created from a template", () => {
+  test("sends the fields list, so the blanked Landing page reaches the backend", async () => {
+    const instrument = makeMockInstrument({ id: null, globalId: null, name: "" });
+    await instrument.setTemplate(templateWithLandingPage());
+
+    // "create" state makes fields editable, so the POST body carries them; this is the premise of
+    // the backend's blank-Landing-page handling
+    expect(instrument.currentlyEditableFields.has("fields")).toBe(true);
+    const params = instrument.paramsForBackend as {
+      fields?: Array<Record<string, unknown>>;
+    };
+    expect(params.fields).toHaveLength(2);
+  });
+
+  test("emits the Landing page with empty content", async () => {
+    const instrument = makeMockInstrument({ id: null, globalId: null, name: "" });
+    await instrument.setTemplate(templateWithLandingPage());
+
+    const params = instrument.paramsForBackend as {
+      fields?: Array<Record<string, unknown>>;
+    };
+    const landingPage = (params.fields ?? []).find((f) => f.name === LANDING_PAGE_FIELD_NAME);
+    expect(landingPage?.content).toBe("");
+  });
+
+  test("keeps the template default of every other field in the same payload", async () => {
+    const instrument = makeMockInstrument({ id: null, globalId: null, name: "" });
+    await instrument.setTemplate(templateWithLandingPage());
+
+    const params = instrument.paramsForBackend as {
+      fields?: Array<Record<string, unknown>>;
+    };
+    const manufacturer = (params.fields ?? []).find((f) => f.name === "Manufacturer");
+    expect(manufacturer?.content).toBe("Acme Instruments");
+  });
+
+  test("emits a landing page the user typed after choosing the template", async () => {
+    const instrument = makeMockInstrument({ id: null, globalId: null, name: "" });
+    await instrument.setTemplate(templateWithLandingPage());
+    const landingPageField = instrument.fields.find((f) => f.name === LANDING_PAGE_FIELD_NAME);
+    landingPageField?.setAttributesDirty({ content: "https://lab.example.org/mine" });
+
+    const params = instrument.paramsForBackend as {
+      fields?: Array<Record<string, unknown>>;
+    };
+    const landingPage = (params.fields ?? []).find((f) => f.name === LANDING_PAGE_FIELD_NAME);
+    expect(landingPage?.content).toBe("https://lab.example.org/mine");
+  });
+});

--- a/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/setTemplate.test.ts
+++ b/src/main/webapp/ui/src/stores/models/__tests__/InstrumentModel/setTemplate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { LANDING_PAGE_FIELD_NAME } from "../../InstrumentModel";
 import { makeMockInstrumentTemplate } from "../InstrumentTemplateModel/mocking";
 import { makeMockInstrument } from "./mocking";
 
@@ -187,6 +188,233 @@ describe("InstrumentModel.setTemplate", () => {
       expect(fetchSpy).toHaveBeenCalledOnce();
     });
 
+    test("blanks the Landing page field but keeps other template defaults", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: LANDING_PAGE_FIELD_NAME,
+            type: "uri",
+            content: "https://lab.example.org/original",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: false,
+          },
+          {
+            id: 2,
+            globalId: "IF2",
+            name: "Manufacturer",
+            type: "text",
+            content: "Acme Instruments",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 2,
+            attachment: null,
+            mandatory: false,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(template);
+
+      const landingPage = instrument.fields.find((f) => f.name === LANDING_PAGE_FIELD_NAME);
+      expect(landingPage?.content).toBe("");
+      expect(landingPage?.hasContent).toBe(false);
+      expect(instrument.fields.find((f) => f.name === "Manufacturer")?.content).toBe("Acme Instruments");
+    });
+
+    test("blanks only the first Landing page field, as the backend resolves only one", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: LANDING_PAGE_FIELD_NAME,
+            type: "uri",
+            content: "https://lab.example.org/first",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: false,
+          },
+          {
+            id: 2,
+            globalId: "IF2",
+            // differs only by case, so the name-distinctness check does not reject it while the
+            // case-insensitive predicate still matches it
+            name: "landing page",
+            type: "uri",
+            content: "https://lab.example.org/second",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 2,
+            attachment: null,
+            mandatory: false,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(template);
+
+      // the backend clears and refills exactly one field; blanking both here would leave the
+      // second permanently empty, since nothing would ever fill it
+      expect(instrument.fields[0].content).toBe("");
+      expect(instrument.fields[1].content).toBe("https://lab.example.org/second");
+    });
+
+    test("matches the Landing page field ignoring case and surrounding whitespace", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: "  landing PAGE ",
+            type: "uri",
+            content: "https://lab.example.org/original",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: false,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(template);
+      expect(instrument.fields[0].content).toBe("");
+    });
+
+    test("does not blank a non-URI field named Landing page", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: LANDING_PAGE_FIELD_NAME,
+            type: "text",
+            content: "see the lab handbook",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: false,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(template);
+      expect(instrument.fields[0].content).toBe("see the lab handbook");
+    });
+
+    test("does not blank a URI field with a different name", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: "Manual",
+            type: "uri",
+            content: "https://lab.example.org/manual",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: false,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(template);
+      expect(instrument.fields[0].content).toBe("https://lab.example.org/manual");
+    });
+
+    test("preserves everything else about the Landing page field", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: LANDING_PAGE_FIELD_NAME,
+            type: "uri",
+            content: "https://lab.example.org/original",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: true,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(template);
+      const field = instrument.fields[0];
+      expect(field.name).toBe(LANDING_PAGE_FIELD_NAME);
+      expect(field.type).toBe("uri");
+      expect(field.mandatory).toBe(true);
+    });
+
+    test("blanking a mandatory Landing page still leaves the instrument submittable", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: LANDING_PAGE_FIELD_NAME,
+            type: "uri",
+            content: "https://lab.example.org/original",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: true,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeUnsavedInstrument();
+      instrument.setAttributes({ name: "New Instrument" });
+      await instrument.setTemplate(template);
+
+      // blanking is only safe because instrument structured fields are not validated client-side;
+      // if that ever changes, a mandatory Landing page would silently block creation in the form
+      expect(instrument.fields[0].content).toBe("");
+      expect(instrument.submittable.isOk).toBe(true);
+    });
+
+    test("a landing page typed after choosing the template is kept", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: LANDING_PAGE_FIELD_NAME,
+            type: "uri",
+            content: "https://lab.example.org/original",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: false,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeUnsavedInstrument();
+      await instrument.setTemplate(template);
+      instrument.fields[0].setAttributesDirty({ content: "https://lab.example.org/mine" });
+      expect(instrument.fields[0].content).toBe("https://lab.example.org/mine");
+    });
+
     test("preserves user-added extra fields when changing templates", async () => {
       const templateA = makeMockInstrumentTemplate({
         extraFields: [
@@ -298,6 +526,46 @@ describe("InstrumentModel.setTemplate", () => {
       const instrument = makeMockInstrument({ id: 99, globalId: "IN99" });
       await instrument.setTemplate(template);
       expect(instrument.fields).toHaveLength(0);
+    });
+
+    test("does not blank an existing Landing page field", async () => {
+      const template = makeMockInstrumentTemplate({
+        fields: [
+          {
+            id: 1,
+            globalId: "IF1",
+            name: LANDING_PAGE_FIELD_NAME,
+            type: "uri",
+            content: "https://lab.example.org/template",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: false,
+          },
+        ],
+      });
+      vi.spyOn(template, "fetchAdditionalInfo").mockResolvedValue(undefined);
+      const instrument = makeMockInstrument({
+        id: 99,
+        globalId: "IN99",
+        fields: [
+          {
+            id: 5,
+            globalId: "IF5",
+            name: LANDING_PAGE_FIELD_NAME,
+            type: "uri",
+            content: "https://lab.example.org/IN99",
+            selectedOptions: null,
+            definition: null,
+            columnIndex: 1,
+            attachment: null,
+            mandatory: false,
+          },
+        ],
+      });
+      await instrument.setTemplate(template);
+      expect(instrument.fields[0].content).toBe("https://lab.example.org/IN99");
     });
 
     test("still sets templateId and templateVersion", async () => {

--- a/src/test/java/com/researchspace/api/v1/controller/InstrumentsApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InstrumentsApiControllerMVCIT.java
@@ -727,40 +727,35 @@ public class InstrumentsApiControllerMVCIT extends API_MVC_InventoryTestBase {
   }
 
   /*
-   * An instrument shaped by the PIDINST template should always carry a landing page: when the user
-   * leaves the field empty, saving fills it with the instrument's own public RSpace address. This is
-   * independent of PIDINST registration - it happens on save.
+   * RSDEV-1307: a landing page names exactly one physical instrument, so a value typed into a
+   * template must not travel onto instruments created from it — each new instrument gets its own
+   * public RSpace address instead, filled on save and independently of PIDINST registration.
+   * (A landing page supplied in the creation request itself is still kept; that is user input on
+   * the new record, covered by InstrumentEntityApiManagerTest.)
+   *
+   * This subsumes the blank-template case: since the template's value is cleared either way, a
+   * template seeded with a landing page and one seeded blank now exercise the same fill.
    */
   @Test
-  public void blankLandingPageIsFilledWithTheInstrumentsOwnAddressOnCreate() throws Exception {
+  public void aTemplateSuppliedLandingPageIsNotInheritedByANewInstrument() throws Exception {
     User anyUser = createInitAndLoginAnyUser();
     String apiKey = createNewApiKeyForUser(anyUser);
-    Long templateId = postPidinstShapedTemplate(anyUser, apiKey, "");
+    Long templateId = postPidinstShapedTemplate(anyUser, apiKey, "https://lab.example.org/mine");
 
     ApiInstrument created = postInstrumentFromTemplate(anyUser, apiKey, templateId);
 
     assertNotNull(created.getGlobalId());
     assertTrue(
         StringUtils.endsWith(landingPageOf(created), "/globalId/" + created.getGlobalId()),
-        "expected the default landing page, got: " + landingPageOf(created));
-  }
-
-  @Test
-  public void aLandingPageTheUserSuppliedIsNeverReplaced() throws Exception {
-    User anyUser = createInitAndLoginAnyUser();
-    String apiKey = createNewApiKeyForUser(anyUser);
-    Long templateId = postPidinstShapedTemplate(anyUser, apiKey, "https://lab.example.org/mine");
-
-    ApiInstrument created = postInstrumentFromTemplate(anyUser, apiKey, templateId);
-
-    assertEquals("https://lab.example.org/mine", landingPageOf(created));
+        "expected the instrument's own landing page, got: " + landingPageOf(created));
   }
 
   @Test
   public void clearingTheLandingPageAndSavingRestoresTheDefault() throws Exception {
     User anyUser = createInitAndLoginAnyUser();
     String apiKey = createNewApiKeyForUser(anyUser);
-    Long templateId = postPidinstShapedTemplate(anyUser, apiKey, "https://lab.example.org/mine");
+    // the template's own value never reaches the instrument, so seeding one would be misleading
+    Long templateId = postPidinstShapedTemplate(anyUser, apiKey, "");
     ApiInstrument created = postInstrumentFromTemplate(anyUser, apiKey, templateId);
     Long fieldId =
         created.getFields().stream()

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryIdentifiersB2instApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryIdentifiersB2instApiControllerMVCIT.java
@@ -110,7 +110,7 @@ public class InventoryIdentifiersB2instApiControllerMVCIT extends API_MVC_Invent
 
     // Step A: a template carrying the filled PIDINST-shaped fields. POST /instruments cannot
     // create fields from a fields[] payload, so the instrument is created FROM a template: the
-    // copy path clones each field including its content.
+    // copy path clones each field including its content, bar the landing page (see below).
     ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
     templatePost.setName("PIDINST template copy");
     templatePost
@@ -202,7 +202,21 @@ public class InventoryIdentifiersB2instApiControllerMVCIT extends API_MVC_Invent
     assertEquals("Commissioned", sent.getDate().get(0).getDateType());
     // "Last calibrated" is not mapped; MeasuredVariable carries the measured quantity verbatim
     assertEquals(List.of("Air temperature"), sent.getMeasuredVariable());
-    assertEquals("https://lab.example.org/aws-42", sent.getLandingPage());
+    /*
+     * The one template field that deliberately does NOT copy across: a landing page names exactly
+     * one physical instrument, so the new instrument gets its own address instead of the template's
+     * (RSDEV-1307). That own address is what gets registered.
+     *
+     * Note this assertion no longer discriminates the landing page mapping itself: the mapped-field
+     * branch and the GlobalIdUrls fallback both produce this same "/globalId/..." string, so it
+     * would still pass if the field mapping were dropped. The mapping is pinned discriminatingly by
+     * the unit tests in RspaceToExternalProviderAdapterImplTest (see
+     * landingPageFromTheFieldSurvivesAnUnsetServerUrl); what this MVCIT pins is that a landing page
+     * reaches B2INST at all on the create-from-template path.
+     */
+    assertTrue(
+        sent.getLandingPage().endsWith("/globalId/" + instrumentGlobalId),
+        "expected the instrument's own landing page, got: " + sent.getLandingPage());
     assertEquals("Other", sent.getAlternateIdentifier().get(0).getAlternateIdentifierType());
     assertEquals(
         "INV-2025-0042", sent.getAlternateIdentifier().get(0).getAlternateIdentifierValue());

--- a/src/test/java/com/researchspace/service/inventory/InstrumentEntityApiManagerTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InstrumentEntityApiManagerTest.java
@@ -15,6 +15,7 @@ import com.researchspace.api.v1.model.ApiExtraField;
 import com.researchspace.api.v1.model.ApiExtraField.ExtraFieldTypeEnum;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentEntity;
 import com.researchspace.api.v1.model.ApiInstrumentSearchResult;
 import com.researchspace.api.v1.model.ApiInstrumentTemplate;
 import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
@@ -40,6 +41,7 @@ import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.service.inventory.impl.InstrumentEntityApiManagerImpl;
 import com.researchspace.testutils.SpringTransactionalTest;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -246,6 +248,153 @@ public class InstrumentEntityApiManagerTest extends SpringTransactionalTest {
     assertEquals(template.getFields().get(0).getName(), created.getFields().get(0).getName());
   }
 
+  /**
+   * A persisted instrument template carrying a single "Landing page" field, the fixture the
+   * RSDEV-1307 derivation tests share.
+   */
+  private ApiInstrumentTemplate templateWithLandingPage(String content, boolean mandatory) {
+    ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
+    templatePost.setName("template with landing page");
+    ApiInventoryEntityField landingPage =
+        createBasicApiSampleField("Landing page", ApiFieldType.URI, content);
+    landingPage.setMandatory(mandatory);
+    templatePost.getFields().add(landingPage);
+    return instrumentApiMgr.createInstrumentTemplate(templatePost, testUser);
+  }
+
+  /** The content of the record's "Landing page" field, matched by name rather than by position. */
+  private String landingPageContentOf(ApiInstrumentEntity record) {
+    return record.getFields().stream()
+        .filter(f -> "Landing page".equalsIgnoreCase(f.getName()))
+        .findFirst()
+        .map(ApiInventoryEntityField::getContent)
+        .orElse(null);
+  }
+
+  @Test
+  public void createInstrumentFromTemplate_templateSuppliedLandingPageIsNotInherited() {
+    ApiInstrumentTemplate template =
+        templateWithLandingPage("https://lab.example.org/original", false);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("from-template-own-page");
+    request.setTemplateId(template.getId());
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+
+    // RSDEV-1307: the template's landing page names no instrument, so it must not travel; the
+    // blank self-fills with the instrument's own address instead
+    assertTrue(landingPageContentOf(created).endsWith("/globalId/" + created.getGlobalId()));
+    // and the source template is untouched by the derivation
+    assertEquals(
+        "https://lab.example.org/original",
+        landingPageContentOf(
+            instrumentApiMgr.getApiInstrumentTemplateById(template.getId(), testUser)));
+  }
+
+  @Test
+  public void createInstrumentFromTemplate_requestSuppliedLandingPageIsKept() {
+    ApiInstrumentTemplate template =
+        templateWithLandingPage("https://lab.example.org/original", false);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("with-own-landing-page");
+    request.setTemplateId(template.getId());
+    // the incoming field list is positional and must match the template's field count (1)
+    ApiInventoryEntityField landingPage = new ApiInventoryEntityField();
+    landingPage.setContent("https://user.example.org/chosen");
+    request.setFields(List.of(landingPage));
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+
+    // a value supplied on the new record itself is user input and is kept
+    assertEquals("https://user.example.org/chosen", landingPageContentOf(created));
+  }
+
+  @Test
+  public void createInstrumentFromTemplate_mandatoryLandingPageStillCreatesSuccessfully() {
+    // a hand-authored template may mark Landing page mandatory; clearing the inherited value
+    // leaves it blank until the post-save fill supplies the instrument's own address, so the
+    // pre-save mandatory validation must not reject it (RSDEV-1307)
+    ApiInstrumentTemplate template =
+        templateWithLandingPage("https://lab.example.org/original", true);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("from-mandatory-template");
+    request.setTemplateId(template.getId());
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+
+    assertNotNull(created.getId());
+    assertTrue(landingPageContentOf(created).endsWith("/globalId/" + created.getGlobalId()));
+  }
+
+  @Test
+  public void createInstrumentFromTemplate_blankLandingPageInRequestIsFilledNotRejected() {
+    // the UI posts the whole field list with the Landing page deliberately blanked, so a blank
+    // incoming value must be treated as "fill this for me", not as a missing mandatory value
+    ApiInstrumentTemplate template =
+        templateWithLandingPage("https://lab.example.org/original", true);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("from-ui-shaped-request");
+    request.setTemplateId(template.getId());
+    ApiInventoryEntityField blankLandingPage = new ApiInventoryEntityField();
+    blankLandingPage.setContent("");
+    request.setFields(List.of(blankLandingPage));
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+
+    assertNotNull(created.getId());
+    assertTrue(landingPageContentOf(created).endsWith("/globalId/" + created.getGlobalId()));
+  }
+
+  @Test
+  public void createInstrumentFromTemplate_blankLandingPageInRequestIsFilledForOptionalField() {
+    // same request shape against a template that does not mark the field mandatory: the fill must
+    // happen in the ordinary case too, not only where the mandatory check would have fired
+    ApiInstrumentTemplate template =
+        templateWithLandingPage("https://lab.example.org/original", false);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("from-ui-shaped-request-optional");
+    request.setTemplateId(template.getId());
+    ApiInventoryEntityField blankLandingPage = new ApiInventoryEntityField();
+    blankLandingPage.setContent("");
+    request.setFields(List.of(blankLandingPage));
+
+    ApiInstrument created = instrumentApiMgr.createNewApiInstrument(request, testUser);
+
+    assertNotNull(created.getId());
+    assertTrue(landingPageContentOf(created).endsWith("/globalId/" + created.getGlobalId()));
+  }
+
+  @Test
+  public void createInstrumentFromTemplate_otherMandatoryBlankFieldIsStillRejected() {
+    // the Landing page exemption must not swallow a genuinely missing mandatory value
+    ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
+    templatePost.setName("template with two mandatory fields");
+    ApiInventoryEntityField mandatoryLandingPage =
+        createBasicApiSampleField(
+            "Landing page", ApiFieldType.URI, "https://lab.example.org/original");
+    mandatoryLandingPage.setMandatory(true);
+    ApiInventoryEntityField mandatorySerial =
+        createBasicApiSampleField("Serial number", ApiFieldType.TEXT, "");
+    mandatorySerial.setMandatory(true);
+    templatePost.getFields().add(mandatoryLandingPage);
+    templatePost.getFields().add(mandatorySerial);
+    ApiInstrumentTemplate template =
+        instrumentApiMgr.createInstrumentTemplate(templatePost, testUser);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("from-two-mandatory-template");
+    request.setTemplateId(template.getId());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> instrumentApiMgr.createNewApiInstrument(request, testUser));
+  }
+
   @Test
   public void createInstrumentWithoutTemplateLeavesTemplateIdNull() {
     ApiInstrument request = new ApiInstrument();
@@ -368,6 +517,24 @@ public class InstrumentEntityApiManagerTest extends SpringTransactionalTest {
     assertFalse(copy.getId().equals(template.getId()));
     assertTrue(copy.isTemplate());
     verify(mockPublisher, Mockito.times(2)).publishEvent(Mockito.any(InventoryCreationEvent.class));
+  }
+
+  @Test
+  public void duplicateInstrumentTemplate_clearsLandingPage() {
+    ApiInstrumentTemplate template =
+        templateWithLandingPage("https://lab.example.org/original", false);
+    assertEquals("https://lab.example.org/original", landingPageContentOf(template));
+
+    ApiInstrumentTemplate copy =
+        instrumentApiMgr.duplicateInstrumentTemplate(template.getId(), testUser);
+
+    // RSDEV-1307: a landing page never belongs in a reusable definition, so the copy starts blank
+    assertTrue(StringUtils.isBlank(landingPageContentOf(copy)));
+
+    // and the source template keeps its value
+    ApiInstrumentTemplate original =
+        instrumentApiMgr.getApiInstrumentTemplateById(template.getId(), testUser);
+    assertEquals("https://lab.example.org/original", landingPageContentOf(original));
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InstrumentEntityApiManagerImplLinkFieldTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -15,22 +16,31 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInstrument;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.dao.ContainerDao;
 import com.researchspace.dao.InstrumentDao;
+import com.researchspace.dao.InstrumentTemplateDao;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.Instrument;
+import com.researchspace.model.inventory.InstrumentEntity;
+import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.model.inventory.field.InventoryStringField;
 import com.researchspace.model.inventory.field.InventoryUriField;
+import com.researchspace.model.record.RecordFactory;
 import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.UserManager;
+import com.researchspace.service.inventory.ApiExtraFieldsHelper;
 import com.researchspace.service.inventory.InventoryLinkManager;
+import com.researchspace.service.inventory.InventoryMoveHelper;
 import com.researchspace.service.inventory.InventoryPermissionUtils;
 import com.researchspace.testutils.TestFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,11 +64,15 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
   @Mock private InventoryLinkManager inventoryLinkManager;
   @Mock private InstrumentDao instrumentDao;
+  @Mock private InstrumentTemplateDao instrumentTemplateDao;
   @Mock private InventoryPermissionUtils invPermissions;
   @Mock private ContainerDao containerDao;
   @Mock private IPropertyHolder properties;
   @Mock private ApplicationEventPublisher publisher;
   @Mock private UserManager userManager;
+  @Mock private ApiExtraFieldsHelper extraFieldHelper;
+  @Mock private InventoryMoveHelper inventoryMoveHelper;
+  @Mock private MessageSourceUtils messages;
   private InstrumentEntityApiManagerImpl manager;
 
   private User user;
@@ -70,11 +84,18 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
     manager = new InstrumentEntityApiManagerImpl();
     ReflectionTestUtils.setField(manager, "inventoryLinkManager", inventoryLinkManager);
     ReflectionTestUtils.setField(manager, "instrumentDao", instrumentDao);
+    ReflectionTestUtils.setField(manager, "instrumentTemplateDao", instrumentTemplateDao);
+    // the real factory, not a mock: building an instrument from a template is the behaviour under
+    // test here, not a trust boundary to stub out
+    ReflectionTestUtils.setField(manager, "recordFactory", new RecordFactory());
     ReflectionTestUtils.setField(manager, "invPermissions", invPermissions);
     ReflectionTestUtils.setField(manager, "containerDao", containerDao);
     ReflectionTestUtils.setField(manager, "properties", properties);
     ReflectionTestUtils.setField(manager, "publisher", publisher);
     ReflectionTestUtils.setField(manager, "userManager", userManager);
+    ReflectionTestUtils.setField(manager, "extraFieldHelper", extraFieldHelper);
+    ReflectionTestUtils.setField(manager, "inventoryMoveHelper", inventoryMoveHelper);
+    ReflectionTestUtils.setField(manager, "messages", messages);
     user = TestFactory.createAnyUser("any");
     dbLink = new InventoryLink();
     dbLink.setRelationType("References");
@@ -225,12 +246,21 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
   // --- duplicateInstrument / landing-page tests ---
 
   private Instrument instrumentWithLandingPage(long id, String landingPageData) {
+    return instrumentWithLandingPage(id, landingPageData, false);
+  }
+
+  private Instrument instrumentWithMandatoryLandingPage(long id, String landingPageData) {
+    return instrumentWithLandingPage(id, landingPageData, true);
+  }
+
+  private Instrument instrumentWithLandingPage(long id, String landingPageData, boolean mandatory) {
     Instrument instrument = new Instrument();
     instrument.setId(id);
     instrument.setName("Test Instrument");
     instrument.setOwner(user);
     InventoryUriField lp = new InventoryUriField("Landing page");
     lp.setFieldData(landingPageData);
+    lp.setMandatory(mandatory);
     addField(instrument, lp);
     return instrument;
   }
@@ -278,14 +308,12 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
   @Test
   void duplicatingInstrumentWithNoLandingPageFieldChangesNothing() {
-    String serverUrl = "https://rspace.example.com";
     // Source has no URI fields at all
     Instrument source = new Instrument();
     source.setId(1L);
     source.setName("Plain Instrument");
     source.setOwner(user);
 
-    when(properties.getServerUrl()).thenReturn(serverUrl);
     stubDuplicateInfrastructure(source);
 
     manager.duplicateInstrument(1L, user);
@@ -294,11 +322,16 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
     verify(instrumentDao, times(1)).save(any());
   }
 
+  /*
+   * Deliberately traverses the same code as the system-generated case above: RSDEV-1261 cleared
+   * only a system-generated value, RSDEV-1307 made the clear unconditional, so the two scenarios
+   * now converge. Kept as a pair because they document the distinction that used to matter, and
+   * would diverge again the moment the clear started inspecting the source value.
+   */
   @Test
-  void duplicatingUserTypedLandingPagePreservesTheValue() {
+  void duplicatingUserTypedLandingPageGivesTheCopyItsOwnAddress() {
     String serverUrl = "https://rspace.example.com";
     String userTypedUrl = "https://external.lab.example.com/my-instrument";
-    // Source has a user-typed URL that does not match the system-generated form for IN1
     Instrument source = instrumentWithLandingPage(1L, userTypedUrl);
 
     when(properties.getServerUrl()).thenReturn(serverUrl);
@@ -306,19 +339,361 @@ class InstrumentEntityApiManagerImplLinkFieldTest {
 
     manager.duplicateInstrument(1L, user);
 
-    // Conservative check did not match → field still non-blank → only one save
+    // First save creates the copy (id=2); second save persists the filled landing page
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(2)).save(captor.capture());
+
+    assertEquals(serverUrl + "/globalId/IN2", landingPageFieldData(captor.getAllValues().get(1)));
+  }
+
+  @Test
+  void duplicatingUserTypedLandingPageWithoutServerUrlLeavesItBlank() {
+    String userTypedUrl = "https://external.lab.example.com/my-instrument";
+    Instrument source = instrumentWithLandingPage(1L, userTypedUrl);
+
+    // No server URL configured: the fill cannot build the copy's own address
+    when(properties.getServerUrl()).thenReturn(null);
+    stubDuplicateInfrastructure(source);
+
+    manager.duplicateInstrument(1L, user);
+
+    // Clear happened, fill had nothing to write — blank is the recoverable state, one save only
     ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
     verify(instrumentDao, times(1)).save(captor.capture());
 
-    assertEquals(userTypedUrl, landingPageFieldData(captor.getValue()));
+    assertNull(landingPageFieldData(captor.getValue()));
   }
 
-  private String landingPageFieldData(Instrument instrument) {
+  @Test
+  void duplicatingAMandatoryLandingPageDoesNotBlowUp() {
+    String serverUrl = "https://rspace.example.com";
+    // A mandatory field rejects blank content through setFieldData, so the clear must bypass
+    // validation — the refill immediately writes a valid URL anyway
+    Instrument source = instrumentWithMandatoryLandingPage(1L, serverUrl + "/globalId/IN1");
+
+    when(properties.getServerUrl()).thenReturn(serverUrl);
+    stubDuplicateInfrastructure(source);
+
+    manager.duplicateInstrument(1L, user);
+
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(2)).save(captor.capture());
+    assertEquals(serverUrl + "/globalId/IN2", landingPageFieldData(captor.getAllValues().get(1)));
+  }
+
+  @Test
+  void duplicatingDoesNotClearOtherUriFields() {
+    String serverUrl = "https://rspace.example.com";
+    Instrument source = new Instrument();
+    source.setId(1L);
+    source.setName("Test Instrument");
+    source.setOwner(user);
+    // ordered first, so a name-blind findFirst would clear this field instead
+    InventoryUriField docs = new InventoryUriField("Documentation URL");
+    docs.setFieldData("https://docs.example.org/manual");
+    addField(source, docs);
+    InventoryUriField lp = new InventoryUriField("Landing page");
+    lp.setFieldData(serverUrl + "/globalId/IN1");
+    addField(source, lp);
+
+    when(properties.getServerUrl()).thenReturn(serverUrl);
+    stubDuplicateInfrastructure(source);
+
+    manager.duplicateInstrument(1L, user);
+
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(2)).save(captor.capture());
+    Instrument copy = captor.getAllValues().get(1);
+    // only the Landing page is identity-bound; an unrelated URI field is copied as-is
+    assertEquals(
+        "https://docs.example.org/manual",
+        copy.getActiveFields().stream()
+            .filter(f -> "Documentation URL".equals(f.getName()))
+            .findFirst()
+            .map(InventoryEntityField::getFieldData)
+            .orElse(null));
+    // and the right field was still found and refilled, despite not being first
+    assertEquals(serverUrl + "/globalId/IN2", landingPageFieldData(copy));
+  }
+
+  @Test
+  void landingPageIsMatchedIgnoringCaseAndSurroundingWhitespace() {
+    String serverUrl = "https://rspace.example.com";
+    Instrument source = new Instrument();
+    source.setId(1L);
+    source.setName("Odd Field Name");
+    source.setOwner(user);
+    InventoryUriField lp = new InventoryUriField(" landing PAGE ");
+    lp.setFieldData("https://external.lab.example.com/my-instrument");
+    addField(source, lp);
+
+    when(properties.getServerUrl()).thenReturn(serverUrl);
+    stubDuplicateInfrastructure(source);
+
+    manager.duplicateInstrument(1L, user);
+
+    // the name predicate trims and ignores case, so this field is still identity-bound
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(2)).save(captor.capture());
+    assertEquals(
+        serverUrl + "/globalId/IN2",
+        captor.getAllValues().get(1).getActiveFields().stream()
+            .filter(f -> f.getType() == FieldType.URI)
+            .findFirst()
+            .map(InventoryEntityField::getFieldData)
+            .orElse(null));
+  }
+
+  private String landingPageFieldData(InstrumentEntity instrument) {
     return instrument.getActiveFields().stream()
         .filter(f -> f.getType() == FieldType.URI)
         .filter(f -> "Landing page".equalsIgnoreCase(f.getName()))
         .findFirst()
         .map(InventoryEntityField::getFieldData)
         .orElse(null);
+  }
+
+  // --- createNewApiInstrument / landing-page tests ---
+
+  private void addTemplateField(InstrumentTemplate template, InventoryEntityField field) {
+    field.setInventoryRecord(template);
+    field.setColumnIndex(template.getFields().size() + 1);
+    template.getFields().add(field);
+    template.refreshActiveFieldsAndColumnIndex();
+  }
+
+  private InstrumentTemplate templateWithLandingPage(long id, String landingPageData) {
+    InstrumentTemplate template = new InstrumentTemplate();
+    template.setId(id);
+    template.setName("Test Template");
+    template.setOwner(user);
+    InventoryUriField lp = new InventoryUriField("Landing page");
+    lp.setFieldData(landingPageData);
+    addTemplateField(template, lp);
+    return template;
+  }
+
+  private ApiInventoryEntityField apiFieldWithContent(String content) {
+    ApiInventoryEntityField field = new ApiInventoryEntityField();
+    field.setContent(content);
+    return field;
+  }
+
+  private void stubCreateFromTemplateInfrastructure(InstrumentTemplate template) {
+    when(instrumentTemplateDao.exists(template.getId())).thenReturn(true);
+    when(instrumentTemplateDao.get(template.getId())).thenReturn(template);
+    when(instrumentDao.save(any()))
+        .thenAnswer(
+            inv -> {
+              Instrument arg = inv.getArgument(0);
+              if (arg.getId() == null) {
+                arg.setId(2L);
+              }
+              return arg;
+            });
+    when(containerDao.getWorkbenchForUser(user)).thenReturn(mock(Container.class));
+  }
+
+  private ApiInstrument creationRequestEchoing(long templateId, String landingPageContent) {
+    ApiInstrument request = new ApiInstrument();
+    request.setTemplateId(templateId);
+    request.setName("New Instrument");
+    request.getFields().add(apiFieldWithContent(landingPageContent));
+    return request;
+  }
+
+  @Test
+  void createFromTemplateWithALandingPageEchoedBackFromTheTemplateGivesItsOwnAddress() {
+    String serverUrl = "https://rspace.example.com";
+    String templateLandingPage = "https://external.lab.example.com/original";
+    InstrumentTemplate template = templateWithLandingPage(1L, templateLandingPage);
+
+    when(properties.getServerUrl()).thenReturn(serverUrl);
+    stubCreateFromTemplateInfrastructure(template);
+
+    // a client that reads the template and posts its fields straight back must not be able to
+    // re-establish the template's landing page on the new instrument (RSDEV-1307)
+    manager.createNewApiInstrument(creationRequestEchoing(1L, templateLandingPage), user);
+
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(2)).save(captor.capture());
+    assertEquals(serverUrl + "/globalId/IN2", landingPageFieldData(captor.getAllValues().get(1)));
+  }
+
+  @Test
+  void createFromTemplateKeepsALandingPageTheUserTypedOnTheNewInstrument() {
+    String userTyped = "https://external.lab.example.com/my-own-page";
+    InstrumentTemplate template =
+        templateWithLandingPage(1L, "https://external.lab.example.com/original");
+
+    stubCreateFromTemplateInfrastructure(template);
+
+    // the boundary of the previous test: only the template's own value is discarded, a value the
+    // user typed for this record is theirs and is kept
+    manager.createNewApiInstrument(creationRequestEchoing(1L, userTyped), user);
+
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(1)).save(captor.capture());
+    assertEquals(userTyped, landingPageFieldData(captor.getValue()));
+    // one save only: nothing was blank, so the fill had nothing to write
+    verify(properties, never()).getServerUrl();
+  }
+
+  @Test
+  void duplicatingATemplateLeavesTheCopysLandingPageBlank() {
+    InstrumentTemplate source =
+        templateWithLandingPage(1L, "https://external.lab.example.com/original");
+
+    when(instrumentTemplateDao.exists(1L)).thenReturn(true);
+    when(instrumentTemplateDao.get(1L)).thenReturn(source);
+    when(instrumentTemplateDao.save(any()))
+        .thenAnswer(
+            inv -> {
+              InstrumentTemplate arg = inv.getArgument(0);
+              if (arg.getId() == null) {
+                arg.setId(2L);
+              }
+              return arg;
+            });
+
+    manager.duplicateInstrumentTemplate(1L, user);
+
+    ArgumentCaptor<InstrumentTemplate> captor = ArgumentCaptor.forClass(InstrumentTemplate.class);
+    verify(instrumentTemplateDao).save(captor.capture());
+    // a template is never filled with an address: stamping one instrument's page onto a reusable
+    // definition would hand it to every instrument later created from it (RSDEV-1307)
+    assertNull(landingPageFieldData(captor.getValue()));
+    // and the source template keeps its own value
+    assertEquals("https://external.lab.example.com/original", landingPageFieldData(source));
+    verify(properties, never()).getServerUrl();
+  }
+
+  @Test
+  void createFromTemplateExemptsTheLandingPageByNameNotByPosition() {
+    String serverUrl = "https://rspace.example.com";
+    String templateLandingPage = "https://external.lab.example.com/original";
+    InstrumentTemplate template = new InstrumentTemplate();
+    template.setId(1L);
+    template.setName("Two Field Template");
+    template.setOwner(user);
+    // Manufacturer sits where a positional exemption would land, Landing page does not
+    InventoryStringField manufacturer = new InventoryStringField("Manufacturer");
+    manufacturer.setFieldData("Template Co");
+    addTemplateField(template, manufacturer);
+    InventoryUriField lp = new InventoryUriField("Landing page");
+    lp.setFieldData(templateLandingPage);
+    addTemplateField(template, lp);
+
+    when(properties.getServerUrl()).thenReturn(serverUrl);
+    stubCreateFromTemplateInfrastructure(template);
+
+    // the landing page is echoed back rather than blanked: a blank would be stored and refilled
+    // identically whichever field the exemption picked, so it could not tell the two apart
+    ApiInstrument request = new ApiInstrument();
+    request.setTemplateId(1L);
+    request.setName("New Instrument");
+    request.getFields().add(apiFieldWithContent("Zeiss"));
+    request.getFields().add(apiFieldWithContent(templateLandingPage));
+
+    manager.createNewApiInstrument(request, user);
+
+    // exempting by index instead would store the echoed value, leaving nothing blank to fill and
+    // so producing a single save holding the template's address
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(2)).save(captor.capture());
+    Instrument created = captor.getAllValues().get(1);
+    assertEquals(serverUrl + "/globalId/IN2", landingPageFieldData(created));
+    assertEquals(
+        "Zeiss",
+        created.getActiveFields().stream()
+            .filter(f -> "Manufacturer".equals(f.getName()))
+            .findFirst()
+            .map(InventoryEntityField::getFieldData)
+            .orElse(null));
+  }
+
+  @Test
+  void createFromTemplateWithoutAServerUrlLeavesTheLandingPageBlank() {
+    String templateLandingPage = "https://external.lab.example.com/original";
+    InstrumentTemplate template = templateWithLandingPage(1L, templateLandingPage);
+
+    // no server URL configured: the fill cannot build the new instrument's own address
+    when(properties.getServerUrl()).thenReturn(null);
+    stubCreateFromTemplateInfrastructure(template);
+
+    manager.createNewApiInstrument(creationRequestEchoing(1L, templateLandingPage), user);
+
+    // the mirror of the duplicate path: cleared, nothing to fill, and blank is the recoverable
+    // state rather than a half-written address
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(1)).save(captor.capture());
+    assertNull(landingPageFieldData(captor.getValue()));
+  }
+
+  @Test
+  void createWithoutATemplateProducesNoStructuredFields() {
+    when(instrumentDao.save(any()))
+        .thenAnswer(
+            inv -> {
+              Instrument arg = inv.getArgument(0);
+              if (arg.getId() == null) {
+                arg.setId(2L);
+              }
+              return arg;
+            });
+    when(containerDao.getWorkbenchForUser(user)).thenReturn(mock(Container.class));
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("Plain Instrument");
+
+    manager.createNewApiInstrument(request, user);
+
+    // pins a cross-repo invariant the landing-page validation exemption relies on: with no
+    // template there are no structured fields to validate, so the exemption cannot be reached
+    ArgumentCaptor<Instrument> captor = ArgumentCaptor.forClass(Instrument.class);
+    verify(instrumentDao, times(1)).save(captor.capture());
+    assertTrue(captor.getValue().getActiveFields().isEmpty());
+  }
+
+  @Test
+  void createFromTemplateRejectsAFieldListThatDoesNotMatchTheTemplate() {
+    InstrumentTemplate template =
+        templateWithLandingPage(1L, "https://external.lab.example.com/original");
+
+    when(instrumentTemplateDao.exists(1L)).thenReturn(true);
+    when(instrumentTemplateDao.get(1L)).thenReturn(template);
+    when(messages.getMessage(eq("errors.inventory.instrument.fieldCountMismatch"), any()))
+        .thenReturn("field count mismatch");
+
+    ApiInstrument request = new ApiInstrument();
+    request.setTemplateId(1L);
+    request.setName("New Instrument");
+    request.getFields().add(apiFieldWithContent(""));
+    request.getFields().add(apiFieldWithContent(""));
+
+    // the message is resolved through the message source, not built inline
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class, () -> manager.createNewApiInstrument(request, user));
+    assertEquals("field count mismatch", thrown.getMessage());
+    verify(instrumentDao, never()).save(any());
+  }
+
+  @Test
+  void createFromTemplateStillRejectsAMalformedLandingPage() {
+    InstrumentTemplate template =
+        templateWithLandingPage(1L, "https://external.lab.example.com/original");
+
+    when(instrumentTemplateDao.exists(1L)).thenReturn(true);
+    when(instrumentTemplateDao.get(1L)).thenReturn(template);
+
+    // the clear-instead-of-store path is reserved for blank and inherited values; anything else is
+    // user input for this record and goes through the ordinary URI validation
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            manager.createNewApiInstrument(creationRequestEchoing(1L, "http://[not a uri"), user));
+
+    verify(instrumentDao, never()).save(any());
   }
 }


### PR DESCRIPTION
## Description ##
- Resolves https://researchspace.atlassian.net/browse/RSDEV-1307
- Follow-up to RSDEV-1261, which cleared the Landing page only when it matched the auto-generated value for the source instrument. A value the user had typed by hand was still carried over. A landing page names exactly one physical instrument, so it must be discarded on every derivation path regardless of where the value came from.

### Backend

- InstrumentEntityApiManagerImpl: clearSystemGeneratedLandingPage is replaced by an unconditional clearLandingPage, applied on all three derivation paths (duplicate instrument, duplicate template, create instrument from template). On a concrete instrument the blank is then refilled with the record's own address; on a template it stays blank, since stamping one instrument's address onto a reusable definition would hand it to every instrument later created from that template.
- The create-from-template path also discards a Landing page that the request echoes back unchanged from the template. Without this, any client that read a template and posted its fields verbatim re-established the template's value, leaving the guarantee dependent on client cooperation rather than on the service. A value the user supplies for the new record is still kept and still validated, so a malformed URI is rejected.
- New package-private PidinstFields helper holds the single copy of the "Landing page" name-and-type predicate, which previously existed as three byte-identical copies in the same package. Follows the GlobalIdUrls precedent. Only the Inventory UI's copy now remains, and it cannot be shared.
- The field-count mismatch error is externalized to server.inventory.json as errors.inventory.instrument.fieldCountMismatch.

### Frontend

- InstrumentModel.setTemplate blanks the inherited Landing page so the creation form shows what will actually be saved. Only the first matching field is blanked, mirroring the backend, which resolves and refills a single field.

### Tests

- Nine new fast backend tests and two new frontend tests, covering the echoed-value case, the user-typed boundary, template duplication (which previously had only DB-backed coverage), name-based rather than positional resolution, the absent-server-URL case, and malformed URI rejection.
- Removed one redundant MVCIT test and a redundant assertion.

CONTEXT.md records the Landing page as an identity-bound field, along with the paths deliberately left out of scope: template-version sync, creating a template from an instrument (opt-in per field), and the absence of a backfill for records derived before this change, since a blanket update cannot distinguish an inherited value from one a user legitimately typed.
