### PR TITLE
mailpit setup and test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ env:
   E2E_INTEGRATION_MODE: ${{ inputs.mode }}
   E2E_MOCK_PORT: "9099"
   RSPACE_BASE_URL: http://localhost:8080
+  MAILPIT_HTTP_URL: http://localhost:8025
   # Keep this in sync with matrix.shard below.
   E2E_SHARD_TOTAL: "3"
 
@@ -92,6 +93,16 @@ jobs:
         image: rspaceops/oss-chemistry:latest
         ports:
           - 8090:8090
+      # SMTP catcher for @mail tests, required in both modes — infra, not an
+      # integration under test, so it's not part of the mock/real split.
+      mailpit:
+        image: axllent/mailpit:latest
+        ports:
+          - 1025:1025
+          - 8025:8025
+        env:
+          MP_SMTP_AUTH_ACCEPT_ANY: "1"
+          MP_SMTP_AUTH_ALLOW_INSECURE: "1"
 
     steps:
       - uses: actions/checkout@v7.0.0
@@ -170,6 +181,13 @@ jobs:
             -DreactDevMode=false \
             -Dchemistry.provider=indigo \
             -Dchemistry.service.url=http://localhost:8090 \
+            -Demail.enabled=true \
+            -Dmail.emailHost=localhost \
+            -Dmail.port=1025 \
+            -Dmail.emailAccount=mailpit \
+            -Dmail.password=mailpit \
+            -Dmail.ssl.enabled=false \
+            -Dmail.from=noreply@rspace-e2e.local \
             -Djdbc.url=jdbc:mysql://localhost:3306/rspace \
             -Djdbc.db.maven=rspace \
             -DRS_FILE_BASE="$RS_FILE_BASE" \

--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -320,6 +320,38 @@ overrides the default filestore location.
 true/false will enable/disable the ability to set HTTP response headers
 to cache.
 
