### PR TITLE
RSDEV-1268 Point MyRSpace API examples link to api-tutorial repo

### DIFF
--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.workspace.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.workspace.json
@@ -837,7 +837,7 @@
     "apiKey": {
       "confirmPasswordLabel": "Please confirm your password",
       "docsLinkPrefix": "See <a href=\"/public/apiDocs\" target=\"_blank\">API Documentation</a>.",
-      "docsLinkSuffix": "For more examples, check out our <a href=\"https://github.com/rspace-os\" target=\"_blank\">GitHub</a>.",
+      "docsLinkSuffix": "For more examples, check out our <a href=\"https://github.com/rspace-os/api-tutorial\" target=\"_blank\">GitHub</a>.",
       "generateKeyButton": "Generate key",
       "generateWarningIntro": "This API key provides access to your account, research data, and intellectual property. If exposed or compromised:",
       "generateWarningRisk1": "Unauthorized users could access and steal your data",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -9759,7 +9759,7 @@ export default interface Resources {
       "apiKey": {
         "confirmPasswordLabel": "Please confirm your password",
         "docsLinkPrefix": "See <a href=\"/public/apiDocs\" target=\"_blank\">API Documentation</a>.",
-        "docsLinkSuffix": "For more examples, check out our <a href=\"https://github.com/rspace-os\" target=\"_blank\">GitHub</a>.",
+        "docsLinkSuffix": "For more examples, check out our <a href=\"https://github.com/rspace-os/api-tutorial\" target=\"_blank\">GitHub</a>.",
         "generateKeyButton": "Generate key",
         "generateWarningIntro": "This API key provides access to your account, research data, and intellectual property. If exposed or compromised:",
         "generateWarningRisk1": "Unauthorized users could access and steal your data",


### PR DESCRIPTION
## What changed

The "For more examples, check out our **GitHub**" link in the API-key section of the MyRSpace profile page now points to the tutorial repository instead of the org root:

`https://github.com/rspace-os` → `https://github.com/rspace-os/api-tutorial`

## Why

Per [RSDEV-1268](https://researchspace.atlassian.net/browse/RSDEV-1268), the link should take users to the relevant API tutorial (runnable examples) rather than the organization landing page.

## How it wires up (for reviewers)

- The link text lives in the en-US JSON catalog key `userform.apiKey.docsLinkSuffix`.
- `userform.jsp` renders it via `<spring:message code="userform.apiKey.docsLinkSuffix"/>`, resolved by the custom `JsonMessageSource` (`classpath*:i18n/locales/**/*.json`, default locale `en-US`). The Maven build copies that catalog onto the classpath at `i18n/locales`, so this catalog is the single source of truth — no `.properties` bundle or secondary-locale copy carries the old URL.
- `resources.d.ts` (generated i18n types) is updated to match; the swap is value-only on an existing key, so it is byte-identical to what regeneration produces.

## Notes

- I could not run `pnpm run i18n:types` / `pnpm tsc` locally: corepack failed signature verification and the pinned pnpm 11.18 needs Node ≥ 22.13 (only v22.11.0 installed). Worth a quick `pnpm run i18n:types` on a compatible Node to confirm a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)