### PR TITLE
Honor filestore duplicate strategies consistently for file and stream uploads

### DIFF
--- a/src/main/java/com/researchspace/files/service/FileStore.java
+++ b/src/main/java/com/researchspace/files/service/FileStore.java
@@ -35,10 +35,16 @@ public interface FileStore {
   /**
    * Save a file to the path to be calculated from {@link FileProperty}.
    *
+   * <p>Both save overloads honor the duplicate strategy: {@code ERROR} returns {@code null} without
+   * changing the existing file, {@code REPLACE} overwrites it, and {@code AS_NEW} reserves a
+   * distinct path and updates the supplied metadata to reference it. On collision, the new filename
+   * uses a UUID and retains the original extension if it is at most 20 UTF-8 bytes. Longer
+   * extensions are omitted. A second collision fails without retrying.
+   *
    * @param fileProperty, a new constructed FileProperty,
    * @param sourceFile, specify the resource/file location
    * @param behaviourOnDuplicate, a {@link FileDuplicateStrategy}
-   * @return new file URI in file store.
+   * @return new file URI in file store, or {@code null} when a duplicate is rejected.
    */
   URI save(FileProperty fileProperty, File sourceFile, FileDuplicateStrategy behaviourOnDuplicate)
       throws IOException;

--- a/src/main/java/com/researchspace/files/service/FileStoreImpl.java
+++ b/src/main/java/com/researchspace/files/service/FileStoreImpl.java
@@ -41,6 +41,9 @@ public class FileStoreImpl implements FileStore {
       throws IOException {
     //  save to local file storage first
     URI localFile = localFileStore.save(fileProperty, sourceFile, behaviourOnDuplicate);
+    if (localFile == null) {
+      return null;
+    }
     // see if we've got external FS setup.
     Optional<ExternalFileStoreWithCredentials> extFileStoreOpt = getExternalFS(fileProperty);
     extFileStoreOpt.map(
@@ -56,6 +59,9 @@ public class FileStoreImpl implements FileStore {
       FileDuplicateStrategy behaviourOnDuplicate)
       throws IOException {
     URI localFile = localFileStore.save(fileProperty, inStream, fileName, behaviourOnDuplicate);
+    if (localFile == null) {
+      return null;
+    }
     Optional<ExternalFileStoreWithCredentials> extFileStoreOpt = getExternalFS(fileProperty);
     extFileStoreOpt.map(
         exFS -> doExternalSave(fileProperty, new File(localFile), behaviourOnDuplicate, exFS));

--- a/src/main/java/com/researchspace/service/impl/DocumentCopyManagerImpl.java
+++ b/src/main/java/com/researchspace/service/impl/DocumentCopyManagerImpl.java
@@ -47,12 +47,12 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.shiro.authz.AuthorizationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -482,17 +482,13 @@ public class DocumentCopyManagerImpl implements DocumentCopyManager {
   }
 
   private String createNewFileName(FileProperty sourceFileProperty) {
-    String originalFileName = sourceFileProperty.getFileName();
-    String result = "";
-    Date date = new Date();
-    // This replaces all _epochMilli timestamps that have been added to the filename previously
-    result = originalFileName.replaceAll("_\\d{13,}", "");
-    result =
-        result.substring(0, result.lastIndexOf('.'))
-            + "_"
-            + date.getTime()
-            + result.substring(result.lastIndexOf('.'));
-    return result;
+    // Remove timestamps previously appended when copying the file.
+    String name = sourceFileProperty.getFileName().replaceAll("_\\d{13,}", "");
+    String extension = FilenameUtils.getExtension(name);
+    return FilenameUtils.getBaseName(name)
+        + "_"
+        + System.currentTimeMillis()
+        + (extension.isEmpty() ? "" : "." + extension);
   }
 
   /* copies and updates content link to media files / thumbnails / av */

--- a/src/main/java/com/researchspace/service/impl/InternalFileStoreImpl.java
+++ b/src/main/java/com/researchspace/service/impl/InternalFileStoreImpl.java
@@ -121,6 +121,7 @@ public class InternalFileStoreImpl implements InternalFileStore {
       if (suc == 0) {
         // Keep the existing file intact until the replacement has been written successfully.
         replacement = Files.createTempFile(out.toPath().getParent(), ".replacement-", ".tmp");
+        Files.setPosixFilePermissions(replacement, Files.getPosixFilePermissions(out.toPath()));
       }
       long size;
       try (FileOutputStream output =

--- a/src/main/java/com/researchspace/service/impl/InternalFileStoreImpl.java
+++ b/src/main/java/com/researchspace/service/impl/InternalFileStoreImpl.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -115,15 +116,31 @@ public class InternalFileStoreImpl implements InternalFileStore {
       return null;
     }
     File out = new File(baseDir, fileProperty.getRelPath());
+    Path replacement = null;
     try {
+      if (suc == 0) {
+        // Keep the existing file intact until the replacement has been written successfully.
+        replacement = Files.createTempFile(out.toPath().getParent(), ".replacement-", ".tmp");
+      }
       long size;
-      try (FileOutputStream output = new FileOutputStream(out)) {
+      try (FileOutputStream output =
+          new FileOutputStream(replacement == null ? out : replacement.toFile())) {
         size = fileOp.copyStream(output, inStream, 0);
       }
       fileProperty.setFileSize(Long.toString(size));
       fileMetadataDao.save(fileProperty);
+      if (replacement != null) {
+        Files.move(
+            replacement,
+            out.toPath(),
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING);
+      }
       return out.toURI();
     } catch (IOException | RuntimeException e) {
+      if (replacement != null) {
+        removeReservedFile(replacement, e);
+      }
       if (suc == 100) {
         removeReservedFile(out.toPath(), e);
       }

--- a/src/main/java/com/researchspace/service/impl/InternalFileStoreImpl.java
+++ b/src/main/java/com/researchspace/service/impl/InternalFileStoreImpl.java
@@ -20,9 +20,14 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
@@ -109,11 +114,11 @@ public class InternalFileStoreImpl implements InternalFileStore {
       FileProperty fileProperty,
       InputStream inStream,
       String fnm,
-      FileDuplicateStrategy behavoiurOnDuplicate)
+      FileDuplicateStrategy behaviourOnDuplicate)
       throws IOException {
     checkInitialised();
     fnm = EscapeReplacement.replaceChars(fnm); // get ride funny characters
-    int suc = addMetadata(fileProperty, fnm, FileDuplicateStrategy.AS_NEW);
+    int suc = addMetadata(fileProperty, fnm, behaviourOnDuplicate);
     FileStoreRoot root = fileMetadataDao.getCurrentFileStoreRoot(false);
     fileProperty.setRoot(root);
     if (suc >= 0) { // success path
@@ -228,56 +233,52 @@ public class InternalFileStoreImpl implements InternalFileStore {
     return path.substring(idx + 1);
   }
 
-  /*
-   *
-   * @param meta
-   * @param fnm
-   * @param existCd -1 =error if already exists, 0 =replace, 1=add as new
-   * @return 0 if replace was successful, 100 if add as new successful
-   *  If could not be added: returns -1 if existCd was -1
-   */
-  int addMetadata(FileProperty meta, String fnm, FileDuplicateStrategy duplicateBehaviour) {
+  /** Reserves a destination for new files before saving their metadata. */
+  int addMetadata(FileProperty meta, String fnm, FileDuplicateStrategy duplicateBehaviour)
+      throws IOException {
     meta.setRoot(currentRootFs);
-    boolean success = true;
-    int rst = 100; // add one
+    if (StringUtils.isEmpty(meta.getFileName())) {
+      meta.setFileName(fnm);
+    }
+    meta.generateURIFromProperties(baseDir);
+    Path destination = baseDir.toPath().resolve(meta.getRelPath());
+    Files.createDirectories(destination.getParent());
+    boolean reserved = false;
+    if (duplicateBehaviour != FileDuplicateStrategy.REPLACE) {
+      try {
+        Files.createFile(destination);
+      } catch (FileAlreadyExistsException e) {
+        if (duplicateBehaviour == FileDuplicateStrategy.ERROR) {
+          return -1;
+        }
+        String extension = FilenameUtils.getExtension(meta.getFileName());
+        // Keep ordinary extensions intact; omit extensions exceeding 20 UTF-8 bytes.
+        if (extension.getBytes(StandardCharsets.UTF_8).length > 20) {
+          extension = "";
+        }
+        meta.setFileName(
+            EscapeReplacement.replaceChars(
+                UUID.randomUUID() + (extension.isEmpty() ? "" : "." + extension)));
+        meta.generateURIFromProperties(baseDir);
+        destination = baseDir.toPath().resolve(meta.getRelPath());
+        Files.createFile(destination);
+      }
+      reserved = true;
+    }
     try {
-      if (StringUtils.isEmpty(meta.getFileName())) {
-        meta.setFileName(fnm);
+      fileMetadataDao.save(meta);
+    } catch (RuntimeException e) {
+      log.warn("Could not save file metadata for file :{}", meta.getRelPath(), e);
+      if (reserved) {
+        try {
+          Files.delete(destination);
+        } catch (IOException cleanupFailure) {
+          e.addSuppressed(cleanupFailure);
+        }
       }
-      meta.generateURIFromProperties(baseDir);
-      if (meta.getAbsolutePathUri() != null
-          && FileDuplicateStrategy.REPLACE.equals(duplicateBehaviour)) {
-        fileMetadataDao.save(meta);
-        rst = 0;
-      } else {
-        fileMetadataDao.save(meta);
-      }
-
-    } catch (Exception ex) {
-      log.warn("Could not save file metadata for file :{}", meta.getRelPath(), ex);
-      success = false;
+      throw e;
     }
-
-    if (!success) {
-      if (FileDuplicateStrategy.ERROR.equals(duplicateBehaviour)) {
-        rst = -1; // return error if exist
-      } else if (FileDuplicateStrategy.REPLACE.equals(duplicateBehaviour)) {
-        fileMetadataDao.remove(meta.getId());
-        fileMetadataDao.save(meta);
-        rst = 0;
-      } else { // add change name add another one: may be recursive call
-        // purly for hibernate entity
-        FileProperty metax = meta.copy();
-        String fnmx = metax.getFileName();
-        fnmx = "A1_" + fnmx;
-        metax.setFileName(fnmx);
-        metax.generateURIFromProperties(baseDir);
-        log.debug("k2= {},", metax.getAbsolutePathUri());
-        fileMetadataDao.save(metax);
-        rst = 1;
-      }
-    }
-    return rst;
+    return reserved ? 100 : 0;
   }
 
   public FileStoreRoot getCurrentFileStoreRoot() {

--- a/src/main/java/com/researchspace/service/impl/InternalFileStoreImpl.java
+++ b/src/main/java/com/researchspace/service/impl/InternalFileStoreImpl.java
@@ -41,7 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** FileStore implementation for storing files locally on RSpace server */
 @Service
-@Transactional
+@Transactional(rollbackFor = IOException.class)
 public class InternalFileStoreImpl implements InternalFileStore {
 
   public void setBaseDir(File rootDir) throws IOException {
@@ -96,17 +96,9 @@ public class InternalFileStoreImpl implements InternalFileStore {
   @Override
   public URI save(FileProperty meta, File sourceFile, FileDuplicateStrategy behaviourOnDuplicate)
       throws IOException {
-    checkInitialised();
-    String sourceFileName = parseFileName(sourceFile);
-    long sourceFileSize = sourceFile.length();
-    meta.setFileSize(Long.toString(sourceFileSize));
-
-    int suc = addMetadata(meta, sourceFileName, behaviourOnDuplicate);
-    if (suc >= 0) { // success
-      String tgPath = meta.makeTargetPath(false);
-      URI rst = fileOp.addFile(tgPath, sourceFile, meta.parseFileKey());
-      return rst;
-    } else return null;
+    try (InputStream input = new FileInputStream(sourceFile)) {
+      return save(meta, input, parseFileName(sourceFile), behaviourOnDuplicate);
+    }
   }
 
   @Override
@@ -119,24 +111,25 @@ public class InternalFileStoreImpl implements InternalFileStore {
     checkInitialised();
     fnm = EscapeReplacement.replaceChars(fnm); // get ride funny characters
     int suc = addMetadata(fileProperty, fnm, behaviourOnDuplicate);
-    FileStoreRoot root = fileMetadataDao.getCurrentFileStoreRoot(false);
-    fileProperty.setRoot(root);
-    if (suc >= 0) { // success path
-      String relPath = fileProperty.makeTargetPath(true);
-      fileOp.getFoldOp().createPath(fileProperty.makeTargetPath(false));
-      File out = new File(fileOp.getFoldOp().getBaseDir(), relPath);
-      log.debug("Saving to {}", out.getAbsolutePath());
-      long fsz;
-
-      try (FileOutputStream fos = new FileOutputStream(out)) {
-        fsz = fileOp.copyStream(fos, inStream, 0);
+    if (suc < 0) {
+      return null;
+    }
+    File out = new File(baseDir, fileProperty.getRelPath());
+    try {
+      long size;
+      try (FileOutputStream output = new FileOutputStream(out)) {
+        size = fileOp.copyStream(output, inStream, 0);
       }
-      URI rst = out.toURI();
-      fileProperty.setFileSize(Long.toString(fsz));
+      fileProperty.setFileSize(Long.toString(size));
       fileMetadataDao.save(fileProperty);
-
-      return rst;
-    } else return null;
+      return out.toURI();
+    } catch (IOException | RuntimeException e) {
+      if (suc == 100) {
+        removeReservedFile(out.toPath(), e);
+      }
+      log.warn("Could not write file :{}", fileProperty.getRelPath(), e);
+      throw e;
+    }
   }
 
   private void checkInitialised() {
@@ -243,14 +236,16 @@ public class InternalFileStoreImpl implements InternalFileStore {
     meta.generateURIFromProperties(baseDir);
     Path destination = baseDir.toPath().resolve(meta.getRelPath());
     Files.createDirectories(destination.getParent());
-    boolean reserved = false;
-    if (duplicateBehaviour != FileDuplicateStrategy.REPLACE) {
-      try {
-        Files.createFile(destination);
-      } catch (FileAlreadyExistsException e) {
-        if (duplicateBehaviour == FileDuplicateStrategy.ERROR) {
-          return -1;
-        }
+    boolean reserved = true;
+    try {
+      Files.createFile(destination);
+    } catch (FileAlreadyExistsException e) {
+      if (duplicateBehaviour == FileDuplicateStrategy.ERROR) {
+        return -1;
+      }
+      if (duplicateBehaviour == FileDuplicateStrategy.REPLACE) {
+        reserved = false;
+      } else {
         String extension = FilenameUtils.getExtension(meta.getFileName());
         // Keep ordinary extensions intact; omit extensions exceeding 20 UTF-8 bytes.
         if (extension.getBytes(StandardCharsets.UTF_8).length > 20) {
@@ -263,22 +258,25 @@ public class InternalFileStoreImpl implements InternalFileStore {
         destination = baseDir.toPath().resolve(meta.getRelPath());
         Files.createFile(destination);
       }
-      reserved = true;
     }
     try {
       fileMetadataDao.save(meta);
     } catch (RuntimeException e) {
-      log.warn("Could not save file metadata for file :{}", meta.getRelPath(), e);
       if (reserved) {
-        try {
-          Files.delete(destination);
-        } catch (IOException cleanupFailure) {
-          e.addSuppressed(cleanupFailure);
-        }
+        removeReservedFile(destination, e);
       }
+      log.warn("Could not save file metadata for file :{}", meta.getRelPath(), e);
       throw e;
     }
     return reserved ? 100 : 0;
+  }
+
+  private void removeReservedFile(Path destination, Exception failure) {
+    try {
+      Files.deleteIfExists(destination);
+    } catch (IOException cleanupFailure) {
+      failure.addSuppressed(cleanupFailure);
+    }
   }
 
   public FileStoreRoot getCurrentFileStoreRoot() {

--- a/src/test/java/com/researchspace/service/DocumentCopyManagerTest.java
+++ b/src/test/java/com/researchspace/service/DocumentCopyManagerTest.java
@@ -1,9 +1,13 @@
 package com.researchspace.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.dao.FolderDao;
@@ -22,10 +26,15 @@ import com.researchspace.service.impl.DocumentCopyManagerImpl;
 import com.researchspace.testutils.RSpaceTestUtils;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Date;
 import java.util.Optional;
+import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -68,6 +77,34 @@ class DocumentCopyManagerTest {
     assertThrows(
         RecordCopyException.class,
         () -> documentCopyManager.copy(mediaFile, "test-image_copy", user, mediaFile.getParent()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "550e8400-e29b-41d4-a716-446655440000",
+        "550e8400-e29b-41d4-a716-446655440000.png"
+      })
+  void copiesCollisionGeneratedFilenames(String storedName) throws IOException {
+    EcatMediaFile mediaFile = getImageMediaFile();
+    mediaFile.getFileProperty().setFileName(storedName);
+    when(recordDao.get(anyLong())).thenReturn(mediaFile);
+    when(recordDao.save(any(Record.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    try (FileInputStream input = new FileInputStream(RSpaceTestUtils.getAnyAttachment())) {
+      when(fileStore.retrieve(any())).thenReturn(Optional.of(input));
+      when(fileStore.save(any(), any(), any(), any())).thenReturn(URI.create("file:/copy"));
+      documentCopyManager.copy(mediaFile, "copy", user, null);
+      ArgumentCaptor<String> name = ArgumentCaptor.forClass(String.class);
+      verify(fileStore)
+          .save(
+              any(FileProperty.class),
+              same(input),
+              name.capture(),
+              eq(FileDuplicateStrategy.AS_NEW));
+      assertTrue(name.getValue().startsWith(FilenameUtils.getBaseName(storedName) + "_"));
+      assertEquals(
+          FilenameUtils.getExtension(storedName), FilenameUtils.getExtension(name.getValue()));
+    }
   }
 
   private EcatImage getImageMediaFile() {

--- a/src/test/java/com/researchspace/service/FileStoreTest.java
+++ b/src/test/java/com/researchspace/service/FileStoreTest.java
@@ -4,6 +4,7 @@ import static com.researchspace.service.FileDuplicateStrategy.AS_NEW;
 import static org.apache.commons.io.IOUtils.readLines;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,18 +16,18 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -37,6 +38,7 @@ public class FileStoreTest extends SpringTransactionalTest {
 
   final String testFilePath = "src/test/resources/TestResources/testTxt.txt";
   private @Autowired FileStoreMetaManager fileStoreMetaMgr;
+  @TempDir Path tempFolder;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -53,11 +55,12 @@ public class FileStoreTest extends SpringTransactionalTest {
     assertNotNull(urix);
 
     // retrieve meta data
-    Map<String, String> wheres = new HashMap<String, String>();
-    wheres.put("fileCategory", "Image");
-    wheres.put("fileGroup", "something");
-    wheres.put("fileUser", user.getUsername());
-    wheres.put("fileVersion", "v1");
+    Map<String, String> wheres =
+        Map.of(
+            "fileCategory", "Image",
+            "fileGroup", "something",
+            "fileUser", user.getUsername(),
+            "fileVersion", "v1");
     List<FileProperty> flst = fileStoreMetaMgr.findProperties(wheres);
     assertTrue(flst.size() >= 0);
 
@@ -81,80 +84,56 @@ public class FileStoreTest extends SpringTransactionalTest {
   }
 
   @Test
-  @Disabled
   public void testVersion() throws IOException {
     User user = createAndSaveRandomUser();
-    // a text file
-
     FileProperty fp = new FileProperty();
     fp.setFileCategory("Image");
-    fp.setFileGroup("any");
-    fp.setFileUser(user.getUsername() + "x");
+    fp.setFileGroup(RandomStringUtils.randomAlphanumeric(12));
+    fp.setFileUser(user.getUsername());
     fp.setFileVersion("v1");
-    File resource = new File(testFilePath);
-    FileInputStream fis = new FileInputStream(resource);
+    Path source = tempFolder.resolve("testText.txt");
+    Files.writeString(source, "first version");
+    URI uri = fileStore.save(fp, source.toFile(), AS_NEW);
+    assertNotNull(uri);
 
-    URI uri = fileStore.save(fp, fis, "testText.txt", AS_NEW);
-
-    fis.close();
-
-    // copy prserves id
     FileProperty fp2 = fp.copy();
-    File resource2 = new File(testFilePath);
-    FileInputStream fis2 = new FileInputStream(resource2);
-    // will return null as is duplicate
-
-    URI uri2 = fileStore.save(fp2, fis2, "testText.txt", FileDuplicateStrategy.ERROR);
-
-    fis2.close();
-    assertNull(uri2);
-
-    // causes a new file to be created as ID is now different.
     fp2.setFileVersion("v2");
-    // create a search map to retrieve version 2
-    Map<String, String> wheres = new HashMap<String, String>();
-    wheres.put("fileVersion", "v2");
-
-    FileInputStream fis3 = new FileInputStream(resource2);
-
+    Map<String, String> wheres =
+        Map.of(
+            "fileCategory", fp2.getFileCategory(),
+            "fileGroup", fp2.getFileGroup(),
+            "fileUser", fp2.getFileUser(),
+            "fileVersion", "v2");
     assertEquals(0, fileStoreMetaMgr.findProperties(wheres).size());
-    URI uri3 = fileStore.save(fp2, fis3, "testText.txt", FileDuplicateStrategy.ERROR);
+    URI version2Uri = fileStore.save(fp2, source.toFile(), FileDuplicateStrategy.ERROR);
     assertEquals(1, fileStoreMetaMgr.findProperties(wheres).size());
-
-    assertNotNull(uri3);
-    assertTrue(uri3.toString().contains("v2"));
-    fis3.close();
+    assertNotNull(version2Uri);
+    assertTrue(version2Uri.toString().contains("v2"));
 
     // update file content
-    String newContent = System.currentTimeMillis() + "";
-    FileUtils.writeStringToFile(resource2, newContent);
-
-    // and write, but forcing update
-    FileInputStream fis4 = new FileInputStream(resource2);
-
-    URI uri4 = fileStore.save(fp2, fis4, "testText.txt", FileDuplicateStrategy.REPLACE);
-
-    assertNotNull(uri4);
-    assertEquals(uri4, uri3); // uri is unchanged
-
-    // check that content has been updated in the repo
+    String newContent = "replacement content";
+    Files.writeString(source, newContent);
+    URI replacedUri = fileStore.save(fp2, source.toFile(), FileDuplicateStrategy.REPLACE);
+    assertEquals(version2Uri, replacedUri);
     assertEquals(newContent, getFileContentAsStringFromRepo(fp2));
+    assertEquals(1, fileStoreMetaMgr.findProperties(wheres).size());
 
-    // v2 file property should still be in DB?
-
-    // assertEquals(1, fileStore.find(wheres).size());
-    fis4.close();
-
-    FileProperty fp4 = fp2.copy();
-    // now we'll save, but forcing a new file to be saved
-    FileInputStream fis5 = new FileInputStream(resource2);
-    URI uri5 = fileStore.save(fp2, fis5, "testText.txt", AS_NEW); // this returned uri is not the
-    // modified one.
-    assertNotNull(uri5);
+    Files.writeString(source, "duplicate content");
+    try (var input = Files.newInputStream(source)) {
+      assertNull(fileStore.save(fp2.copy(), input, "testText.txt", FileDuplicateStrategy.ERROR));
+    }
     assertEquals(newContent, getFileContentAsStringFromRepo(fp2));
+    assertEquals(1, fileStoreMetaMgr.findProperties(wheres).size());
 
-    // assertFalse(uri5.equals(uri4));
-    fis5.close();
+    FileProperty duplicate = fp2.copy();
+    try (var input = Files.newInputStream(source)) {
+      URI duplicateUri = fileStore.save(duplicate, input, "testText.txt", AS_NEW);
+      assertNotNull(duplicateUri);
+      assertNotEquals(version2Uri, duplicateUri);
+    }
+    assertEquals("duplicate content", getFileContentAsStringFromRepo(duplicate));
+    assertEquals(newContent, getFileContentAsStringFromRepo(fp2));
+    assertEquals(2, fileStoreMetaMgr.findProperties(wheres).size());
   }
 
   String getFileContentAsStringFromRepo(FileProperty fp) throws IOException {

--- a/src/test/java/com/researchspace/service/InternalFileStoreIT.java
+++ b/src/test/java/com/researchspace/service/InternalFileStoreIT.java
@@ -10,7 +10,8 @@ import com.researchspace.model.FileProperty;
 import com.researchspace.testutils.RealTransactionSpringTestBase;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,26 +22,31 @@ public class InternalFileStoreIT extends RealTransactionSpringTestBase {
 
   @Autowired private InternalFileStore internalFileStore;
 
+  @BeforeEach
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    super.tearDown();
+  }
+
   @Test
   void failedStreamWriteRollsBackPersistedMetadata() throws IOException {
     assertTrue(AopUtils.isAopProxy(internalFileStore));
     assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
     internalFileStore.setupInternalFileStoreRoot();
     FileProperty property = new FileProperty();
-    property.setFileUser(UUID.randomUUID().toString());
+    property.setFileUser(piUser.getUsername());
     JdbcTemplate jdbc = new JdbcTemplate(dataSource);
     try (InputStream input =
         new InputStream() {
           @Override
           public int read() throws IOException {
             assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
+            assertTrue(property.getId() != null);
             sessionFactory.getCurrentSession().flush();
-            assertEquals(
-                1,
-                jdbc.queryForObject(
-                    "select count(*) from FileProperty where id = ?",
-                    Integer.class,
-                    property.getId()));
             throw new IOException("source failed after metadata was persisted");
           }
         }) {

--- a/src/test/java/com/researchspace/service/InternalFileStoreIT.java
+++ b/src/test/java/com/researchspace/service/InternalFileStoreIT.java
@@ -1,0 +1,60 @@
+package com.researchspace.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.files.service.InternalFileStore;
+import com.researchspace.model.FileProperty;
+import com.researchspace.testutils.RealTransactionSpringTestBase;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class InternalFileStoreIT extends RealTransactionSpringTestBase {
+
+  @Autowired private InternalFileStore internalFileStore;
+
+  @Test
+  void failedStreamWriteRollsBackPersistedMetadata() throws IOException {
+    assertTrue(AopUtils.isAopProxy(internalFileStore));
+    assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
+    internalFileStore.setupInternalFileStoreRoot();
+    FileProperty property = new FileProperty();
+    property.setFileUser(UUID.randomUUID().toString());
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    try (InputStream input =
+        new InputStream() {
+          @Override
+          public int read() throws IOException {
+            assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
+            sessionFactory.getCurrentSession().flush();
+            assertEquals(
+                1,
+                jdbc.queryForObject(
+                    "select count(*) from FileProperty where id = ?",
+                    Integer.class,
+                    property.getId()));
+            throw new IOException("source failed after metadata was persisted");
+          }
+        }) {
+      assertThrows(
+          IOException.class,
+          () ->
+              internalFileStore.save(
+                  property, input, "rollback.txt", FileDuplicateStrategy.AS_NEW));
+    }
+    assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
+    assertEquals(
+        0,
+        jdbc.queryForObject(
+            "select count(*) from FileProperty where id = ?", Integer.class, property.getId()));
+    assertFalse(internalFileStore.findFile(property).exists());
+  }
+}

--- a/src/test/java/com/researchspace/service/impl/FileStoreImpTest.java
+++ b/src/test/java/com/researchspace/service/impl/FileStoreImpTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -113,7 +115,7 @@ public class FileStoreImpTest {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   void duplicateStrategiesPreserveOrReplaceContents(boolean stream) throws IOException {
-    FileMetadataDao metadata = setUpStore(stream);
+    FileMetadataDao metadata = setUpStore();
     FileProperty original = new FileProperty();
     original.setFileCategory("test");
     original.setFileGroup("group");
@@ -158,11 +160,24 @@ public class FileStoreImpTest {
     failedSave.setFileVersion("v2");
     IllegalStateException failure = new IllegalStateException("metadata unavailable");
     when(metadata.save(failedSave)).thenThrow(failure);
-    assertSame(
-        failure,
-        assertThrows(
-            IllegalStateException.class,
-            () -> saveContents(failedSave, "failed", FileDuplicateStrategy.AS_NEW, stream)));
+    if (stream) {
+      try (var input = new ByteArrayInputStream("failed".getBytes(StandardCharsets.UTF_8))) {
+        assertSame(
+            failure,
+            assertThrows(
+                IllegalStateException.class,
+                () -> fs.save(failedSave, input, "test.txt", FileDuplicateStrategy.AS_NEW)));
+      }
+    } else {
+      Path source = tempDir.resolve("test.txt");
+      Files.writeString(source, "failed");
+      File sourceFile = source.toFile();
+      assertSame(
+          failure,
+          assertThrows(
+              IllegalStateException.class,
+              () -> fs.save(failedSave, sourceFile, FileDuplicateStrategy.AS_NEW)));
+    }
     assertFalse(fs.findFile(failedSave).exists());
     assertEquals("replacement", Files.readString(Path.of(first)));
   }
@@ -170,7 +185,7 @@ public class FileStoreImpTest {
   @ParameterizedTest
   @MethodSource("collisionNames")
   void collidingLongNamesUseBoundedUuidNames(String name) throws IOException {
-    setUpStore(true);
+    setUpStore();
     FileProperty original = new FileProperty();
     original.setFileName(name);
     URI first = saveContents(original, "original", FileDuplicateStrategy.AS_NEW, true);
@@ -199,7 +214,85 @@ public class FileStoreImpTest {
         "no-extension");
   }
 
-  private FileMetadataDao setUpStore(boolean stream) throws IOException {
+  @Test
+  void missingSourceDoesNotReserveDestination() throws IOException {
+    setUpStore();
+    FileProperty property = new FileProperty();
+    File source = tempDir.resolve("missing.txt").toFile();
+    Path destination =
+        fs.fileOp
+            .getFoldOp()
+            .getBaseDir()
+            .toPath()
+            .resolve(property.makeTargetPath(false))
+            .resolve(source.getName());
+    assertThrows(IOException.class, () -> fs.save(property, source, FileDuplicateStrategy.AS_NEW));
+    assertFalse(Files.exists(destination));
+    Files.writeString(source.toPath(), "retry");
+    assertNotNull(fs.save(property, source, FileDuplicateStrategy.ERROR));
+    assertEquals("retry", Files.readString(destination));
+  }
+
+  @ParameterizedTest
+  @EnumSource(FileDuplicateStrategy.class)
+  void failedStreamWriteReleasesReservation(FileDuplicateStrategy strategy) throws IOException {
+    setUpStore();
+    FileProperty property = new FileProperty();
+    try (InputStream input =
+        new InputStream() {
+          private boolean firstByte = true;
+
+          @Override
+          public int read() throws IOException {
+            if (firstByte) {
+              firstByte = false;
+              return 'x';
+            }
+            throw new IOException("source failed during read");
+          }
+        }) {
+      assertThrows(IOException.class, () -> fs.save(property, input, "test.txt", strategy));
+    }
+    assertFalse(fs.findFile(property).exists());
+    URI retry = saveContents(property, "retry", FileDuplicateStrategy.ERROR, true);
+    assertNotNull(retry);
+    assertEquals("retry", Files.readString(Path.of(retry)));
+  }
+
+  @Test
+  void failedReplacementDoesNotDeleteExistingFile() throws IOException {
+    FileMetadataDao metadata = setUpStore();
+    FileProperty original = new FileProperty();
+    URI first = saveContents(original, "original", FileDuplicateStrategy.AS_NEW, true);
+    IllegalStateException failure = new IllegalStateException("metadata unavailable");
+    when(metadata.save(original)).thenThrow(failure);
+    try (var input = new ByteArrayInputStream("replacement".getBytes(StandardCharsets.UTF_8))) {
+      assertSame(
+          failure,
+          assertThrows(
+              IllegalStateException.class,
+              () -> fs.save(original, input, "test.txt", FileDuplicateStrategy.REPLACE)));
+    }
+    assertEquals("original", Files.readString(Path.of(first)));
+  }
+
+  @Test
+  void failedMetadataUpdateAfterWritingReleasesReservation() throws IOException {
+    FileMetadataDao metadata = setUpStore();
+    FileProperty property = new FileProperty();
+    IllegalStateException failure = new IllegalStateException("metadata update failed");
+    when(metadata.save(property)).thenReturn(property).thenThrow(failure);
+    try (var input = new ByteArrayInputStream("contents".getBytes(StandardCharsets.UTF_8))) {
+      assertSame(
+          failure,
+          assertThrows(
+              IllegalStateException.class,
+              () -> fs.save(property, input, "test.txt", FileDuplicateStrategy.AS_NEW)));
+    }
+    assertFalse(fs.findFile(property).exists());
+  }
+
+  private FileMetadataDao setUpStore() throws IOException {
     Path store = Files.createDirectory(tempDir.resolve("store"));
     fs.setBaseDir(store.toFile());
     FileMetadataDao metadata = mock(FileMetadataDao.class);
@@ -207,9 +300,6 @@ public class FileStoreImpTest {
     FileStoreRoot root = new FileStoreRoot(base.toURI().toString());
     root.setCurrent(true);
     when(metadata.findByFileStorePath(base.getAbsolutePath())).thenReturn(root);
-    if (stream) {
-      when(metadata.getCurrentFileStoreRoot(false)).thenReturn(root);
-    }
     fs.setFileMetadataDao(metadata);
     return metadata;
   }

--- a/src/test/java/com/researchspace/service/impl/FileStoreImpTest.java
+++ b/src/test/java/com/researchspace/service/impl/FileStoreImpTest.java
@@ -265,6 +265,7 @@ public class FileStoreImpTest {
     FileProperty original = new FileProperty();
     Path destination =
         Path.of(saveContents(original, "original", FileDuplicateStrategy.AS_NEW, true));
+    var originalPermissions = Files.getPosixFilePermissions(destination);
     try (InputStream input =
         new InputStream() {
           private boolean firstByte = true;
@@ -283,12 +284,14 @@ public class FileStoreImpTest {
           () -> fs.save(original, input, "test.txt", FileDuplicateStrategy.REPLACE));
     }
     assertEquals("original", Files.readString(destination));
+    assertEquals(originalPermissions, Files.getPosixFilePermissions(destination));
     try (Stream<Path> siblings = Files.list(destination.getParent())) {
       assertEquals(List.of(destination), siblings.toList());
     }
     assertEquals(
         destination.toUri(), saveContents(original, "retry", FileDuplicateStrategy.REPLACE, true));
     assertEquals("retry", Files.readString(destination));
+    assertEquals(originalPermissions, Files.getPosixFilePermissions(destination));
   }
 
   @Test

--- a/src/test/java/com/researchspace/service/impl/FileStoreImpTest.java
+++ b/src/test/java/com/researchspace/service/impl/FileStoreImpTest.java
@@ -1,25 +1,50 @@
 package com.researchspace.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import com.researchspace.core.util.TransformerUtils;
+import com.researchspace.dao.FileMetadataDao;
+import com.researchspace.files.service.ExternalFileService;
+import com.researchspace.files.service.ExternalFileStoreLocator;
+import com.researchspace.files.service.FileStoreImpl;
 import com.researchspace.model.FileProperty;
 import com.researchspace.model.FileStoreRoot;
 import com.researchspace.model.User;
+import com.researchspace.service.FileDuplicateStrategy;
 import com.researchspace.testutils.RSpaceTestUtils;
 import com.researchspace.testutils.TestFactory;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class FileStoreImpTest {
 
@@ -81,6 +106,125 @@ public class FileStoreImpTest {
     // mimic messed up stream
     fp.setRelPath(corruptedName);
     assertThrows(IllegalStateException.class, () -> tss.handlePossibleUTF8Error(fp, fnfe()));
+  }
+
+  @TempDir Path tempDir;
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void duplicateStrategiesPreserveOrReplaceContents(boolean stream) throws IOException {
+    FileMetadataDao metadata = setUpStore(stream);
+    FileProperty original = new FileProperty();
+    original.setFileCategory("test");
+    original.setFileGroup("group");
+    original.setFileUser("user");
+    original.setFileVersion("v1");
+    URI first = saveContents(original, "original", FileDuplicateStrategy.AS_NEW, stream);
+
+    assertNull(saveContents(original.copy(), "rejected", FileDuplicateStrategy.ERROR, stream));
+    assertEquals("original", Files.readString(Path.of(first)));
+    ExternalFileStoreLocator locator = mock(ExternalFileStoreLocator.class);
+    ExternalFileService external = mock(ExternalFileService.class);
+    FileStoreImpl composite = new FileStoreImpl(fs, locator, external);
+    if (stream) {
+      try (var input = new ByteArrayInputStream("rejected".getBytes(StandardCharsets.UTF_8))) {
+        assertNull(composite.save(original.copy(), input, "test.txt", FileDuplicateStrategy.ERROR));
+      }
+    } else {
+      assertNull(
+          composite.save(
+              original.copy(), tempDir.resolve("test.txt").toFile(), FileDuplicateStrategy.ERROR));
+    }
+    verifyNoInteractions(locator, external);
+
+    assertEquals(
+        first, saveContents(original, "replacement", FileDuplicateStrategy.REPLACE, stream));
+    assertEquals("replacement", Files.readString(Path.of(first)));
+
+    FileProperty duplicate = original.copy();
+    URI second = saveContents(duplicate, "new", FileDuplicateStrategy.AS_NEW, stream);
+    assertNotEquals(first, second);
+    assertEquals("new", Files.readString(Path.of(second)));
+    assertEquals("replacement", Files.readString(Path.of(first)));
+    assertEquals(Path.of(second).toFile(), fs.findFile(duplicate));
+
+    URI third = saveContents(original.copy(), "third", FileDuplicateStrategy.AS_NEW, stream);
+    assertNotEquals(first, third);
+    assertNotEquals(second, third);
+    assertEquals("new", Files.readString(Path.of(second)));
+    assertEquals("third", Files.readString(Path.of(third)));
+
+    FileProperty failedSave = original.copy();
+    failedSave.setFileVersion("v2");
+    IllegalStateException failure = new IllegalStateException("metadata unavailable");
+    when(metadata.save(failedSave)).thenThrow(failure);
+    assertSame(
+        failure,
+        assertThrows(
+            IllegalStateException.class,
+            () -> saveContents(failedSave, "failed", FileDuplicateStrategy.AS_NEW, stream)));
+    assertFalse(fs.findFile(failedSave).exists());
+    assertEquals("replacement", Files.readString(Path.of(first)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("collisionNames")
+  void collidingLongNamesUseBoundedUuidNames(String name) throws IOException {
+    setUpStore(true);
+    FileProperty original = new FileProperty();
+    original.setFileName(name);
+    URI first = saveContents(original, "original", FileDuplicateStrategy.AS_NEW, true);
+    FileProperty duplicate = original.copy();
+    URI second = saveContents(duplicate, "duplicate", FileDuplicateStrategy.AS_NEW, true);
+    String storedName = Path.of(second).getFileName().toString();
+    String extension = FilenameUtils.getExtension(name);
+    if (extension.getBytes(StandardCharsets.UTF_8).length > 20) {
+      extension = "";
+    }
+    assertEquals(extension, FilenameUtils.getExtension(storedName));
+    assertNotNull(UUID.fromString(FilenameUtils.getBaseName(storedName)));
+    assertTrue(storedName.getBytes(StandardCharsets.UTF_8).length <= 57);
+    assertEquals(storedName, duplicate.getFileName());
+    assertEquals(Path.of(second).toFile(), fs.findFile(duplicate));
+    assertEquals("original", Files.readString(Path.of(first)));
+    assertEquals("duplicate", Files.readString(Path.of(second)));
+  }
+
+  static Stream<String> collisionNames() {
+    return Stream.of(
+        "a".repeat(251) + ".txt",
+        "é".repeat(125) + ".csv",
+        "test." + "x".repeat(21),
+        "test.报告",
+        "no-extension");
+  }
+
+  private FileMetadataDao setUpStore(boolean stream) throws IOException {
+    Path store = Files.createDirectory(tempDir.resolve("store"));
+    fs.setBaseDir(store.toFile());
+    FileMetadataDao metadata = mock(FileMetadataDao.class);
+    File base = fs.fileOp.getFoldOp().getBaseDir();
+    FileStoreRoot root = new FileStoreRoot(base.toURI().toString());
+    root.setCurrent(true);
+    when(metadata.findByFileStorePath(base.getAbsolutePath())).thenReturn(root);
+    if (stream) {
+      when(metadata.getCurrentFileStoreRoot(false)).thenReturn(root);
+    }
+    fs.setFileMetadataDao(metadata);
+    return metadata;
+  }
+
+  private URI saveContents(
+      FileProperty property, String contents, FileDuplicateStrategy strategy, boolean stream)
+      throws IOException {
+    if (stream) {
+      try (var input = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8))) {
+        return fs.save(property, input, "test.txt", strategy);
+      }
+    }
+    Path source = tempDir.resolve("test.txt");
+    Files.writeString(source, contents);
+    return fs.save(property, source.toFile(), strategy);
   }
 
   private FileNotFoundException fnfe() {

--- a/src/test/java/com/researchspace/service/impl/FileStoreImpTest.java
+++ b/src/test/java/com/researchspace/service/impl/FileStoreImpTest.java
@@ -260,6 +260,38 @@ public class FileStoreImpTest {
   }
 
   @Test
+  void failedReplacementStreamPreservesContentsAndRemovesTemporaryFile() throws IOException {
+    setUpStore();
+    FileProperty original = new FileProperty();
+    Path destination =
+        Path.of(saveContents(original, "original", FileDuplicateStrategy.AS_NEW, true));
+    try (InputStream input =
+        new InputStream() {
+          private boolean firstByte = true;
+
+          @Override
+          public int read() throws IOException {
+            if (firstByte) {
+              firstByte = false;
+              return 'x';
+            }
+            throw new IOException("source failed during read");
+          }
+        }) {
+      assertThrows(
+          IOException.class,
+          () -> fs.save(original, input, "test.txt", FileDuplicateStrategy.REPLACE));
+    }
+    assertEquals("original", Files.readString(destination));
+    try (Stream<Path> siblings = Files.list(destination.getParent())) {
+      assertEquals(List.of(destination), siblings.toList());
+    }
+    assertEquals(
+        destination.toUri(), saveContents(original, "retry", FileDuplicateStrategy.REPLACE, true));
+    assertEquals("retry", Files.readString(destination));
+  }
+
+  @Test
   void failedReplacementDoesNotDeleteExistingFile() throws IOException {
     FileMetadataDao metadata = setUpStore();
     FileProperty original = new FileProperty();


### PR DESCRIPTION
-- AI writing below --

## Description ##
Honor filestore duplicate strategies consistently for file and stream uploads. Previously, duplicate handling could overwrite existing files or leave empty and partial files after a failed save.

- Reserve new destinations atomically. On collision, `AS_NEW` uses a bounded UUID filename, retaining extensions up to 20 UTF-8 bytes; a second collision fails without retrying.
- Make `ERROR` reject duplicates without modifying existing contents and preserve `REPLACE` overwrite behavior.
- Remove newly reserved files after write or metadata failures and roll back transactions on `IOException`.
- Support extensionless filenames when copying gallery files.

Includes regression coverage for duplicate strategies, long and Unicode filenames, failed saves, and gallery copies. Existing stored paths remain unchanged; no migration is required.