### PR TITLE
RSDEV-1327: stop sending redirect_uri on the GitHub authorize URL

### DIFF
--- a/src/main/java/com/researchspace/webapp/integrations/github/GitHubController.java
+++ b/src/main/java/com/researchspace/webapp/integrations/github/GitHubController.java
@@ -15,8 +15,6 @@ import com.researchspace.webapp.integrations.helper.OauthAuthorizationError;
 import com.researchspace.webapp.integrations.helper.OauthAuthorizationError.OauthAuthorizationErrorBuilder;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -200,18 +198,9 @@ public class GitHubController extends BaseOAuth2Controller {
   @GetMapping("/oauthUrl")
   @ResponseBody
   public AjaxReturnObject<String> oauthUrl() {
-    String redirectUri =
-        URLEncoder.encode(
-            properties.getServerUrl() + "/github/redirect_uri", StandardCharsets.UTF_8);
     String state = generateState();
     var url =
-        githubAuthorizeUrl
-            + "?scope=repo,user&client_id="
-            + this.clientId
-            + "&redirect_uri="
-            + redirectUri
-            + "&state="
-            + state;
+        githubAuthorizeUrl + "?scope=repo,user&client_id=" + this.clientId + "&state=" + state;
     return new AjaxReturnObject<>(url, null);
   }
 

--- a/src/test/java/com/researchspace/webapp/integrations/github/GitHubControllerMVCIT.java
+++ b/src/test/java/com/researchspace/webapp/integrations/github/GitHubControllerMVCIT.java
@@ -3,6 +3,8 @@ package com.researchspace.webapp.integrations.github;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
@@ -14,6 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.researchspace.Constants;
 import com.researchspace.model.User;
 import com.researchspace.service.IntegrationsHandler;
@@ -35,7 +38,9 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @WebAppConfiguration
 public class GitHubControllerMVCIT extends MVCTestBase {
@@ -133,6 +138,34 @@ public class GitHubControllerMVCIT extends MVCTestBase {
     assertNull(result.getModelAndView().getModel().get("connectionToken"));
     assertNotNull(result.getModelAndView().getModel().get("connectionError"));
     server.verify();
+  }
+
+  @Test
+  public void testOauthUrlOmitsRedirectUri() throws Exception {
+    User user = createAndSaveUser(getRandomAlphabeticString("user"), Constants.USER_ROLE);
+    initUsers(user);
+    logoutAndLoginAs(user);
+
+    MvcResult result =
+        this.mockMvc
+            .perform(get("/github/oauthUrl").principal(user::getUsername))
+            .andExpect(status().isOk())
+            .andReturn();
+    String url =
+        new ObjectMapper().readTree(result.getResponse().getContentAsString()).get("data").asText();
+    MultiValueMap<String, String> query =
+        UriComponentsBuilder.fromUriString(url).build().getQueryParams();
+
+    // GitHub validates redirect_uri only when it is sent and requires an exact match with the
+    // callback registered on the OAuth app, so the authorize URL must leave it out.
+    assertFalse(query.containsKey("redirect_uri"));
+    assertEquals(githubClientId, query.getFirst("client_id"));
+    assertEquals("repo,user", query.getFirst("scope"));
+    String state = query.getFirst("state");
+    assertNotNull(state);
+    assertFalse(state.isEmpty());
+    assertEquals(
+        state, SessionAttributeUtils.getSessionAttribute(SessionAttributeUtils.RS_OAUTH_STATE));
   }
 
   private void addExampleRepositories(User user) {


### PR DESCRIPTION
## Description ##

Fixes RSDEV-1327. Since #1024 the GitHub authorize URL carried `redirect_uri=<server.urls.prefix>/github/redirect_uri`. GitHub only validates that parameter when it is present, and requires an exact match with the callback URL registered on the OAuth app.

This caused the integration to stop working on some internal servers.

This PR drops the parameter to revert the behaviour to as it was before #1024.

Tested locally using ngrok. Recreated the issue, then applied to fix and was able to authenticate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