+#### Capturing real emails locally with Mailpit
+
+`dev/deployment.properties` sets `email.enabled=false`, To exercise a real mail flow (password reset,forgotten username, signup verification, sharing notifications) against a
+local mailbox, run a [Mailpit](https://mailpit.axllent.org/) container and
+point RSpace's mail properties at it:
+
+```bash
+docker run -d --name mailpit --rm \
+  -p 1025:1025 -p 8025:8025 \
+  -e MP_SMTP_AUTH_ACCEPT_ANY=1 -e MP_SMTP_AUTH_ALLOW_INSECURE=1 \
+  axllent/mailpit:latest
+
+mvn clean jetty:run -Denvironment=keepdbintact -DRS.devlogLevel=INFO \
+  -Dspring.profiles.active=run -DreactDevMode=true \
+  -Demail.enabled=true -Dmail.emailHost=localhost -Dmail.port=1025 \
+  -Dmail.emailAccount=mailpit -Dmail.password=mailpit -Dmail.ssl.enabled=false \
+  -Dmail.from=noreply@rspace-e2e.local
+```
+
+`EmailBroadcastImpl` always performs SMTP AUTH; Mailpit accepts any
+credentials when started with `MP_SMTP_AUTH_ACCEPT_ANY=1`/
+`MP_SMTP_AUTH_ALLOW_INSECURE=1`, so `mail.emailAccount`/`mail.password` can be
+any placeholder no code changes are needed. `mail.from` does need a
+syntactically valid override though: `deployments/dev/deployment.properties`
+doesn't set it, so it inherits `defaultDeployment.properties`' literal
+`support@<your_server>.com` placeholder, which Mailpit's strict SMTP
+validation rejects outright (`553 5.1.3 The address is not a valid RFC 5321
+address`) on `MAIL FROM`. Read captured mail at
+`http://localhost:8025`. If you're using the Docker dev stack instead of a
+bare `mvn jetty:run`, use `rspace-dev up --mailpit` instead (see
+`docker/dev/README.md`) — it wires the same properties automatically.
+
 #### Running RSpace in production mode locally
 
 Run the usual `mvn jetty:run` command, just change the active spring profile to `prod`

--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -322,7 +322,7 @@ to cache.
 
 #### Capturing real emails locally with Mailpit
 
-`dev/deployment.properties` sets `email.enabled=false`, To exercise a real mail flow (password reset,forgotten username, signup verification, sharing notifications) against a
+`dev/deployment.properties` sets `email.enabled=false`. To exercise a real mail flow (password reset, forgotten username, signup verification, sharing notifications) against a
 local mailbox, run a [Mailpit](https://mailpit.axllent.org/) container and
 point RSpace's mail properties at it:
 
@@ -342,7 +342,7 @@ mvn clean jetty:run -Denvironment=keepdbintact -DRS.devlogLevel=INFO \
 `EmailBroadcastImpl` always performs SMTP AUTH; Mailpit accepts any
 credentials when started with `MP_SMTP_AUTH_ACCEPT_ANY=1`/
 `MP_SMTP_AUTH_ALLOW_INSECURE=1`, so `mail.emailAccount`/`mail.password` can be
-any placeholder no code changes are needed. `mail.from` does need a
+any placeholder; no code changes are needed. `mail.from` does need a
 syntactically valid override though: `deployments/dev/deployment.properties`
 doesn't set it, so it inherits `defaultDeployment.properties`' literal
 `support@<your_server>.com` placeholder, which Mailpit's strict SMTP

--- a/docker/dev/.env.example
+++ b/docker/dev/.env.example
@@ -19,6 +19,8 @@ DB_PORT=3306
 DEBUG_PORT=5005
 # E2E integration mock server, allocated per worktree.
 E2E_MOCK_PORT=9099
+# Mailpit SMTP-catcher HTTP UI/API, allocated per worktree.
+MAILPIT_HTTP_PORT=8025
 
 # Browser-facing HMR host. Keep `localhost`; the Vite server still binds 0.0.0.0
 # inside the container so the app container can proxy to it.
@@ -37,11 +39,17 @@ VITE_USE_POLLING=true
 # it. Normally toggled with `rspace-dev up --e2e` / `--no-e2e`.
 # RSPACE_E2E_MOCKS=true
 
+# Start the local Mailpit SMTP catcher and point outbound mail at it
+# (email.enabled=true). Normally toggled with `rspace-dev up --mailpit` /
+# `--no-mailpit`.
+# RSPACE_MAILPIT=true
+
 # --- Optional overrides ------------------------------------------------------
 # DB_IMAGE=mariadb:12.3
 # MAVEN_IMAGE=maven:3.9-eclipse-temurin-17
 # NODE_IMAGE=node:24-bookworm-slim
 # CHEMISTRY_IMAGE=rspaceops/oss-chemistry:latest
+# MAILPIT_IMAGE=axllent/mailpit:latest
 # MAVEN_OPTS=-Xmx2g
 # PyRAT real mode needs a server-level secret:
 # MAVEN_OPTS=-Xmx2g -Dpyrat.server.config={"default-server":{"url":"...","token":"..."}}

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -129,7 +129,9 @@ endpoints.
 ./docker/dev/rspace-dev up --chemistry # also start the chemistry microservice
 ./docker/dev/rspace-dev up --e2e       # start and use third-party integration mocks
 ./docker/dev/rspace-dev up --no-e2e    # stop using integration mocks
-./docker/dev/rspace-dev logs [svc]     # follow logs: app | frontend | db | chemistry
+./docker/dev/rspace-dev up --mailpit   # also start the Mailpit SMTP catcher
+./docker/dev/rspace-dev up --no-mailpit # stop using Mailpit
+./docker/dev/rspace-dev logs [svc]     # follow logs: app | frontend | db | chemistry | mailpit
 ./docker/dev/rspace-dev ps             # status + URLs/ports for this worktree
 ./docker/dev/rspace-dev reload         # recompile Java + hot-redeploy webapp
 ./docker/dev/rspace-dev restart        # full backend JVM restart
@@ -162,6 +164,32 @@ the service is only reachable on the project's internal Docker network (no host
 port). Its working data lives in a per-worktree `chemistry-files` volume,
 removed by `nuke` like the others. Override the image with `CHEMISTRY_IMAGE` in
 `.env`.
+
+Note: toggling the flag changes the app container's environment, so the next
+`up` recreates the backend (expect the usual startup wait).
+
+## Optional: Mailpit SMTP catcher
+
+RSpace sends real email for flows like password reset, forgotten username,
+signup verification, and sharing notifications. Locally this is disabled by
+default (`email.enabled=false` in `deployments/dev/deployment.properties`), enable [Mailpit](https://mailpit.axllent.org/), a lightweight
+local SMTP catcher with a web UI and REST API:
+
+```bash
+./docker/dev/rspace-dev up --mailpit     # start it + point the app at it
+./docker/dev/rspace-dev up --no-mailpit  # turn it off again
+```
+
+The choice persists in `docker/dev/.env` (`RSPACE_MAILPIT=true`). When
+enabled, the app is started with `email.enabled=true` and `mail.emailHost`
+pointed at Mailpit's SMTP listener (`mailpit:1025`, Mailpit is started with
+`MP_SMTP_AUTH_ACCEPT_ANY=1`/`MP_SMTP_AUTH_ALLOW_INSECURE=1` so it accepts any
+placeholder credentials. The web UI/API
+is published at the per-worktree URL printed by `rspace-dev ps` (default
+`http://localhost:8025`); open it in a browser to read captured mail, or point
+the e2e suite's `MAILPIT_HTTP_URL` at it. Messages are not persisted — they
+live only for the container's lifetime. Override the image with
+`MAILPIT_IMAGE` in `.env`.
 
 Note: toggling the flag changes the app container's environment, so the next
 `up` recreates the backend (expect the usual startup wait).
@@ -417,6 +445,7 @@ is the quick lookup.
 | Frontend edits don't appear in the browser | HMR not receiving file events (common on macOS/Windows or `/mnt/c` on WSL2) | Set `VITE_USE_POLLING=true` in `.env`, then recreate the frontend container so it re-reads the var: `rspace-dev compose up -d --force-recreate frontend` (`rspace-dev restart` only recreates the backend `app`). On WSL2 keep the repo on the Linux filesystem. |
 | Java edits don't take effect after `reload` | Change needs a context rebuild or new JVM (see "What still requires a full restart") | `rspace-dev reload`, and if still stale `rspace-dev restart`. |
 | E2E integration calls reach live services or fail DNS | The stack was started without its mock mode | Run `rspace-dev up --e2e`; use the mock port printed by `rspace-dev ps` when running Playwright. |
+| Password reset / signup / notification emails never arrive anywhere | Mailpit not enabled — `email.enabled=false` by default locally, so mail is only logged | Run `rspace-dev up --mailpit`; read captured mail at the Mailpit URL printed by `rspace-dev ps`. |
 | Docker Desktop using too much RAM/disk | Multiple stacks running, or large caches | `rspace-dev down` worktrees you aren't using; reclaim disk per "Destroying a worktree's instance". |
 
 ## Notes & gotchas
@@ -427,6 +456,9 @@ is the quick lookup.
 - **E2E integration mocks**: `up --e2e` starts them beside Vite and persists
   `RSPACE_E2E_MOCKS=true`. `up --no-e2e` disables them. `rspace-dev ps` prints
   the per-worktree mock URL.
+- **Mailpit**: `up --mailpit` starts it and persists `RSPACE_MAILPIT=true`.
+  `up --no-mailpit` disables it. `rspace-dev ps` prints the per-worktree
+  Mailpit URL.
 - **Spotless**: `jetty:run` runs `spotless:apply` during compile, exactly as a
   local Maven run does. If you have unformatted Java, it may reformat files in
   your worktree.

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -103,6 +103,11 @@ services:
       # from both the Java backend and the host Playwright process.
       RSPACE_E2E_MOCKS: ${RSPACE_E2E_MOCKS:-false}
       E2E_MOCK_PORT: ${E2E_MOCK_PORT:-9099}
+      # Optional Mailpit SMTP catcher (started with `rspace-dev up --mailpit`,
+      # which activates the "mailpit" compose profile). When enabled, the
+      # entrypoint flips email.enabled=true and points mail.* at Mailpit's SMTP
+      # listener over the project network (mailpit:1025).
+      RSPACE_MAILPIT: ${RSPACE_MAILPIT:-false}
     volumes:
       - ${RSPACE_SRC:?run via ./rspace-dev}:/rspace:cached
       - m2-repo:/root/.m2
@@ -183,6 +188,29 @@ services:
     profiles: ["chemistry"]
     volumes:
       - chemistry-files:/home/app
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Mailpit SMTP catcher (OPTIONAL): captures outbound mail so real email flows
+  # (password reset, forgotten username, signup verification, sharing
+  # notifications) can be exercised locally. Off by default — enable with
+  # `rspace-dev up --mailpit` (compose profile "mailpit"), which also points the
+  # app at it (email.enabled=true). The app reaches its SMTP listener at
+  # mailpit:1025 over the project network; only the HTTP UI/API (8025) is
+  # published to the host, for a browser and for Playwright. No volume: message
+  # store is ephemeral, matching the E2E mock server's fresh-per-run behaviour.
+  # ---------------------------------------------------------------------------
+  mailpit:
+    image: ${MAILPIT_IMAGE:-axllent/mailpit:latest}
+    container_name: ${COMPOSE_PROJECT_NAME:-rspace-dev}-mailpit
+    profiles: ["mailpit"]
+    environment:
+      # EmailBroadcastImpl always performs SMTP AUTH; accept any credentials so
+      # no backend code change is needed to talk to Mailpit.
+      MP_SMTP_AUTH_ACCEPT_ANY: "1"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "1"
+    ports:
+      - "127.0.0.1:${MAILPIT_HTTP_PORT:-8025}:8025"
     restart: unless-stopped
 
 volumes:

--- a/docker/dev/entrypoint-app.sh
+++ b/docker/dev/entrypoint-app.sh
@@ -106,6 +106,21 @@ if [ "${RSPACE_E2E_MOCKS:-false}" = "true" ]; then
   echo "[entrypoint] E2E integration mocks enabled at ${E2E_MOCK_URL}"
 fi
 
+# Optional Mailpit SMTP catcher (rspace-dev up --mailpit).
+MAILPIT_ARGS=()
+if [ "${RSPACE_MAILPIT:-false}" = "true" ]; then
+  MAILPIT_ARGS=(
+    -Demail.enabled=true
+    -Dmail.emailHost=mailpit
+    -Dmail.port=1025
+    -Dmail.emailAccount=mailpit
+    -Dmail.password=mailpit
+    -Dmail.ssl.enabled=false
+    -Dmail.from=noreply@rspace-e2e.local
+  )
+  echo "[entrypoint] Mailpit enabled — SMTP at mailpit:1025, UI/API on the published host port"
+fi
+
 echo "[entrypoint] Starting RSpace (db mode: ${DB_MODE}) ..."
 echo "[entrypoint] App will be reachable on the host at http://localhost:${APP_PUBLIC_PORT}"
 
@@ -115,6 +130,7 @@ echo "[entrypoint] App will be reachable on the host at http://localhost:${APP_P
 exec mvn -B jetty:run \
   "${CHEMISTRY_ARGS[@]}" \
   "${E2E_MOCK_ARGS[@]}" \
+  "${MAILPIT_ARGS[@]}" \
   -Denvironment="${DB_MODE}" \
   -Dspring.profiles.active=run \
   -DreactDevMode=true \

--- a/docker/dev/rspace-dev
+++ b/docker/dev/rspace-dev
@@ -11,7 +11,7 @@
 #   ./docker/dev/rspace-dev <command> [args]
 #
 # Commands:
-#   up [--fresh] [--chemistry|--no-chemistry] [--e2e|--no-e2e]
+#   up [--fresh] [--chemistry|--no-chemistry] [--e2e|--no-e2e] [--mailpit|--no-mailpit]
 #                  Build images (if needed) and start db + app + frontend.
 #                  First boot (or --fresh) recreates the DB schema + sample data.
 #                  --chemistry also starts the optional chemistry microservice
@@ -20,6 +20,9 @@
 #                  --e2e starts the integration mock server and points the
 #                  backend integrations at it; the choice persists until
 #                  --no-e2e.
+#                  --mailpit starts the optional Mailpit SMTP catcher and points
+#                  the app's outbound mail at it (email.enabled=true); the choice
+#                  persists in .env until --no-mailpit.
 #   down           Stop and remove the containers (keeps the database + caches).
 #   reload         Recompile and hot-redeploy the whole webapp (rebuilds the
 #                  Spring context) in the same JVM — applies any Java/JSP/config
@@ -101,13 +104,14 @@ ensure_env() {
     return 0
   fi
   echo "rspace-dev: first run for this worktree — allocating ports ..." >&2
-  local offset app_port vite_port db_port debug_port mock_port polling
+  local offset app_port vite_port db_port debug_port mock_port mailpit_port polling
   offset="$(path_offset)"
   app_port="$(free_port_from "$((8080 + offset))")"
   vite_port="$(free_port_from "$((5173 + offset))")"
   db_port="$(free_port_from "$((3306 + offset))")"
   debug_port="$(free_port_from "$((5005 + offset))")"
   mock_port="$(free_port_from "$((9099 + offset))")"
+  mailpit_port="$(free_port_from "$((8025 + offset))")"
   # File-watch polling is needed where inotify events do not reach the container
   # (macOS/Windows Docker Desktop VMs) but burns CPU needlessly on native Linux
   # Docker, where events are delivered. WSL2 reports Linux and gets events when
@@ -126,6 +130,7 @@ VITE_PORT=${vite_port}
 DB_PORT=${db_port}
 DEBUG_PORT=${debug_port}
 E2E_MOCK_PORT=${mock_port}
+MAILPIT_HTTP_PORT=${mailpit_port}
 VITE_HMR_HOST=localhost
 VITE_USE_POLLING=${polling}
 EOF
@@ -141,6 +146,9 @@ compose() {
   # compose subcommand (up/down/ps/logs/...) consistently includes the service.
   local profiles=""
   [ "$(env_get RSPACE_CHEMISTRY)" = "true" ] && profiles="chemistry"
+  if [ "$(env_get RSPACE_MAILPIT)" = "true" ]; then
+    profiles="${profiles:+${profiles},}mailpit"
+  fi
   COMPOSE_PROFILES="${profiles}" docker compose \
     --project-directory "${SCRIPT_DIR}" \
     --env-file "${ENV_FILE}" \
@@ -166,16 +174,20 @@ db_volume_exists() {
 }
 
 print_urls() {
-  local app_port vite_port db_port debug_port mock_port chem e2e
+  local app_port vite_port db_port debug_port mock_port mailpit_port chem e2e mailpit
   app_port="$(env_get APP_PORT)"; vite_port="$(env_get VITE_PORT)"; db_port="$(env_get DB_PORT)"
   debug_port="$(env_get DEBUG_PORT)"
   mock_port="$(env_get E2E_MOCK_PORT)"
+  mailpit_port="$(env_get MAILPIT_HTTP_PORT)"
   debug_port="${debug_port:-5005}"
   mock_port="${mock_port:-9099}"
+  mailpit_port="${mailpit_port:-8025}"
   chem="off (enable with: up --chemistry)"
   [ "$(env_get RSPACE_CHEMISTRY)" = "true" ] && chem="on (http://chemistry:8090, internal)"
   e2e="off (enable with: up --e2e)"
   [ "$(env_get RSPACE_E2E_MOCKS)" = "true" ] && e2e="on (http://localhost:${mock_port})"
+  mailpit="off (enable with: up --mailpit)"
+  [ "$(env_get RSPACE_MAILPIT)" = "true" ] && mailpit="on (http://localhost:${mailpit_port})"
   cat <<EOF
 
   RSpace (this worktree: $(basename "${RSPACE_SRC}"))
@@ -185,6 +197,7 @@ print_urls() {
     Debug      127.0.0.1:${debug_port}  (JDWP — attach IntelliJ "Remote JVM Debug")
     Chemistry  ${chem}
     E2E mocks  ${e2e}
+    Mailpit    ${mailpit}
 
     Logins: user1a .. user8h / user1234   sysadmin1 / sysWisc23!
 EOF
@@ -216,6 +229,13 @@ cmd_up() {
                       echo "rspace-dev: E2E integration mocks enabled (persisted in .env)" >&2 ;;
       --no-e2e)       env_set RSPACE_E2E_MOCKS false
                       echo "rspace-dev: E2E integration mocks disabled (persisted in .env)" >&2 ;;
+      --mailpit)      env_set RSPACE_MAILPIT true
+                      echo "rspace-dev: Mailpit enabled (persisted in .env)" >&2 ;;
+      --no-mailpit)   env_set RSPACE_MAILPIT false
+                      # A profile-disabled service is invisible to later compose
+                      # commands, so stop a leftover container explicitly.
+                      docker rm -f "$(env_get COMPOSE_PROJECT_NAME)-mailpit" >/dev/null 2>&1 || true
+                      echo "rspace-dev: Mailpit disabled (persisted in .env)" >&2 ;;
       *) die "unknown flag for up: '${arg}'" ;;
     esac
   done

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
     "@types/jquery": "4.0.1",
-    "@types/jsdom": "^30.0.0",
+    "@types/jsdom": "30.0.0",
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "24.12.4",
     "@types/react": "19.2.18",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
     "@types/jquery": "4.0.1",
-    "@types/jsdom": "30.0.0",
+    "@types/jsdom": "28.0.3",
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "24.12.4",
     "@types/react": "19.2.18",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
     "@types/jquery": "4.0.1",
+    "@types/jsdom": "^30.0.0",
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "24.12.4",
     "@types/react": "19.2.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       '@types/jquery':
         specifier: 4.0.1
         version: 4.0.1
+      '@types/jsdom':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/jsonwebtoken':
         specifier: 9.0.10
         version: 9.0.10
@@ -2313,6 +2316,9 @@ packages:
   '@types/jquery@4.0.1':
     resolution: {integrity: sha512-9a59A/tycXgYuPABcp6/3spSShn0NT2UOM4EfHvMumjYi4lJWTsK5SZWjhx3yRm9IHGCeWXdV2YfNsrWrft/CA==}
 
+  '@types/jsdom@30.0.0':
+    resolution: {integrity: sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2364,6 +2370,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -4718,10 +4727,6 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.23:
-    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5478,6 +5483,9 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici-types@8.10.0:
+    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
 
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
@@ -8045,6 +8053,13 @@ snapshots:
 
   '@types/jquery@4.0.1': {}
 
+  '@types/jsdom@30.0.0':
+    dependencies:
+      '@types/node': 24.12.4
+      '@types/tough-cookie': 4.0.5
+      parse5: 8.0.1
+      undici-types: 8.10.0
+
   '@types/json-schema@7.0.15': {}
 
   '@types/jsonwebtoken@9.0.10':
@@ -8093,6 +8108,8 @@ snapshots:
   '@types/sockjs-client@1.5.4': {}
 
   '@types/statuses@2.0.6': {}
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -8319,7 +8336,7 @@ snapshots:
       '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.23
+      postcss: 8.5.25
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -10749,12 +10766,6 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.23:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
@@ -11648,6 +11659,8 @@ snapshots:
   ua-parser-js@1.0.41: {}
 
   undici-types@7.16.0: {}
+
+  undici-types@8.10.0: {}
 
   undici@7.29.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,7 +264,7 @@ importers:
         specifier: 4.0.1
         version: 4.0.1
       '@types/jsdom':
-        specifier: ^30.0.0
+        specifier: 30.0.0
         version: 30.0.0
       '@types/jsonwebtoken':
         specifier: 9.0.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1
       '@types/jsdom':
-        specifier: 30.0.0
-        version: 30.0.0
+        specifier: 28.0.3
+        version: 28.0.3
       '@types/jsonwebtoken':
         specifier: 9.0.10
         version: 9.0.10
@@ -2316,8 +2316,8 @@ packages:
   '@types/jquery@4.0.1':
     resolution: {integrity: sha512-9a59A/tycXgYuPABcp6/3spSShn0NT2UOM4EfHvMumjYi4lJWTsK5SZWjhx3yRm9IHGCeWXdV2YfNsrWrft/CA==}
 
-  '@types/jsdom@30.0.0':
-    resolution: {integrity: sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==}
+  '@types/jsdom@28.0.3':
+    resolution: {integrity: sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -5484,8 +5484,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici-types@8.10.0:
-    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
+  undici-types@7.29.0:
+    resolution: {integrity: sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==}
 
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
@@ -8053,12 +8053,12 @@ snapshots:
 
   '@types/jquery@4.0.1': {}
 
-  '@types/jsdom@30.0.0':
+  '@types/jsdom@28.0.3':
     dependencies:
       '@types/node': 24.12.4
       '@types/tough-cookie': 4.0.5
       parse5: 8.0.1
-      undici-types: 8.10.0
+      undici-types: 7.29.0
 
   '@types/json-schema@7.0.15': {}
 
@@ -11660,7 +11660,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@8.10.0: {}
+  undici-types@7.29.0: {}
 
   undici@7.29.0: {}
 

--- a/src/main/webapp/ui/src/__tests__/e2e/api/clients/MailpitClient.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/api/clients/MailpitClient.ts
@@ -41,4 +41,10 @@ export class MailpitClient {
     const { document } = new JSDOM(html).window;
     return [...document.querySelectorAll("a[href]")].map((a) => a.getAttribute("href") as string);
   }
+
+  /** Extracts the visible plain text from an HTML email body. */
+  extractText(html: string): string {
+    const { document } = new JSDOM(html).window;
+    return document.body.textContent ?? "";
+  }
 }

--- a/src/main/webapp/ui/src/__tests__/e2e/api/clients/MailpitClient.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/api/clients/MailpitClient.ts
@@ -1,0 +1,44 @@
+import type { APIRequestContext } from "@playwright/test";
+import { JSDOM } from "jsdom";
+import type { MailpitMessage, MailpitMessageSummary } from "../models/mailpit";
+
+export class MailpitClient {
+  constructor(private readonly request: APIRequestContext) {}
+
+  private async assertOk(
+    res: { ok(): boolean; status(): number; statusText(): string; text(): Promise<string> },
+    action: string,
+  ): Promise<void> {
+    if (!res.ok()) {
+      throw new Error(`${action} failed: ${res.status()} ${res.statusText()} — ${await res.text()}`);
+    }
+  }
+
+  /**
+   * @param query Mailpit search syntax, e.g. `to:user@example.com` or `subject:"Reset your password"`.
+   */
+  async listMessages(query?: string): Promise<MailpitMessageSummary[]> {
+    const path = query ? `/api/v1/search?query=${encodeURIComponent(query)}` : "/api/v1/messages";
+    const res = await this.request.get(path);
+    await this.assertOk(res, "listMessages");
+    const body = (await res.json()) as { messages: MailpitMessageSummary[] };
+    return body.messages;
+  }
+
+  async getMessage(id: string): Promise<MailpitMessage> {
+    const res = await this.request.get(`/api/v1/message/${id}`);
+    await this.assertOk(res, "getMessage");
+    return res.json() as Promise<MailpitMessage>;
+  }
+
+  async deleteAllMessages(): Promise<void> {
+    const res = await this.request.delete("/api/v1/messages");
+    await this.assertOk(res, "deleteAllMessages");
+  }
+
+  /** Extracts href values from an HTML email body. */
+  extractLinks(html: string): string[] {
+    const { document } = new JSDOM(html).window;
+    return [...document.querySelectorAll("a[href]")].map((a) => a.getAttribute("href") as string);
+  }
+}

--- a/src/main/webapp/ui/src/__tests__/e2e/api/models/mailpit.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/api/models/mailpit.ts
@@ -1,0 +1,31 @@
+export interface MailpitAddress {
+  Name: string;
+  Address: string;
+}
+
+export interface MailpitMessageSummary {
+  ID: string;
+  MessageID: string;
+  From: MailpitAddress;
+  To: MailpitAddress[];
+  Cc: MailpitAddress[];
+  Bcc: MailpitAddress[];
+  Subject: string;
+  Created: string;
+  Size: number;
+}
+
+export interface MailpitMessagesResponse {
+  total: number;
+  unread: number;
+  count: number;
+  messages_count: number;
+  start: number;
+  messages: MailpitMessageSummary[];
+}
+
+export interface MailpitMessage extends MailpitMessageSummary {
+  Text: string;
+  HTML: string;
+  Headers: Record<string, string[]>;
+}

--- a/src/main/webapp/ui/src/__tests__/e2e/env.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/env.ts
@@ -29,6 +29,7 @@ export const env = {
   playwrightLog: optional("PW_LOG", "off") as "trace" | "info" | "off",
 
   mockBaseUrl: `http://localhost:${optional("E2E_MOCK_PORT", "9099")}`,
+  mailpitBaseUrl: optional("MAILPIT_HTTP_URL", "http://localhost:8025"),
 
   get mockBackendBaseUrl(): string {
     return optional("E2E_MOCK_BACKEND_URL", this.mockBaseUrl);

--- a/src/main/webapp/ui/src/__tests__/e2e/fixtures/api.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/fixtures/api.ts
@@ -4,6 +4,7 @@ import { DocumentsClient } from "../api/clients/DocumentsClient";
 import { FilesClient } from "../api/clients/FilesClient";
 import { FoldersClient } from "../api/clients/FoldersClient";
 import { InventoryClient } from "../api/clients/InventoryClient";
+import { MailpitClient } from "../api/clients/MailpitClient";
 import { SysadminClient } from "../api/clients/SysadminClient";
 import { env } from "../env";
 import { SYSADMIN } from "../users";
@@ -16,6 +17,7 @@ type ApiFixtures = {
   clientFolders: FoldersClient;
   clientInventory: InventoryClient;
   clientSysadmin: SysadminClient;
+  clientMailpit: MailpitClient;
 };
 
 export const apiTest = uiTest.extend<ApiFixtures>({
@@ -50,5 +52,12 @@ export const apiTest = uiTest.extend<ApiFixtures>({
         }
       }
     }
+  },
+
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright requires destructuring pattern for fixture arg
+  clientMailpit: async ({}, use) => {
+    const context = await request.newContext({ baseURL: env.mailpitBaseUrl });
+    await use(new MailpitClient(context));
+    await context.dispose();
   },
 });

--- a/src/main/webapp/ui/src/__tests__/e2e/fixtures/ui.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/fixtures/ui.ts
@@ -7,6 +7,10 @@ import { ToastsComponent } from "../components/shared/ToastsComponent";
 import { env } from "../env";
 import { AppsPage } from "../pageObjects/apps/AppsPage";
 import { LoginPage } from "../pageObjects/auth/LoginPage";
+import { RequestPasswordResetPage } from "../pageObjects/auth/RequestPasswordResetPage";
+import { RequestUsernameReminderPage } from "../pageObjects/auth/RequestUsernameReminderPage";
+import { ResetPasswordPage } from "../pageObjects/auth/ResetPasswordPage";
+import { SignupPage } from "../pageObjects/auth/SignupPage";
 import { DocumentEditorPage } from "../pageObjects/document/DocumentEditorPage";
 import { DocumentPage } from "../pageObjects/document/DocumentPage";
 import { GalleryPage } from "../pageObjects/gallery/GalleryPage";
@@ -25,6 +29,10 @@ export type E2EOptions = { appUser: AppUser };
 type UiFixtures = {
   browserContextOptions: BrowserContextOptions;
   pageLogin: LoginPage;
+  pageRequestPasswordReset: RequestPasswordResetPage;
+  pageResetPassword: ResetPasswordPage;
+  pageRequestUsernameReminder: RequestUsernameReminderPage;
+  pageSignup: SignupPage;
   pageApps: AppsPage;
   pageWorkspace: WorkspacePage;
   pageDocument: DocumentPage;
@@ -56,6 +64,10 @@ export const uiTest = base.extend<E2EOptions & UiFixtures>({
     await use({ baseURL: env.baseURL, ignoreHTTPSErrors: browserName === "webkit" });
   },
   pageLogin: pageFixture(LoginPage),
+  pageRequestPasswordReset: pageFixture(RequestPasswordResetPage),
+  pageResetPassword: pageFixture(ResetPasswordPage),
+  pageRequestUsernameReminder: pageFixture(RequestUsernameReminderPage),
+  pageSignup: pageFixture(SignupPage),
   pageApps: pageFixture(AppsPage),
   pageWorkspace: pageFixture(WorkspacePage),
   pageDocument: pageFixture(DocumentPage),

--- a/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/LoginPage.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/LoginPage.ts
@@ -1,6 +1,8 @@
 import type { Locator, Page } from "@playwright/test";
 import { PublicNavComponent } from "@/__tests__/e2e/components/navigation/PublicNavComponent";
 import { BasePage } from "../BasePage";
+import { RequestPasswordResetPage } from "./RequestPasswordResetPage";
+import { RequestUsernameReminderPage } from "./RequestUsernameReminderPage";
 
 export class LoginPage extends BasePage {
   readonly path = "/login";
@@ -26,11 +28,13 @@ export class LoginPage extends BasePage {
     await this.submitButton.click();
   }
 
-  async clickForgotUsername(): Promise<void> {
+  async clickForgotUsername(): Promise<RequestUsernameReminderPage> {
     await this.page.getByRole("link", { name: "Forgotten your username?" }).click();
+    return new RequestUsernameReminderPage(this.page);
   }
 
-  async clickForgotPassword(): Promise<void> {
+  async clickForgotPassword(): Promise<RequestPasswordResetPage> {
     await this.page.getByRole("link", { name: "Forgotten your password?" }).click();
+    return new RequestPasswordResetPage(this.page);
   }
 }

--- a/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/RequestPasswordResetPage.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/RequestPasswordResetPage.ts
@@ -1,0 +1,25 @@
+import type { Locator, Page } from "@playwright/test";
+import { BasePage } from "../BasePage";
+
+export class RequestPasswordResetPage extends BasePage {
+  readonly path = "/public/requestPasswordReset";
+
+  readonly emailInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    // No <label> for this field in the JSP (see requestPasswordReset.jsp) — the
+    // placeholder is the only user-facing text, so it's the best available locator.
+    this.emailInput = page.getByPlaceholder("Your Email Address");
+    this.submitButton = page.locator('form[action="/signup/passwordResetRequest"]').getByRole("button", {
+      name: "Submit",
+    });
+  }
+
+  async requestReset(email: string): Promise<void> {
+    await this.emailInput.fill(email);
+    await this.submitButton.click();
+    await this.page.waitForURL((url) => url.pathname === "/signup/passwordResetRequest");
+  }
+}

--- a/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/RequestUsernameReminderPage.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/RequestUsernameReminderPage.ts
@@ -1,0 +1,23 @@
+import type { Locator, Page } from "@playwright/test";
+import { BasePage } from "../BasePage";
+
+export class RequestUsernameReminderPage extends BasePage {
+  readonly path = "/public/requestUsernameReminder";
+
+  readonly emailInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.emailInput = page.getByPlaceholder("Your Email Address");
+    this.submitButton = page.locator('form[action="/signup/usernameReminderRequest"]').getByRole("button", {
+      name: "Submit",
+    });
+  }
+
+  async requestReminder(email: string): Promise<void> {
+    await this.emailInput.fill(email);
+    await this.submitButton.click();
+    await this.page.waitForURL((url) => url.pathname === "/signup/usernameReminderRequest");
+  }
+}

--- a/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/ResetPasswordPage.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/ResetPasswordPage.ts
@@ -1,0 +1,25 @@
+import type { Locator, Page } from "@playwright/test";
+import { BasePage } from "../BasePage";
+
+export class ResetPasswordPage extends BasePage {
+  readonly path = "/signup/passwordResetReply";
+
+  readonly passwordInput: Locator;
+  readonly confirmPasswordInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.passwordInput = page.getByLabel("New password", { exact: true });
+    this.confirmPasswordInput = page.getByLabel("Confirm password", { exact: true });
+    this.submitButton = page.locator('form[action="/signup/passwordResetReply"]').getByRole("button", {
+      name: "Reset",
+    });
+  }
+
+  async submitNewPassword(newPassword: string): Promise<void> {
+    await this.passwordInput.fill(newPassword);
+    await this.confirmPasswordInput.fill(newPassword);
+    await this.submitButton.click();
+  }
+}

--- a/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/SignupPage.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/pageObjects/auth/SignupPage.ts
@@ -1,0 +1,43 @@
+import type { Locator, Page } from "@playwright/test";
+import { BasePage } from "../BasePage";
+
+export interface SignupDetails {
+  username: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export class SignupPage extends BasePage {
+  readonly path = "/signup";
+
+  readonly usernameInput: Locator;
+  readonly passwordInput: Locator;
+  readonly confirmPasswordInput: Locator;
+  readonly firstNameInput: Locator;
+  readonly lastNameInput: Locator;
+  readonly emailInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.usernameInput = page.getByLabel("Create Username", { exact: true });
+    this.passwordInput = page.getByLabel("Create a Password");
+    this.confirmPasswordInput = page.getByLabel("Confirm Password", { exact: true });
+    this.firstNameInput = page.getByLabel("First Name", { exact: true });
+    this.lastNameInput = page.getByLabel("Last Name", { exact: true });
+    this.emailInput = page.getByLabel("Email address", { exact: true });
+    this.submitButton = page.getByRole("button", { name: "Sign up" });
+  }
+
+  async signUp(details: SignupDetails): Promise<void> {
+    await this.usernameInput.fill(details.username);
+    await this.passwordInput.fill(details.password);
+    await this.confirmPasswordInput.fill(details.password);
+    await this.firstNameInput.fill(details.firstName);
+    await this.lastNameInput.fill(details.lastName);
+    await this.emailInput.fill(details.email);
+    await this.submitButton.click();
+  }
+}

--- a/src/main/webapp/ui/src/__tests__/e2e/specs/auth/passwordReset.e2e.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/specs/auth/passwordReset.e2e.ts
@@ -55,6 +55,8 @@ test.describe("Password reset", () => {
       if (!link) {
         throw new Error(`no password-reset link found in email body: ${message.HTML}`);
       }
+      const token = new URL(link).searchParams.get("token");
+      expect(token).toBeTruthy();
       return link;
     });
 

--- a/src/main/webapp/ui/src/__tests__/e2e/specs/auth/passwordReset.e2e.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/specs/auth/passwordReset.e2e.ts
@@ -1,0 +1,73 @@
+import { expect } from "@playwright/test";
+import { test } from "@/__tests__/e2e/fixtures/flows";
+import { alphaNumericUnique } from "@/__tests__/e2e/testData";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const NEW_PASSWORD = "NewPassw0rd!456";
+
+test.describe("Password reset", () => {
+  test("As a user, I receive a reset email and can set a new password", async ({
+    page,
+    pageLogin,
+    pageResetPassword,
+    clientSysadmin,
+    clientMailpit,
+  }) => {
+    const username = alphaNumericUnique("e2ePwReset");
+    const email = `${username}@example.com`;
+    await clientMailpit.deleteAllMessages();
+
+    const RESET_EMAIL_SUBJECT = "RSpace password change request";
+    await clientSysadmin.createUser({
+      username,
+      password: "Passw0rd!23",
+      email,
+      firstName: "E2E",
+      lastName: "PasswordReset",
+      role: "ROLE_USER",
+    });
+
+    await test.step("request a password reset", async () => {
+      await pageLogin.open();
+      const pageRequestReset = await pageLogin.clickForgotPassword();
+      await pageRequestReset.requestReset(email);
+    });
+
+    const resetLink = await test.step("read the reset link from the email", async () => {
+      await expect
+        .poll(
+          async () => {
+            const messages = await clientMailpit.listMessages(`to:${email}`);
+            return messages.some((m) => m.Subject === RESET_EMAIL_SUBJECT);
+          },
+          { timeout: 15_000 },
+        )
+        .toBe(true);
+      const messages = await clientMailpit.listMessages(`to:${email}`);
+      const summary = messages.find((m) => m.Subject === RESET_EMAIL_SUBJECT);
+      if (!summary) {
+        throw new Error(`no "${RESET_EMAIL_SUBJECT}" email found for ${email}`);
+      }
+      const message = await clientMailpit.getMessage(summary.ID);
+      const links = clientMailpit.extractLinks(message.HTML);
+      const link = links.find((href) => href.includes("/signup/passwordResetReply?token="));
+      if (!link) {
+        throw new Error(`no password-reset link found in email body: ${message.HTML}`);
+      }
+      return link;
+    });
+
+    await test.step("set a new password from the emailed link", async () => {
+      await page.goto(resetLink);
+      await pageResetPassword.submitNewPassword(NEW_PASSWORD);
+      await expect(page).toHaveURL((url) => url.pathname === "/signup/passwordResetReply");
+    });
+
+    await test.step("log in with the new password", async () => {
+      await pageLogin.open();
+      await pageLogin.login(username, NEW_PASSWORD);
+      await expect(page).toHaveURL((url) => url.pathname === "/workspace");
+    });
+  });
+});

--- a/src/main/webapp/ui/src/__tests__/e2e/specs/auth/signup.e2e.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/specs/auth/signup.e2e.ts
@@ -1,0 +1,24 @@
+import { expect } from "@playwright/test";
+import { test } from "@/__tests__/e2e/fixtures/flows";
+import { alphaNumericUnique } from "@/__tests__/e2e/testData";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("Signup", () => {
+  test("As a new user, I can self-register and land on the Workspace", async ({ page, pageSignup, pageWorkspace }) => {
+    const username = alphaNumericUnique("e2eSignup");
+    const email = `${username}@example.com`;
+
+    await pageSignup.open();
+    await pageSignup.signUp({
+      username,
+      password: "Passw0rd!23",
+      firstName: "E2E",
+      lastName: "Signup",
+      email,
+    });
+
+    await expect(page).toHaveURL((url) => url.pathname === "/workspace");
+    await expect(pageWorkspace.toolbar.createMenu.createButton).toBeVisible();
+  });
+});

--- a/src/main/webapp/ui/src/__tests__/e2e/specs/auth/usernameReminder.e2e.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/specs/auth/usernameReminder.e2e.ts
@@ -49,7 +49,18 @@ test.describe("Username reminder", () => {
         throw new Error(`no "${REMINDER_EMAIL_SUBJECT}" email found for ${email}`);
       }
       const message = await clientMailpit.getMessage(summary.ID);
-      expect(message.HTML).toContain(username);
+      const bodyText = clientMailpit.extractText(message.HTML);
+      const [, afterMarker] = bodyText.split("Your username is ");
+      if (afterMarker === undefined) {
+        throw new Error(`"Your username is " not found in email body: ${message.HTML}`);
+      }
+      expect(afterMarker.startsWith(username)).toBe(true);
+
+      const links = clientMailpit.extractLinks(message.HTML);
+      const loginLink = links.find((href) => href.endsWith("/login"));
+      if (!loginLink) {
+        throw new Error(`no login link found in email body: ${message.HTML}`);
+      }
     });
   });
 });

