### PR TITLE
RSDEV-1253: Map `Calibration` and `Measurement Technique` for PIDINST (DataCite and B2inst)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,20 +40,22 @@ resolved during design. This file is a glossary only — no implementation detai
 ## Instrument PID registration (B2INST/PIDINST)
 
 - **PIDINST-mapped field** — a custom field on a concrete Instrument that feeds
-  the B2INST/PIDINST registration metadata because both its name (compared
-  case-insensitively, ignoring surrounding whitespace) and its declared field
-  type match a field of the default PIDINST template. A field matching by name
-  but not by type is ignored. Participation is decided by name+type
+  the B2INST/PIDINST and DataCite PIDINST registration metadata because both its
+  name (compared case-insensitively, ignoring surrounding whitespace) and its
+  declared field type match a field of the default PIDINST template. A field
+  matching by name but not by type is ignored. Participation is decided by name+type
   conformance, never by template lineage: any instrument carrying conforming
   fields is mapped, however it was created. The template's field names are the
   canonical spelling of the mapping contract.
 - **Documentation-only field** — a field of the default PIDINST template that
   deliberately feeds no registration metadata, existing purely so users can
-  record the fact against the instrument. The measurement technique, the
-  calibration and the last calibration date are documentation-only: they have no
-  PIDINST property that fits them, and inventing one was tried and rejected. A
-  documentation-only field is still an ordinary instrument field, so users fill,
-  edit and read it as usual; it simply never leaves RSpace.
+  record the fact against the instrument. Only the last calibration date is
+  documentation-only now: PIDINST's Date vocabulary has no home for it. The
+  measurement technique and calibration links were documentation-only until
+  RSDEV-1253 mapped them to RelatedIdentifier entries with a fixed IsDescribedBy
+  relation (see ADR 0007); the relation type stored on the link itself still
+  never leaves RSpace. A documentation-only field is still an ordinary
+  instrument field, so users fill, edit and read it as usual.
 - **Legacy auto-filled landing page** — a landing page RSpace itself wrote into
   an instrument's Landing page field, back when saving an instrument filled a
   blank field with the record's own globalId address. RSpace no longer writes

--- a/DevDocs/adr/0005-measured-variable-narratives.md
+++ b/DevDocs/adr/0005-measured-variable-narratives.md
@@ -7,15 +7,14 @@ status: superseded
 > **Superseded (2026-07-27), during RSDEV-1220, before any of this shipped.**
 > The narratives were dropped. `MeasuredVariable` now carries only the *Measured
 > quantity* field's content verbatim, which is what the property was designed
-> for. *Measurement technique*, *Calibration* and *Last calibrated* are no longer
-> mapped to anything and stay on the template as documentation-only fields (see
-> `CONTEXT.md`). The reasoning below is kept because the underlying problem is
-> unchanged — PIDINST still has no home for those three facts — so anyone
-> proposing to map them again should start here and read the Considered options.
->
-> RSDEV-1253 later did map the two link fields, resolving the vocabulary clash by
-> fixing the sent relation to `IsDescribedBy`; see ADR 0007. *Last calibrated* alone
-> remains unmapped.
+> for. Nothing narrative reaches `MeasuredVariable` from the other fields.
+> *Measurement technique* and *Calibration* were documentation-only from then
+> until RSDEV-1253 mapped them to `RelatedIdentifier` entries, resolving the
+> vocabulary clash by fixing the sent relation to `IsDescribedBy` (see ADR
+> 0007). Only *Last calibrated* remains unmapped, PIDINST's Date vocabulary
+> still having no home for it. The reasoning below is kept because it explains
+> why the narrative route stays closed; anyone proposing to map these fields
+> another way should start here and read the Considered options.
 
 ## Context
 

--- a/DevDocs/adr/0005-measured-variable-narratives.md
+++ b/DevDocs/adr/0005-measured-variable-narratives.md
@@ -12,6 +12,10 @@ status: superseded
 > `CONTEXT.md`). The reasoning below is kept because the underlying problem is
 > unchanged — PIDINST still has no home for those three facts — so anyone
 > proposing to map them again should start here and read the Considered options.
+>
+> RSDEV-1253 later did map the two link fields, resolving the vocabulary clash by
+> fixing the sent relation to `IsDescribedBy`; see ADR 0007. *Last calibrated* alone
+> remains unmapped.
 
 ## Context
 

--- a/DevDocs/adr/0007-pidinst-related-identifiers.md
+++ b/DevDocs/adr/0007-pidinst-related-identifiers.md
@@ -39,17 +39,19 @@ B2INST draft metadata (`RelatedIdentifier`) and the DataCite attributes
 - Guard rails mirror the landing page: an address that would not be absolute http(s) is
   omitted with a WARN; an absent field, empty, deleted or target-less link is omitted
   silently.
-- **No read-permission re-check on the link target** at registration, publish or retract,
-  deliberately. READ is asserted where the link is written (`InventoryLinkManagerImpl`, on
-  create and update); from then on the target's globalId is part of the instrument's own
-  data, and RSpace already shows that id to every instrument viewer even when the target
-  itself is unreadable — the link summary redacts name and type, never the id
-  (`LinkTargetSnapshotResolverImpl`). The registered entry discloses exactly that id plus a
-  fixed label, never the target's name or content, and the address resolves only for
-  signed-in users who pass the target's own checks. Re-checking at publish time would also
-  key the permanent payload to whichever editor happens to click publish on a shared
-  instrument, so the same instrument could register different metadata depending on the
-  actor — a worse property than the disclosure it would prevent.
+- **The target is re-checked at registration time, as the instrument's owner**, and an
+  entry is omitted (with a WARN) when the target is deleted or the owner cannot read it.
+  Write-time READ (`InventoryLinkManagerImpl`) is not enough on its own: duplicating an
+  instrument copies its links with no target check, so a link can exist that nobody ever
+  verified; sharing can be revoked after the link was made; and deleting a record does not
+  delete links pointing at it, so an unchecked entry could permanently name a dead record.
+  The owner is the actor, not whoever triggers the registration, because the owner is
+  stable: the payload must not vary with which editor of a shared instrument happens to
+  click. The check runs through the same snapshot the link-card UI shows
+  (`LinkTargetSnapshotResolver`), so registration and display cannot disagree about a
+  target being deleted or redacted. What a qualifying entry still discloses publicly is the
+  bare globalId plus a fixed label, never a name or content, and the address resolves only
+  for signed-in users who pass the target's own checks.
 - B2INST receives the entries at draft-register time (its only metadata write). DataCite
   receives them on publish and again on retract, because both resend full metadata and
   the entries are computed from the instrument, not persisted on the DOI.
@@ -58,11 +60,23 @@ B2INST draft metadata (`RelatedIdentifier`) and the DataCite attributes
   explicit empty array; an absent or null property leaves the registered value alone. An
   instrument whose link fields were all cleared after registration therefore has to send
   `[]`, or the entries registered beforehand stay attached to a findable DOI with no way to
-  withdraw them. B2INST keeps sending null for empty, having no metadata-update call and so
-  nothing to clear.
+  withdraw them. The one exception is an **environment failure**: when no usable http(s)
+  server URL exists, no address can be built for any link, so an empty list would be
+  indistinguishable from "the user cleared the fields" and would strip entries that are
+  still correct — the property is left untouched instead, until the deployment is fixed.
+  Emptiness that reflects the data (fields cleared, targets deleted or no longer
+  owner-readable) does clear. B2INST keeps sending null for empty, having no
+  metadata-update call and so nothing to clear.
 
 *Last calibrated* stays documentation-only; PIDINST's `Date.dateType` vocabulary is
 still strictly Commissioned/DeCommissioned.
+
+Two wire-level caveats, accepted: DataCite's `relationTypeInformation` was introduced in
+Metadata Schema 4.7 (March 2026), so a registrar still on 4.6 or earlier silently drops
+the label while keeping the rest of the entry. And the same literal serves two subtly
+different slots — B2INST's `relatedIdentifierName` names the linked resource, DataCite's
+`relationTypeInformation` describes the relation — which is deliberate: one label per
+field keeps the two registries recognisably in step.
 
 ## Consequences
 

