### PR TITLE
RSDEV-1103: dependency precursors for Java 21 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,15 @@
         <artifactId>byte-buddy</artifactId>
         <!-- Keep >= the version Hibernate ORM ships (6.4.4 ships 1.14.11); pinned here for
              dependencyConvergence between Hibernate and Mockito -->
-        <version>1.14.11</version>
+        <version>1.17.5</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <!-- Must match byte-buddy above. The agent does the class retransformation behind
+             Mockito's inline mock maker, and an old agent paired with a new byte-buddy
+             corrupts reflective constructor calls on Java 21. -->
+        <version>1.17.5</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -2694,10 +2702,13 @@
     <commons.fileupload.version>1.4</commons.fileupload.version>
     <guava.version>23.4-jre</guava.version>
     <icu4j.version>78.3</icu4j.version>
-    <javassist.version>3.24.0-GA</javassist.version>
     <jsonwebtoken.version>0.11.2</jsonwebtoken.version>
     <jstl.version>3.0.0</jstl.version>
     <lucene.version>9.8.0</lucene.version>
+    <!-- The parent inherits mockito-core as a direct dependency, so its 3.7.7 wins over the
+         version mockito-junit-jupiter would pull in. Override it here or the tests run on
+         Mockito 3, which cannot mock on a Java 21 JVM. -->
+    <mockito.version>5.18.0</mockito.version>
     <!-- EE 10 to match Spring 6.2's Servlet 6.0 build baseline and both target containers:
          dev Jetty 12.1 (ee10) and Tomcat 10.1 are Servlet 6.0. Do NOT bump to 6.1.0 (EE 11):
          that over-reaches Spring's baseline and both containers. -->

--- a/src/main/java/com/researchspace/api/v1/DocumentsApi.java
+++ b/src/main/java/com/researchspace/api/v1/DocumentsApi.java
@@ -13,7 +13,7 @@ import com.researchspace.model.User;
 import com.researchspace.service.DocumentAlreadyEditedException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import javassist.NotFoundException;
+import jakarta.ws.rs.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;

--- a/src/test/java/com/axiope/service/cfg/DocConverterConfigTest.java
+++ b/src/test/java/com/axiope/service/cfg/DocConverterConfigTest.java
@@ -58,7 +58,7 @@ public class DocConverterConfigTest {
     }
 
     private void initMocks() {
-      MockitoAnnotations.initMocks(DocConverterProdConfigTSS.class);
+      MockitoAnnotations.openMocks(this);
     }
 
     @Bean

--- a/src/test/java/com/researchspace/api/v1/config/ProdProfileCanSetFromPropertiesTest.java
+++ b/src/test/java/com/researchspace/api/v1/config/ProdProfileCanSetFromPropertiesTest.java
@@ -14,9 +14,12 @@ import com.researchspace.api.v1.service.ExportApiHandler;
 import com.researchspace.api.v1.service.RSFormApiHandler;
 import com.researchspace.api.v1.throttling.APIRequestThrottler;
 import com.researchspace.model.permissions.IPermissionUtils;
+import com.researchspace.model.permissions.IUserPermissionUtils;
 import com.researchspace.service.ApiAvailabilityHandler;
 import com.researchspace.service.FormManager;
 import com.researchspace.service.IconImageManager;
+import com.researchspace.service.OAuthTokenManager;
+import com.researchspace.service.RecordManager;
 import com.researchspace.service.UserApiKeyManager;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Nested;
