### PR TITLE
update(e2e): omero real test url

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -226,6 +226,7 @@ jobs:
           else
             INTEGRATION_ARGS=(
               "-Dpyrat.server.config={\"default-server\":{\"url\":\"https://demo.pyrat.cloud/rspace511/api/v3/\",\"token\":\"$PYRAT_SERVER_TOKEN\"}}"
+              "-Domero.api.url=https://demo.openmicroscopy.org/"
               "-Dclustermarket.api.url=https://api.clustermarket.dev/v1/"
               "-Dclustermarket.web.url=https://app.clustermarket.dev/"
               "-Dclustermarket.client.id=$CALIRA_CLIENT_ID"


### PR DESCRIPTION
## Description ##
- update real omero url  `omero.api.url=https://demo.openmicroscopy.org`
- omero passed in ci  [real mode](https://github.com/rspace-os/rspace-web/actions/runs/33278487534/job/99169703087)
