### PR TITLE
switch ProcessBuilder to calling ldapsearch directly

### DIFF
--- a/DevDocs/public/RSpaceConfiguration.md
+++ b/DevDocs/public/RSpaceConfiguration.md
@@ -419,7 +419,7 @@ These optional settings will enable you to import user data from LDAP, or enable
 * **ldap.url** ldap server URL, only needed if ldap.enabled is true. E.g. ldaps://kudu.rspace.com
 * **ldap.baseSuffix** ldap server url, only needed if ldap.enabled is true. E.g. 'dc=test,dc=kudu,dc=axiope,dc=com'
 * **ldap.ignorePartialResultException** if set to 'true' suppresses PartialResultException on search queries
-* **ldap.fallbackDnCalculationEnabled** if set to 'true' RSpace will run 'sh -c ldapsearch' command to retrieve user's dn
+* **ldap.fallbackDnCalculationEnabled** if set to 'true' RSpace will run the 'ldapsearch' command to retrieve user's dn
 
 * **ldap.bindQuery.dn** user to use for non-anonymous LDAP bind
 * **ldap.bindQuery.password** password to use for non-anonymous LDAP bind

--- a/src/main/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutor.java
+++ b/src/main/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutor.java
@@ -4,10 +4,13 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.ldap.support.LdapEncoder;
 
-/** Calls shell `ldapsearch` command to retrieve user's LDAP details. */
+/** Runs the `ldapsearch` command to retrieve user's LDAP details. */
 @Slf4j
 public class LdapSearchCmdLineExecutor {
 
@@ -22,36 +25,52 @@ public class LdapSearchCmdLineExecutor {
   }
 
   /**
-   * Executes 'sh -c ldapsearch' command with and finds dn attribute in response.
+   * Runs the ldapsearch command as an argument array (no shell) and finds the dn attribute in the
+   * response.
    *
    * @param ldapUsername uid to match in ldapsearch
    * @return dn or null if not found
    */
   public String findDnForUid(String ldapUsername) {
 
-    String command = getLdapSearchCommandString(ldapUsername);
-    log.debug("running: " + command);
+    List<String> command = getLdapSearchCommand(ldapUsername);
+    log.debug("running: {}", command);
 
     String foundDn = null;
     try {
-      ProcessBuilder builder = new ProcessBuilder();
-      builder.command("/bin/sh", "-c", command);
+      ProcessBuilder builder = new ProcessBuilder(command);
+      // Discard stderr rather than merging it: keeps server-controlled text out of the dn scan and
+      // avoids the stderr pipe buffer filling and deadlocking against our stdout read.
+      builder.redirectError(ProcessBuilder.Redirect.DISCARD);
       Process process = builder.start();
       foundDn = readDnFromProcessOutput(process.getInputStream());
-      log.info("ldapsearch found dn: " + foundDn);
+      log.info("ldapsearch found dn: {}", foundDn);
       if (StringUtils.isBlank(foundDn)) {
-        log.warn("dn not found by ldapsearch command: " + command);
+        log.warn("dn not found by ldapsearch command: {}", command);
       }
-      process.waitFor();
-    } catch (IOException | InterruptedException e) {
-      log.warn("error when executing ldapsearch command: " + command, e);
+      if (!process.waitFor(30, TimeUnit.SECONDS)) {
+        log.warn("ldapsearch command timed out, destroying process: {}", command);
+        process.destroyForcibly();
+      }
+    } catch (IOException e) {
+      log.warn("error when executing ldapsearch command: {}", command, e);
+    } catch (InterruptedException e) {
+      log.warn("interrupted when executing ldapsearch command: {}", command, e);
+      Thread.currentThread().interrupt();
     }
 
     return foundDn;
   }
 
-  protected String getLdapSearchCommandString(String ldapUsername) {
-    return String.format("ldapsearch -x -H %s -b \"%s\" uid=%s", host, searchBase, ldapUsername);
+  protected List<String> getLdapSearchCommand(String ldapUsername) {
+    return List.of(
+        "ldapsearch",
+        "-x",
+        "-H",
+        host,
+        "-b",
+        searchBase,
+        "uid=" + LdapEncoder.filterEncode(ldapUsername));
   }
 
   private String readDnFromProcessOutput(InputStream inputStream) throws IOException {

--- a/src/main/resources/deployments/defaultDeployment.properties
+++ b/src/main/resources/deployments/defaultDeployment.properties
@@ -116,7 +116,7 @@ ldap.userSearchQuery.uidField=uid
 ldap.userSearchQuery.dnField=
 # name of search result attribute taken as RSpace user's objectSid (with AD the value should be 'objectSid')
 ldap.userSearchQuery.objectSidField=
-# enables alternative mechanism for retrieval of user DN, based on parsing 'sh -c ldapsearch' output
+# enables alternative mechanism for retrieval of user DN, based on parsing 'ldapsearch' output
 ldap.fallbackDnCalculationEnabled=false
 
 

--- a/src/test/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutorTest.java
+++ b/src/test/java/com/researchspace/ldap/impl/LdapSearchCmdLineExecutorTest.java
@@ -2,21 +2,35 @@ package com.researchspace.ldap.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class LdapSearchCmdLineExecutorTest {
 
+  private final LdapSearchCmdLineExecutor cmdLineExecutor =
+      new LdapSearchCmdLineExecutor(
+          "dc=test,dc=howler,dc=researchspace,dc=com",
+          "ldap://howler.researchspace.com",
+          "description");
+
   @Test
   public void testLdapsearchCommandConstruction() {
-    LdapSearchCmdLineExecutor cmdLineExecutor =
-        new LdapSearchCmdLineExecutor(
-            "dc=test,dc=howler,dc=researchspace,dc=com",
+    List<String> expectedCmd =
+        List.of(
+            "ldapsearch",
+            "-x",
+            "-H",
             "ldap://howler.researchspace.com",
-            "description");
+            "-b",
+            "dc=test,dc=howler,dc=researchspace,dc=com",
+            "uid=ldapUser1");
+    assertEquals(expectedCmd, cmdLineExecutor.getLdapSearchCommand("ldapUser1"));
+  }
 
-    String expectedCmd =
-        "ldapsearch -x -H ldap://howler.researchspace.com -b"
-            + " \"dc=test,dc=howler,dc=researchspace,dc=com\" uid=ldapUser1";
-    assertEquals(expectedCmd, cmdLineExecutor.getLdapSearchCommandString("ldapUser1"));
+  @Test
+  public void filterMetacharactersAreEscapedInUidArg() {
+    // RFC4515 special chars ( ) * are escaped (not stripped), so the exact value is pinned.
+    List<String> cmd = cmdLineExecutor.getLdapSearchCommand("evil)(uid=*");
+    assertEquals("uid=evil\\29\\28uid=\\2a", cmd.get(cmd.size() - 1));
   }
 }


### PR DESCRIPTION
The LDAP fallback DN lookup interpolated the username into an `ldapsearch`
command string run through `/bin/sh -c`, so a uid containing shell
metacharacters was executed as OS commands. The path is gated (opt-in fallback,
LDAP auth enabled, username must already match a real directory uid), but it is
a security vulnerability when reached.

Run `ldapsearch` as an argument array with no shell, RFC4515-escape the uid
filter value via LdapEncoder, discard the child stderr, bound the process with a
timeout, restore the interrupt flag, and correct the docs/property comment that
still referenced `sh -c ldapsearch`. Tests assert the exact escaped argument.

---------

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>