@@ -47,8 +50,12 @@ public class ProdProfileCanSetFromPropertiesTest {
 
     @Mock FormManager formMgr;
 
+    @Mock IUserPermissionUtils userPermissionUtils;
+    @Mock OAuthTokenManager tokenManager;
+    @Mock RecordManager recordManager;
+
     private void initMocks() {
-      MockitoAnnotations.initMocks(ApiProdConfigTestHelper.class);
+      MockitoAnnotations.openMocks(this);
     }
 
     @Bean
@@ -68,6 +75,24 @@ public class ProdProfileCanSetFromPropertiesTest {
       initMocks();
       return formMgr;
     }
+
+    @Bean
+    IUserPermissionUtils userPermissionUtils() {
+      initMocks();
+      return userPermissionUtils;
+    }
+
+    @Bean
+    OAuthTokenManager oAuthTokenManager() {
+      initMocks();
+      return tokenManager;
+    }
+
+    @Bean
+    RecordManager recordManager() {
+      initMocks();
+      return recordManager;
+    }
   }
 
   @Configuration
@@ -84,7 +109,7 @@ public class ProdProfileCanSetFromPropertiesTest {
     @Mock RSFormApiHandler formApiHandler;
 
     private void initMocks() {
-      MockitoAnnotations.initMocks(ProdApiConfTss.class);
+      MockitoAnnotations.openMocks(this);
     }
 
     @Bean

--- a/src/test/java/com/researchspace/core/util/imageutils/ImageUtilsTest.java
+++ b/src/test/java/com/researchspace/core/util/imageutils/ImageUtilsTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.researchspace.core.util.RSpaceCoreTestUtils;
 import java.awt.image.BufferedImage;
@@ -47,7 +47,7 @@ public class ImageUtilsTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    initMocks(this);
+    openMocks(this);
   }
 
   @AfterEach

--- a/src/test/java/com/researchspace/service/impl/EmailSenderTest.java
+++ b/src/test/java/com/researchspace/service/impl/EmailSenderTest.java
@@ -43,7 +43,7 @@ public class EmailSenderTest {
     emailSender.init();
     emailSender.sendEmail(anyHtmlBody(), List.of("user@example.com"), new MessageOrRequest());
 
-    verify(logger, times(3)).warn(Mockito.anyString(), new Object[] {Mockito.any()});
+    verify(logger, times(3)).warn(Mockito.anyString(), Mockito.any(Object[].class));
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/impl/UserManagerImplTest.java
+++ b/src/test/java/com/researchspace/service/impl/UserManagerImplTest.java
@@ -51,6 +51,8 @@ public class UserManagerImplTest extends BaseManagerMockTestCase {
   public void setUp() throws Exception {
     ReflectionTestUtils.setField(
         userManager, "messages", new MessageSourceUtils(new JsonMessageSource()));
+    ReflectionTestUtils.setField(userManager, "communityDao", communityDao);
+    ReflectionTestUtils.setField(userManager, "analyticsManager", analyticsManager);
   }
 
   @Test


### PR DESCRIPTION
## Description ##

First of three PRs for RSDEV-1103 phase 1: make the tests run on a Java 21 JVM. Bytecode stays at `release 17`, nothing shipped to customers changes.

- Mockito 5.18.0 (`mockito.version` override, because the parent inherits `mockito-core` 3.7.7 as a direct dependency), Byte Buddy and `byte-buddy-agent` pinned together at 1.17.5. Mockito 3's 2020 agent corrupts reflective constructor calls on Java 21.
- Child `javassist.version` 3.24.0-GA override removed so the parent's 3.33.0-GA applies; the old one cannot read Java 21 class files.
- `DocumentsApi` imported `javassist.NotFoundException` by accident; it throws the JAX-RS one.
- Test fixes forced by Mockito 5: `initMocks` to `openMocks`, vararg matcher arity in `EmailSenderTest`, and `@InjectMocks` no longer filling fields after constructor injection in `UserManagerImplTest` (mockito/mockito#2602). The config helpers in `DocConverterConfigTest` and `ProdProfileCanSetFromPropertiesTest` passed a `Class` to `initMocks`, so their mocks were never created; fixed, with mock beans for the dependencies Spring then autowires.

## Testing notes

`mvn clean test -Dfast=true` on Temurin 17 and 21: 3779 tests, 0 failures. Local 21 runs need a 21 entry in `~/.m2/toolchains.xml` plus `-Djava-version=21`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
