### PR TITLE
RSDEV-1306 Fix sidebar nav leaving stale record details in single-column layout

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Layout/Sidebar.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Layout/Sidebar.tsx
@@ -527,10 +527,7 @@ function Sidebar({ id }: SidebarArgs): React.ReactNode {
     max: isSysAdmin ? 9 : 8,
   });
 
-  /*
-   * Must not set the visible panel: navigation defaults handle it, and the
-   * create-new flow shows the right panel itself (createNewHelper).
-   */
+  // Must not set the visible panel: the create-new flow does that itself (createNewHelper).
   const afterClick = () => {
     if (!uiStore.alwaysVisibleSidebar) uiStore.toggleSidebar(false);
   };

--- a/src/main/webapp/ui/src/Inventory/components/Layout/Sidebar.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Layout/Sidebar.tsx
@@ -527,9 +527,12 @@ function Sidebar({ id }: SidebarArgs): React.ReactNode {
     max: isSysAdmin ? 9 : 8,
   });
 
+  /*
+   * Must not set the visible panel: navigation defaults handle it, and the
+   * create-new flow shows the right panel itself (createNewHelper).
+   */
   const afterClick = () => {
     if (!uiStore.alwaysVisibleSidebar) uiStore.toggleSidebar(false);
-    uiStore.setVisiblePanel("right");
   };
 
   return (

--- a/src/main/webapp/ui/src/Inventory/components/Layout/__tests__/Sidebar.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Layout/__tests__/Sidebar.test.tsx
@@ -50,10 +50,7 @@ describe("Sidebar", () => {
     await expect(container).toBeAccessible();
   });
 
-  /*
-   * The sidebar used to force the right panel visible on every click, which
-   * in single-column layouts hid the new listing behind stale record details.
-   */
+  // Forcing the right panel visible on nav clicks left stale record details on screen in single-column layouts.
   test("Clicking a record type nav item should not change the visible panel.", async () => {
     mockAxios.onGet("livechatProperties").reply(200, {
       livechatEnabled: false,

--- a/src/main/webapp/ui/src/Inventory/components/Layout/__tests__/Sidebar.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Layout/__tests__/Sidebar.test.tsx
@@ -1,10 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
 import "@/__tests__/__mocks__/matchMedia";
 import { ThemeProvider } from "@mui/material/styles";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import MockAdapter from "axios-mock-adapter";
 import axios from "@/common/axios";
 import { LandmarksProvider } from "../../../../components/LandmarksContext";
+import NavigateContext from "../../../../stores/contexts/Navigate";
 import { makeMockRootStore } from "../../../../stores/stores/__tests__/RootStore/mocking";
 import { storesContext } from "../../../../stores/stores-context";
 import materialTheme from "../../../../theme";
@@ -46,5 +48,62 @@ describe("Sidebar", () => {
 
     // @ts-expect-error toBeAccessible is from @sa11y/vitest
     await expect(container).toBeAccessible();
+  });
+
+  /*
+   * The sidebar used to force the right panel visible on every click, which
+   * in single-column layouts hid the new listing behind stale record details.
+   */
+  test("Clicking a record type nav item should not change the visible panel.", async () => {
+    mockAxios.onGet("livechatProperties").reply(200, {
+      livechatEnabled: false,
+    });
+    const user = userEvent.setup();
+    const navFn =
+      vi.fn<(url: string, opts?: { skipToParentContext?: boolean; modifyVisiblePanel?: boolean }) => void>();
+    const setVisiblePanel = vi.fn<(panel: "left" | "right") => void>();
+    const rootStore = makeMockRootStore({
+      uiStore: {
+        alwaysVisibleSidebar: true,
+        sidebarOpen: true,
+        isVerySmall: false,
+        setVisiblePanel,
+      },
+      searchStore: {
+        search: {
+          benchSearch: true,
+        },
+        fetcher: {
+          generateNewQuery: () => new URLSearchParams({ resultType: "INSTRUMENT" }),
+        },
+      },
+    });
+    render(
+      <ThemeProvider theme={materialTheme}>
+        <LandmarksProvider>
+          <storesContext.Provider value={rootStore}>
+            <NavigateContext.Provider
+              value={{
+                useNavigate: () => navFn,
+                useLocation: () => ({
+                  hash: "",
+                  pathname: "",
+                  search: "",
+                  state: {},
+                  key: "",
+                }),
+              }}
+            >
+              <Sidebar id="foo" />
+            </NavigateContext.Provider>
+          </storesContext.Provider>
+        </LandmarksProvider>
+      </ThemeProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "inventory:recordTypes.instrument.plural" }));
+
+    expect(navFn).toHaveBeenCalledWith(expect.stringMatching(/^\/inventory\/search\?/) as string);
+    expect(setVisiblePanel).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description ##
- In single-column layout (right panel hidden, or small viewports), clicking a record type in the Inventory sidebar left the previously selected record's details on screen instead of showing the listing.
- Cause: the sidebar's shared click handler unconditionally set the visible panel to "right" after every click. That was added for the Create menu but was also attached to the record-type tabs, overriding the navigation default of returning to the listing.
- Fix: remove the override from the shared handler. The create-new flow already shows the right panel itself (SearchStore's createNewHelper), so the Create menu is unaffected. Added a regression test asserting a record-type nav click does not touch the visible panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)