--- a/src/main/webapp/ui/src/__tests__/e2e/specs/auth/usernameReminder.e2e.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/specs/auth/usernameReminder.e2e.ts
@@ -1,0 +1,55 @@
+import { expect } from "@playwright/test";
+import { test } from "@/__tests__/e2e/fixtures/flows";
+import { alphaNumericUnique } from "@/__tests__/e2e/testData";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const REMINDER_EMAIL_SUBJECT = "RSpace username reminder";
+
+test.describe("Username reminder", () => {
+  test("As a user, I receive an email reminding me of my username", async ({
+    page,
+    pageLogin,
+    clientSysadmin,
+    clientMailpit,
+  }) => {
+    const username = alphaNumericUnique("e2eUserReminder");
+    const email = `${username}@example.com`;
+    await clientMailpit.deleteAllMessages();
+
+    await clientSysadmin.createUser({
+      username,
+      password: "Passw0rd!23",
+      email,
+      firstName: "E2E",
+      lastName: "UsernameReminder",
+      role: "ROLE_USER",
+    });
+
+    await test.step("request a username reminder", async () => {
+      await pageLogin.open();
+      const pageRequestReminder = await pageLogin.clickForgotUsername();
+      await pageRequestReminder.requestReminder(email);
+      await expect(page).toHaveURL((url) => url.pathname === "/signup/usernameReminderRequest");
+    });
+
+    await test.step("read the username from the email", async () => {
+      await expect
+        .poll(
+          async () => {
+            const messages = await clientMailpit.listMessages(`to:${email}`);
+            return messages.some((m) => m.Subject === REMINDER_EMAIL_SUBJECT);
+          },
+          { timeout: 15_000 },
+        )
+        .toBe(true);
+      const messages = await clientMailpit.listMessages(`to:${email}`);
+      const summary = messages.find((m) => m.Subject === REMINDER_EMAIL_SUBJECT);
+      if (!summary) {
+        throw new Error(`no "${REMINDER_EMAIL_SUBJECT}" email found for ${email}`);
+      }
+      const message = await clientMailpit.getMessage(summary.ID);
+      expect(message.HTML).toContain(username);
+    });
+  });
+});


### PR DESCRIPTION
## Description ##
***REQUIRED***
Adds mailpit client and extends Docker dev stack + CI e2e workflow to optionally (dev) / always (CI).

## Testing notes
***OPTIONAL***
- Local docker setup  follow `docker/dev/README.md` 
- once you have mailpit up and running,  to confirm run `passwordReset.e2e.ts`
