### PR TITLE
RSDEV-1147: address the cosmetic review comments on the imported sources

### DIFF
--- a/src/main/java/com/researchspace/model/PermissionStringConverter.java
+++ b/src/main/java/com/researchspace/model/PermissionStringConverter.java
@@ -7,9 +7,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Converter
-public class PermissionStringConverter implements AttributeConverter<Set, String> {
+public class PermissionStringConverter implements AttributeConverter<Set<String>, String> {
   @Override
-  public String convertToDatabaseColumn(Set permissionList) {
+  public String convertToDatabaseColumn(Set<String> permissionList) {
     if (permissionList == null) {
       return null;
     }

--- a/src/main/java/com/researchspace/zipprocessing/ZipEntryProcessor.java
+++ b/src/main/java/com/researchspace/zipprocessing/ZipEntryProcessor.java
@@ -1,11 +1,13 @@
 package com.researchspace.zipprocessing;
 
-import java.io.File;
 import java.util.zip.ZipEntry;
 
-/** Processes a single Zip entry that is available as a {@link File}. */
+/**
+ * Processes a single {@link ZipEntry}. See {@link ZipEntryFileProcessor} for the variant that
+ * receives the entry extracted to a file.
+ */
 @FunctionalInterface
 public interface ZipEntryProcessor {
 
-  void process(ZipEntry entryAsFile);
+  void process(ZipEntry entry);
 }

--- a/src/test/java/com/researchspace/core/util/throttling/AllowanceTrackerSourceImplTest.java
+++ b/src/test/java/com/researchspace/core/util/throttling/AllowanceTrackerSourceImplTest.java
@@ -3,22 +3,19 @@ package com.researchspace.core.util.throttling;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.researchspace.core.util.TimeSource;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class AllowanceTrackerSourceImplTest {
-  public @Rule MockitoRule rule = MockitoJUnit.rule();
   AllowanceTrackerSourceImpl allowanceTrackerSourceImpl;
   @Mock TimeSource timesource;
 
   @BeforeEach
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     allowanceTrackerSourceImpl =
         new AllowanceTrackerSourceImpl(timesource, new ThrottleDefinitionSet());
   }


### PR DESCRIPTION
## Description ##

Stacked on #1045. Fixes the three cosmetic comments from Copilot's review of #1041, all in imported sources:

- `PermissionStringConverter` is now typed `AttributeConverter<Set<String>, String>`, matching the `Set<String>` entity properties it converts (raw `Set` before).
- `ZipEntryProcessor`'s javadoc and parameter name claimed the entry arrives as a `File`; that description belongs to its sibling `ZipEntryFileProcessor`. Also drops the unused `File` import.
- `AllowanceTrackerSourceImplTest` used a JUnit 4 `@Rule` that Jupiter ignores plus the deprecated `MockitoAnnotations.initMocks`; it now uses `@ExtendWith(MockitoExtension.class)`.

No behaviour changes. With this, every comment from the #1041 review is addressed: the four validator findings by deletion in #1045, and these three here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
