### PR TITLE
RSDEV-1354-export-import-inventory-links

### DIFF
--- a/src/main/java/com/researchspace/api/v1/model/ApiInventoryLink.java
+++ b/src/main/java/com/researchspace/api/v1/model/ApiInventoryLink.java
@@ -1,12 +1,15 @@
 package com.researchspace.api.v1.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.researchspace.model.core.GlobalIdentifier;
 import com.researchspace.model.inventory.field.InventoryLink;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /** API payload representing a Link extra-field's target/relation metadata. */
 @Data
@@ -23,6 +26,15 @@ public class ApiInventoryLink {
 
   @JsonProperty("versionPin")
   private Long versionPin;
+
+  /**
+   * Set only by the CSV importer: store the link even when its target is missing or unreadable on
+   * this server, so an exported dangling link re-imports as a dangling link (RSDEV-1354). Never
+   * settable from JSON, so API clients cannot bypass the target check.
+   */
+  // ponytail: a boolean on the DTO instead of threading an "import" flag through three managers;
+  // promote to a dedicated createLink variant if a second lenient caller appears
+  @JsonIgnore @EqualsAndHashCode.Exclude @ToString.Exclude private boolean skipTargetCheck;
 
   public ApiInventoryLink(InventoryLink link) {
     this.relationType = link.getRelationType();

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
@@ -33,7 +33,11 @@ public class InventoryLinkField extends InventoryEntityField {
   private String allowedRelationTypes;
 
   public InventoryLinkField() {
-    super(FieldType.LINK, "");
+    this("");
+  }
+
+  public InventoryLinkField(String name) {
+    super(FieldType.LINK, name);
   }
 
   /*

--- a/src/main/java/com/researchspace/service/inventory/csvexport/CsvInstrumentExporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvexport/CsvInstrumentExporter.java
@@ -6,6 +6,7 @@ import com.researchspace.model.User;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -164,7 +165,10 @@ public class CsvInstrumentExporter extends InventoryItemCsvExporter {
 
     if (CsvExportMode.FULL.equals(exportMode) && instrument.getActiveFields() != null) {
       for (InventoryEntityField sf : instrument.getActiveFields()) {
-        String valueForProp = sf.getData();
+        String valueForProp =
+            sf instanceof InventoryLinkField
+                ? csvValueForLink(((InventoryLinkField) sf).getLink())
+                : sf.getData();
         int columnIndexForValue = csvColumnNames.indexOf(getColumnNameForInstrumentField(sf));
         if (columnIndexForValue >= 0) {
           itemProperties.set(columnIndexForValue, valueForProp != null ? valueForProp : "");

--- a/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleExporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvexport/CsvSampleExporter.java
@@ -7,6 +7,7 @@ import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleEntity;
 import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -174,7 +175,10 @@ public class CsvSampleExporter extends InventoryItemCsvExporter {
 
     if (CsvExportMode.FULL.equals(exportMode) && sample.getActiveExtraFields() != null) {
       for (InventoryEntityField sf : sample.getActiveFields()) {
-        String valueForProp = sf.getData();
+        String valueForProp =
+            sf instanceof InventoryLinkField
+                ? csvValueForLink(((InventoryLinkField) sf).getLink())
+                : sf.getData();
         int columnIndexForValue = csvColumnNames.indexOf(getColumnNameForSampleField(sf));
         itemProperties.set(columnIndexForValue, valueForProp != null ? valueForProp : "");
       }

--- a/src/main/java/com/researchspace/service/inventory/csvexport/InventoryItemCsvExporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvexport/InventoryItemCsvExporter.java
@@ -7,6 +7,9 @@ import com.researchspace.archive.ExportScope;
 import com.researchspace.model.User;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.field.ExtraField;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.MessageSourceUtils;
 import com.researchspace.service.inventory.csvexport.CsvExportCommentGenerator.ExportedCommentProperty;
 import java.io.ByteArrayOutputStream;
@@ -100,6 +103,29 @@ public abstract class InventoryItemCsvExporter {
 
   protected @Autowired CsvExportCommentGenerator exportCommentGenerator;
   protected @Autowired MessageSourceUtils messages;
+  protected @Autowired IPropertyHolder properties;
+
+  /**
+   * CSV cell for a link field: {@code "<RelationType> <serverUrl>/globalId/<GID>[vN]"}, or empty
+   * when the field holds no link. The version pin travels as the {@code vN} suffix so a single
+   * Global ID URL carries the whole link.
+   */
+  protected String csvValueForLink(InventoryLink link) {
+    if (link == null) {
+      return "";
+    }
+    String serverUrl = properties.getServerUrl();
+    if (serverUrl.endsWith("/")) {
+      serverUrl = serverUrl.substring(0, serverUrl.length() - 1);
+    }
+    String versionSuffix = link.getVersionPin() == null ? "" : "v" + link.getVersionPin();
+    return link.getRelationType()
+        + " "
+        + serverUrl
+        + "/globalId/"
+        + link.getTargetGlobalId()
+        + versionSuffix;
+  }
 
   public String getCsvCommentHeader() {
     return messages.getMessageForLocale("export.inventory.csv.commentHeader", CSV_HEADER_LOCALE);
@@ -171,7 +197,10 @@ public abstract class InventoryItemCsvExporter {
 
     if (CsvExportMode.FULL.equals(exportMode) && item.getActiveExtraFields() != null) {
       for (ExtraField ef : item.getActiveExtraFields()) {
-        String valueForProp = ef.getData();
+        String valueForProp =
+            ef instanceof ExtraLinkField
+                ? csvValueForLink(((ExtraLinkField) ef).getLink())
+                : ef.getData();
         int columnIndexForValue = csvColumnNames.indexOf(getColumnNameForExtraField(ef));
         itemProperties.set(columnIndexForValue, valueForProp != null ? valueForProp : "");
       }

--- a/src/main/java/com/researchspace/service/inventory/csvimport/CsvInstrumentImporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/CsvInstrumentImporter.java
@@ -1,5 +1,6 @@
 package com.researchspace.service.inventory.csvimport;
 
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInstrument;
 import com.researchspace.api.v1.model.ApiInstrumentTemplate;
 import com.researchspace.api.v1.model.ApiInstrumentTemplatePost;
@@ -208,6 +209,8 @@ public class CsvInstrumentImporter extends InventoryItemCsvImporter {
             if (!StringUtils.isBlank(value)) {
               if (instrumentField.isOptionsStoringField()) {
                 instrumentField.setSelectedOptions(Arrays.asList(value));
+              } else if (ApiFieldType.LINK.equals(instrumentField.getType())) {
+                instrumentField.setLink(linkParser.parse(value));
               } else {
                 instrumentField.setContent(value);
               }

--- a/src/main/java/com/researchspace/service/inventory/csvimport/CsvLinkValueParser.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/CsvLinkValueParser.java
@@ -1,0 +1,82 @@
+package com.researchspace.service.inventory.csvimport;
+
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.model.core.GlobalIdentifier;
+import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.MessageSourceUtils;
+import com.researchspace.service.inventory.DataCiteRelationType;
+import com.researchspace.service.inventory.InventoryLinkValidator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses the CSV cell the exporters write for a link field: {@code "<RelationType>
+ * <serverUrl>/globalId/<GID>[vN]"}. Only URLs on this server are accepted (RSDEV-1354), so a Global
+ * ID from another RSpace instance is never silently attached to the wrong local record.
+ */
+@Component
+public class CsvLinkValueParser {
+
+  private static final Pattern CELL = Pattern.compile("^(\\S+)\\s+(\\S+)$");
+
+  @Autowired IPropertyHolder properties;
+  @Autowired MessageSourceUtils messages;
+
+  /**
+   * @return the link described by the cell, flagged to skip the exists-and-readable check so a
+   *     target that is missing or unreadable on this server still imports as a dangling link
+   * @throws IllegalArgumentException with a user-facing message when the cell is not a link
+   */
+  public ApiInventoryLink parse(String cell) {
+    ApiInventoryLink link = tryParse(cell);
+    if (link == null) {
+      throw new IllegalArgumentException(
+          messages.getMessage("errors.inventory.import.linkValueInvalid", new Object[] {cell}));
+    }
+    return link;
+  }
+
+  public boolean isParseable(String cell) {
+    return tryParse(cell) != null;
+  }
+
+  private ApiInventoryLink tryParse(String cell) {
+    if (cell == null) {
+      return null;
+    }
+    Matcher m = CELL.matcher(cell.trim());
+    if (!m.matches() || !DataCiteRelationType.isValid(m.group(1))) {
+      return null;
+    }
+    String url = m.group(2);
+    String prefix = globalIdUrlPrefix();
+    if (!url.regionMatches(true, 0, prefix, 0, prefix.length())) {
+      return null;
+    }
+    GlobalIdentifier gid;
+    try {
+      gid = new GlobalIdentifier(url.substring(prefix.length()));
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+    if (!InventoryLinkValidator.isAllowedTargetPrefix(gid.getPrefix())) {
+      return null;
+    }
+    ApiInventoryLink link = new ApiInventoryLink();
+    link.setRelationType(m.group(1));
+    link.setTargetGlobalId(new GlobalIdentifier(gid.getPrefix(), gid.getDbId()).getIdString());
+    link.setVersionPin(gid.hasVersionId() ? gid.getVersionId() : null);
+    link.setSkipTargetCheck(true);
+    return link;
+  }
+
+  private String globalIdUrlPrefix() {
+    String serverUrl = properties.getServerUrl();
+    if (serverUrl.endsWith("/")) {
+      serverUrl = serverUrl.substring(0, serverUrl.length() - 1);
+    }
+    return serverUrl + "/globalId/";
+  }
+}

--- a/src/main/java/com/researchspace/service/inventory/csvimport/CsvSampleImporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/CsvSampleImporter.java
@@ -1,5 +1,6 @@
 package com.researchspace.service.inventory.csvimport;
 
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult;
 import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryImportResult;
@@ -253,6 +254,8 @@ public class CsvSampleImporter extends InventoryItemCsvImporter {
             if (!StringUtils.isBlank(value)) {
               if (sampleField.isOptionsStoringField()) {
                 sampleField.setSelectedOptions(Arrays.asList(value)); // assumes a single option
+              } else if (ApiFieldType.LINK.equals(sampleField.getType())) {
+                sampleField.setLink(linkParser.parse(value));
               } else {
                 sampleField.setContent(value);
               }

--- a/src/main/java/com/researchspace/service/inventory/csvimport/InventoryImportSampleFieldCreator.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/InventoryImportSampleFieldCreator.java
@@ -4,6 +4,7 @@ import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.field.InventoryDateField;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryIdentifierField;
+import com.researchspace.model.inventory.field.InventoryLinkField;
 import com.researchspace.model.inventory.field.InventoryNumberField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
 import com.researchspace.model.inventory.field.InventoryRadioFieldDef;
@@ -24,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** Recognise potential sample field type from provided values. */
@@ -35,6 +37,8 @@ public class InventoryImportSampleFieldCreator {
 
   /** Maximum number of distinct values for which field type 'radio' will be suggested */
   public static final int MAX_RADIO_OPTIONS = 20;
+
+  @Autowired CsvLinkValueParser linkParser;
 
   /** Ratio of distinct values to all values below which the radio type is suggested. */
   public static final double RADIO_REPEATING_OPTIONS_RATIO = 0.76;
@@ -67,6 +71,9 @@ public class InventoryImportSampleFieldCreator {
     // uri
     if (isSuggestedFieldForValues(valueSet, new InventoryUriField())) {
       return new InventoryUriField(name);
+    }
+    if (valueSet.stream().allMatch(linkParser::isParseable)) {
+      return new InventoryLinkField(name);
     }
     // time
     if (isSuggestedFieldForValues(valueSet, new InventoryTimeField())) {

--- a/src/main/java/com/researchspace/service/inventory/csvimport/InventoryItemCsvImporter.java
+++ b/src/main/java/com/researchspace/service/inventory/csvimport/InventoryItemCsvImporter.java
@@ -46,6 +46,7 @@ public abstract class InventoryItemCsvImporter {
 
   @Autowired protected InventoryBulkOperationHandler bulkOperationHandler;
   @Autowired protected InventoryImportSampleFieldCreator importedFieldCreator;
+  @Autowired protected CsvLinkValueParser linkParser;
   @Autowired protected InventoryIdentifierApiManager inventoryIdentifierApiManager;
   @Autowired protected MessageSourceUtils messages;
   @Autowired private ApiAvailabilityHandler apiHandler;

--- a/src/main/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImpl.java
+++ b/src/main/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImpl.java
@@ -33,7 +33,9 @@ public class InventoryLinkManagerImpl implements InventoryLinkManager {
   @Override
   public InventoryLink createLink(ApiInventoryLink apiLink, User actor) {
     validateForWrite(apiLink);
-    assertTargetExistsAndReadable(apiLink, actor);
+    if (!apiLink.isSkipTargetCheck()) {
+      assertTargetExistsAndReadable(apiLink, actor);
+    }
     InventoryLink entity = new InventoryLink();
     applyApiToEntity(apiLink, entity);
     return linkDao.save(entity);

--- a/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
+++ b/src/main/webapp/ui/src/modules/common/i18n/locales/en-US/server.inventory.json
@@ -100,6 +100,7 @@
         "instrumentCsvLineUnexpectedColumnCount": "Unexpected CSV line field count: expected {0, plural, one {# value} other {# values}}, but found {1, plural, one {# value} other {# values}}.",
         "instrumentTemplateIdAndTemplateInfoConflict": "Provide either ''templateId'' to use an existing instrument template or ''templateInfo'' to create a new one, but not both.",
         "instrumentUnrecognizedFieldMapping": "Unrecognized field mapping for instrument import: {0}",
+        "linkValueInvalid": "Link value ''{0}'' must be a DataCite relation type followed by a link URL on this server, for example ''IsDerivedFrom https://your-rspace/globalId/SA123v2''",
         "parentContainerImportIdWithGlobalId": "Parent container should be set via either 'Parent Container Import ID' or 'Parent Container Global ID', but not both at the same time",
         "parentContainerNotEditable": "Parent container with global id ''{0}'' doesn''t exist, or user has no permission to move items into it",
         "parentContainerNotFound": "Parent container with import id ''{0}'' could not be found",

--- a/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
+++ b/src/main/webapp/ui/src/modules/common/i18n/resources.d.ts
@@ -6807,6 +6807,7 @@ export default interface Resources {
           "instrumentCsvLineUnexpectedColumnCount": "Unexpected CSV line field count: expected {0, plural, one {# value} other {# values}}, but found {1, plural, one {# value} other {# values}}.",
           "instrumentTemplateIdAndTemplateInfoConflict": "Provide either ''templateId'' to use an existing instrument template or ''templateInfo'' to create a new one, but not both.",
           "instrumentUnrecognizedFieldMapping": "Unrecognized field mapping for instrument import: {0}",
+          "linkValueInvalid": "Link value ''{0}'' must be a DataCite relation type followed by a link URL on this server, for example ''IsDerivedFrom https://your-rspace/globalId/SA123v2''",
           "parentContainerGlobalIdInvalid": "Parent Container Global Id ''{0}'' is not a valid global id of an inventory container",
           "parentContainerImportIdWithGlobalId": "Parent container should be set via either 'Parent Container Import ID' or 'Parent Container Global ID', but not both at the same time",
           "parentContainerNotEditable": "Parent container with global id ''{0}'' doesn''t exist, or user has no permission to move items into it",

--- a/src/main/webapp/ui/src/stores/models/__tests__/ImportModel/instruments.test.tsx
+++ b/src/main/webapp/ui/src/stores/models/__tests__/ImportModel/instruments.test.tsx
@@ -350,3 +350,27 @@ describe("setFile", () => {
     expect(model.instrumentTemplateName).not.toBe(initialName);
   });
 });
+
+describe("link-typed columns", () => {
+  test("a column the backend suggests as link defaults to Link and submits as type link", () => {
+    const model = new ImportModel("INSTRUMENTS");
+    const linkMapping = makeMapping(model, "INSTRUMENTS", {
+      field: Fields.custom,
+      fieldName: "Calibrated by",
+      columnName: "Calibrated by",
+      fieldType: FieldTypes.link,
+    });
+    expect(linkMapping.chosenFieldType).toBe(FieldTypes.link);
+    expect(linkMapping.allValidTypes).toContain(FieldTypes.link);
+    runInAction(() => {
+      model.instrumentTemplateInfo = {
+        name: "template",
+        fields: [{ name: "Calibrated by", type: "link" }],
+      };
+      model.instrumentTemplateName = "Links";
+      model.instrumentsMappings = [linkMapping];
+    });
+    const result = model.transformInstrumentTemplateInfoForSubmission();
+    expect((result.fields[0] as { type: string }).type).toBe("link");
+  });
+});

--- a/src/test/java/com/researchspace/api/v1/controller/InventoryImportApiControllerMVCIT.java
+++ b/src/test/java/com/researchspace/api/v1/controller/InventoryImportApiControllerMVCIT.java
@@ -12,11 +12,13 @@ import com.researchspace.api.v1.model.ApiContainer;
 import com.researchspace.api.v1.model.ApiField.ApiFieldType;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult;
 import com.researchspace.api.v1.model.ApiInventoryBulkOperationResult.InventoryBulkOperationStatus;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
 import com.researchspace.api.v1.model.ApiInventoryImportPartialResult;
 import com.researchspace.api.v1.model.ApiInventoryImportResult;
 import com.researchspace.api.v1.model.ApiInventoryImportSampleImportResult;
 import com.researchspace.api.v1.model.ApiInventoryImportSampleParseResult;
 import com.researchspace.api.v1.model.ApiInventoryImportSubSampleImportResult;
+import com.researchspace.api.v1.model.ApiInventoryLink;
 import com.researchspace.api.v1.model.ApiInventoryRecordInfo;
 import com.researchspace.api.v1.model.ApiInventorySearchResult;
 import com.researchspace.api.v1.model.ApiSampleTemplatePost;
@@ -32,12 +34,14 @@ import com.researchspace.model.inventory.DigitalObjectIdentifier;
 import com.researchspace.model.inventory.SampleSource;
 import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.units.RSUnitDef;
+import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.ApiAvailabilityHandler;
 import com.researchspace.service.inventory.ContainerApiManager;
 import com.researchspace.service.inventory.SampleApiManager;
 import com.researchspace.service.inventory.csvimport.CsvSampleImporter;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,6 +80,7 @@ public class InventoryImportApiControllerMVCIT extends API_MVC_InventoryTestBase
 
   @Autowired private DigitalObjectIdentifierDao doiDao;
   @Autowired private CsvSampleImporter csvSampleImporter;
+  @Autowired private IPropertyHolder propertyHolder;
   @Mock private ApiAvailabilityHandler apiHandler;
 
   @BeforeEach
@@ -1188,6 +1193,85 @@ public class InventoryImportApiControllerMVCIT extends API_MVC_InventoryTestBase
     assertEquals(
         "CSV file is too long, import limit is set to 500 containers.",
         csvSizeException.getMessage());
+  }
+
+  /**
+   * RSDEV-1354: a link column exported as "RelationType serverUrl/globalId/GID[vN]" is suggested as
+   * a Link field on parse and re-imported as a link, even when the target does not exist on this
+   * server (a dangling link, rendered by the UI as a missing target).
+   */
+  @Test
+  public void parseAndImportSampleCsvWithLinkColumn() throws Exception {
+    String serverUrl = propertyHolder.getServerUrl();
+    if (serverUrl.endsWith("/")) {
+      serverUrl = serverUrl.substring(0, serverUrl.length() - 1);
+    }
+    String csv =
+        "Name,Related\n"
+            + "linked sample,IsDerivedFrom "
+            + serverUrl
+            + "/globalId/SA999999v2\n"
+            + "unlinked sample,\n";
+    MockMultipartFile parseFile =
+        new MockMultipartFile(
+            "file", "links.csv", "text/csv", csv.getBytes(StandardCharsets.UTF_8));
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                multipart(createUrl(API_VERSION.ONE, "/import/parseFile"))
+                    .file(parseFile)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .param("recordType", "SAMPLES")
+                    .header("apiKey", apiKey))
+            .andReturn();
+    assertNull(result.getResolvedException());
+    ApiInventoryImportSampleParseResult parseResult =
+        getFromJsonResponseBody(result, ApiInventoryImportSampleParseResult.class);
+    ApiSampleTemplatePost templateInfo = parseResult.getTemplateInfo();
+    assertEquals(ApiFieldType.LINK, templateInfo.getFields().get(1).getType());
+    templateInfo.setExpiryDate(null);
+    templateInfo.getFields().remove(0); // Name column maps to the sample name
+
+    String settingsJson =
+        "{ \"sampleSettings\": { \"fieldMappings\": { \"Name\": \"name\"}, \"templateInfo\": "
+            + JacksonUtil.toJson(templateInfo)
+            + "} }";
+    result =
+        mockMvc
+            .perform(
+                multipart(createUrl(API_VERSION.ONE, "/import/importFiles"))
+                    .file(
+                        new MockMultipartFile(
+                            "samplesFile",
+                            "links.csv",
+                            "text/csv",
+                            csv.getBytes(StandardCharsets.UTF_8)))
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .param("importSettings", settingsJson)
+                    .header("apiKey", apiKey))
+            .andReturn();
+    assertNull(result.getResolvedException());
+
+    ApiInventoryImportResult importResult =
+        getFromJsonResponseBody(result, ApiInventoryImportResult.class);
+    ApiInventoryImportSampleImportResult sampleResults = importResult.getSampleResult();
+    assertEquals(InventoryBulkOperationStatus.COMPLETED, sampleResults.getStatus());
+    assertEquals(2, sampleResults.getSuccessCount());
+
+    ApiSampleWithFullSubSamples linked =
+        (ApiSampleWithFullSubSamples) sampleResults.getResults().get(0).getRecord();
+    ApiInventoryEntityField linkField = linked.getFields().get(0);
+    assertEquals(ApiFieldType.LINK, linkField.getType());
+    ApiInventoryLink link = linkField.getLink();
+    assertNotNull(link);
+    assertEquals("IsDerivedFrom", link.getRelationType());
+    assertEquals("SA999999", link.getTargetGlobalId());
+    assertEquals(2L, link.getVersionPin());
+
+    ApiSampleWithFullSubSamples unlinked =
+        (ApiSampleWithFullSubSamples) sampleResults.getResults().get(1).getRecord();
+    assertNull(unlinked.getFields().get(0).getLink());
   }
 
   private MockMultipartFile getTestCsvFile(String paramName, String fileName)

--- a/src/test/java/com/researchspace/service/inventory/csvexport/CsvSampleLinkExportTest.java
+++ b/src/test/java/com/researchspace/service/inventory/csvexport/CsvSampleLinkExportTest.java
@@ -1,0 +1,94 @@
+package com.researchspace.service.inventory.csvexport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
+import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.model.inventory.field.InventoryLinkField;
+import com.researchspace.properties.IPropertyHolder;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Link fields export as "<RelationType> <serverUrl>/globalId/<GID>[vN]" in a single cell. */
+public class CsvSampleLinkExportTest {
+
+  private final CsvSampleExporter exporter = new CsvSampleExporter();
+  private Sample sample;
+  private InventoryLinkField templateLinkField;
+  private ExtraLinkField extraLinkField;
+
+  @BeforeEach
+  void setUp() {
+    IPropertyHolder properties = mock(IPropertyHolder.class);
+    when(properties.getServerUrl()).thenReturn("https://rspace.example.com/");
+    exporter.properties = properties;
+
+    SampleTemplate template = new SampleTemplate();
+    template.setId(7L);
+    InventoryLinkField templateField = new InventoryLinkField();
+    templateField.setName("Derived from");
+    template.addSampleField(templateField);
+
+    sample = new Sample();
+    sample.setId(5L);
+    templateLinkField = new InventoryLinkField();
+    templateLinkField.setName("Derived from");
+    templateLinkField.setTemplateField(templateField);
+    sample.addSampleField(templateLinkField);
+
+    extraLinkField = new ExtraLinkField();
+    extraLinkField.setName("See also");
+    sample.addExtraField(extraLinkField);
+  }
+
+  @Test
+  void pinnedAndUnpinnedLinksExportAsRelationTypeAndGlobalIdUrl() throws IOException {
+    templateLinkField.setLink(link("IsDerivedFrom", GlobalIdPrefix.SA, 123L, 2L));
+    extraLinkField.setLink(link("Cites", GlobalIdPrefix.GL, 44L, null));
+
+    List<String> row = exportRow();
+
+    assertEquals("IsDerivedFrom https://rspace.example.com/globalId/SA123v2", cell(row, 12));
+    assertEquals("Cites https://rspace.example.com/globalId/GL44", cell(row, 13));
+  }
+
+  @Test
+  void unsetLinksExportAsEmptyCells() throws IOException {
+    List<String> row = exportRow();
+
+    assertEquals("", cell(row, 12));
+    assertEquals("", cell(row, 13));
+  }
+
+  private List<String> exportRow() throws IOException {
+    List<String> columns = new ArrayList<>(Collections.nCopies(12, "basic"));
+    columns.add(exporter.getColumnNameForSampleField(templateLinkField));
+    columns.add(exporter.getColumnNameForExtraField(extraLinkField));
+    return exporter.writeSampleCsvDetailsIntoOutput(
+        sample, columns, CsvExportMode.FULL, null, new ByteArrayOutputStream());
+  }
+
+  private static String cell(List<String> row, int index) {
+    return row.get(index);
+  }
+
+  private static InventoryLink link(String relation, GlobalIdPrefix prefix, long dbId, Long pin) {
+    InventoryLink link = new InventoryLink();
+    link.setRelationType(relation);
+    link.setTargetPrefix(prefix);
+    link.setTargetDbId(dbId);
+    link.setTargetGlobalId(prefix.name() + dbId);
+    link.setVersionPin(pin);
+    return link;
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/csvimport/CsvInstrumentImporterLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/csvimport/CsvInstrumentImporterLinkFieldTest.java
@@ -1,0 +1,79 @@
+package com.researchspace.service.inventory.csvimport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInstrument;
+import com.researchspace.api.v1.model.ApiInstrumentTemplate;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryImportInstrumentImportResult;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.model.User;
+import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.MessageSourceUtils;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Instrument import applies the same link-cell handling as sample import. */
+public class CsvInstrumentImporterLinkFieldTest {
+
+  private final CsvInstrumentImporter importer = new CsvInstrumentImporter();
+  private final ApiInventoryImportInstrumentImportResult result =
+      new ApiInventoryImportInstrumentImportResult();
+
+  @BeforeEach
+  void setUp() {
+    CsvLinkValueParser parser = new CsvLinkValueParser();
+    IPropertyHolder properties = mock(IPropertyHolder.class);
+    when(properties.getServerUrl()).thenReturn("https://rspace.example.com");
+    parser.properties = properties;
+    MessageSourceUtils messages = mock(MessageSourceUtils.class);
+    when(messages.getMessage(eq("errors.inventory.import.linkValueInvalid"), any()))
+        .thenReturn("bad link cell");
+    parser.messages = messages;
+    importer.linkParser = parser;
+    importer.messages = messages;
+
+    ApiInstrumentTemplate template = new ApiInstrumentTemplate();
+    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
+    linkField.setName("Calibrated by");
+    linkField.setType(ApiFieldType.LINK);
+    template.getFields().add(linkField);
+    result.addCreatedTemplateResult(template);
+  }
+
+  @Test
+  void linkCellBecomesInstrumentFieldLink() {
+    List<String[]> lines =
+        List.<String[]>of(
+            new String[] {"i1", "IsCalibratedBy https://rspace.example.com/globalId/SD7"});
+
+    importer.convertLinesToInstruments(result, lines, Map.of(0, "name"), 2, new User("u"));
+
+    assertEquals(1, result.getSuccessCount());
+    ApiInventoryEntityField field =
+        ((ApiInstrument) result.getResults().get(0).getRecord()).getFields().get(0);
+    ApiInventoryLink link = field.getLink();
+    assertEquals("IsCalibratedBy", link.getRelationType());
+    assertEquals("SD7", link.getTargetGlobalId());
+    assertNull(link.getVersionPin());
+    assertNull(field.getContent());
+  }
+
+  @Test
+  void malformedLinkCellFailsTheRow() {
+    List<String[]> lines = List.<String[]>of(new String[] {"i1", "nonsense"});
+
+    importer.convertLinesToInstruments(result, lines, Map.of(0, "name"), 2, new User("u"));
+
+    assertEquals(1, result.getErrorCount());
+    assertEquals("bad link cell", result.getResults().get(0).getError().getErrors().get(0));
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/csvimport/CsvLinkValueParserTest.java
+++ b/src/test/java/com/researchspace/service/inventory/csvimport/CsvLinkValueParserTest.java
@@ -1,0 +1,77 @@
+package com.researchspace.service.inventory.csvimport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.MessageSourceUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Parses the "<RelationType> <serverUrl>/globalId/<GID>[vN]" cell written by the CSV exporters. */
+public class CsvLinkValueParserTest {
+
+  private final CsvLinkValueParser parser = new CsvLinkValueParser();
+
+  @BeforeEach
+  void setUp() {
+    IPropertyHolder properties = mock(IPropertyHolder.class);
+    when(properties.getServerUrl()).thenReturn("https://rspace.example.com/");
+    parser.properties = properties;
+    MessageSourceUtils messages = mock(MessageSourceUtils.class);
+    when(messages.getMessage(eq("errors.inventory.import.linkValueInvalid"), any()))
+        .thenReturn("bad link cell");
+    parser.messages = messages;
+  }
+
+  @Test
+  void parsesPinnedLinkIntoRelationBaseIdAndVersion() {
+    ApiInventoryLink link =
+        parser.parse("IsDerivedFrom https://rspace.example.com/globalId/SA123v2");
+
+    assertEquals("IsDerivedFrom", link.getRelationType());
+    assertEquals("SA123", link.getTargetGlobalId());
+    assertEquals(2L, link.getVersionPin());
+    assertTrue(link.isSkipTargetCheck());
+  }
+
+  @Test
+  void unpinnedLinkHasNullVersion() {
+    ApiInventoryLink link = parser.parse("Cites https://rspace.example.com/globalId/GL44");
+
+    assertEquals("GL44", link.getTargetGlobalId());
+    assertNull(link.getVersionPin());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "NotARelation https://rspace.example.com/globalId/SA123",
+        "Cites https://other.example.com/globalId/SA123",
+        "Cites SA123",
+        "Cites https://rspace.example.com/globalId/US123",
+        "https://rspace.example.com/globalId/SA123",
+        "Cites https://rspace.example.com/globalId/SA123 extra"
+      })
+  void rejectsMalformedForeignHostBareIdAndDisallowedPrefix(String cell) {
+    assertEquals(
+        "bad link cell",
+        assertThrows(IllegalArgumentException.class, () -> parser.parse(cell)).getMessage());
+    assertFalse(parser.isParseable(cell));
+  }
+
+  @Test
+  void isParseableIsTrueForValidCell() {
+    assertTrue(parser.isParseable("Cites https://rspace.example.com/globalId/SD9"));
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/csvimport/CsvSampleImporterLinkFieldTest.java
+++ b/src/test/java/com/researchspace/service/inventory/csvimport/CsvSampleImporterLinkFieldTest.java
@@ -1,0 +1,93 @@
+package com.researchspace.service.inventory.csvimport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.model.ApiField.ApiFieldType;
+import com.researchspace.api.v1.model.ApiInventoryEntityField;
+import com.researchspace.api.v1.model.ApiInventoryImportSampleImportResult;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.api.v1.model.ApiSampleTemplate;
+import com.researchspace.api.v1.model.ApiSampleWithFullSubSamples;
+import com.researchspace.model.User;
+import com.researchspace.properties.IPropertyHolder;
+import com.researchspace.service.MessageSourceUtils;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A CSV column mapped to a Link template field becomes the sample field's link, not its content.
+ */
+public class CsvSampleImporterLinkFieldTest {
+
+  private final CsvSampleImporter importer = new CsvSampleImporter();
+  private final ApiInventoryImportSampleImportResult result =
+      new ApiInventoryImportSampleImportResult();
+
+  @BeforeEach
+  void setUp() {
+    CsvLinkValueParser parser = new CsvLinkValueParser();
+    IPropertyHolder properties = mock(IPropertyHolder.class);
+    when(properties.getServerUrl()).thenReturn("https://rspace.example.com");
+    parser.properties = properties;
+    MessageSourceUtils messages = mock(MessageSourceUtils.class);
+    when(messages.getMessage(eq("errors.inventory.import.linkValueInvalid"), any()))
+        .thenReturn("bad link cell");
+    parser.messages = messages;
+    importer.linkParser = parser;
+    importer.messages = messages;
+
+    ApiSampleTemplate template = new ApiSampleTemplate();
+    ApiInventoryEntityField linkField = new ApiInventoryEntityField();
+    linkField.setName("Derived from");
+    linkField.setType(ApiFieldType.LINK);
+    template.getFields().add(linkField);
+    result.addCreatedTemplateResult(template);
+  }
+
+  @Test
+  void linkCellBecomesFieldLinkAndBlankCellLeavesNoLink() {
+    List<String[]> lines =
+        List.of(
+            new String[] {"s1", "IsDerivedFrom https://rspace.example.com/globalId/SA1v3"},
+            new String[] {"s2", ""});
+
+    importer.convertLinesToSamples(result, lines, Map.of(0, "name"), 2, new User("u"));
+
+    assertEquals(2, result.getSuccessCount());
+    ApiInventoryLink link = field(0).getLink();
+    assertEquals("IsDerivedFrom", link.getRelationType());
+    assertEquals("SA1", link.getTargetGlobalId());
+    assertEquals(3L, link.getVersionPin());
+    assertTrue(link.isSkipTargetCheck());
+    assertNull(field(0).getContent());
+    assertNull(field(1).getLink());
+  }
+
+  @Test
+  void malformedLinkCellFailsTheRowOnly() {
+    List<String[]> lines =
+        List.of(
+            new String[] {"s1", "not a link"},
+            new String[] {"s2", "Cites https://rspace.example.com/globalId/SD9"});
+
+    importer.convertLinesToSamples(result, lines, Map.of(0, "name"), 2, new User("u"));
+
+    assertEquals(1, result.getErrorCount());
+    assertEquals(1, result.getSuccessCount());
+    assertEquals("bad link cell", result.getResults().get(0).getError().getErrors().get(0));
+  }
+
+  private ApiInventoryEntityField field(int row) {
+    ApiSampleWithFullSubSamples sample =
+        (ApiSampleWithFullSubSamples) result.getResults().get(row).getRecord();
+    return sample.getFields().get(0);
+  }
+}

--- a/src/test/java/com/researchspace/service/inventory/csvimport/InventoryImportInventoryEntityFieldCreatorTest.java
+++ b/src/test/java/com/researchspace/service/inventory/csvimport/InventoryImportInventoryEntityFieldCreatorTest.java
@@ -3,20 +3,48 @@ package com.researchspace.service.inventory.csvimport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryRadioField;
 import com.researchspace.model.units.RSUnitDef;
+import com.researchspace.properties.IPropertyHolder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class InventoryImportInventoryEntityFieldCreatorTest {
 
   InventoryImportSampleFieldCreator helper = new InventoryImportSampleFieldCreator();
+
+  @BeforeEach
+  void wireLinkParser() {
+    CsvLinkValueParser linkParser = new CsvLinkValueParser();
+    IPropertyHolder properties = mock(IPropertyHolder.class);
+    when(properties.getServerUrl()).thenReturn("https://rspace.example.com");
+    linkParser.properties = properties;
+    helper.linkParser = linkParser;
+  }
+
+  @Test
+  public void linkSuggestedOnlyWhenEveryValueIsALinkCell() {
+    List<String> values = new ArrayList<>();
+    values.add("IsDerivedFrom https://rspace.example.com/globalId/SA1v2");
+    values.add("");
+    values.add("Cites https://rspace.example.com/globalId/SD9");
+    InventoryEntityField field = helper.getSuggestedSampleFieldForNameAndValues("links", values);
+    assertEquals(FieldType.LINK, field.getType());
+    assertEquals("links", field.getName());
+
+    values.add("Cites https://elsewhere.example.com/globalId/SD9");
+    field = helper.getSuggestedSampleFieldForNameAndValues("links", values);
+    assertEquals(FieldType.STRING, field.getType());
+  }
 
   @Test
   public void testColumnTypeRecognition() {

--- a/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplSkipTargetCheckTest.java
+++ b/src/test/java/com/researchspace/service/inventory/impl/InventoryLinkManagerImplSkipTargetCheckTest.java
@@ -1,0 +1,62 @@
+package com.researchspace.service.inventory.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.api.v1.auth.ApiRuntimeException;
+import com.researchspace.api.v1.model.ApiInventoryLink;
+import com.researchspace.dao.InventoryLinkDao;
+import com.researchspace.model.User;
+import com.researchspace.model.inventory.field.InventoryLink;
+import com.researchspace.service.inventory.LinkTargetResolver;
+import com.researchspace.service.inventory.LinkTargetSnapshotResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** CSV import stores dangling links; every other caller still needs a readable target. */
+@ExtendWith(MockitoExtension.class)
+class InventoryLinkManagerImplSkipTargetCheckTest {
+
+  @Mock private InventoryLinkDao linkDao;
+  @Mock private LinkTargetResolver linkTargetResolver;
+  @Mock private LinkTargetSnapshotResolver snapshotResolver;
+  @InjectMocks private InventoryLinkManagerImpl manager;
+
+  private final User actor = new User("importer");
+  private ApiInventoryLink apiLink;
+
+  @BeforeEach
+  void setUp() {
+    apiLink = new ApiInventoryLink();
+    apiLink.setRelationType("Cites");
+    apiLink.setTargetGlobalId("SA123");
+  }
+
+  @Test
+  void skipTargetCheckStoresLinkWithoutResolvingTarget() {
+    apiLink.setSkipTargetCheck(true);
+    when(linkDao.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    InventoryLink saved = manager.createLink(apiLink, actor);
+
+    assertEquals("SA123", saved.getTargetGlobalId());
+    assertEquals("Cites", saved.getRelationType());
+    verify(linkTargetResolver, never()).targetExistsAndIsReadable(any(), any());
+  }
+
+  @Test
+  void defaultStillRejectsUnresolvableTarget() {
+    when(linkTargetResolver.targetExistsAndIsReadable(any(), any())).thenReturn(false);
+
+    assertThrows(ApiRuntimeException.class, () -> manager.createLink(apiLink, actor));
+    verify(linkDao, never()).save(any());
+  }
+}


### PR DESCRIPTION
## Summary

Inventory link fields (RSDEV-1131) now round-trip through CSV export and import.

### Export

Every link field, whether a sample or instrument template field or an extra field on any record type, now exports to its existing column as a single cell:

```
<RelationType> <serverUrl>/globalId/<GID>[vN]
```

for example `IsDerivedFrom https://rspace.example.com/globalId/SA123v2`. The version pin travels as the `vN` suffix. Unset links export as an empty cell. Previously the cell was always empty because link fields hold no data-column value.

### Import (samples and instruments)

- The server-side type suggester proposes **Link** for a column whose non-blank values all parse, so the mapping UI defaults that column to "Custom Field (Link)" and offers Link in the type dropdown. No frontend code change was needed: the Link type, label, icon and help text already existed.
- A Link-typed column becomes the field's link (relation type, base Global ID, version pin) instead of its content. A malformed cell fails that row with a new externalised message and leaves other rows unaffected.
- Only URLs on this server are accepted. A Global ID from another RSpace instance is rejected rather than silently attached to a different local record.
- Targets that are missing or unreadable on this server are still stored. The import sets a JSON-ignored `skipTargetCheck` flag on the link DTO, and the link manager skips only the exists-and-readable check for it. The UI then shows the existing missing or no-access state for that link, matching what happens when a target is deleted or unshared after linking.

Container and subsample import has no custom-field path today, so their link fields export but have nowhere to land on import. That is unchanged by this PR.

### Tests

Fast unit tests (all green locally): `CsvSampleLinkExportTest`, `CsvLinkValueParserTest`, `InventoryImportInventoryEntityFieldCreatorTest`, `InventoryLinkManagerImplSkipTargetCheckTest`, `CsvSampleImporterLinkFieldTest`, `CsvInstrumentImporterLinkFieldTest`, plus a link-column case in `ImportModel/instruments.test.tsx`.

`InventoryImportApiControllerMVCIT.parseAndImportSampleCsvWithLinkColumn` covers parse and import of a dangling pinned link end to end. It compiles but was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
