### PR TITLE
RSDEV-1147: Harden the imported measurement-input validators

### DIFF
--- a/src/main/java/com/researchspace/model/units/AmountConstraintValidator.java
+++ b/src/main/java/com/researchspace/model/units/AmountConstraintValidator.java
@@ -11,6 +11,9 @@ public class AmountConstraintValidator implements ConstraintValidator<ValidAmoun
 
   @Override
   public boolean isValid(Quantifiable value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
     return AmountValidator.validate(value);
   }
 }

--- a/src/main/java/com/researchspace/model/units/HalfLifeInput.java
+++ b/src/main/java/com/researchspace/model/units/HalfLifeInput.java
@@ -1,6 +1,6 @@
 package com.researchspace.model.units;
 
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -13,18 +13,18 @@ import lombok.NoArgsConstructor;
 public class HalfLifeInput {
 
   @NotNull
-  @Min(value = 0, message = "Please supply a halflife > 0")
+  @DecimalMin(value = "0", inclusive = false, message = "Please supply a halflife > 0")
   private Double halfLife;
 
   @NotNull
-  @Pattern(regexp = "(min)|h|(day)|(year)|", message = "{valid.time.message}")
+  @Pattern(regexp = "(min)|h|(day)|(year)", message = "{valid.time.message}")
   private String halfLifeTimeUnit;
 
   @NotNull
-  @Min(value = 0, message = "Please supply a decay time > 0")
+  @DecimalMin(value = "0", inclusive = false, message = "Please supply a decay time > 0")
   private Double decayTime;
 
   @NotNull
-  @Pattern(regexp = "(min)|h|(day)|(year)|", message = "{valid.time.message}")
+  @Pattern(regexp = "(min)|h|(day)|(year)", message = "{valid.time.message}")
   private String decayTimeUnit;
 }

--- a/src/main/java/com/researchspace/model/units/ValidA260InputValidator.java
+++ b/src/main/java/com/researchspace/model/units/ValidA260InputValidator.java
@@ -6,9 +6,7 @@ import jakarta.validation.ConstraintValidatorContext;
 public class ValidA260InputValidator implements ConstraintValidator<ValidA260Input, A260Input> {
 
   @Override
-  public void initialize(ValidA260Input constraintAnnotation) {
-    ;
-  }
+  public void initialize(ValidA260Input constraintAnnotation) {}
 
   @Override
   public boolean isValid(A260Input value, ConstraintValidatorContext context) {
@@ -19,7 +17,7 @@ public class ValidA260InputValidator implements ConstraintValidator<ValidA260Inp
     if (value.getA280() != null && value.getA320() != null && value.getA280() <= value.getA320()) {
       return false;
     }
-    if (value.getA320() != null && value.getA260() <= value.getA320()) {
+    if (value.getA320() != null && value.getA260() != null && value.getA260() <= value.getA320()) {
       return false;
     }
     return true;

--- a/src/main/java/com/researchspace/model/units/ValidCellDoublingInputValidator.java
+++ b/src/main/java/com/researchspace/model/units/ValidCellDoublingInputValidator.java
@@ -11,7 +11,9 @@ public class ValidCellDoublingInputValidator
 
   @Override
   public boolean isValid(CellDoublingTimeInput cellDoubleTime, ConstraintValidatorContext context) {
-    if (cellDoubleTime == null) {
+    if (cellDoubleTime == null
+        || cellDoubleTime.getFinalConc() == null
+        || cellDoubleTime.getInitConc() == null) {
       return true;
     }
     return cellDoubleTime.getFinalConc() > cellDoubleTime.getInitConc();

--- a/src/test/java/com/researchspace/model/units/HalfLifeInputTest.java
+++ b/src/test/java/com/researchspace/model/units/HalfLifeInputTest.java
@@ -36,6 +36,20 @@ public class HalfLifeInputTest {
   }
 
   @Test
+  public void emptyOrUnknownTimeUnitIsRejected() {
+    Set<ConstraintViolation<HalfLifeInput>> constraintViolations =
+        validator.validate(new HalfLifeInput(3.1, "", 2.0, "week"));
+    assertEquals(2, constraintViolations.size());
+  }
+
+  @Test
+  public void zeroTimesAreRejected() {
+    Set<ConstraintViolation<HalfLifeInput>> constraintViolations =
+        validator.validate(new HalfLifeInput(0d, "day", 0d, "h"));
+    assertEquals(2, constraintViolations.size());
+  }
+
+  @Test
   public void test2() {
     BaseUnit<Dimensionless> PEOPLE = new BaseUnit<>("people");
     javax.measure.Quantity<Dimensionless> pop = Quantities.getQuantity(100, PEOPLE);

--- a/src/test/java/com/researchspace/model/units/InputValidatorNullSafetyTest.java
+++ b/src/test/java/com/researchspace/model/units/InputValidatorNullSafetyTest.java
@@ -1,0 +1,46 @@
+package com.researchspace.model.units;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The class-level validators can be invoked with null values even when field-level @NotNull
+ * constraints are also violated, so they must treat null as valid rather than throw.
+ */
+class InputValidatorNullSafetyTest {
+
+  @Test
+  void amountValidatorTreatsNullAsValid() {
+    assertTrue(new AmountConstraintValidator().isValid(null, null));
+  }
+
+  @Test
+  void a260ValidatorHandlesNullA260() {
+    A260Input input = new A260Input();
+    input.setA320(1.0);
+    assertTrue(new ValidA260InputValidator().isValid(input, null));
+  }
+
+  @Test
+  void a260ValidatorStillRejectsA260NotAboveA320() {
+    A260Input input = new A260Input();
+    input.setA260(1.0);
+    input.setA320(2.0);
+    assertFalse(new ValidA260InputValidator().isValid(input, null));
+  }
+
+  @Test
+  void cellDoublingValidatorHandlesNullConcentrations() {
+    assertTrue(new ValidCellDoublingInputValidator().isValid(new CellDoublingTimeInput(), null));
+  }
+
+  @Test
+  void cellDoublingValidatorStillRejectsNonIncreasingConcentration() {
+    CellDoublingTimeInput input = new CellDoublingTimeInput();
+    input.setInitConc(5.0);
+    input.setFinalConc(4.0);
+    assertFalse(new ValidCellDoublingInputValidator().isValid(input, null));
+  }
+}


### PR DESCRIPTION
## Description ##

Stacked on #1041. Fixes the four real defects Copilot's review of the core-repository merge found in the imported validation helpers, all in `com.researchspace.model.units`:

- `AmountConstraintValidator`, `ValidA260InputValidator`, and `ValidCellDoublingInputValidator` threw `NullPointerException` when class-level validation ran against null values or null fields; they now treat null as valid and leave requiredness to the field-level `@NotNull` constraints, per the usual Bean Validation contract.
- `HalfLifeInput`'s time-unit patterns had a trailing `|` that made the empty string validate, and `@Min(0)` accepted 0 while the message promised "> 0"; the patterns are fixed and the constraint is now an exclusive `DecimalMin`.

Severity context: none of these classes currently has a live caller in the tree, so the bugs were unreachable in production; this is hardening of latent helpers rather than a behaviour change.

Copilot's remaining three comments on #1041 (raw `Set` generics in `PermissionStringConverter`, `ZipEntryProcessor` javadoc and unused import, JUnit 4 `@Rule` in `AllowanceTrackerSourceImplTest`) are cosmetic and deliberately not included here.

## Testing notes

New `InputValidatorNullSafetyTest` covers the null paths and the surviving rejection cases; `HalfLifeInputTest` gains cases for the empty-string unit and zero times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
