### PR TITLE
RSDEV-1271: Load more items in the workspace root in the ELN link picker

### DIFF
--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnFolderBrowser.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnFolderBrowser.tsx
@@ -149,6 +149,14 @@ function usePagedFolderListing(id?: number): {
   const { getFolderTree } = useFolders();
   const [records, setRecords] = React.useState<ReadonlyArray<FolderTreeNode>>([]);
   const [totalHits, setTotalHits] = React.useState(0);
+  // Raw rows fetched, including any dropped as duplicates below. Termination is
+  // judged against this rather than records.length so that a dropped duplicate
+  // cannot leave "Load more" visible forever after the last page.
+  const [fetchedCount, setFetchedCount] = React.useState(0);
+  // Set when an appended page comes back empty: deletions during pagination can
+  // shift unseen records up into pages already fetched, so the tail stays empty
+  // while fetchedCount never reaches totalHits.
+  const [exhausted, setExhausted] = React.useState(false);
   const [currentPage, setCurrentPage] = React.useState(0);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(false);
@@ -171,6 +179,8 @@ function usePagedFolderListing(id?: number): {
           const seen = new Set(prev.map((r) => r.id));
           return [...prev, ...response.records.filter((r) => !seen.has(r.id))];
         });
+        setFetchedCount((prev) => (append ? prev + response.records.length : response.records.length));
+        setExhausted(append && response.records.length === 0);
         setTotalHits(response.totalHits);
         setCurrentPage(pageNumber);
       } catch {
@@ -190,7 +200,7 @@ function usePagedFolderListing(id?: number): {
     records,
     loading,
     error,
-    hasMorePages: records.length < totalHits,
+    hasMorePages: !exhausted && fetchedCount < totalHits,
     loadNextPage: () => void loadPage(currentPage + 1, true),
     reload: () => void loadPage(0, false),
   };

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnFolderBrowser.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/ElnFolderBrowser.tsx
@@ -133,29 +133,44 @@ function CollapseArrow(): React.ReactElement {
 }
 
 /**
- * A single tree node. Folders and notebooks are expandable and lazily load their
- * own contents (mirroring FolderTree's load strategy); documents render as leaves.
+ * A paged listing of one tree level: the workspace root when {@code id} is
+ * undefined, otherwise the contents of the folder or notebook with that id.
+ * Loads the first page on mount; loadNextPage appends further pages until
+ * every record the endpoint reports has been fetched.
  */
-function TreeNodeContent({ node }: { node: FolderTreeNode }): React.ReactNode {
-  const { t } = useTranslation(["inventory", "common"]);
+function usePagedFolderListing(id?: number): {
+  records: ReadonlyArray<FolderTreeNode>;
+  loading: boolean;
+  error: boolean;
+  hasMorePages: boolean;
+  loadNextPage: () => void;
+  reload: () => void;
+} {
   const { getFolderTree } = useFolders();
-  const [children, setChildren] = React.useState<ReadonlyArray<FolderTreeNode>>([]);
+  const [records, setRecords] = React.useState<ReadonlyArray<FolderTreeNode>>([]);
   const [totalHits, setTotalHits] = React.useState(0);
   const [currentPage, setCurrentPage] = React.useState(0);
-  const [loading, setLoading] = React.useState(false);
+  const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(false);
 
-  const loadChildren = React.useCallback(
+  const loadPage = React.useCallback(
     async (pageNumber: number, append: boolean) => {
       setLoading(true);
       setError(false);
       try {
         const response = await getFolderTree({
-          id: node.id,
+          id,
           typesToInclude: TYPES_TO_INCLUDE,
           pageNumber,
         });
-        setChildren((prev) => (append ? [...prev, ...response.records] : response.records));
+        setRecords((prev) => {
+          if (!append) return response.records;
+          // Offset pagination can re-serve a record already shown when the
+          // listing shifts between page fetches (e.g. something was created or
+          // renamed meanwhile). The tree requires unique item ids, so drop them.
+          const seen = new Set(prev.map((r) => r.id));
+          return [...prev, ...response.records.filter((r) => !seen.has(r.id))];
+        });
         setTotalHits(response.totalHits);
         setCurrentPage(pageNumber);
       } catch {
@@ -164,22 +179,52 @@ function TreeNodeContent({ node }: { node: FolderTreeNode }): React.ReactNode {
         setLoading(false);
       }
     },
-    [node.id, getFolderTree],
+    [id, getFolderTree],
   );
 
   React.useEffect(() => {
-    if (isExpandable(node)) void loadChildren(0, false);
-  }, [loadChildren, node]);
+    void loadPage(0, false);
+  }, [loadPage]);
 
+  return {
+    records,
+    loading,
+    error,
+    hasMorePages: records.length < totalHits,
+    loadNextPage: () => void loadPage(currentPage + 1, true),
+    reload: () => void loadPage(0, false),
+  };
+}
+
+function LoadMoreRow({ onClick }: { onClick: () => void }): React.ReactElement {
+  const { t } = useTranslation(["inventory", "common"]);
+  return (
+    <Box sx={{ p: 1 }}>
+      <Button size="small" onClick={onClick}>
+        {t("fields.link.elnFolderBrowser.loadMore")}
+      </Button>
+    </Box>
+  );
+}
+
+/**
+ * A single tree node. Folders and notebooks are expandable and lazily load their
+ * own contents (mirroring FolderTree's load strategy); documents render as leaves.
+ */
+function TreeNodeContent({ node }: { node: FolderTreeNode }): React.ReactNode {
   if (!isExpandable(node)) {
     return <TreeItem item={node} label={<NodeLabel node={node} />} role="treeitem" />;
   }
+  return <ExpandableTreeNode node={node} />;
+}
 
-  const hasMorePages = children.length < totalHits;
+function ExpandableTreeNode({ node }: { node: FolderTreeNode }): React.ReactElement {
+  const { t } = useTranslation(["inventory", "common"]);
+  const { records, loading, error, hasMorePages, loadNextPage } = usePagedFolderListing(node.id);
 
   return (
     <TreeItem item={node} label={<NodeLabel node={node} />} role="treeitem">
-      {children.map((child) => (
+      {records.map((child) => (
         <TreeNodeContent key={child.id} node={child} />
       ))}
       {loading && (
@@ -192,13 +237,7 @@ function TreeNodeContent({ node }: { node: FolderTreeNode }): React.ReactNode {
           <Alert severity="error">{t("fields.link.elnFolderBrowser.failedToLoadContents")}</Alert>
         </Box>
       )}
-      {hasMorePages && !loading && (
-        <Box sx={{ p: 1 }}>
-          <Button size="small" onClick={() => void loadChildren(currentPage + 1, true)}>
-            {t("fields.link.elnFolderBrowser.loadMore")}
-          </Button>
-        </Box>
-      )}
+      {hasMorePages && !loading && <LoadMoreRow onClick={loadNextPage} />}
     </TreeItem>
   );
 }
@@ -220,29 +259,9 @@ export default function ElnFolderBrowser({
   onSelectionChange: (selection: ElnTreeSelection | null) => void;
 }): React.ReactElement {
   const { t } = useTranslation(["inventory", "common"]);
-  const { getFolderTree } = useFolders();
-  const [roots, setRoots] = React.useState<ReadonlyArray<FolderTreeNode>>([]);
+  const { records: roots, loading, error, hasMorePages, loadNextPage, reload } = usePagedFolderListing();
   const [expanded, setExpanded] = React.useState<Array<FolderTreeNode>>([]);
   const [selected, setSelected] = React.useState<FolderTreeNode | null>(null);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState(false);
-
-  const loadRoots = React.useCallback(async () => {
-    setLoading(true);
-    setError(false);
-    try {
-      const response = await getFolderTree({ typesToInclude: TYPES_TO_INCLUDE });
-      setRoots(response.records);
-    } catch {
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
-  }, [getFolderTree]);
-
-  React.useEffect(() => {
-    void loadRoots();
-  }, [loadRoots]);
 
   return (
     <Box>
@@ -251,7 +270,7 @@ export default function ElnFolderBrowser({
           severity="error"
           sx={{ mb: 1 }}
           action={
-            <Button size="small" onClick={() => void loadRoots()}>
+            <Button size="small" onClick={reload}>
               {t("common:actions.retry")}
             </Button>
           }
@@ -300,6 +319,7 @@ export default function ElnFolderBrowser({
           <TreeNodeContent key={node.id} node={node} />
         ))}
       </Tree>
+      {hasMorePages && !loading && <LoadMoreRow onClick={loadNextPage} />}
       {!loading && !error && roots.length === 0 && (
         <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
           {t("fields.link.elnFolderBrowser.nothingToBrowse")}

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnFolderBrowser.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnFolderBrowser.test.tsx
@@ -137,6 +137,108 @@ describe("ElnFolderBrowser", () => {
   });
 });
 
+describe("ElnFolderBrowser pagination", () => {
+  const LOAD_MORE = "inventory:fields.link.elnFolderBrowser.loadMore";
+
+  beforeEach(() => {
+    mockGetFolderTree.mockReset();
+  });
+  afterEach(cleanup);
+
+  it("offers Load more at the workspace root and appends the next page", async () => {
+    const rootPages: ReadonlyArray<ReadonlyArray<Node>> = [
+      [
+        { id: 1, globalId: "SD1", name: "Doc one", type: "DOCUMENT" },
+        { id: 2, globalId: "SD2", name: "Doc two", type: "DOCUMENT" },
+      ],
+      [{ id: 3, globalId: "SD3", name: "Doc three", type: "DOCUMENT" }],
+    ];
+    mockGetFolderTree.mockImplementation(({ id, pageNumber = 0 }: { id?: number; pageNumber?: number }) => {
+      if (id !== undefined) return Promise.resolve({ totalHits: 0, pageNumber: 0, records: [] });
+      return Promise.resolve({
+        totalHits: 3,
+        pageNumber,
+        records: rootPages[pageNumber] ?? [],
+      });
+    });
+    renderBrowser(vi.fn());
+    const user = userEvent.setup();
+
+    // only the first page is shown, with a way to fetch the rest
+    await screen.findByRole("treeitem", { name: "Doc two" });
+    expect(screen.queryByRole("treeitem", { name: "Doc three" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: LOAD_MORE }));
+
+    // the next page is appended after the first, and no more pages remain
+    expect(await screen.findByRole("treeitem", { name: "Doc three" })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: "Doc one" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: LOAD_MORE })).not.toBeInTheDocument();
+  });
+
+  it("drops records re-served by a later page when the listing shifted meanwhile", async () => {
+    // simulates the workspace changing between page fetches: page 1 re-serves
+    // "Doc two", which the tree must not render twice (duplicate ids crash it)
+    const rootPages: ReadonlyArray<ReadonlyArray<Node>> = [
+      [
+        { id: 1, globalId: "SD1", name: "Doc one", type: "DOCUMENT" },
+        { id: 2, globalId: "SD2", name: "Doc two", type: "DOCUMENT" },
+      ],
+      [
+        { id: 2, globalId: "SD2", name: "Doc two", type: "DOCUMENT" },
+        { id: 3, globalId: "SD3", name: "Doc three", type: "DOCUMENT" },
+      ],
+    ];
+    mockGetFolderTree.mockImplementation(({ id, pageNumber = 0 }: { id?: number; pageNumber?: number }) => {
+      if (id !== undefined) return Promise.resolve({ totalHits: 0, pageNumber: 0, records: [] });
+      return Promise.resolve({
+        totalHits: 4,
+        pageNumber,
+        records: rootPages[pageNumber] ?? [],
+      });
+    });
+    renderBrowser(vi.fn());
+    const user = userEvent.setup();
+
+    await screen.findByRole("treeitem", { name: "Doc two" });
+    await user.click(screen.getByRole("button", { name: LOAD_MORE }));
+
+    expect(await screen.findByRole("treeitem", { name: "Doc three" })).toBeInTheDocument();
+    expect(screen.getAllByRole("treeitem", { name: "Doc two" })).toHaveLength(1);
+  });
+
+  it("offers Load more inside an expanded folder and appends the next page", async () => {
+    const childPages: ReadonlyArray<ReadonlyArray<Node>> = [
+      [{ id: 101, globalId: "SD101", name: "Child one", type: "DOCUMENT" }],
+      [{ id: 102, globalId: "SD102", name: "Child two", type: "DOCUMENT" }],
+    ];
+    mockGetFolderTree.mockImplementation(({ id, pageNumber = 0 }: { id?: number; pageNumber?: number }) => {
+      if (id === undefined)
+        return Promise.resolve({
+          totalHits: 1,
+          pageNumber: 0,
+          records: [{ id: 100, globalId: "FL100", name: "Projects", type: "FOLDER" }],
+        });
+      return Promise.resolve({
+        totalHits: 2,
+        pageNumber,
+        records: childPages[pageNumber] ?? [],
+      });
+    });
+    renderBrowser(vi.fn());
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText("Projects"));
+    await screen.findByRole("treeitem", { name: "Child one" });
+    expect(screen.queryByRole("treeitem", { name: "Child two" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: LOAD_MORE }));
+
+    expect(await screen.findByRole("treeitem", { name: "Child two" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: LOAD_MORE })).not.toBeInTheDocument();
+  });
+});
+
 describe("ElnFolderBrowser selection highlight", () => {
   beforeEach(() => {
     mockGetFolderTree.mockReset();

--- a/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnFolderBrowser.test.tsx
+++ b/src/main/webapp/ui/src/Inventory/components/Fields/Link/__tests__/ElnFolderBrowser.test.tsx
@@ -205,6 +205,36 @@ describe("ElnFolderBrowser pagination", () => {
 
     expect(await screen.findByRole("treeitem", { name: "Doc three" })).toBeInTheDocument();
     expect(screen.getAllByRole("treeitem", { name: "Doc two" })).toHaveLength(1);
+    // termination is judged on rows fetched (4), not rows retained (3), so a
+    // dropped duplicate must not leave the button behind
+    expect(screen.queryByRole("button", { name: LOAD_MORE })).not.toBeInTheDocument();
+  });
+
+  it("stops offering Load more when an appended page comes back empty", async () => {
+    // simulates deletions during pagination: unseen records shifted up into the
+    // already-fetched page, so the tail page is empty while totalHits still
+    // reports more rows than were fetched
+    mockGetFolderTree.mockImplementation(({ id, pageNumber = 0 }: { id?: number; pageNumber?: number }) => {
+      if (id !== undefined) return Promise.resolve({ totalHits: 0, pageNumber: 0, records: [] });
+      return Promise.resolve({
+        totalHits: 4,
+        pageNumber,
+        records:
+          pageNumber === 0
+            ? [
+                { id: 1, globalId: "SD1", name: "Doc one", type: "DOCUMENT" },
+                { id: 2, globalId: "SD2", name: "Doc two", type: "DOCUMENT" },
+              ]
+            : [],
+      });
+    });
+    renderBrowser(vi.fn());
+    const user = userEvent.setup();
+
+    await screen.findByRole("treeitem", { name: "Doc two" });
+    await user.click(screen.getByRole("button", { name: LOAD_MORE }));
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: LOAD_MORE })).not.toBeInTheDocument());
   });
 
   it("offers Load more inside an expanded folder and appends the next page", async () => {


### PR DESCRIPTION
## Description ##
Fixes RSDEV-1271: the "Browse ELN" picker used when creating a link from Inventory fetched only the first page of 20 items at the workspace root and offered no way to load more, so a workspace with more than 20 top-level items appeared silently truncated. Child folders and notebooks already had a "Load more" button; the root level never did.

- Extracted the paged-listing logic both levels share into a `usePagedFolderListing` hook and rendered the same "Load more" button below the root of the tree.

## Design decisions
- "Load more" (append) rather than numbered page navigation or scroll-triggered loading, matching the pattern already used by the Gallery listing, the shared `FolderTree` component, and this picker's own child levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
