### PR TITLE
RSDEV-1291: upgrade Apache Shiro from 2.1.0 to 3.0.0

### DIFF
--- a/DevDocs/DeveloperNotes/SecurityAndPermissions.md
+++ b/DevDocs/DeveloperNotes/SecurityAndPermissions.md
@@ -15,16 +15,29 @@ Is configured in `WEB-INF/security.xml`, which defines role based access
 to URLs and the various Spring bean integrations. There is some good
 documentation in the Shiro project web docs which describes the basics.
 
-Since Shiro 3, the URL filter chains in `security.xml` behave as follows
-by default (all three are configurable):
+Notes on how the URL filter chains in `security.xml` are resolved,
+including what the Shiro 3 upgrade did and did not change:
 
-- Chain patterns match case-insensitively, so `/SYSTEM/foo` hits the
-  `/system/**` chain rather than falling through to `/**`.
-- A request that matches no chain is denied rather than allowed. This
-  does not currently apply to us because the `/**` catch-all matches
-  everything.
-- CORS preflight `OPTIONS` requests are allowed through authentication
-  filters without credentials.
+- Chain patterns match case-sensitively, so `/SYSTEM/foo` does not hit
+  the `/system/**` chain and instead falls through to the `/**`
+  catch-all (still authenticated). This is configurable via the filter
+  factory's `caseInsensitive` property, which defaults to false.
+- Since Shiro 3, the filter factory guarantees a `/**` chain exists: if
+  none is defined it appends `/** = noAccess`, which redirects unmatched
+  requests to the login page instead of letting them through to the
+  servlet container (or `/** = anon` when `allowAccessByDefault` is
+  set). Our explicit `/** = authc, ssl[8443]` takes precedence, so this
+  default is inert here, but removing our catch-all would engage it
+  rather than opening unmatched paths.
+- Since Shiro 3, CORS preflight `OPTIONS` requests are allowed without
+  credentials through Shiro's Basic and Bearer HTTP authentication
+  filters only. Our chains do not use those filters, so this has no
+  effect here; our form-based `authc` filter still applies to `OPTIONS`
+  requests.
+- Since Shiro 3, custom filters must be listed explicitly in the filter
+  factory's `filters` map. The automatic discovery of `Filter` beans
+  moved to `ShiroFilterFactoryBeanPostProcessor`, which we do not
+  register.
 
 ## Authentication
 

--- a/DevDocs/DeveloperNotes/SecurityAndPermissions.md
+++ b/DevDocs/DeveloperNotes/SecurityAndPermissions.md
@@ -15,6 +15,17 @@ Is configured in `WEB-INF/security.xml`, which defines role based access
 to URLs and the various Spring bean integrations. There is some good
 documentation in the Shiro project web docs which describes the basics.
 
+Since Shiro 3, the URL filter chains in `security.xml` behave as follows
+by default (all three are configurable):
+
+- Chain patterns match case-insensitively, so `/SYSTEM/foo` hits the
+  `/system/**` chain rather than falling through to `/**`.
+- A request that matches no chain is denied rather than allowed. This
+  does not currently apply to us because the `/**` catch-all matches
+  everything.
+- CORS preflight `OPTIONS` requests are allowed through authentication
+  filters without credentials.
+
 ## Authentication
 
 ### Standalone application

--- a/DevDocs/DeveloperNotes/SecurityAndPermissions.md
+++ b/DevDocs/DeveloperNotes/SecurityAndPermissions.md
@@ -15,30 +15,6 @@ Is configured in `WEB-INF/security.xml`, which defines role based access
 to URLs and the various Spring bean integrations. There is some good
 documentation in the Shiro project web docs which describes the basics.
 