--- a/DevDocs/adr/0007-pidinst-related-identifiers.md
+++ b/DevDocs/adr/0007-pidinst-related-identifiers.md
@@ -1,0 +1,47 @@
+---
+status: accepted
+---
+
+# PIDINST related identifiers for Measurement technique and Calibration
+
+## Context
+
+ADR 0005 left *Measurement technique*, *Calibration* and *Last calibrated* unmapped
+("documentation-only"): PIDINST's `RelatedIdentifier.relationType` vocabulary contains
+neither `IsDocumentedBy` nor `IsCalibratedBy`, the relation types the template's link
+fields store, and inventing narrative workarounds was rejected. RSDEV-1253 now requires
+the two link fields to reach both providers as related identifiers.
+
+## Decision
+
+At registration the two link fields become related-identifier entries, in both the
+B2INST draft metadata (`RelatedIdentifier`) and the DataCite attributes
+(`relatedIdentifiers`):
+
+- `relationType` is always `IsDescribedBy`, whatever relation the link stores. It is
+  the one semantically usable type present in PIDINST's vocabulary; the stored relation
+  survives unchanged inside RSpace.
+- The value is the link target's internal globalId page, `<serverUrl>/globalId/<id>`,
+  built by `InventoryUrls.globalIdPageUrl`. The target generally has no public page, so
+  the sign-in-walled address is accepted (unlike a LandingPage, ADR 0006, a
+  RelatedIdentifier makes no promise of anonymous resolvability).
+- The human label ("Measurement Technique", "Calibration", the ticket's capitalisation)
+  goes to B2INST's `relatedIdentifierName` and DataCite's `relationTypeInformation`.
+- `relatedIdentifierType` is `URL`.
+- Guard rails mirror the landing page: an address that would not be absolute http(s) is
+  omitted with a WARN; an absent field, empty, deleted or target-less link is omitted
+  silently.
+- B2INST receives the entries at draft-register time (its only metadata write). DataCite
+  receives them on publish and again on retract, because both resend full metadata and
+  the entries are computed from the instrument, not persisted on the DOI.
+
+*Last calibrated* stays documentation-only; PIDINST's `Date.dateType` vocabulary is
+still strictly Commissioned/DeCommissioned.
+
+## Consequences
+
+- `datacite-java-client` >= 1.1.0 is required (`relatedIdentifiers` on
+  `DataCiteDoiAttributes`).
+- The registered entries reflect the link fields at register/publish time; editing a
+  link afterwards updates nothing at the provider (B2INST has no metadata-update call;
+  DataCite would refresh on the next publish/retract).

--- a/DevDocs/adr/0007-pidinst-related-identifiers.md
+++ b/DevDocs/adr/0007-pidinst-related-identifiers.md
@@ -25,6 +25,14 @@ B2INST draft metadata (`RelatedIdentifier`) and the DataCite attributes
   built by `InventoryUrls.globalIdPageUrl`. The target generally has no public page, so
   the sign-in-walled address is accepted (unlike a LandingPage, ADR 0006, a
   RelatedIdentifier makes no promise of anonymous resolvability).
+- The link's **version pin is carried** into that address (`<id>v<pin>`) when the target
+  type resolves a version-suffixed globalId, i.e. the inventory prefixes
+  `GlobalLookupController` routes to the versioned viewer (SA, SS, IC, IT, IN, NT). A pin
+  on any other allowed target is dropped: NB has no versioned route at all, and SD's and
+  GL's lead to an audit view and a file stream rather than the record's page, so there the
+  unpinned address is the safer thing to make permanent. Rationale: a pinned link names one
+  version deliberately, and a registered address cannot be corrected, so it must not
+  silently follow the record's latest state.
 - The human label ("Measurement Technique", "Calibration", the ticket's capitalisation)
   goes to B2INST's `relatedIdentifierName` and DataCite's `relationTypeInformation`.
 - `relatedIdentifierType` is `URL`.
@@ -34,6 +42,13 @@ B2INST draft metadata (`RelatedIdentifier`) and the DataCite attributes
 - B2INST receives the entries at draft-register time (its only metadata write). DataCite
   receives them on publish and again on retract, because both resend full metadata and
   the entries are computed from the instrument, not persisted on the DOI.
+- For DataCite the list is sent **unconditionally, the empty list included**. DataCite
+  replaces the whole property with what the payload carries and clears it only on an
+  explicit empty array; an absent or null property leaves the registered value alone. An
+  instrument whose link fields were all cleared after registration therefore has to send
+  `[]`, or the entries registered beforehand stay attached to a findable DOI with no way to
+  withdraw them. B2INST keeps sending null for empty, having no metadata-update call and so
+  nothing to clear.
 
 *Last calibrated* stays documentation-only; PIDINST's `Date.dateType` vocabulary is
 still strictly Commissioned/DeCommissioned.

--- a/DevDocs/adr/0007-pidinst-related-identifiers.md
+++ b/DevDocs/adr/0007-pidinst-related-identifiers.md
@@ -39,6 +39,17 @@ B2INST draft metadata (`RelatedIdentifier`) and the DataCite attributes
 - Guard rails mirror the landing page: an address that would not be absolute http(s) is
   omitted with a WARN; an absent field, empty, deleted or target-less link is omitted
   silently.
+- **No read-permission re-check on the link target** at registration, publish or retract,
+  deliberately. READ is asserted where the link is written (`InventoryLinkManagerImpl`, on
+  create and update); from then on the target's globalId is part of the instrument's own
+  data, and RSpace already shows that id to every instrument viewer even when the target
+  itself is unreadable — the link summary redacts name and type, never the id
+  (`LinkTargetSnapshotResolverImpl`). The registered entry discloses exactly that id plus a
+  fixed label, never the target's name or content, and the address resolves only for
+  signed-in users who pass the target's own checks. Re-checking at publish time would also
+  key the permanent payload to whichever editor happens to click publish on a shared
+  instrument, so the same instrument could register different metadata depending on the
+  actor — a worse property than the disclosure it would prevent.
 - B2INST receives the entries at draft-register time (its only metadata write). DataCite
   receives them on publish and again on retract, because both resend full metadata and
   the entries are computed from the instrument, not persisted on the DOI.

--- a/pom.xml
+++ b/pom.xml
@@ -1779,7 +1779,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>datacite-java-client</artifactId>
-      <version>RSDEV-1253-datacite-SNAPSHOT</version>
+      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1779,7 +1779,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>datacite-java-client</artifactId>
-      <version>1.0.0</version>
+      <version>RSDEV-1253-datacite-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/axiope/service/cfg/BaseConfig.java
+++ b/src/main/java/com/axiope/service/cfg/BaseConfig.java
@@ -214,6 +214,7 @@ import com.researchspace.service.impl.SysadminUserCreationHandlerImpl;
 import com.researchspace.service.impl.SystemConfigurationInitialisor;
 import com.researchspace.service.impl.SystemPropertyPermissionManagerImpl;
 import com.researchspace.service.impl.UserExternalIdResolverImpl;
+import com.researchspace.service.inventory.LinkTargetResolver;
 import com.researchspace.service.inventory.RspaceToExternalProviderAdapter;
 import com.researchspace.service.inventory.impl.RspaceToExternalProviderAdapterImpl;
 import com.researchspace.slack.SlackMessageSender;
@@ -1314,8 +1315,9 @@ public abstract class BaseConfig {
   }
 
   @Bean(name = "rspaceToExternalProviderAdapter")
-  public RspaceToExternalProviderAdapter getRspaceToExternalProviderAdapter() {
-    return new RspaceToExternalProviderAdapterImpl(propertyHolder());
+  public RspaceToExternalProviderAdapter getRspaceToExternalProviderAdapter(
+      LinkTargetResolver linkTargetResolver) {
+    return new RspaceToExternalProviderAdapterImpl(propertyHolder(), linkTargetResolver);
   }
 
   @Bean(name = "pyrat")

--- a/src/main/java/com/axiope/service/cfg/BaseConfig.java
+++ b/src/main/java/com/axiope/service/cfg/BaseConfig.java
@@ -1315,7 +1315,7 @@ public abstract class BaseConfig {
 
   @Bean(name = "rspaceToExternalProviderAdapter")
   public RspaceToExternalProviderAdapter getRspaceToExternalProviderAdapter() {
-    return new RspaceToExternalProviderAdapterImpl();
+    return new RspaceToExternalProviderAdapterImpl(propertyHolder());
   }
 
   @Bean(name = "pyrat")

--- a/src/main/java/com/researchspace/service/inventory/InventoryUrls.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryUrls.java
@@ -15,7 +15,8 @@ import org.apache.commons.lang3.StringUtils;
  * this one, and the two halves of that invariant would silently stop matching.
  *
  * <p>Replaces {@code GlobalIdUrls}, whose builder went with the retired auto-fill (ADR 0006 item
- * 3), leaving only a path segment RSpace still has to recognise.
+ * 3), leaving only a path segment RSpace had to recognise. RSDEV-1253 gave that segment a composer
+ * again, for a different purpose: PIDINST related identifiers (ADR 0007).
  */
 public final class InventoryUrls {
 
@@ -23,9 +24,10 @@ public final class InventoryUrls {
   private static final String PUBLIC_PAGE_PATH = "/public/inventory/";
 
   /**
-   * Path segment marking an address as a record's globalId page. RSpace no longer composes these,
-   * since the auto-fill that did is retired, but it must still recognise the ones already written
-   * so they read as an empty field rather than as something a user chose.
+   * Path segment marking an address as a record's globalId page. Composed by {@link
+   * #globalIdPageUrl} for PIDINST related identifiers, and recognised by {@link
+   * #namesGlobalIdPage}, which must still spot the ones the retired auto-fill wrote so they read as
+   * an empty Landing page field rather than as something a user chose.
    */
   private static final String GLOBAL_ID_PATH = "/globalId/";
 
@@ -47,6 +49,25 @@ public final class InventoryUrls {
     // stripEnd, not removeEnd: repeated trailing slashes have to go too, because the recogniser
     // normalises them away and a builder that kept them would stop recognising its own output.
     return Optional.of(StringUtils.stripEnd(trimmed, "/") + PUBLIC_PAGE_PATH + suffix);
+  }
+
+  /**
+   * The globalId page address for a record, used as the RelatedIdentifier value when PIDINST
+   * registration maps the instrument's link fields (RSDEV-1253, ADR 0007). Empty when either part
+   * is blank, for the same reason as {@link #publicLandingPageUrl}: a missing related identifier is
+   * recoverable, a wrong registered one is not.
+   *
+   * <p>Reuses the same path segment {@link #namesGlobalIdPage} recognises, so builder and
+   * recogniser cannot drift apart. This deliberately revives a globalId-page builder after the
+   * auto-fill's one was retired: unlike a LandingPage, a RelatedIdentifier is not required to be
+   * anonymously resolvable, and the linked record generally has no public page to point at.
+   */
+  public static Optional<String> globalIdPageUrl(String serverUrl, String globalId) {
+    String trimmed = StringUtils.trimToEmpty(serverUrl);
+    if (trimmed.isEmpty() || StringUtils.isBlank(globalId)) {
+      return Optional.empty();
+    }
+    return Optional.of(StringUtils.stripEnd(trimmed, "/") + GLOBAL_ID_PATH + globalId.trim());
   }
 
   /**

--- a/src/main/java/com/researchspace/service/inventory/InventoryUrls.java
+++ b/src/main/java/com/researchspace/service/inventory/InventoryUrls.java
@@ -1,7 +1,10 @@
 package com.researchspace.service.inventory;
 
+import com.researchspace.model.core.GlobalIdPrefix;
 import java.net.URI;
+import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -24,12 +27,37 @@ public final class InventoryUrls {
   private static final String PUBLIC_PAGE_PATH = "/public/inventory/";
 
   /**
+   * The globalId lookup route, consumed by {@code GlobalLookupController}'s request mapping so the
+   * route and the addresses composed here cannot move apart: a renamed route would silently strand
+   * every already-registered address (they are permanent), so the two halves share this constant.
+   */
+  public static final String GLOBAL_ID_MAPPING = "/globalId";
+
+  /**
    * Path segment marking an address as a record's globalId page. Composed by {@link
    * #globalIdPageUrl} for PIDINST related identifiers, and recognised by {@link
    * #namesGlobalIdPage}, which must still spot the ones the retired auto-fill wrote so they read as
    * an empty Landing page field rather than as something a user chose.
    */
-  private static final String GLOBAL_ID_PATH = "/globalId/";
+  private static final String GLOBAL_ID_PATH = GLOBAL_ID_MAPPING + "/";
+
+  /**
+   * The record types whose version-suffixed globalId ({@code SA42v4}) resolves to that version's
+   * read-only view. Consumed by {@code GlobalLookupController} (which routes those addresses) and
+   * by the PIDINST related-identifier mapping (which must not register a version suffix the route
+   * cannot resolve), so the router and the composer cannot drift: a drift here registers a
+   * permanently wrong address. SD and GL resolve version suffixes too, but to an audit view and a
+   * file stream rather than the record's page, so they are deliberately not in this set.
+   */
+  public static final Set<GlobalIdPrefix> VERSIONED_PAGE_PREFIXES =
+      Set.copyOf(
+          EnumSet.of(
+              GlobalIdPrefix.SA,
+              GlobalIdPrefix.SS,
+              GlobalIdPrefix.IC,
+              GlobalIdPrefix.IT,
+              GlobalIdPrefix.IN,
+              GlobalIdPrefix.NT));
 
   private InventoryUrls() {}
 

--- a/src/main/java/com/researchspace/service/inventory/LinkTargetResolver.java
+++ b/src/main/java/com/researchspace/service/inventory/LinkTargetResolver.java
@@ -20,4 +20,16 @@ public interface LinkTargetResolver {
    *     exist, is not readable, or has an unsupported prefix
    */
   boolean targetExistsAndIsReadable(GlobalIdentifier target, User user);
+
+  /**
+   * Like {@link #targetExistsAndIsReadable}, but additionally false when the target record is
+   * soft-deleted. Registration flows use this: a deleted target is still readable by its owner, but
+   * a permanent registry entry must not name a dead record.
+   *
+   * @param target the parsed link target GlobalID (any version suffix is ignored)
+   * @param user the user whose READ permission decides, typically the owning record's owner rather
+   *     than the acting user, so the outcome cannot vary with who triggers the flow
+   * @return true if the target resolves to a live (non-deleted) record the user can READ
+   */
+  boolean targetIsLiveAndReadable(GlobalIdentifier target, User user);
 }

--- a/src/main/java/com/researchspace/service/inventory/RspaceToExternalProviderAdapter.java
+++ b/src/main/java/com/researchspace/service/inventory/RspaceToExternalProviderAdapter.java
@@ -7,9 +7,10 @@ import com.researchspace.model.inventory.InventoryRecord;
 
 /**
  * Translates an RSpace inventory record into the domain wrapper of the requested external PID
- * provider. This is the seam the future generic registration endpoints (RSDEV-1209) will build on;
- * in this story only the B2INST path is routed through it, while DataCite delegates to the existing
- * {@link ApiInventoryDOI#convertToDataCiteDoi()}.
+ * provider. This is the seam the future generic registration endpoints (RSDEV-1209) will build on.
+ * The B2INST path is built here in full; the DataCite path delegates the base conversion to {@link
+ * ApiInventoryDOI#convertToDataCiteDoi()} and adds the PIDINST properties that have no home on the
+ * RSpace DOI representation (ADR 0007).
  *
  * <p>Provider guard rails: {@code PIDINST_*} providers accept only Instrument records ({@code
  * IN*}); {@code IGSN_*} providers accept only {@code IC*}/{@code SA*}/{@code SS*}.
@@ -25,10 +26,11 @@ public interface RspaceToExternalProviderAdapter {
    * wrong (see ADR 0006). Owner always has exactly one entry (field content, falling back to the
    * record owner).
    *
-   * <p>Not every template field is mapped. "Measurement technique", "Calibration" and "Last
-   * calibrated" are documentation-only and feed nothing, because PIDINST has no property that fits
-   * them; see CONTEXT.md ("Documentation-only field") and the superseded
-   * DevDocs/adr/0005-measured-variable-narratives.md for the attempt that was rejected.
+   * <p>The "Measurement technique" and "Calibration" link fields are mapped to RelatedIdentifier
+   * entries (fixed IsDescribedBy relation, the target's globalId page as a URL; RSDEV-1253, ADR
+   * 0007). "Last calibrated" remains documentation-only, because PIDINST has no property that fits
+   * it; see CONTEXT.md ("Documentation-only field") and
+   * DevDocs/adr/0005-measured-variable-narratives.md.
    *
    * <p>Must be called inside an existing transaction: the mapping reads the instrument's lazy
    * associations. The implementation declares {@code @Transactional(propagation = MANDATORY)}, so a
@@ -42,6 +44,24 @@ public interface RspaceToExternalProviderAdapter {
    */
   B2instDoi buildB2instDoi(InventoryRecord instrument, String publicLandingPageUrl);
 
-  /** Build the DataCite DOI wrapper from the RSpace DOI representation. */
-  DataCiteDoi buildDataCiteDoi(ApiInventoryDOI doi);
+  /**
+   * Build the DataCite DOI wrapper: the RSpace DOI representation converted by {@link
+   * ApiInventoryDOI#convertToDataCiteDoi()}, then, when the associated record is an Instrument, the
+   * PIDINST related identifiers appended from the Measurement technique and Calibration link fields
+   * (RSDEV-1253, ADR 0007): the link target's globalId page as a URL, always related as
+   * IsDescribedBy, labelled through relationTypeInformation. Entries whose address would not be an
+   * absolute http(s) URL are omitted with a WARN rather than sent wrong.
+   *
+   * <p>Callers resending full metadata (publish and retract both do) must route through this
+   * method, not {@code convertToDataCiteDoi()} directly, or the registered related identifiers
+   * silently regress.
+   *
+   * <p>Must be called inside an existing transaction when the record is an Instrument: the mapping
+   * reads the instrument's lazy fields. The implementation declares
+   * {@code @Transactional(propagation = MANDATORY)}, matching {@link #buildB2instDoi}.
+   *
+   * @param associatedRecord the inventory record the DOI belongs to; null or a non-Instrument
+   *     yields the plain conversion
+   */
+  DataCiteDoi buildDataCiteDoi(ApiInventoryDOI doi, InventoryRecord associatedRecord);
 }

--- a/src/main/java/com/researchspace/service/inventory/RspaceToExternalProviderAdapter.java
+++ b/src/main/java/com/researchspace/service/inventory/RspaceToExternalProviderAdapter.java
@@ -50,9 +50,11 @@ public interface RspaceToExternalProviderAdapter {
    * PIDINST related identifiers appended from the Measurement technique and Calibration link fields
    * (RSDEV-1253, ADR 0007): the link target's globalId page as a URL, carrying the link's version
    * pin when the target type resolves one, always related as IsDescribedBy, labelled through
-   * relationTypeInformation. An instrument with no live links sends an explicit empty list, which
-   * is how DataCite is told to clear the property. Entries whose address would not be an absolute
-   * http(s) URL are omitted with a WARN rather than sent wrong.
+   * relationTypeInformation. A link whose target is deleted, or no longer readable by the
+   * instrument's owner, is omitted with a WARN. An instrument whose entries come to nothing sends
+   * an explicit empty list, which is how DataCite is told to clear the property - except when no
+   * usable http(s) server URL exists, an environment failure under which the property is left
+   * untouched rather than wrongly cleared.
    *
    * <p>Callers resending full metadata (publish and retract both do) must route through this
    * method, not {@code convertToDataCiteDoi()} directly, or the registered related identifiers

--- a/src/main/java/com/researchspace/service/inventory/RspaceToExternalProviderAdapter.java
+++ b/src/main/java/com/researchspace/service/inventory/RspaceToExternalProviderAdapter.java
@@ -27,10 +27,10 @@ public interface RspaceToExternalProviderAdapter {
    * record owner).
    *
    * <p>The "Measurement technique" and "Calibration" link fields are mapped to RelatedIdentifier
-   * entries (fixed IsDescribedBy relation, the target's globalId page as a URL; RSDEV-1253, ADR
-   * 0007). "Last calibrated" remains documentation-only, because PIDINST has no property that fits
-   * it; see CONTEXT.md ("Documentation-only field") and
-   * DevDocs/adr/0005-measured-variable-narratives.md.
+   * entries (fixed IsDescribedBy relation, the target's globalId page as a URL, carrying the link's
+   * version pin when the target type resolves a version-suffixed id; RSDEV-1253, ADR 0007). "Last
+   * calibrated" remains documentation-only, because PIDINST has no property that fits it; see
+   * CONTEXT.md ("Documentation-only field") and DevDocs/adr/0005-measured-variable-narratives.md.
    *
    * <p>Must be called inside an existing transaction: the mapping reads the instrument's lazy
    * associations. The implementation declares {@code @Transactional(propagation = MANDATORY)}, so a
@@ -48,9 +48,11 @@ public interface RspaceToExternalProviderAdapter {
    * Build the DataCite DOI wrapper: the RSpace DOI representation converted by {@link
    * ApiInventoryDOI#convertToDataCiteDoi()}, then, when the associated record is an Instrument, the
    * PIDINST related identifiers appended from the Measurement technique and Calibration link fields
-   * (RSDEV-1253, ADR 0007): the link target's globalId page as a URL, always related as
-   * IsDescribedBy, labelled through relationTypeInformation. Entries whose address would not be an
-   * absolute http(s) URL are omitted with a WARN rather than sent wrong.
+   * (RSDEV-1253, ADR 0007): the link target's globalId page as a URL, carrying the link's version
+   * pin when the target type resolves one, always related as IsDescribedBy, labelled through
+   * relationTypeInformation. An instrument with no live links sends an explicit empty list, which
+   * is how DataCite is told to clear the property. Entries whose address would not be an absolute
+   * http(s) URL are omitted with a WARN rather than sent wrong.
    *
    * <p>Callers resending full metadata (publish and retract both do) must route through this
    * method, not {@code convertToDataCiteDoi()} directly, or the registered related identifiers

--- a/src/main/java/com/researchspace/service/inventory/RspaceToExternalProviderAdapter.java
+++ b/src/main/java/com/researchspace/service/inventory/RspaceToExternalProviderAdapter.java
@@ -56,9 +56,13 @@ public interface RspaceToExternalProviderAdapter {
    * method, not {@code convertToDataCiteDoi()} directly, or the registered related identifiers
    * silently regress.
    *
-   * <p>Must be called inside an existing transaction when the record is an Instrument: the mapping
-   * reads the instrument's lazy fields. The implementation declares
-   * {@code @Transactional(propagation = MANDATORY)}, matching {@link #buildB2instDoi}.
+   * <p>Must be called inside an existing transaction, whatever the record: the implementation
+   * declares {@code @Transactional(propagation = MANDATORY)}, matching {@link #buildB2instDoi}, so
+   * a caller without one fails immediately rather than part-way through the mapping. Only the
+   * Instrument path actually needs the session, to read the instrument's lazy fields, but the
+   * requirement is deliberately uniform: both production callers (publish and retract) are already
+   * transactional, and a transaction requirement that changed with the argument's runtime type
+   * would be the harder contract to honour.
    *
    * @param associatedRecord the inventory record the DOI belongs to; null or a non-Instrument
    *     yields the plain conversion

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
@@ -608,9 +608,7 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
       publishResult = dataCiteConnector.publishDoi(doiToPublish, settingTypeFor(doi.getType()));
     } catch (DataCiteConnectionException dcException) {
       throw new DataCiteConnectionException(
-          "Error when publishing the DOI in DataCite. "
-              + "If the problem persists, please contact your System Admin",
-          dcException);
+          messages.getMessage("errors.inventory.identifier.dataCitePublishFailed"), dcException);
     }
     if (publishResult == null || !"findable".equals(publishResult.getAttributes().getState())) {
       throw new IllegalStateException("DataCite publish failed");
@@ -644,9 +642,7 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
       retractResult = dataCiteConnector.retractDoi(doiToRetract, settingTypeFor(doi.getType()));
     } catch (DataCiteConnectionException dcException) {
       throw new DataCiteConnectionException(
-          "Error when retracting the DOI in DataCite. "
-              + "If the problem persists, please contact your System Admin",
-          dcException);
+          messages.getMessage("errors.inventory.identifier.dataCiteRetractFailed"), dcException);
     }
     if (retractResult == null || !"registered".equals(retractResult.getAttributes().getState())) {
       throw new IllegalStateException("datacite retract failed");

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryIdentifierApiManagerImpl.java
@@ -602,7 +602,7 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
     ApiInventoryDOI actualdoi = new ApiInventoryDOI(doi);
     actualdoi.setCreatorAffiliation(rorAffiliationName);
     actualdoi.setCreatorAffiliationIdentifier(rorAffiliationID);
-    DataCiteDoi doiToPublish = actualdoi.convertToDataCiteDoi();
+    DataCiteDoi doiToPublish = rspaceToExternalProviderAdapter.buildDataCiteDoi(actualdoi, invRec);
     DataCiteDoi publishResult;
     try {
       publishResult = dataCiteConnector.publishDoi(doiToPublish, settingTypeFor(doi.getType()));
@@ -637,7 +637,7 @@ public class InventoryIdentifierApiManagerImpl implements InventoryIdentifierApi
     ApiInventoryDOI actualdoi = new ApiInventoryDOI(doi);
     actualdoi.setCreatorAffiliation(rorAffiliationName);
     actualdoi.setCreatorAffiliationIdentifier(rorAffiliationID);
-    DataCiteDoi doiToRetract = actualdoi.convertToDataCiteDoi();
+    DataCiteDoi doiToRetract = rspaceToExternalProviderAdapter.buildDataCiteDoi(actualdoi, invRec);
 
     DataCiteDoi retractResult;
     try {

--- a/src/main/java/com/researchspace/service/inventory/impl/LinkTargetResolverImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/LinkTargetResolverImpl.java
@@ -3,6 +3,7 @@ package com.researchspace.service.inventory.impl;
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
 import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.permissions.IPermissionUtils;
 import com.researchspace.model.record.BaseRecord;
 import com.researchspace.service.BaseRecordManager;
@@ -12,6 +13,7 @@ import jakarta.ws.rs.NotFoundException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.shiro.authz.AuthorizationException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,6 +67,31 @@ public class LinkTargetResolverImpl implements LinkTargetResolver {
     return false;
   }
 
+  @Override
+  public boolean targetIsLiveAndReadable(GlobalIdentifier target, User user) {
+    if (target == null) {
+      return false;
+    }
+    permissionUtils.refreshCacheIfNotified();
+    GlobalIdentifier base =
+        target.hasVersionId() ? new GlobalIdentifier(target.getPrefix(), target.getDbId()) : target;
+    GlobalIdPrefix prefix = base.getPrefix();
+    if (INVENTORY_PREFIXES.contains(prefix)) {
+      try {
+        InventoryRecord record =
+            inventoryPermissionUtils.getInvRecByGlobalIdOrThrowNotFoundException(base);
+        return !record.isDeleted()
+            && inventoryPermissionUtils.canUserReadInventoryRecord(record, user);
+      } catch (NotFoundException e) {
+        return false;
+      }
+    }
+    if (ELN_BASE_RECORD_PREFIXES.contains(prefix)) {
+      return liveReadableElnRecord(base, user).isPresent();
+    }
+    return false;
+  }
+
   private boolean isInventoryReadable(GlobalIdentifier target, User user) {
     try {
       return inventoryPermissionUtils.canUserReadInventoryRecord(target, user);
@@ -74,6 +101,14 @@ public class LinkTargetResolverImpl implements LinkTargetResolver {
   }
 
   private boolean isElnReadable(GlobalIdentifier target, User user) {
+    return readableElnRecord(target, user).isPresent();
+  }
+
+  private Optional<BaseRecord> liveReadableElnRecord(GlobalIdentifier target, User user) {
+    return readableElnRecord(target, user).filter(record -> !record.isDeleted());
+  }
+
+  private Optional<BaseRecord> readableElnRecord(GlobalIdentifier target, User user) {
     try {
       List<BaseRecord> readable =
           baseRecordManager.getByGlobalIdsAndReadPermission(
@@ -84,12 +119,12 @@ public class LinkTargetResolverImpl implements LinkTargetResolver {
       // counts as the link target
       for (BaseRecord record : readable) {
         if (record.getOid() != null && record.getOid().getPrefix() == target.getPrefix()) {
-          return true;
+          return Optional.of(record);
         }
       }
-      return false;
+      return Optional.empty();
     } catch (ObjectRetrievalFailureException | AuthorizationException e) {
-      return false;
+      return Optional.empty();
     }
   }
 }

--- a/src/main/java/com/researchspace/service/inventory/impl/PidinstFields.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/PidinstFields.java
@@ -3,7 +3,10 @@ package com.researchspace.service.inventory.impl;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.service.inventory.InventoryUrls;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
@@ -42,6 +45,20 @@ final class PidinstFields {
         .filter(f -> f.getType() == expectedType)
         .filter(f -> f.getName() != null && canonicalName.equalsIgnoreCase(f.getName().trim()))
         .findFirst();
+  }
+
+  /**
+   * The live link held by the record's link field with this canonical name: present only when the
+   * field exists (name matched as in {@link #mappedField}, type LINK), holds a link that is not
+   * soft-deleted, and that link names a target. Anything else reads as an empty field.
+   */
+  static Optional<InventoryLink> mappedLink(InstrumentEntity record, String canonicalName) {
+    return mappedField(record, canonicalName, FieldType.LINK)
+        .filter(InventoryLinkField.class::isInstance)
+        .map(field -> ((InventoryLinkField) field).getLink())
+        .filter(Objects::nonNull)
+        .filter(link -> !link.isDeleted())
+        .filter(link -> StringUtils.isNotBlank(link.getTargetGlobalId()));
   }
 
   /**

--- a/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
@@ -12,13 +12,18 @@ import com.researchspace.b2inst.model.metadata.B2instInstrumentType;
 import com.researchspace.b2inst.model.metadata.B2instManufacturer;
 import com.researchspace.b2inst.model.metadata.B2instModel;
 import com.researchspace.b2inst.model.metadata.B2instOwner;
+import com.researchspace.b2inst.model.metadata.B2instRelatedIdentifier;
 import com.researchspace.b2inst.model.request.B2instDoi;
 import com.researchspace.datacite.model.DataCiteDoi;
+import com.researchspace.datacite.model.DataCiteDoiAttributes;
 import com.researchspace.model.User;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.inventory.InventoryUrls;
 import com.researchspace.service.inventory.RspaceToExternalProviderAdapter;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,11 +53,28 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
   private static final String FIELD_DECOMMISSIONED = "Decommissioned";
   private static final String FIELD_MEASURED_QUANTITY = "Measured quantity";
   private static final String FIELD_ALTERNATE_IDENTIFIER = "Alternate Identifier";
+  private static final String FIELD_MEASUREMENT_TECHNIQUE = "Measurement technique";
+  private static final String FIELD_CALIBRATION = "Calibration";
 
   // PIDINST controlled values ("DeCommissioned" deliberately differs from the field name).
   private static final String DATE_TYPE_COMMISSIONED = "Commissioned";
   private static final String DATE_TYPE_DECOMMISSIONED = "DeCommissioned";
   private static final String ALTERNATE_ID_TYPE_OTHER = "Other";
+
+  // Wire values fixed by RSDEV-1253 (see ADR 0007). The labels are the ticket's spelling, capital
+  // T, not the template field name's. IsDescribedBy is sent whatever relation the link stores,
+  // because PIDINST's RelatedIdentifier vocabulary has no IsDocumentedBy/IsCalibratedBy.
+  private static final String RELATED_ID_NAME_MEASUREMENT_TECHNIQUE = "Measurement Technique";
+  private static final String RELATED_ID_NAME_CALIBRATION = "Calibration";
+  private static final String RELATION_TYPE_IS_DESCRIBED_BY = "IsDescribedBy";
+  private static final String RELATED_ID_TYPE_URL = "URL";
+
+  /** Deployment configuration; the server URL feeds the related-identifier addresses. */
+  private final IPropertyHolder properties;
+
+  public RspaceToExternalProviderAdapterImpl(IPropertyHolder properties) {
+    this.properties = properties;
+  }
 
   /*
    * MANDATORY, not REQUIRED: this walks the instrument's lazy associations (getActiveFields, and the
@@ -142,6 +164,7 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
             a ->
                 metadata.setAlternateIdentifier(
                     List.of(new B2instAlternateIdentifier(ALTERNATE_ID_TYPE_OTHER, a))));
+    metadata.setRelatedIdentifier(nullIfEmpty(relatedIdentifiers(source)));
 
     B2instAccess access = new B2instAccess();
     access.setRecord(PUBLIC_ACCESS);
@@ -187,15 +210,70 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
 
   /**
    * The measured quantity is the one instrument fact PIDINST's {@code MeasuredVariable} was meant
-   * to carry, so it is sent as-is. "Measurement technique", "Calibration" and "Last calibrated" are
-   * deliberately not mapped: they have no PIDINST home and are kept on the template purely as
-   * instrument documentation (see DevDocs/adr/0005-measured-variable-narratives.md, superseded).
+   * to carry, so it is sent as-is. Nothing else reaches MeasuredVariable: the narrative mapping of
+   * the other fields was rejected (see DevDocs/adr/0005-measured-variable-narratives.md).
+   * "Measurement technique" and "Calibration" instead become RelatedIdentifier entries (ADR 0007);
+   * only "Last calibrated" is still unmapped, having no PIDINST home at all.
    */
   private List<String> measuredVariables(InstrumentEntity instrument) {
     List<String> measuredVariables = new ArrayList<>();
     mappedFieldData(instrument, FIELD_MEASURED_QUANTITY, FieldType.STRING)
         .ifPresent(measuredVariables::add);
     return measuredVariables;
+  }
+
+  /**
+   * RelatedIdentifier entries for the Measurement technique and Calibration link fields
+   * (RSDEV-1253, ADR 0007): the link target's globalId page as a URL, always related as
+   * IsDescribedBy. Measurement Technique first, Calibration second, matching the ticket's example
+   * payloads.
+   */
+  private List<B2instRelatedIdentifier> relatedIdentifiers(InstrumentEntity instrument) {
+    List<B2instRelatedIdentifier> related = new ArrayList<>();
+    pidinstLinkUrl(instrument, FIELD_MEASUREMENT_TECHNIQUE)
+        .ifPresent(
+            url ->
+                related.add(
+                    new B2instRelatedIdentifier(
+                        RELATED_ID_TYPE_URL,
+                        url,
+                        RELATION_TYPE_IS_DESCRIBED_BY,
+                        RELATED_ID_NAME_MEASUREMENT_TECHNIQUE)));
+    pidinstLinkUrl(instrument, FIELD_CALIBRATION)
+        .ifPresent(
+            url ->
+                related.add(
+                    new B2instRelatedIdentifier(
+                        RELATED_ID_TYPE_URL,
+                        url,
+                        RELATION_TYPE_IS_DESCRIBED_BY,
+                        RELATED_ID_NAME_CALIBRATION)));
+    return related;
+  }
+
+  /**
+   * The registrable address of the record this link field points at, or empty when the field holds
+   * no live link. Guarded like the LandingPage: an address without an http(s) scheme (server URL
+   * unset or scheme-less) is omitted with a WARN rather than registered, because a wrong published
+   * value cannot be corrected and a missing one can.
+   */
+  private Optional<String> pidinstLinkUrl(InstrumentEntity instrument, String canonicalName) {
+    Optional<InventoryLink> link = PidinstFields.mappedLink(instrument, canonicalName);
+    if (link.isEmpty()) {
+      return Optional.empty();
+    }
+    Optional<String> url =
+        InventoryUrls.globalIdPageUrl(properties.getServerUrl(), link.get().getTargetGlobalId())
+            .filter(PidinstFields::isResolvableAddress);
+    if (url.isEmpty()) {
+      log.warn(
+          "Not registering the {} link of {} as a RelatedIdentifier: no usable http(s) address"
+              + " could be built, which means no server URL is configured or it carries no http(s)"
+              + " scheme.",
+          canonicalName,
+          instrument.getGlobalIdentifier());
+    }
+    return url;
   }
 
   private Optional<String> mappedFieldData(
@@ -211,7 +289,35 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
   }
 
   @Override
-  public DataCiteDoi buildDataCiteDoi(ApiInventoryDOI doi) {
-    return doi.convertToDataCiteDoi();
+  @Transactional(propagation = Propagation.MANDATORY)
+  public DataCiteDoi buildDataCiteDoi(ApiInventoryDOI doi, InventoryRecord associatedRecord) {
+    DataCiteDoi dataCiteDoi = doi.convertToDataCiteDoi();
+    if (associatedRecord == null || !associatedRecord.isInstrument()) {
+      return dataCiteDoi;
+    }
+    InstrumentEntity instrument = (InstrumentEntity) associatedRecord;
+    List<DataCiteDoiAttributes.RelatedIdentifier> related = new ArrayList<>();
+    pidinstLinkUrl(instrument, FIELD_MEASUREMENT_TECHNIQUE)
+        .ifPresent(
+            url ->
+                related.add(
+                    new DataCiteDoiAttributes.RelatedIdentifier(
+                        RELATION_TYPE_IS_DESCRIBED_BY,
+                        url,
+                        RELATED_ID_TYPE_URL,
+                        RELATED_ID_NAME_MEASUREMENT_TECHNIQUE)));
+    pidinstLinkUrl(instrument, FIELD_CALIBRATION)
+        .ifPresent(
+            url ->
+                related.add(
+                    new DataCiteDoiAttributes.RelatedIdentifier(
+                        RELATION_TYPE_IS_DESCRIBED_BY,
+                        url,
+                        RELATED_ID_TYPE_URL,
+                        RELATED_ID_NAME_CALIBRATION)));
+    if (!related.isEmpty()) {
+      dataCiteDoi.getAttributes().setRelatedIdentifiers(related);
+    }
+    return dataCiteDoi;
   }
 }

--- a/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
@@ -17,6 +17,8 @@ import com.researchspace.b2inst.model.request.B2instDoi;
 import com.researchspace.datacite.model.DataCiteDoi;
 import com.researchspace.datacite.model.DataCiteDoiAttributes;
 import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.InventoryRecord;
@@ -26,8 +28,11 @@ import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.inventory.InventoryUrls;
 import com.researchspace.service.inventory.RspaceToExternalProviderAdapter;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.transaction.annotation.Propagation;
@@ -68,6 +73,22 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
   private static final String RELATED_ID_NAME_CALIBRATION = "Calibration";
   private static final String RELATION_TYPE_IS_DESCRIBED_BY = "IsDescribedBy";
   private static final String RELATED_ID_TYPE_URL = "URL";
+
+  /**
+   * Link target types whose version-suffixed globalId resolves to that version, mirroring {@code
+   * GlobalLookupController.VERSIONED_INVENTORY_PREFIXES}, which is the authority. A pin on any
+   * other allowed target is deliberately not registered: NB has no versioned route at all, and SD's
+   * and GL's lead to an audit view and a file stream rather than the record's page, so for those
+   * the unpinned address stays the safer thing to make permanent.
+   */
+  private static final Set<GlobalIdPrefix> VERSION_PINNABLE_TARGETS =
+      EnumSet.of(
+          GlobalIdPrefix.SA,
+          GlobalIdPrefix.SS,
+          GlobalIdPrefix.IC,
+          GlobalIdPrefix.IT,
+          GlobalIdPrefix.IN,
+          GlobalIdPrefix.NT);
 
   /** Deployment configuration; the server URL feeds the related-identifier addresses. */
   private final IPropertyHolder properties;
@@ -164,7 +185,13 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
             a ->
                 metadata.setAlternateIdentifier(
                     List.of(new B2instAlternateIdentifier(ALTERNATE_ID_TYPE_OTHER, a))));
-    metadata.setRelatedIdentifier(nullIfEmpty(relatedIdentifiers(source)));
+    metadata.setRelatedIdentifier(
+        nullIfEmpty(
+            relatedIdentifiers(
+                source,
+                (url, label) ->
+                    new B2instRelatedIdentifier(
+                        RELATED_ID_TYPE_URL, url, RELATION_TYPE_IS_DESCRIBED_BY, label))));
 
     B2instAccess access = new B2instAccess();
     access.setRecord(PUBLIC_ACCESS);
@@ -227,27 +254,19 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
    * (RSDEV-1253, ADR 0007): the link target's globalId page as a URL, always related as
    * IsDescribedBy. Measurement Technique first, Calibration second, matching the ticket's example
    * payloads.
+   *
+   * <p>Which fields are sent, and in what order, is decided here alone so the two providers cannot
+   * drift apart: each passes a builder taking the address and the label, and a third link field is
+   * added in one place. The two provider types take the same four values in different positional
+   * orders, so keeping one constructor call per provider also keeps that easy mistake to one site.
    */
-  private List<B2instRelatedIdentifier> relatedIdentifiers(InstrumentEntity instrument) {
-    List<B2instRelatedIdentifier> related = new ArrayList<>();
+  private <T> List<T> relatedIdentifiers(
+      InstrumentEntity instrument, BiFunction<String, String, T> entry) {
+    List<T> related = new ArrayList<>();
     pidinstLinkUrl(instrument, FIELD_MEASUREMENT_TECHNIQUE)
-        .ifPresent(
-            url ->
-                related.add(
-                    new B2instRelatedIdentifier(
-                        RELATED_ID_TYPE_URL,
-                        url,
-                        RELATION_TYPE_IS_DESCRIBED_BY,
-                        RELATED_ID_NAME_MEASUREMENT_TECHNIQUE)));
+        .ifPresent(url -> related.add(entry.apply(url, RELATED_ID_NAME_MEASUREMENT_TECHNIQUE)));
     pidinstLinkUrl(instrument, FIELD_CALIBRATION)
-        .ifPresent(
-            url ->
-                related.add(
-                    new B2instRelatedIdentifier(
-                        RELATED_ID_TYPE_URL,
-                        url,
-                        RELATION_TYPE_IS_DESCRIBED_BY,
-                        RELATED_ID_NAME_CALIBRATION)));
+        .ifPresent(url -> related.add(entry.apply(url, RELATED_ID_NAME_CALIBRATION)));
     return related;
   }
 
@@ -263,7 +282,8 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
       return Optional.empty();
     }
     Optional<String> url =
-        InventoryUrls.globalIdPageUrl(properties.getServerUrl(), link.get().getTargetGlobalId())
+        InventoryUrls.globalIdPageUrl(
+                properties.getServerUrl(), registrableTargetGlobalId(link.get()))
             .filter(PidinstFields::isResolvableAddress);
     if (url.isEmpty()) {
       log.warn(
@@ -274,6 +294,26 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
           instrument.getGlobalIdentifier());
     }
     return url;
+  }
+
+  /**
+   * The target globalId to register, carrying the link's version pin when the target type resolves
+   * a version-suffixed id. A pinned link names one version deliberately, and a registered address
+   * is permanent, so it must not quietly follow the record's latest state instead. The stored id is
+   * unsuffixed by contract ({@code InventoryLinkManagerImpl.applyApiToEntity} keeps the version in
+   * versionPin), and one already carrying a suffix is left alone rather than doubled.
+   */
+  private String registrableTargetGlobalId(InventoryLink link) {
+    String target = StringUtils.trimToEmpty(link.getTargetGlobalId());
+    Long versionPin = link.getVersionPin();
+    if (versionPin == null) {
+      return target;
+    }
+    GlobalIdentifier oid = new GlobalIdentifier(target);
+    if (oid.hasVersionId() || !VERSION_PINNABLE_TARGETS.contains(oid.getPrefix())) {
+      return target;
+    }
+    return target + "v" + versionPin;
   }
 
   private Optional<String> mappedFieldData(
@@ -296,25 +336,12 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
       return dataCiteDoi;
     }
     InstrumentEntity instrument = (InstrumentEntity) associatedRecord;
-    List<DataCiteDoiAttributes.RelatedIdentifier> related = new ArrayList<>();
-    pidinstLinkUrl(instrument, FIELD_MEASUREMENT_TECHNIQUE)
-        .ifPresent(
-            url ->
-                related.add(
-                    new DataCiteDoiAttributes.RelatedIdentifier(
-                        RELATION_TYPE_IS_DESCRIBED_BY,
-                        url,
-                        RELATED_ID_TYPE_URL,
-                        RELATED_ID_NAME_MEASUREMENT_TECHNIQUE)));
-    pidinstLinkUrl(instrument, FIELD_CALIBRATION)
-        .ifPresent(
-            url ->
-                related.add(
-                    new DataCiteDoiAttributes.RelatedIdentifier(
-                        RELATION_TYPE_IS_DESCRIBED_BY,
-                        url,
-                        RELATED_ID_TYPE_URL,
-                        RELATED_ID_NAME_CALIBRATION)));
+    List<DataCiteDoiAttributes.RelatedIdentifier> related =
+        relatedIdentifiers(
+            instrument,
+            (url, label) ->
+                new DataCiteDoiAttributes.RelatedIdentifier(
+                    RELATION_TYPE_IS_DESCRIBED_BY, url, RELATED_ID_TYPE_URL, label));
     // Set unconditionally, the empty list included. DataCite replaces the whole property with
     // whatever the payload carries and clears it only when sent an explicit empty array; a property
     // that is absent or null leaves the registered value alone. An instrument whose link fields

--- a/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
@@ -315,9 +315,13 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
                         url,
                         RELATED_ID_TYPE_URL,
                         RELATED_ID_NAME_CALIBRATION)));
-    if (!related.isEmpty()) {
-      dataCiteDoi.getAttributes().setRelatedIdentifiers(related);
-    }
+    // Set unconditionally, the empty list included. DataCite replaces the whole property with
+    // whatever the payload carries and clears it only when sent an explicit empty array; a property
+    // that is absent or null leaves the registered value alone. An instrument whose link fields
+    // have
+    // all been cleared therefore has to send [], or the entries registered before the user cleared
+    // them stay attached to a findable DOI with no way to withdraw them.
+    dataCiteDoi.getAttributes().setRelatedIdentifiers(related);
     return dataCiteDoi;
   }
 }

--- a/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImpl.java
@@ -17,7 +17,6 @@ import com.researchspace.b2inst.model.request.B2instDoi;
 import com.researchspace.datacite.model.DataCiteDoi;
 import com.researchspace.datacite.model.DataCiteDoiAttributes;
 import com.researchspace.model.User;
-import com.researchspace.model.core.GlobalIdPrefix;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.InstrumentEntity;
@@ -26,13 +25,13 @@ import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryLink;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.inventory.InventoryUrls;
+import com.researchspace.service.inventory.LinkTargetResolver;
 import com.researchspace.service.inventory.RspaceToExternalProviderAdapter;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.transaction.annotation.Propagation;
@@ -74,27 +73,19 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
   private static final String RELATION_TYPE_IS_DESCRIBED_BY = "IsDescribedBy";
   private static final String RELATED_ID_TYPE_URL = "URL";
 
-  /**
-   * Link target types whose version-suffixed globalId resolves to that version, mirroring {@code
-   * GlobalLookupController.VERSIONED_INVENTORY_PREFIXES}, which is the authority. A pin on any
-   * other allowed target is deliberately not registered: NB has no versioned route at all, and SD's
-   * and GL's lead to an audit view and a file stream rather than the record's page, so for those
-   * the unpinned address stays the safer thing to make permanent.
-   */
-  private static final Set<GlobalIdPrefix> VERSION_PINNABLE_TARGETS =
-      EnumSet.of(
-          GlobalIdPrefix.SA,
-          GlobalIdPrefix.SS,
-          GlobalIdPrefix.IC,
-          GlobalIdPrefix.IT,
-          GlobalIdPrefix.IN,
-          GlobalIdPrefix.NT);
+  /** A globalId already carrying a version suffix, e.g. {@code SA42v4}. */
+  private static final Pattern VERSION_SUFFIXED = Pattern.compile(".+v\\d+$");
 
   /** Deployment configuration; the server URL feeds the related-identifier addresses. */
   private final IPropertyHolder properties;
 
-  public RspaceToExternalProviderAdapterImpl(IPropertyHolder properties) {
+  /** Judges each link target's live state before it is allowed into a permanent registry entry. */
+  private final LinkTargetResolver linkTargetResolver;
+
+  public RspaceToExternalProviderAdapterImpl(
+      IPropertyHolder properties, LinkTargetResolver linkTargetResolver) {
     this.properties = properties;
+    this.linkTargetResolver = linkTargetResolver;
   }
 
   /*
@@ -281,6 +272,9 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
     if (link.isEmpty()) {
       return Optional.empty();
     }
+    if (!targetQualifiesForRegistration(link.get(), instrument, canonicalName)) {
+      return Optional.empty();
+    }
     Optional<String> url =
         InventoryUrls.globalIdPageUrl(
                 properties.getServerUrl(), registrableTargetGlobalId(link.get()))
@@ -297,20 +291,54 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
   }
 
   /**
+   * Whether the linked record still qualifies for a permanent registry entry: it must exist, not be
+   * deleted, and be readable by the instrument's owner. Judged live, by the owner rather than the
+   * acting user, because the owner is a stable actor: the payload must not vary with whichever
+   * editor happens to trigger the registration. Write-time READ alone is not enough, since
+   * duplicating an instrument copies its links with no target check, a target can be unshared after
+   * the link was made, and deleting a record does not delete links pointing at it. Built from the
+   * link's typed columns, never by parsing the stored string, so a malformed row disqualifies its
+   * own entry and can never throw out of the shared MANDATORY transaction and fail the whole
+   * registration. A disqualified link is omitted with a WARN, never sent: omission is recoverable,
+   * a published wrong entry is not.
+   */
+  private boolean targetQualifiesForRegistration(
+      InventoryLink link, InstrumentEntity instrument, String canonicalName) {
+    boolean qualifies =
+        link.getTargetPrefix() != null
+            && link.getTargetDbId() != null
+            && linkTargetResolver.targetIsLiveAndReadable(
+                new GlobalIdentifier(link.getTargetPrefix(), link.getTargetDbId()),
+                instrument.getOwner());
+    if (!qualifies) {
+      log.warn(
+          "Not registering the {} link of {} as a RelatedIdentifier: the linked record is deleted,"
+              + " unresolvable, or not readable by the instrument's owner.",
+          canonicalName,
+          instrument.getGlobalIdentifier());
+    }
+    return qualifies;
+  }
+
+  /**
    * The target globalId to register, carrying the link's version pin when the target type resolves
-   * a version-suffixed id. A pinned link names one version deliberately, and a registered address
-   * is permanent, so it must not quietly follow the record's latest state instead. The stored id is
-   * unsuffixed by contract ({@code InventoryLinkManagerImpl.applyApiToEntity} keeps the version in
-   * versionPin), and one already carrying a suffix is left alone rather than doubled.
+   * a version-suffixed id ({@link InventoryUrls#VERSIONED_PAGE_PREFIXES}). A pinned link names one
+   * version deliberately, and a registered address is permanent, so it must not quietly follow the
+   * record's latest state instead. Decided from the link's typed columns, never by parsing the
+   * stored string, so a malformed row can only mis-address its own entry and never throw out of the
+   * shared MANDATORY transaction and fail the whole registration. The stored id is unsuffixed by
+   * contract ({@code InventoryLinkManagerImpl.applyApiToEntity} keeps the version in versionPin),
+   * and one already carrying a suffix is left alone rather than doubled.
    */
   private String registrableTargetGlobalId(InventoryLink link) {
     String target = StringUtils.trimToEmpty(link.getTargetGlobalId());
     Long versionPin = link.getVersionPin();
-    if (versionPin == null) {
-      return target;
-    }
-    GlobalIdentifier oid = new GlobalIdentifier(target);
-    if (oid.hasVersionId() || !VERSION_PINNABLE_TARGETS.contains(oid.getPrefix())) {
+    // the null prefix guard is load-bearing: the immutable set throws on contains(null), and a
+    // malformed row must mis-address only its own entry, never fail the registration
+    if (versionPin == null
+        || link.getTargetPrefix() == null
+        || !InventoryUrls.VERSIONED_PAGE_PREFIXES.contains(link.getTargetPrefix())
+        || VERSION_SUFFIXED.matcher(target).matches()) {
       return target;
     }
     return target + "v" + versionPin;
@@ -336,18 +364,35 @@ public class RspaceToExternalProviderAdapterImpl implements RspaceToExternalProv
       return dataCiteDoi;
     }
     InstrumentEntity instrument = (InstrumentEntity) associatedRecord;
+    if (!PidinstFields.isResolvableAddress(properties.getServerUrl())) {
+      /*
+       * Environment failure, not data: with no usable server URL no address can be built for ANY
+       * link, so an empty list here would be indistinguishable from "the user cleared the fields"
+       * and would permanently strip entries that are still correct. Leave the property untouched
+       * (absent means "no change" at DataCite) until the deployment is fixed.
+       */
+      log.warn(
+          "Leaving the registered related identifiers of {} untouched: no usable http(s) address"
+              + " can be built, which means no server URL is configured or it carries no http(s)"
+              + " scheme.",
+          instrument.getGlobalIdentifier());
+      return dataCiteDoi;
+    }
     List<DataCiteDoiAttributes.RelatedIdentifier> related =
         relatedIdentifiers(
             instrument,
             (url, label) ->
                 new DataCiteDoiAttributes.RelatedIdentifier(
                     RELATION_TYPE_IS_DESCRIBED_BY, url, RELATED_ID_TYPE_URL, label));
-    // Set unconditionally, the empty list included. DataCite replaces the whole property with
-    // whatever the payload carries and clears it only when sent an explicit empty array; a property
-    // that is absent or null leaves the registered value alone. An instrument whose link fields
-    // have
-    // all been cleared therefore has to send [], or the entries registered before the user cleared
-    // them stay attached to a findable DOI with no way to withdraw them.
+    /*
+     * Set unconditionally, the empty list included. DataCite replaces the whole property with
+     * whatever the payload carries and clears it only when sent an explicit empty array; a
+     * property that is absent or null leaves the registered value alone. Once the environment
+     * guard above has passed, an empty list is a statement about the data - the fields are
+     * cleared, or their targets no longer qualify - so it must reach DataCite as [], or entries
+     * registered before the user cleared them stay attached to a findable DOI with no way to
+     * withdraw them.
+     */
     dataCiteDoi.getAttributes().setRelatedIdentifiers(related);
     return dataCiteDoi;
   }

--- a/src/main/java/com/researchspace/webapp/controller/GlobalLookupController.java
+++ b/src/main/java/com/researchspace/webapp/controller/GlobalLookupController.java
@@ -2,7 +2,7 @@ package com.researchspace.webapp.controller;
 
 import com.researchspace.model.core.GlobalIdPrefix;
 import com.researchspace.model.core.GlobalIdentifier;
-import java.util.EnumSet;
+import com.researchspace.service.inventory.InventoryUrls;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 /** Given a globalID will attempt to look it up based on its type */
 @Controller("globalLookupController")
-@RequestMapping("/globalId")
+@RequestMapping(InventoryUrls.GLOBAL_ID_MAPPING)
 public class GlobalLookupController extends BaseController {
 
   protected static final String FORM_REDIRECT_URL = "/workspace/editor/form/edit/";
@@ -68,15 +68,13 @@ public class GlobalLookupController extends BaseController {
     prefixToUrl.put(GlobalIdPrefix.NT, "/inventory/instrumenttemplate/");
   }
 
-  /** Inventory record types whose version-suffixed global IDs open the versioned viewer. */
+  /**
+   * Inventory record types whose version-suffixed global IDs open the versioned viewer. Shared with
+   * the PIDINST related-identifier composer, which must never register a suffix this router cannot
+   * resolve.
+   */
   private static final Set<GlobalIdPrefix> VERSIONED_INVENTORY_PREFIXES =
-      EnumSet.of(
-          GlobalIdPrefix.SA,
-          GlobalIdPrefix.SS,
-          GlobalIdPrefix.IC,
-          GlobalIdPrefix.IT,
-          GlobalIdPrefix.IN,
-          GlobalIdPrefix.NT);
+      InventoryUrls.VERSIONED_PAGE_PREFIXES;
 
   private String getRedirect(GlobalIdentifier oid) {
     GlobalIdPrefix prefix = oid.getPrefix();

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
@@ -81,6 +81,8 @@
         "bulkMaxExceeded": "cannot allocate more than {0} IGSNs in a single request",
         "bulkPositiveRequired": "not a valid number of IGSNs to allocate: \"{0}\". The number must be greater than 0",
         "dataCiteRegisterNoDraft": "Could not register a new identifier with DataCite: the service accepted the request but returned no draft record.",
+        "dataCitePublishFailed": "Error when publishing the DOI in DataCite. If the problem persists, please contact your System Admin",
+        "dataCiteRetractFailed": "Error when retracting the DOI in DataCite. If the problem persists, please contact your System Admin",
         "deleteNotOwner": "You can only delete an identifier that you own.",
         "integrationNotEnabled": "{0} integration is not enabled on this RSpace instance.",
         "mintingUnsupportedType": "unsupported type for minting: {0}",

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryIdentifiersB2instApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryIdentifiersB2instApiControllerMVCIT.java
@@ -36,10 +36,13 @@ import org.springframework.validation.BindingResult;
  * PIDINST-mapped field content to B2INST. A {@link B2instConnectorDummy} captures the payload, so
  * no B2INST instance is contacted.
  *
- * <p>Link-field narratives ("Measurement technique", "Calibration") are covered by {@code
- * RspaceToExternalProviderAdapterImplTest}; building an {@code InventoryLink} target through the
- * API would need a second record and relation setup, which adds nothing to the plumbing this test
- * exercises.
+ * <p>The two link fields ("Measurement technique", "Calibration") are deliberately absent here.
+ * They stopped being documentation-only in RSDEV-1253 and now map to RelatedIdentifier entries, but
+ * their value comes from a linked record rather than the field's own content, so exercising them
+ * needs a second record and relation setup that this template-copy flow does not otherwise use.
+ * They are covered against real persistence by {@code
+ * InventoryIdentifierApiManagerRelatedIdentifierTest}, which resolves the link through Hibernate
+ * for both providers, and by {@code RspaceToExternalProviderAdapterImplTest} for the mapping rules.
  */
 @WebAppConfiguration
 public class InventoryIdentifiersB2instApiControllerMVCIT extends API_MVC_InventoryTestBase {

--- a/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerRelatedIdentifierTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerRelatedIdentifierTest.java
@@ -1,8 +1,9 @@
 package com.researchspace.service.inventory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +25,8 @@ import com.researchspace.webapp.integrations.b2inst.B2instConnectorDummy;
 import com.researchspace.webapp.integrations.datacite.DataCiteConnectorDummy;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -64,11 +67,21 @@ public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTr
     realB2instConnector =
         ReflectionTestUtils.getField(inventoryIdentifierApiMgr, "b2instConnector");
     ReflectionTestUtils.setField(inventoryIdentifierApiMgr, "b2instConnector", b2instOff);
+    /*
+     * The expected addresses below are derived from the live server URL. Without an http(s) scheme
+     * the mapping omits every entry by design, and the failures would then read as "the caller
+     * bypassed the adapter", pointing at the wrong cause. Fail with the real reason instead.
+     */
+    String serverUrl = propertyHolder.getServerUrl();
+    assertTrue(
+        "this test needs rs.serverurl to carry an http(s) scheme, but it is: " + serverUrl,
+        StringUtils.startsWithIgnoreCase(serverUrl, "http://")
+            || StringUtils.startsWithIgnoreCase(serverUrl, "https://"));
     user = createAndSaveUserIfNotExists(getRandomAlphabeticString("api"));
     initialiseContentWithEmptyContent(user);
   }
 
-  @org.junit.After
+  @After
   public void tearDown() {
     // the manager is a singleton in a Spring context cached across test classes, so the real
     // connector has to go back or later tests silently run against the mock
@@ -137,11 +150,11 @@ public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTr
       String stage) {
     List<DataCiteDoiAttributes.RelatedIdentifier> sent = lastSentRelatedIdentifiers();
     assertNotNull(
-        sent,
         "no related identifiers reached DataCite on "
             + stage
             + "; the caller most likely converted the DOI directly instead of routing through"
-            + " RspaceToExternalProviderAdapter.buildDataCiteDoi");
+            + " RspaceToExternalProviderAdapter.buildDataCiteDoi",
+        sent);
     return sent;
   }
 
@@ -218,7 +231,7 @@ public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTr
     inventoryIdentifierApiMgr.publishIdentifier(instrumentOid, user);
 
     List<DataCiteDoiAttributes.RelatedIdentifier> sent = requireSentRelatedIdentifiers("publish");
-    assertEquals(1, sent.size(), "the cleared Measurement technique field must not be registered");
+    assertEquals("the cleared Measurement technique field must not be registered", 1, sent.size());
     assertNamesTheLinkedRecord(sent.get(0), "Calibration", calibrationId);
   }
 
@@ -241,7 +254,7 @@ public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTr
 
     List<B2instRelatedIdentifier> sent =
         b2instDummy.getDoiSentToB2inst().getMetadata().getRelatedIdentifier();
-    assertNotNull(sent, "no RelatedIdentifier reached B2INST at draft-register time");
+    assertNotNull("no RelatedIdentifier reached B2INST at draft-register time", sent);
     assertEquals(2, sent.size());
     assertEquals("Measurement Technique", sent.get(0).getRelatedIdentifierName());
     assertEquals("IsDescribedBy", sent.get(0).getRelationType());

--- a/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerRelatedIdentifierTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerRelatedIdentifierTest.java
@@ -1,0 +1,259 @@
+package com.researchspace.service.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.b2inst.model.metadata.B2instRelatedIdentifier;
+import com.researchspace.datacite.model.DataCiteDoiAttributes;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.testutils.SpringTransactionalTest;
+import com.researchspace.webapp.integrations.b2inst.B2instConnector;
+import com.researchspace.webapp.integrations.b2inst.B2instConnectorDummy;
+import com.researchspace.webapp.integrations.datacite.DataCiteConnectorDummy;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The PIDINST related-identifier mapping (RSDEV-1253, ADR 0007) against real persistence and the
+ * real adapter bean, which {@code RspaceToExternalProviderAdapterImplTest} cannot reach: it builds
+ * instruments and links by hand, so it never exercises the link resolved through Hibernate, nor the
+ * manager's choice of what to send at each stage of a DOI's life.
+ *
+ * <p>Guards the wiring specifically. Publish and retract both resend full metadata, so both must
+ * route through {@code buildDataCiteDoi}; a caller reverting either to {@code
+ * convertToDataCiteDoi()} would leave every unit test green while the registered related
+ * identifiers silently regressed.
+ */
+public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTransactionalTest {
+
+  private static final String MEASUREMENT_TECHNIQUE = "Measurement technique";
+  private static final String CALIBRATION = "Calibration";
+
+  private User user;
+  private DataCiteConnectorDummy dataCiteConnectorDummy;
+  private Object realB2instConnector;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    dataCiteConnectorDummy = new DataCiteConnectorDummy();
+    inventoryIdentifierApiMgr.setDataCiteConnector(dataCiteConnectorDummy);
+    /*
+     * Instruments take the B2INST path whenever B2INST is configured AND enabled
+     * (createUpdateWithNewDoi), which on a developer machine depends on the local deployment
+     * settings. Disabling it here pins this test to the DataCite branch, the one this class is
+     * about, so it cannot pass or fail according to how the machine happens to be configured.
+     */
+    B2instConnector b2instOff = mock(B2instConnector.class);
+    when(b2instOff.isConfiguredAndEnabled()).thenReturn(false);
+    realB2instConnector =
+        ReflectionTestUtils.getField(inventoryIdentifierApiMgr, "b2instConnector");
+    ReflectionTestUtils.setField(inventoryIdentifierApiMgr, "b2instConnector", b2instOff);
+    user = createAndSaveUserIfNotExists(getRandomAlphabeticString("api"));
+    initialiseContentWithEmptyContent(user);
+  }
+
+  @org.junit.After
+  public void tearDown() {
+    // the manager is a singleton in a Spring context cached across test classes, so the real
+    // connector has to go back or later tests silently run against the mock
+    ReflectionTestUtils.setField(inventoryIdentifierApiMgr, "b2instConnector", realB2instConnector);
+  }
+
+  /** An instrument carrying the two PIDINST link fields, each pointing at a real sample. */
+  private ApiInstrument instrumentWithBothLinks() {
+    ApiInstrumentTemplatePost templatePost = new ApiInstrumentTemplatePost();
+    templatePost.setName("pidinst-links-" + getRandomAlphabeticString("n"));
+    templatePost.getFields().add(linkFieldDefinition(MEASUREMENT_TECHNIQUE));
+    templatePost.getFields().add(linkFieldDefinition(CALIBRATION));
+    ApiInstrumentTemplate template = instrumentApiMgr.createInstrumentTemplate(templatePost, user);
+
+    ApiInstrument request = new ApiInstrument();
+    request.setName("Microscope X");
+    request.setTemplateId(template.getId());
+    ApiInstrument instrument = instrumentApiMgr.createNewApiInstrument(request, user);
+
+    ApiSampleWithFullSubSamples technique = createBasicSampleForUser(user, "technique-doc");
+    ApiSampleWithFullSubSamples calibration = createBasicSampleForUser(user, "calibration-cert");
+    linkTo(instrument, MEASUREMENT_TECHNIQUE, technique.getGlobalId(), "IsDocumentedBy");
+    linkTo(instrument, CALIBRATION, calibration.getGlobalId(), "IsCalibratedBy");
+    return instrumentApiMgr.getApiInstrumentById(instrument.getId(), user);
+  }
+
+  private ApiInventoryEntityField linkFieldDefinition(String name) {
+    ApiInventoryEntityField field = new ApiInventoryEntityField();
+    field.setName(name);
+    field.setType(ApiFieldType.LINK);
+    return field;
+  }
+
+  /** Fills one named link field of an existing instrument, by field id. */
+  private void linkTo(
+      ApiInstrument instrument, String fieldName, String targetGlobalId, String relationType) {
+    ApiInventoryLink apiLink = new ApiInventoryLink();
+    apiLink.setTargetGlobalId(targetGlobalId);
+    apiLink.setRelationType(relationType);
+    ApiInventoryEntityField fieldUpdate = new ApiInventoryEntityField();
+    fieldUpdate.setId(fieldByName(instrument, fieldName).getId());
+    fieldUpdate.setLink(apiLink);
+
+    ApiInstrument update = new ApiInstrument();
+    update.setId(instrument.getId());
+    update.setFields(List.of(fieldUpdate));
+    instrumentApiMgr.updateApiInstrument(update, user);
+  }
+
+  private ApiInventoryEntityField fieldByName(ApiInstrument instrument, String name) {
+    Optional<ApiInventoryEntityField> field =
+        instrument.getFields().stream().filter(f -> name.equals(f.getName())).findFirst();
+    return field.orElseThrow(() -> new AssertionError("no field named " + name));
+  }
+
+  private List<DataCiteDoiAttributes.RelatedIdentifier> lastSentRelatedIdentifiers() {
+    return dataCiteConnectorDummy.getDoiSentToDatacite().getAttributes().getRelatedIdentifiers();
+  }
+
+  /**
+   * The related identifiers of the last payload DataCite received, failing with the reason rather
+   * than a bare NPE: absent entries mean the caller bypassed the adapter, which is the specific
+   * regression this class exists to catch.
+   */
+  private List<DataCiteDoiAttributes.RelatedIdentifier> requireSentRelatedIdentifiers(
+      String stage) {
+    List<DataCiteDoiAttributes.RelatedIdentifier> sent = lastSentRelatedIdentifiers();
+    assertNotNull(
+        sent,
+        "no related identifiers reached DataCite on "
+            + stage
+            + "; the caller most likely converted the DOI directly instead of routing through"
+            + " RspaceToExternalProviderAdapter.buildDataCiteDoi");
+    return sent;
+  }
+
+  private void assertNamesTheLinkedRecord(
+      DataCiteDoiAttributes.RelatedIdentifier entry, String label, String targetGlobalId) {
+    assertEquals(label, entry.getRelationTypeInformation());
+    // IsDescribedBy whatever the link stores (IsDocumentedBy / IsCalibratedBy): PIDINST's
+    // vocabulary has neither, see ADR 0007
+    assertEquals("IsDescribedBy", entry.getRelationType());
+    assertEquals("URL", entry.getRelatedIdentifierType());
+    assertEquals(
+        propertyHolder.getServerUrl() + "/globalId/" + targetGlobalId,
+        entry.getRelatedIdentifier());
+  }
+
+  @Test
+  public void publishAndRetractBothSendTheInstrumentsRelatedIdentifiers() {
+    ApiInstrument instrument = instrumentWithBothLinks();
+    String techniqueId =
+        fieldByName(instrument, MEASUREMENT_TECHNIQUE).getLink().getTargetGlobalId();
+    String calibrationId = fieldByName(instrument, CALIBRATION).getLink().getTargetGlobalId();
+    GlobalIdentifier instrumentOid = instrument.getOid();
+
+    // Register sends an empty DataCiteDoi by design (the metadata follows on publish), so there is
+    // nothing to carry yet; asserted so the deliberate emptiness is not mistaken for a regression.
+    inventoryIdentifierApiMgr.registerNewIdentifier(instrumentOid, user);
+    assertNull(lastSentRelatedIdentifiers());
+
+    ApiInventoryRecordInfo published =
+        inventoryIdentifierApiMgr.publishIdentifier(instrumentOid, user);
+    assertEquals("findable", published.getIdentifiers().get(0).getState());
+
+    List<DataCiteDoiAttributes.RelatedIdentifier> onPublish =
+        requireSentRelatedIdentifiers("publish");
+    assertEquals(2, onPublish.size());
+    assertNamesTheLinkedRecord(onPublish.get(0), "Measurement Technique", techniqueId);
+    assertNamesTheLinkedRecord(onPublish.get(1), "Calibration", calibrationId);
+
+    /*
+     * Retract resends the full metadata, so it has to resend these too. Nothing persists them on
+     * the DOI: they are recomputed from the instrument each time, which is exactly why a retract
+     * that skipped the adapter would quietly strip them from the registered record.
+     */
+    inventoryIdentifierApiMgr.retractIdentifier(instrumentOid, user);
+
+    List<DataCiteDoiAttributes.RelatedIdentifier> onRetract =
+        requireSentRelatedIdentifiers("retract");
+    assertEquals(2, onRetract.size());
+    assertNamesTheLinkedRecord(onRetract.get(0), "Measurement Technique", techniqueId);
+    assertNamesTheLinkedRecord(onRetract.get(1), "Calibration", calibrationId);
+  }
+
+  @Test
+  public void publishOmitsALinkFieldThatHasSinceBeenCleared() {
+    ApiInstrument instrument = instrumentWithBothLinks();
+    String calibrationId = fieldByName(instrument, CALIBRATION).getLink().getTargetGlobalId();
+    GlobalIdentifier instrumentOid = instrument.getOid();
+    inventoryIdentifierApiMgr.registerNewIdentifier(instrumentOid, user);
+
+    /*
+     * Clearing a link field is an update carrying the field with no link payload
+     * (InstrumentEntityApiManagerImpl.applyLinkFieldValue), which detaches the row via
+     * orphanRemoval. Worth proving from the API inwards: the entries are recomputed from the
+     * instrument on every publish, so an emptied field has to stop being registered rather than
+     * lingering because it was present when the identifier was created.
+     */
+    ApiInventoryEntityField cleared = new ApiInventoryEntityField();
+    cleared.setId(fieldByName(instrument, MEASUREMENT_TECHNIQUE).getId());
+    ApiInstrument update = new ApiInstrument();
+    update.setId(instrument.getId());
+    update.setFields(List.of(cleared));
+    instrumentApiMgr.updateApiInstrument(update, user);
+
+    inventoryIdentifierApiMgr.publishIdentifier(instrumentOid, user);
+
+    List<DataCiteDoiAttributes.RelatedIdentifier> sent = requireSentRelatedIdentifiers("publish");
+    assertEquals(1, sent.size(), "the cleared Measurement technique field must not be registered");
+    assertNamesTheLinkedRecord(sent.get(0), "Calibration", calibrationId);
+  }
+
+  /**
+   * The B2INST branch of the same mapping. It is a separate code path in the adapter and a separate
+   * provider branch in the manager, and unlike DataCite it gets exactly one shot: B2INST has no
+   * metadata-update call, so whatever the draft carries at register time is what the record keeps.
+   */
+  @Test
+  public void b2instRegistrationCarriesTheInstrumentsRelatedIdentifiers() {
+    B2instConnectorDummy b2instDummy = new B2instConnectorDummy();
+    ReflectionTestUtils.setField(inventoryIdentifierApiMgr, "b2instConnector", b2instDummy);
+
+    ApiInstrument instrument = instrumentWithBothLinks();
+    String techniqueId =
+        fieldByName(instrument, MEASUREMENT_TECHNIQUE).getLink().getTargetGlobalId();
+    String calibrationId = fieldByName(instrument, CALIBRATION).getLink().getTargetGlobalId();
+
+    inventoryIdentifierApiMgr.registerNewIdentifier(instrument.getOid(), user);
+
+    List<B2instRelatedIdentifier> sent =
+        b2instDummy.getDoiSentToB2inst().getMetadata().getRelatedIdentifier();
+    assertNotNull(sent, "no RelatedIdentifier reached B2INST at draft-register time");
+    assertEquals(2, sent.size());
+    assertEquals("Measurement Technique", sent.get(0).getRelatedIdentifierName());
+    assertEquals("IsDescribedBy", sent.get(0).getRelationType());
+    assertEquals("URL", sent.get(0).getRelatedIdentifierType());
+    assertEquals(
+        propertyHolder.getServerUrl() + "/globalId/" + techniqueId,
+        sent.get(0).getRelatedIdentifierValue());
+    assertEquals("Calibration", sent.get(1).getRelatedIdentifierName());
+    assertEquals("IsDescribedBy", sent.get(1).getRelationType());
+    assertEquals("URL", sent.get(1).getRelatedIdentifierType());
+    assertEquals(
+        propertyHolder.getServerUrl() + "/globalId/" + calibrationId,
+        sent.get(1).getRelatedIdentifierValue());
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerRelatedIdentifierTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryIdentifierApiManagerRelatedIdentifierTest.java
@@ -82,9 +82,12 @@ public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTr
   }
 
   @After
-  public void tearDown() {
-    // the manager is a singleton in a Spring context cached across test classes, so the real
-    // connector has to go back or later tests silently run against the mock
+  public void tearDown() throws Exception {
+    // the base tearDown re-enables custom content initialisation for the classes that run after
+    // this one in the same cached Spring context; skipping it would starve them of content
+    super.tearDown();
+    // the manager is a singleton in that same cached context, so the real connector has to go
+    // back or later tests silently run against the mock
     ReflectionTestUtils.setField(inventoryIdentifierApiMgr, "b2instConnector", realB2instConnector);
   }
 
@@ -183,6 +186,12 @@ public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTr
     inventoryIdentifierApiMgr.registerNewIdentifier(instrumentOid, user);
     assertNull(lastSentRelatedIdentifiers());
 
+    // detach everything built above so publish resolves the instrument and its links through
+    // Hibernate rather than the session cache, making the "against real persistence" claim real
+    sessionFactory.getCurrentSession().flush();
+    sessionFactory.getCurrentSession().clear();
+    dataCiteConnectorDummy.doiSentToDatacite = null;
+
     ApiInventoryRecordInfo published =
         inventoryIdentifierApiMgr.publishIdentifier(instrumentOid, user);
     assertEquals("findable", published.getIdentifiers().get(0).getState());
@@ -198,6 +207,7 @@ public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTr
      * the DOI: they are recomputed from the instrument each time, which is exactly why a retract
      * that skipped the adapter would quietly strip them from the registered record.
      */
+    dataCiteConnectorDummy.doiSentToDatacite = null;
     inventoryIdentifierApiMgr.retractIdentifier(instrumentOid, user);
 
     List<DataCiteDoiAttributes.RelatedIdentifier> onRetract =
@@ -233,6 +243,34 @@ public class InventoryIdentifierApiManagerRelatedIdentifierTest extends SpringTr
     List<DataCiteDoiAttributes.RelatedIdentifier> sent = requireSentRelatedIdentifiers("publish");
     assertEquals("the cleared Measurement technique field must not be registered", 1, sent.size());
     assertNamesTheLinkedRecord(sent.get(0), "Calibration", calibrationId);
+  }
+
+  /**
+   * Clearing BOTH link fields must reach DataCite as an explicit empty list: [] is how the
+   * registered property is cleared, while an absent or null property would leave the previously
+   * registered entries attached forever.
+   */
+  @Test
+  public void publishSendsAnExplicitEmptyListWhenBothLinkFieldsAreCleared() {
+    ApiInstrument instrument = instrumentWithBothLinks();
+    GlobalIdentifier instrumentOid = instrument.getOid();
+    inventoryIdentifierApiMgr.registerNewIdentifier(instrumentOid, user);
+
+    ApiInventoryEntityField clearedTechnique = new ApiInventoryEntityField();
+    clearedTechnique.setId(fieldByName(instrument, MEASUREMENT_TECHNIQUE).getId());
+    ApiInventoryEntityField clearedCalibration = new ApiInventoryEntityField();
+    clearedCalibration.setId(fieldByName(instrument, CALIBRATION).getId());
+    ApiInstrument update = new ApiInstrument();
+    update.setId(instrument.getId());
+    update.setFields(List.of(clearedTechnique, clearedCalibration));
+    instrumentApiMgr.updateApiInstrument(update, user);
+
+    dataCiteConnectorDummy.doiSentToDatacite = null;
+    inventoryIdentifierApiMgr.publishIdentifier(instrumentOid, user);
+
+    List<DataCiteDoiAttributes.RelatedIdentifier> sent = lastSentRelatedIdentifiers();
+    assertNotNull("both fields cleared must clear the property with [], not leave it absent", sent);
+    assertEquals(0, sent.size());
   }
 
   /**

--- a/src/test/java/com/researchspace/service/inventory/InventoryUrlsTest.java
+++ b/src/test/java/com/researchspace/service/inventory/InventoryUrlsTest.java
@@ -43,6 +43,29 @@ class InventoryUrlsTest {
   }
 
   @Test
+  void globalIdPageUrlJoinsServerUrlAndGlobalId() {
+    assertEquals(
+        Optional.of(SERVER + "/globalId/IN114"), InventoryUrls.globalIdPageUrl(SERVER, "IN114"));
+    assertEquals(
+        Optional.of(SERVER + "/globalId/IN114"),
+        InventoryUrls.globalIdPageUrl(SERVER + "//", "IN114"),
+        "trailing slashes are stripped, same normalisation as publicLandingPageUrl");
+    assertEquals(
+        Optional.of(SERVER + "/globalId/IN114"),
+        InventoryUrls.globalIdPageUrl(SERVER, "  IN114  "),
+        "a padded global id must not reach the provider as part of the address");
+  }
+
+  /** Empty rather than "null/globalId/IN114", for the same reason as the public page. */
+  @Test
+  void globalIdPageUrlIsEmptyWhenEitherPartIsMissing() {
+    assertTrue(InventoryUrls.globalIdPageUrl(null, "IN114").isEmpty(), "null server URL");
+    assertTrue(InventoryUrls.globalIdPageUrl("  ", "IN114").isEmpty(), "no server URL");
+    assertTrue(InventoryUrls.globalIdPageUrl(SERVER, "  ").isEmpty(), "blank global id");
+    assertTrue(InventoryUrls.globalIdPageUrl(SERVER, null).isEmpty(), "null global id");
+  }
+
+  @Test
   void namesPublicLandingPageRecognisesRSpacesOwnAddressForThatSuffix() {
     assertTrue(
         InventoryUrls.namesPublicLandingPage(SERVER + "/public/inventory/" + SUFFIX, SUFFIX));

--- a/src/test/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImplTest.java
@@ -750,17 +750,34 @@ class RspaceToExternalProviderAdapterImplTest {
   }
 
   @Test
-  void dataCiteDoiLeavesRelatedIdentifiersNullForNonInstrumentsAndLinklessInstruments() {
+  void dataCiteDoiLeavesRelatedIdentifiersNullForNonInstruments() {
     ApiInventoryDOI doi = new ApiInventoryDOI();
     doi.setDoi("10.82316/abc");
     doi.setTitle("a sample");
 
+    // never registered any for these, so there is nothing to clear and the property stays absent
     assertNull(adapter.buildDataCiteDoi(doi, new Sample()).getAttributes().getRelatedIdentifiers());
     assertNull(adapter.buildDataCiteDoi(doi, null).getAttributes().getRelatedIdentifiers());
-    assertNull(
+  }
+
+  /**
+   * An instrument with no live links must send an explicit empty list, not null. DataCite replaces
+   * the whole property with what the payload carries and clears it only on an empty array, so an
+   * instrument whose link fields were cleared after registration would otherwise keep the entries
+   * registered before the user cleared them, permanently, on a findable DOI.
+   */
+  @Test
+  void dataCiteDoiSendsAnEmptyRelatedIdentifierListForAnInstrumentWithNoLiveLinks() {
+    ApiInventoryDOI doi = new ApiInventoryDOI();
+    doi.setDoi("10.82316/abc");
+    doi.setTitle("an instrument with nothing linked");
+
+    assertEquals(
+        List.of(),
         adapter
             .buildDataCiteDoi(doi, templateShapedInstrument())
             .getAttributes()
-            .getRelatedIdentifiers());
+            .getRelatedIdentifiers(),
+        "an instrument with no links must clear the property, not leave it untouched");
   }
 }

--- a/src/test/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImplTest.java
@@ -712,6 +712,38 @@ class RspaceToExternalProviderAdapterImplTest {
         adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier());
   }
 
+  /**
+   * A pinned link names one version deliberately, and the registered address is permanent, so it
+   * has to carry the pin rather than follow the record's latest state.
+   */
+  @Test
+  void relatedIdentifierCarriesTheLinksVersionPinForATargetTypeThatResolvesOne() {
+    Instrument instrument = templateShapedInstrument();
+    InventoryLinkField pinned = linkField("Calibration", "IsCalibratedBy", "SA42");
+    pinned.getLink().setVersionPin(4L);
+    addField(instrument, pinned);
+
+    List<B2instRelatedIdentifier> related =
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier();
+    assertEquals(SERVER + "/globalId/SA42v4", related.get(0).getRelatedIdentifierValue());
+  }
+
+  /**
+   * NB has no version-suffixed route at all (see GlobalLookupController), so registering the pin
+   * would make a permanent address that resolves to nothing. The unpinned one is kept instead.
+   */
+  @Test
+  void relatedIdentifierDropsAVersionPinTheTargetTypeCannotResolve() {
+    Instrument instrument = templateShapedInstrument();
+    InventoryLinkField pinned = linkField("Calibration", "IsCalibratedBy", "NB7");
+    pinned.getLink().setVersionPin(2L);
+    addField(instrument, pinned);
+
+    List<B2instRelatedIdentifier> related =
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier();
+    assertEquals(SERVER + "/globalId/NB7", related.get(0).getRelatedIdentifierValue());
+  }
+
   @Test
   void relatedIdentifierFieldNamesMatchCaseInsensitively() {
     Instrument instrument = templateShapedInstrument();

--- a/src/test/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImplTest.java
@@ -12,11 +12,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.researchspace.api.v1.model.ApiInventoryDOI;
 import com.researchspace.b2inst.model.metadata.B2instInstrumentMetadata;
+import com.researchspace.b2inst.model.metadata.B2instRelatedIdentifier;
 import com.researchspace.b2inst.model.request.B2instDoi;
 import com.researchspace.datacite.model.DataCiteDoi;
+import com.researchspace.datacite.model.DataCiteDoiAttributes;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.field.InventoryDateField;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryLink;
@@ -24,6 +27,7 @@ import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.inventory.field.InventoryStringField;
 import com.researchspace.model.inventory.field.InventoryTextField;
 import com.researchspace.model.inventory.field.InventoryUriField;
+import com.researchspace.properties.IPropertyHolder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,10 +43,13 @@ class RspaceToExternalProviderAdapterImplTest {
   private static final String PUBLIC_PAGE = SERVER + "/public/inventory/abc123XYZ_-456789";
 
   private RspaceToExternalProviderAdapterImpl adapter;
+  private IPropertyHolder properties;
 
   @BeforeEach
   void setUp() {
-    adapter = new RspaceToExternalProviderAdapterImpl();
+    properties = mock(IPropertyHolder.class);
+    when(properties.getServerUrl()).thenReturn(SERVER);
+    adapter = new RspaceToExternalProviderAdapterImpl(properties);
   }
 
   private Instrument templateShapedInstrument() {
@@ -475,7 +482,7 @@ class RspaceToExternalProviderAdapterImplTest {
   }
 
   @Test
-  void doesNotMapMeasurementTechniqueCalibrationOrLastCalibrated() {
+  void doesNotMapLastCalibratedAndKeepsTheTwoLinksOutOfMeasuredVariable() {
     Instrument instrument = templateShapedInstrument();
     addField(instrument, linkField("Measurement technique", "IsDocumentedBy", "SD101"));
     addField(instrument, linkField("Calibration", "IsCalibratedBy", "SD202"));
@@ -483,8 +490,11 @@ class RspaceToExternalProviderAdapterImplTest {
 
     B2instInstrumentMetadata md = adapter.buildB2instDoi(instrument, null).getMetadata();
 
-    // fully populated, and still nothing: these three fields feed no PIDINST property
+    // The two links reach RelatedIdentifier (ADR 0007), never MeasuredVariable: the narrative
+    // mapping ADR 0005 rejected. "Last calibrated" still feeds no PIDINST property at all.
     assertNull(md.getMeasuredVariable());
+    assertNull(md.getDate());
+    assertEquals(2, md.getRelatedIdentifier().size());
   }
 
   @Test
@@ -563,6 +573,7 @@ class RspaceToExternalProviderAdapterImplTest {
     addField(instrument, stringField("Instrument type", "Weather station"));
     addField(instrument, stringField("Measured quantity", "Air temperature"));
     addField(instrument, uriField("Landing page", "https://lab.example.org/aws-42"));
+    addField(instrument, linkField("Measurement technique", "IsDocumentedBy", "IN114"));
 
     JsonNode md =
         new ObjectMapper().valueToTree(adapter.buildB2instDoi(instrument, null)).at("/metadata");
@@ -575,6 +586,12 @@ class RspaceToExternalProviderAdapterImplTest {
     assertEquals("Weather station", md.at("/InstrumentType/0/instrumentTypeName").asText());
     assertEquals("Air temperature", md.at("/MeasuredVariable/0").asText());
     assertEquals("https://lab.example.org/aws-42", md.at("/LandingPage").asText());
+    assertEquals("URL", md.at("/RelatedIdentifier/0/relatedIdentifierType").asText());
+    assertEquals(
+        SERVER + "/globalId/IN114", md.at("/RelatedIdentifier/0/relatedIdentifierValue").asText());
+    assertEquals("IsDescribedBy", md.at("/RelatedIdentifier/0/relationType").asText());
+    assertEquals(
+        "Measurement Technique", md.at("/RelatedIdentifier/0/relatedIdentifierName").asText());
   }
 
   /**
@@ -596,6 +613,7 @@ class RspaceToExternalProviderAdapterImplTest {
     assertTrue(md.at("/Date").isMissingNode());
     assertTrue(md.at("/MeasuredVariable").isMissingNode());
     assertTrue(md.at("/AlternateIdentifier").isMissingNode());
+    assertTrue(md.at("/RelatedIdentifier").isMissingNode());
     // Name, SchemaVersion and Owner always resolve, and LandingPage does here because a public
     // landing page was supplied, so all four must still be present
     assertFalse(md.at("/Name").isMissingNode());
@@ -618,8 +636,131 @@ class RspaceToExternalProviderAdapterImplTest {
     ApiInventoryDOI doi = new ApiInventoryDOI();
     doi.setTitle("My DOI");
 
-    DataCiteDoi result = adapter.buildDataCiteDoi(doi);
+    DataCiteDoi result = adapter.buildDataCiteDoi(doi, null);
 
     assertEquals("My DOI", result.getAttributes().getTitles().get(0).getTitle());
+  }
+
+  @Test
+  void mapsMeasurementTechniqueAndCalibrationLinksIntoRelatedIdentifier() {
+    Instrument instrument = templateShapedInstrument();
+    addField(instrument, linkField("Measurement technique", "IsDocumentedBy", "IN114"));
+    addField(instrument, linkField("Calibration", "IsCalibratedBy", "IN115"));
+
+    B2instDoi doi = adapter.buildB2instDoi(instrument, PUBLIC_PAGE);
+
+    List<B2instRelatedIdentifier> related = doi.getMetadata().getRelatedIdentifier();
+    assertEquals(2, related.size());
+    // Measurement Technique first, Calibration second, as in the ticket's example payloads.
+    // relationType is always IsDescribedBy, whatever the link stores: PIDINST's vocabulary has
+    // no IsDocumentedBy/IsCalibratedBy (ADR 0007).
+    assertEquals("Measurement Technique", related.get(0).getRelatedIdentifierName());
+    assertEquals("IsDescribedBy", related.get(0).getRelationType());
+    assertEquals("URL", related.get(0).getRelatedIdentifierType());
+    assertEquals(SERVER + "/globalId/IN114", related.get(0).getRelatedIdentifierValue());
+    assertEquals("Calibration", related.get(1).getRelatedIdentifierName());
+    assertEquals("IsDescribedBy", related.get(1).getRelationType());
+    assertEquals("URL", related.get(1).getRelatedIdentifierType());
+    assertEquals(SERVER + "/globalId/IN115", related.get(1).getRelatedIdentifierValue());
+  }
+
+  @Test
+  void relatedIdentifierIsOmittedWhenLinkFieldsAreAbsentOrEmpty() {
+    // no link fields at all
+    assertNull(
+        adapter
+            .buildB2instDoi(templateShapedInstrument(), PUBLIC_PAGE)
+            .getMetadata()
+            .getRelatedIdentifier());
+
+    // fields present but holding no link
+    Instrument instrument = templateShapedInstrument();
+    InventoryLinkField empty = new InventoryLinkField();
+    empty.setName("Measurement technique");
+    addField(instrument, empty);
+    assertNull(
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier());
+  }
+
+  /**
+   * The blank target is a reachable state; the soft-deleted link is a defensive guard. A link is
+   * only ever soft-deleted along with its field ({@code
+   * SampleApiManagerImpl.softDeleteLinkOfDeletedLinkField}), and a deleted field is already
+   * excluded by {@code getActiveFields}, so no current flow presents a live field holding a deleted
+   * link. The guard stays because the entry it would produce is registered permanently, and this
+   * pins it against a future change to that lifecycle.
+   */
+  @Test
+  void relatedIdentifierSkipsDeletedLinksAndBlankTargets() {
+    Instrument instrument = templateShapedInstrument();
+    InventoryLinkField deleted = linkField("Measurement technique", "IsDocumentedBy", "IN114");
+    deleted.getLink().setDeleted(true);
+    addField(instrument, deleted);
+    addField(instrument, linkField("Calibration", "IsCalibratedBy", "  "));
+
+    assertNull(
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier());
+  }
+
+  @Test
+  void relatedIdentifierIsOmittedWhenNoUsableServerUrlExists() {
+    when(properties.getServerUrl()).thenReturn("rspace.example.com"); // no scheme
+    Instrument instrument = templateShapedInstrument();
+    addField(instrument, linkField("Calibration", "IsCalibratedBy", "IN115"));
+
+    assertNull(
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier());
+  }
+
+  @Test
+  void relatedIdentifierFieldNamesMatchCaseInsensitively() {
+    Instrument instrument = templateShapedInstrument();
+    addField(instrument, linkField("  MEASUREMENT TECHNIQUE ", "IsDocumentedBy", "IN114"));
+
+    List<B2instRelatedIdentifier> related =
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier();
+    assertEquals(1, related.size());
+    assertEquals("Measurement Technique", related.get(0).getRelatedIdentifierName());
+  }
+
+  @Test
+  void dataCiteDoiCarriesRelatedIdentifiersFromInstrumentLinks() {
+    Instrument instrument = templateShapedInstrument();
+    addField(instrument, linkField("Measurement technique", "IsDocumentedBy", "IN114"));
+    addField(instrument, linkField("Calibration", "IsCalibratedBy", "IN115"));
+    ApiInventoryDOI doi = new ApiInventoryDOI();
+    doi.setDoi("10.82316/r6m6-v851");
+    doi.setTitle("Nico-PIDINST");
+
+    DataCiteDoi result = adapter.buildDataCiteDoi(doi, instrument);
+
+    List<DataCiteDoiAttributes.RelatedIdentifier> related =
+        result.getAttributes().getRelatedIdentifiers();
+    assertEquals(2, related.size());
+    assertEquals("IsDescribedBy", related.get(0).getRelationType());
+    assertEquals(SERVER + "/globalId/IN114", related.get(0).getRelatedIdentifier());
+    assertEquals("URL", related.get(0).getRelatedIdentifierType());
+    assertEquals("Measurement Technique", related.get(0).getRelationTypeInformation());
+    assertEquals("IsDescribedBy", related.get(1).getRelationType());
+    assertEquals(SERVER + "/globalId/IN115", related.get(1).getRelatedIdentifier());
+    assertEquals("URL", related.get(1).getRelatedIdentifierType());
+    assertEquals("Calibration", related.get(1).getRelationTypeInformation());
+    // the base conversion still happened
+    assertEquals("Nico-PIDINST", result.getAttributes().getTitles().get(0).getTitle());
+  }
+
+  @Test
+  void dataCiteDoiLeavesRelatedIdentifiersNullForNonInstrumentsAndLinklessInstruments() {
+    ApiInventoryDOI doi = new ApiInventoryDOI();
+    doi.setDoi("10.82316/abc");
+    doi.setTitle("a sample");
+
+    assertNull(adapter.buildDataCiteDoi(doi, new Sample()).getAttributes().getRelatedIdentifiers());
+    assertNull(adapter.buildDataCiteDoi(doi, null).getAttributes().getRelatedIdentifiers());
+    assertNull(
+        adapter
+            .buildDataCiteDoi(doi, templateShapedInstrument())
+            .getAttributes()
+            .getRelatedIdentifiers());
   }
 }

--- a/src/test/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImplTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/RspaceToExternalProviderAdapterImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -17,6 +18,7 @@ import com.researchspace.b2inst.model.request.B2instDoi;
 import com.researchspace.datacite.model.DataCiteDoi;
 import com.researchspace.datacite.model.DataCiteDoiAttributes;
 import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
@@ -28,7 +30,9 @@ import com.researchspace.model.inventory.field.InventoryStringField;
 import com.researchspace.model.inventory.field.InventoryTextField;
 import com.researchspace.model.inventory.field.InventoryUriField;
 import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.inventory.LinkTargetResolver;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,12 +48,16 @@ class RspaceToExternalProviderAdapterImplTest {
 
   private RspaceToExternalProviderAdapterImpl adapter;
   private IPropertyHolder properties;
+  private LinkTargetResolver linkTargetResolver;
 
   @BeforeEach
   void setUp() {
     properties = mock(IPropertyHolder.class);
     when(properties.getServerUrl()).thenReturn(SERVER);
-    adapter = new RspaceToExternalProviderAdapterImpl(properties);
+    linkTargetResolver = mock(LinkTargetResolver.class);
+    // targets qualify by default; individual tests disqualify them
+    when(linkTargetResolver.targetIsLiveAndReadable(any(), any())).thenReturn(true);
+    adapter = new RspaceToExternalProviderAdapterImpl(properties, linkTargetResolver);
   }
 
   private Instrument templateShapedInstrument() {
@@ -99,6 +107,14 @@ class RspaceToExternalProviderAdapterImplTest {
     InventoryLink link = new InventoryLink();
     link.setTargetGlobalId(targetGlobalId);
     link.setRelationType(relationType);
+    // mirror the write path, which always stores the typed columns beside the string
+    try {
+      GlobalIdentifier gid = new GlobalIdentifier(StringUtils.trimToEmpty(targetGlobalId));
+      link.setTargetPrefix(gid.getPrefix());
+      link.setTargetDbId(gid.getDbId());
+    } catch (IllegalArgumentException | NullPointerException e) {
+      // deliberately malformed or blank: leave the typed columns unset
+    }
     field.setLink(link);
     return field;
   }
@@ -744,6 +760,47 @@ class RspaceToExternalProviderAdapterImplTest {
     assertEquals(SERVER + "/globalId/NB7", related.get(0).getRelatedIdentifierValue());
   }
 
+  /**
+   * A target that stopped qualifying after the link was written - deleted, unshared from the
+   * instrument's owner, or gone - must not be registered: deleting a record does not delete links
+   * pointing at it, and duplicating an instrument copies links no one re-checked. The judge is the
+   * instrument's owner, a stable actor, so the payload cannot vary with who triggers registration.
+   */
+  @Test
+  void relatedIdentifierOmitsATargetThatIsDeletedOrNotOwnerReadable() {
+    when(linkTargetResolver.targetIsLiveAndReadable(any(), any())).thenReturn(false);
+    Instrument instrument = templateShapedInstrument();
+    addField(instrument, linkField("Calibration", "IsCalibratedBy", "SA42"));
+
+    assertNull(
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier());
+  }
+
+  /**
+   * Qualification and the pin decision read the link's typed columns and never parse the stored id,
+   * so a malformed row (no typed prefix) disqualifies its own entry: it must not throw out of the
+   * shared transaction and fail the whole registration.
+   */
+  @Test
+  void relatedIdentifierToleratesAMalformedStoredTargetId() {
+    Instrument instrument = templateShapedInstrument();
+    InventoryLinkField malformed = linkField("Calibration", "IsCalibratedBy", "not-a-global-id");
+    malformed.getLink().setVersionPin(5L);
+    addField(instrument, malformed);
+
+    assertNull(
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier());
+  }
+
+  @Test
+  void relatedIdentifierIgnoresAWrongTypedFieldWithACanonicalName() {
+    Instrument instrument = templateShapedInstrument();
+    addField(instrument, stringField("Calibration", "a narrative, not a link"));
+
+    assertNull(
+        adapter.buildB2instDoi(instrument, PUBLIC_PAGE).getMetadata().getRelatedIdentifier());
+  }
+
   @Test
   void relatedIdentifierFieldNamesMatchCaseInsensitively() {
     Instrument instrument = templateShapedInstrument();
@@ -798,6 +855,52 @@ class RspaceToExternalProviderAdapterImplTest {
    * instrument whose link fields were cleared after registration would otherwise keep the entries
    * registered before the user cleared them, permanently, on a findable DOI.
    */
+  /**
+   * The empty-list clear is a statement about the data, so it must never fire on an environment
+   * failure: with no usable server URL nothing can be built for ANY link, and [] would permanently
+   * strip entries that are still correct. The property is left untouched instead.
+   */
+  @Test
+  void dataCiteDoiLeavesRelatedIdentifiersUntouchedWhenNoUsableServerUrlExists() {
+    when(properties.getServerUrl()).thenReturn("rspace.example.com"); // no scheme
+    Instrument instrument = templateShapedInstrument();
+    addField(instrument, linkField("Calibration", "IsCalibratedBy", "IN115"));
+    ApiInventoryDOI doi = new ApiInventoryDOI();
+    doi.setDoi("10.82316/abc");
+    doi.setTitle("an instrument");
+
+    assertNull(adapter.buildDataCiteDoi(doi, instrument).getAttributes().getRelatedIdentifiers());
+  }
+
+  /**
+   * The DataCite JSON keys are the wire contract, and getter assertions bypass Jackson entirely;
+   * the RelatedIdentifier type also arrives from an unreleased client build, so pin the keys and
+   * the []-serialization the clearing behaviour depends on.
+   */
+  @Test
+  void dataCiteWireFormatNamesTheRelatedIdentifierProperties() throws Exception {
+    Instrument instrument = templateShapedInstrument();
+    addField(instrument, linkField("Measurement technique", "IsDocumentedBy", "IN114"));
+    ApiInventoryDOI doi = new ApiInventoryDOI();
+    doi.setDoi("10.82316/abc");
+    doi.setTitle("an instrument");
+
+    JsonNode attributes =
+        new ObjectMapper().valueToTree(adapter.buildDataCiteDoi(doi, instrument)).at("/attributes");
+    JsonNode entry = attributes.at("/relatedIdentifiers/0");
+    assertEquals("IsDescribedBy", entry.at("/relationType").asText());
+    assertEquals(SERVER + "/globalId/IN114", entry.at("/relatedIdentifier").asText());
+    assertEquals("URL", entry.at("/relatedIdentifierType").asText());
+    assertEquals("Measurement Technique", entry.at("/relationTypeInformation").asText());
+
+    JsonNode cleared =
+        new ObjectMapper()
+            .valueToTree(adapter.buildDataCiteDoi(doi, templateShapedInstrument()))
+            .at("/attributes/relatedIdentifiers");
+    assertTrue(cleared.isArray(), "the clear must serialize as [], not null");
+    assertEquals(0, cleared.size());
+  }
+
   @Test
   void dataCiteDoiSendsAnEmptyRelatedIdentifierListForAnInstrumentWithNoLiveLinks() {
     ApiInventoryDOI doi = new ApiInventoryDOI();


### PR DESCRIPTION
related PR: https://github.com/rspace-os/datacite-java-client/pull/6
AWS instance: https://rsdev-1253-map-clibration-and-measurement-f50c365a-11.researchspace.com

## Description ##

- Resolves https://researchspace.atlassian.net/browse/RSDEV-1253

An instrument's **Measurement technique** and **Calibration** fields hold links to other RSpace records: the document describing how a measurement is taken, the certificate behind a calibration. Until now those links stayed inside RSpace and were left out of the instrument's registered metadata, so the published identifier said nothing about the material behind it.

Registering an instrument PID now sends both links to the provider as related identifiers, for B2INST and DataCite alike. Each entry carries the linked record's RSpace address, labelled "Measurement Technique" or "Calibration".

A field that is empty, or whose link has since been cleared, is simply left out. Nothing changes in the UI, and no API or database changes were needed.

## Design decisions

- **The relation we send is always `IsDescribedBy`.** The PIDINST standard's list of permitted relations contains neither of the two the fields actually store (`IsDocumentedBy`, `IsCalibratedBy`), and `IsDescribedBy` is the one usable option in it. The relation stored on the link inside RSpace is untouched.
- **The address we send is the linked record's ordinary RSpace page**, which asks for a sign-in. Unlike a landing page, a related identifier makes no promise of being publicly resolvable, and the linked records generally have no public page to point at.
- **B2INST is told once, at registration**, as it has no way to update a record's metadata afterwards. **DataCite is told on publish and again on retract**, since both resend the full metadata and the entries would otherwise be dropped.
- If no usable web address can be built, for example on a deployment with no server URL configured, the entry is left out with a warning rather than registered wrong. Same rule as the landing page: a missing value can be added later, a published wrong one cannot.
- **Last calibrated** is still not mapped, as the standard has no property that fits it.
- The reasoning and the rejected alternatives are recorded in `DevDocs/adr/0007-pidinst-related-identifiers.md`.

## Testing notes

- ⚠️ **Before merge:** `datacite-java-client` needs a release (suggested `1.1.0`) and the pin in `pom.xml` swapped off `RSDEV-1253-datacite-SNAPSHOT`.
- Unit tests cover the mapping rules; a new Spring test covers both providers end to end against real instruments and links, including that publish and retract each send the entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