-Notes on how the URL filter chains in `security.xml` are resolved,
-including what the Shiro 3 upgrade did and did not change:
-
-- Chain patterns match case-sensitively, so `/SYSTEM/foo` does not hit
-  the `/system/**` chain and instead falls through to the `/**`
-  catch-all (still authenticated). This is configurable via the filter
-  factory's `caseInsensitive` property, which defaults to false.
-- Since Shiro 3, the filter factory guarantees a `/**` chain exists: if
-  none is defined it appends `/** = noAccess`, which redirects unmatched
-  requests to the login page instead of letting them through to the
-  servlet container (or `/** = anon` when `allowAccessByDefault` is
-  set). Our explicit `/** = authc, ssl[8443]` takes precedence, so this
-  default is inert here, but removing our catch-all would engage it
-  rather than opening unmatched paths.
-- Since Shiro 3, CORS preflight `OPTIONS` requests are allowed without
-  credentials through Shiro's Basic and Bearer HTTP authentication
-  filters only. Our chains do not use those filters, so this has no
-  effect here; our form-based `authc` filter still applies to `OPTIONS`
-  requests.
-- Since Shiro 3, custom filters must be listed explicitly in the filter
-  factory's `filters` map. The automatic discovery of `Filter` beans
-  moved to `ShiroFilterFactoryBeanPostProcessor`, which we do not
-  register.
-
 ## Authentication
 
 ### Standalone application

--- a/pom.xml
+++ b/pom.xml
@@ -1610,7 +1610,9 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <version>3.2.1</version>
+      <!-- jitpack commit pin: core-model built with Shiro 3 via parent 3.1.0; move to
+           the next core-model release once its branch is merged -->
+      <version>2af3f34891</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>
@@ -1623,12 +1625,6 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <!-- core-model builds against Shiro 2.1.0; rspace-web supplies Shiro 3
-             (the class names core-model uses are identical in both lines) -->
-        <exclusion>
-          <groupId>org.apache.shiro</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
         <!-- core-model (>= 2.26.1) re-introduces ical4j (calendar/ICS), which drags in older
              slf4j-api:1.7.25 and commons-lang3:3.8.1 and breaks dependency convergence (the rest

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,9 @@
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
-    <version>3.0.1</version>
+    <!-- jitpack commit pin: parent branch with Shiro 3; move to the next tagged
+         parent release once that branch is merged -->
+    <version>0d7221d476</version>
   </parent>
 
   <repositories>
@@ -2690,9 +2692,6 @@
     <hibernate.logLevel>ERROR</hibernate.logLevel>
 
     <javax.cache.version>1.1.1</javax.cache.version>
-
-    <!-- overrides rspace-parent (2.1.0, EOSL); fold into the parent pom later -->
-    <shiro.version>3.0.0</shiro.version>
 
     <hibernate.search.index>FTsearchIndices</hibernate.search.index>
     <lucene.attachment.searchIndex>LuceneFTsearchIndices</lucene.attachment.searchIndex>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,7 @@
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
-    <!-- jitpack commit pin: parent branch with Shiro 3; move to the next tagged
-         parent release once that branch is merged -->
-    <version>0d7221d476</version>
+    <version>3.1.0</version>
   </parent>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1610,9 +1610,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-model</artifactId>
-      <!-- jitpack commit pin: core-model built with Shiro 3 via parent 3.1.0; move to
-           the next core-model release once its branch is merged -->
-      <version>2af3f34891</version>
+      <version>3.3.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1130,7 +1130,6 @@
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-core</artifactId>
       <version>${shiro.version}</version>
-      <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -1142,7 +1141,6 @@
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-web</artifactId>
       <version>${shiro.version}</version>
-      <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.apache.shiro</groupId>
@@ -1154,7 +1152,6 @@
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-spring</artifactId>
       <version>${shiro.version}</version>
-      <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.apache.shiro</groupId>
@@ -1625,9 +1622,11 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <!-- core-model builds against Shiro 2.1.0; rspace-web supplies Shiro 3
+             (the class names core-model uses are identical in both lines) -->
         <exclusion>
           <groupId>org.apache.shiro</groupId>
-          <artifactId>shiro-core</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
         <!-- core-model (>= 2.26.1) re-introduces ical4j (calendar/ICS), which drags in older
              slf4j-api:1.7.25 and commons-lang3:3.8.1 and breaks dependency convergence (the rest
@@ -2689,6 +2688,9 @@
     <hibernate.logLevel>ERROR</hibernate.logLevel>
 
     <javax.cache.version>1.1.1</javax.cache.version>
+
+    <!-- overrides rspace-parent (2.1.0, EOSL); fold into the parent pom later -->
+    <shiro.version>3.0.0</shiro.version>
 
     <hibernate.search.index>FTsearchIndices</hibernate.search.index>
     <lucene.attachment.searchIndex>LuceneFTsearchIndices</lucene.attachment.searchIndex>

--- a/src/main/java/com/axiope/service/cfg/SecurityRunProdConfig.java
+++ b/src/main/java/com/axiope/service/cfg/SecurityRunProdConfig.java
@@ -2,6 +2,7 @@ package com.axiope.service.cfg;
 
 import static org.apache.commons.lang3.ArrayUtils.contains;
 
+import com.researchspace.auth.ApiAwareWebSecurityManager;
 import com.researchspace.auth.FirstSuccessOrExceptionAuthStrategy;
 import com.researchspace.auth.JCacheShiroCacheManager;
 import java.time.Duration;
@@ -26,7 +27,7 @@ public class SecurityRunProdConfig extends SecurityBaseConfig {
 
   @Bean
   public SecurityManager securityManager() {
-    DefaultWebSecurityManager rc = new DefaultWebSecurityManager();
+    DefaultWebSecurityManager rc = new ApiAwareWebSecurityManager();
     Collection<Realm> realms = new ArrayList<>();
 
     if (deploymentPropertyConfig.isStandalone()

--- a/src/main/java/com/researchspace/api/v1/auth/AbstractApiAuthenticator.java
+++ b/src/main/java/com/researchspace/api/v1/auth/AbstractApiAuthenticator.java
@@ -2,6 +2,7 @@ package com.researchspace.api.v1.auth;
 
 import static com.researchspace.core.util.StringAbbreviationUtils.abbreviate;
 
+import com.researchspace.auth.ApiAwareWebSecurityManager;
 import com.researchspace.auth.ApiKeyAuthenticationToken;
 import com.researchspace.model.User;
 import com.researchspace.model.UserAuthenticationMethod;
@@ -81,6 +82,9 @@ abstract class AbstractApiAuthenticator implements ApiAuthenticator {
       // When it does, we know that session  preservation is not possible.
     }
 
+    // this login must not disturb any session that arrived with the request (for example a
+    // browser session cookie sent alongside the API key); see ApiAwareWebSecurityManager
+    request.setAttribute(ApiAwareWebSecurityManager.STATELESS_API_LOGIN, Boolean.TRUE);
     doLogin(accessToken, targetUser);
     return targetUser;
   }

--- a/src/main/java/com/researchspace/auth/ApiAwareWebSecurityManager.java
+++ b/src/main/java/com/researchspace/auth/ApiAwareWebSecurityManager.java
@@ -1,0 +1,44 @@
+package com.researchspace.auth;
+
+import jakarta.servlet.ServletRequest;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
+import org.apache.shiro.web.subject.support.WebDelegatingSubject;
+
+/**
+ * A {@link DefaultWebSecurityManager} that skips session-fixation protection for stateless API
+ * logins.
+ *
+ * <p>Since Shiro 3, a login by a subject that already has an HTTP session rotates the session id
+ * (see {@code DefaultWebSecurityManager#beforeSuccessfulLogin}). That is desirable for form logins
+ * but not for the REST API, which performs a fresh {@code subject.login} on every request: an API
+ * request carrying both an API key and a valid session cookie would rotate, and so invalidate, the
+ * browser session it arrived with, silently logging that browser out. API requests are stateless by
+ * design (their filter chains use noSessionCreation), so the rotation protects nothing there.
+ *
+ * <p>The API authenticator marks such requests with the {@link #STATELESS_API_LOGIN} request
+ * attribute; marked logins keep the session id they arrived with.
+ */
+public class ApiAwareWebSecurityManager extends DefaultWebSecurityManager {
+
+  /** Request attribute marking the current login as a stateless API login. */
+  public static final String STATELESS_API_LOGIN =
+      ApiAwareWebSecurityManager.class.getName() + ".STATELESS_API_LOGIN";
+
+  @Override
+  protected void beforeSuccessfulLogin(Subject subject) {
+    if (isStatelessApiLogin(subject)) {
+      return;
+    }
+    super.beforeSuccessfulLogin(subject);
+  }
+
+  /** True if the subject's current request is marked as a stateless API login. */
+  public static boolean isStatelessApiLogin(Subject subject) {
+    if (subject instanceof WebDelegatingSubject webSubject) {
+      ServletRequest request = webSubject.getServletRequest();
+      return request != null && request.getAttribute(STATELESS_API_LOGIN) != null;
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/researchspace/webapp/filter/LazySecurityManagerShiroFilterFactoryBean.java
+++ b/src/main/java/com/researchspace/webapp/filter/LazySecurityManagerShiroFilterFactoryBean.java
@@ -9,14 +9,18 @@ import org.springframework.beans.factory.BeanFactoryAware;
  * A {@link ShiroFilterFactoryBean} that resolves the securityManager bean on first use instead of
  * having it injected at construction.
  *
- * <p>ShiroFilterFactoryBean is a BeanPostProcessor, so it is created before context refresh
- * completes. A direct securityManager property reference would instantiate the realms' entire
- * service-bean dependency graph inside that early window, where annotation-driven advice
- * (@Transactional, Shiro's authorization annotations) is silently skipped; see the AOP notes in
- * applicationContext-service.xml. {@link #getSecurityManager()} is first called from {@code
- * createInstance()} when the servlet container initialises the filter, which is safely after
- * refresh, and hands the real securityManager instance to the filter so downstream code (e.g. casts
- * to DefaultSecurityManager) behaves exactly as with direct injection.
+ * <p>Under Shiro 2, ShiroFilterFactoryBean was itself a BeanPostProcessor, so it was created before
+ * context refresh completed. A direct securityManager property reference would instantiate the
+ * realms' entire service-bean dependency graph inside that early window, where annotation-driven
+ * advice (@Transactional, Shiro's authorization annotations) is silently skipped; see the AOP notes
+ * in applicationContext-service.xml. Shiro 3 moved the post-processing into a separate
+ * ShiroFilterFactoryBeanPostProcessor (not used here), so the filter itself no longer instantiates
+ * early. The companion advisor still does (see
+ * LazySecurityManagerAuthorizationAttributeSourceAdvisor), and keeping the filter lazy as well is a
+ * cheap guard against the early window reappearing. {@link #getSecurityManager()} is first called
+ * from {@code createInstance()} when the servlet container initialises the filter, which is safely
+ * after refresh, and hands the real securityManager instance to the filter so downstream code (e.g.
+ * casts to DefaultSecurityManager) behaves exactly as with direct injection.
  */
 public class LazySecurityManagerShiroFilterFactoryBean extends ShiroFilterFactoryBean
     implements BeanFactoryAware {

--- a/src/main/webapp/WEB-INF/security.xml
+++ b/src/main/webapp/WEB-INF/security.xml
@@ -9,10 +9,11 @@
     <bean id="authc" name="authc" class="org.apache.shiro.web.filter.authc.PassThruAuthenticationFilter" />
 
     <!-- The shiroFilter and the AuthorizationAttributeSourceAdvisor below deliberately do
-         NOT take a securityManager ref: both beans are created before context refresh
-         completes (the filter is a BeanPostProcessor, SHIRO-829), and a direct ref would
-         drag the realms' entire service-bean dependency graph into that early window,
-         where annotation-driven advice (@Transactional, Shiro's authorization annotations)
+         NOT take a securityManager ref: the advisor is created during early advisor
+         retrieval, before context refresh completes (under Shiro 2 the filter was too,
+         as a BeanPostProcessor: SHIRO-829), and a direct ref would drag the realms'
+         entire service-bean dependency graph into that early window, where
+         annotation-driven advice (@Transactional, Shiro's authorization annotations)
          is silently skipped. The Lazy* subclasses resolve the securityManager bean on
          first use, safely after refresh; TransactionAdviceStartupCheck initialises it
          right after refresh. See the AOP notes in applicationContext-service.xml. -->

--- a/src/main/webapp/WEB-INF/security.xml
+++ b/src/main/webapp/WEB-INF/security.xml
@@ -22,12 +22,10 @@
         <property name="successUrl" value="/workspace" />
         <property name="unauthorizedUrl" value="login?error=true" />
 
-        <!-- Every custom filter used in the chain definitions must be listed here (Shiro's
-             built-in defaults such as anon and noSessionCreation need not be). Shiro 3 moved
-             the automatic discovery of Filter beans into ShiroFilterFactoryBeanPostProcessor,
-             which we deliberately do not register: it would sweep every servlet Filter bean
-             in the context into this map and, as a BeanPostProcessor depending on this
-             factory bean, reintroduce the early-instantiation window described above. -->
+        <!-- Custom filters used in the chain definitions must be listed here; Shiro 3
+             no longer auto-discovers Filter beans (we deliberately do not register its
+             ShiroFilterFactoryBeanPostProcessor). Shiro's built-in defaults such as
+             anon and noSessionCreation need no entry. -->
         <property name="filters">
             <util:map>
                 <!-- Overrides defaul sslFilter to better handle enablement/disablement -->

--- a/src/main/webapp/WEB-INF/security.xml
+++ b/src/main/webapp/WEB-INF/security.xml
@@ -6,8 +6,6 @@
              http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
        default-lazy-init="true">
 
-    <bean id="authc" name="authc" class="org.apache.shiro.web.filter.authc.PassThruAuthenticationFilter" />
-
     <!-- The shiroFilter and the AuthorizationAttributeSourceAdvisor below deliberately do
          NOT take a securityManager ref: the advisor is created during early advisor
          retrieval, before context refresh completes (under Shiro 2 the filter was too,

--- a/src/main/webapp/WEB-INF/security.xml
+++ b/src/main/webapp/WEB-INF/security.xml
@@ -24,9 +24,12 @@
         <property name="successUrl" value="/workspace" />
         <property name="unauthorizedUrl" value="login?error=true" />
 
-        <!-- The 'filters' property is not necessary since any declared jakarta.servlet.Filter bean -->
-        <!-- defined will be automatically acquired and available via its beanName in chain -->
-        <!-- definitions, but you can perform instance overrides or name aliases here if you like: -->
+        <!-- Every custom filter used in the chain definitions must be listed here (Shiro's
+             built-in defaults such as anon and noSessionCreation need not be). Shiro 3 moved
+             the automatic discovery of Filter beans into ShiroFilterFactoryBeanPostProcessor,
+             which we deliberately do not register: it would sweep every servlet Filter bean
+             in the context into this map and, as a BeanPostProcessor depending on this
+             factory bean, reintroduce the early-instantiation window described above. -->
         <property name="filters">
             <util:map>
                 <!-- Overrides defaul sslFilter to better handle enablement/disablement -->

--- a/src/main/webapp/ui/src/__tests__/e2e/fixtures/api.ts
+++ b/src/main/webapp/ui/src/__tests__/e2e/fixtures/api.ts
@@ -21,7 +21,13 @@ type ApiFixtures = {
 export const apiTest = uiTest.extend<ApiFixtures>({
   // biome-ignore lint/correctness/noEmptyPattern: Playwright requires destructuring pattern for fixture arg
   apiContext: async ({}, use) => {
-    const context = await request.newContext({ baseURL: env.baseURL });
+    // Playwright request contexts inherit the project's storageState by default, which would
+    // send the signed-in user's session cookie alongside the apiKey header. API clients must be
+    // pure key clients, so start with an explicitly empty storage state.
+    const context = await request.newContext({
+      baseURL: env.baseURL,
+      storageState: { cookies: [], origins: [] },
+    });
     await use(context);
     await context.dispose();
   },

--- a/src/test/java/com/researchspace/auth/ApiAwareWebSecurityManagerTest.java
+++ b/src/test/java/com/researchspace/auth/ApiAwareWebSecurityManagerTest.java
@@ -1,0 +1,75 @@
+package com.researchspace.auth;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.SimplePrincipalCollection;
+import org.apache.shiro.web.subject.support.WebDelegatingSubject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ApiAwareWebSecurityManagerTest {
+
+  private ApiAwareWebSecurityManager securityManager;
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+  private Session session;
+
+  @BeforeEach
+  public void setUp() {
+    securityManager = new ApiAwareWebSecurityManager();
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+    session = mock(Session.class);
+  }
+
+  private WebDelegatingSubject subjectWithSession() {
+    return new WebDelegatingSubject(
+        new SimplePrincipalCollection("user1a", "realm"),
+        true,
+        null,
+        session,
+        request,
+        response,
+        securityManager);
+  }
+
+  @Test
+  public void statelessApiLoginKeepsArrivingSessionId() {
+    when(request.getAttribute(ApiAwareWebSecurityManager.STATELESS_API_LOGIN))
+        .thenReturn(Boolean.TRUE);
+
+    securityManager.beforeSuccessfulLogin(subjectWithSession());
+
+    verify(request, never()).changeSessionId();
+  }
+
+  @Test
+  public void ordinaryLoginStillRotatesSessionId() {
+    securityManager.beforeSuccessfulLogin(subjectWithSession());
+
+    verify(request).changeSessionId();
+  }
+
+  @Test
+  public void loginWithoutSessionRotatesNothing() {
+    WebDelegatingSubject noSession =
+        new WebDelegatingSubject(
+            new SimplePrincipalCollection("user1a", "realm"),
+            true,
+            null,
+            null,
+            request,
+            response,
+            securityManager);
+
+    securityManager.beforeSuccessfulLogin(noSession);
+
+    verify(request, never()).changeSessionId();
+  }
+}

--- a/src/test/java/com/researchspace/testutils/ApiAwareTestSecurityManager.java
+++ b/src/test/java/com/researchspace/testutils/ApiAwareTestSecurityManager.java
@@ -1,0 +1,22 @@
+package com.researchspace.testutils;
+
+import com.researchspace.auth.ApiAwareWebSecurityManager;
+import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.subject.Subject;
+
+/**
+ * Test-profile mirror of {@link ApiAwareWebSecurityManager}: stateless API logins never disturb a
+ * session that arrived with the request. The core {@link DefaultSecurityManager} used in test
+ * wiring performs no session-fixation rotation today, so this class only keeps the test wiring
+ * structurally identical to run/prod.
+ */
+public class ApiAwareTestSecurityManager extends DefaultSecurityManager {
+
+  @Override
+  protected void beforeSuccessfulLogin(Subject subject) {
+    if (ApiAwareWebSecurityManager.isStatelessApiLogin(subject)) {
+      return;
+    }
+    super.beforeSuccessfulLogin(subject);
+  }
+}

--- a/src/test/java/com/researchspace/testutils/SecurityTestConfig.java
+++ b/src/test/java/com/researchspace/testutils/SecurityTestConfig.java
@@ -27,7 +27,7 @@ public class SecurityTestConfig extends SecurityBaseConfig {
   @Bean(name = "securityManagerTest")
   @Override
   public SecurityManager securityManager() {
-    DefaultSecurityManager rc = new DefaultSecurityManager();
+    DefaultSecurityManager rc = new ApiAwareTestSecurityManager();
     Collection<Realm> realms = new ArrayList<>();
     realms.add(standardRealm());
     realms.add(ssoRealm());


### PR DESCRIPTION
## Description ##

Upgrades Apache Shiro to 3.0.0, the first release line targeting `jakarta.*` natively. Shiro 2.1.0 has reached end of support life.

### Dependency changes

* `shiro.version` is inherited from rspace-parent 3.1.0, which carries the Shiro 3.0.0 bump (rspace-os/rspace-parent#12, merged and released).
* The `jakarta` classifier is dropped from `shiro-core`, `shiro-web`, and `shiro-spring`: Shiro 3 publishes jakarta-native primary artifacts.
* rspace-core-model is pinned to the commit built against parent 3.1.0 (rspace-os/rspace-core-model#86), so its Shiro transitives converge with ours and no shiro exclusion is needed; the pin moves to the next core-model release once that PR merges.

### Behavioral notes (verified against Shiro source and a live build)

* No filter-chain behavior changes. Chain matching remains case-sensitive, our explicit `/** = authc, ssl[8443]` catch-all still takes precedence over Shiro 3's new `noAccess` default chain, and the new CORS preflight bypass only applies to Shiro's Basic/Bearer filters, which our chains do not use.
* Form logins now rotate the session id on login (Shiro 3's session-fixation protection, deliberately kept). API-key/token logins explicitly do not: Shiro 3's rotation would otherwise invalidate a browser session whose cookie arrived alongside an API key, silently logging that browser out (this was the cause of the e2e failures on this branch). `ApiAwareWebSecurityManager` skips rotation only for logins the API authenticator marks as stateless; a unit test pins both behaviours, and the fix was verified live (cookie-plus-apiKey request keeps the session, form login still rotates). The e2e API fixtures were also made cookie-less, as API clients should authenticate by key alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
