### PR TITLE
RSDEV-1334: reject empty passwords in LDAP authentication

### DIFF
--- a/src/main/java/com/researchspace/auth/LdapRealm.java
+++ b/src/main/java/com/researchspace/auth/LdapRealm.java
@@ -3,6 +3,7 @@ package com.researchspace.auth;
 import com.researchspace.ldap.UserLdapRepo;
 import com.researchspace.model.SignupSource;
 import com.researchspace.model.User;
+import com.researchspace.model.permissions.SecurityLogger;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.UserManager;
 import com.researchspace.service.UserSignupException;
@@ -22,6 +23,7 @@ public class LdapRealm extends RSpaceRealm {
   public static final String LDAP_REALM_NAME = "LDAP_REALM";
 
   private static final Logger log = LoggerFactory.getLogger(LdapRealm.class);
+  private static final Logger SECURITY_LOG = LoggerFactory.getLogger(SecurityLogger.class);
 
   private @Autowired UserLdapRepo userLdapRepo;
   private @Autowired UserManager userManager;
@@ -39,6 +41,14 @@ public class LdapRealm extends RSpaceRealm {
 
     UsernamePasswordToken upToken = (UsernamePasswordToken) token;
     String username = upToken.getUsername();
+
+    char[] password = upToken.getPassword();
+    if (password == null || password.length == 0) {
+      SECURITY_LOG.warn(
+          "Rejecting LDAP authentication attempt with empty password for user: {}", username);
+      return null;
+    }
+
     User rspaceUser = null;
 
     // if user found in RSpace proceed with LDAP authentication only if it's LDAP user
@@ -53,7 +63,7 @@ public class LdapRealm extends RSpaceRealm {
     // check provided username/password in LDAP
     log.info(
         "starting LdapRealm authentication for user: {} (exists: {})", username, rspaceUserExists);
-    User ldapUser = userLdapRepo.authenticate(username, new String(upToken.getPassword()));
+    User ldapUser = userLdapRepo.authenticate(username, new String(password));
 
     // incorrect LDAP credentials
     if (ldapUser == null) {

--- a/src/main/java/com/researchspace/ldap/impl/UserLdapRepoImpl.java
+++ b/src/main/java/com/researchspace/ldap/impl/UserLdapRepoImpl.java
@@ -11,6 +11,7 @@ import com.researchspace.model.Role;
 import com.researchspace.model.SignupSource;
 import com.researchspace.model.User;
 import com.researchspace.model.dtos.UserValidator;
+import com.researchspace.model.permissions.SecurityLogger;
 import com.researchspace.properties.IPropertyHolder;
 import com.researchspace.service.EmailBroadcast;
 import com.researchspace.service.ISignupHandlerPolicy;
@@ -23,6 +24,8 @@ import java.util.List;
 import javax.naming.directory.DirContext;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,6 +38,8 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class UserLdapRepoImpl implements UserLdapRepo {
+
+  private static final Logger SECURITY_LOG = LoggerFactory.getLogger(SecurityLogger.class);
 
   private @Autowired LdapContextSource ldapContext;
   private @Autowired LdapTemplate ldapTemplate;
@@ -123,6 +128,18 @@ public class UserLdapRepoImpl implements UserLdapRepo {
   public User authenticate(String username, String credentials) {
     assertLdapEnabled();
     assertLdapAuthenticationEnabled();
+
+    // a bind with a zero-length password is an unauthenticated bind (RFC 4513), which some
+    // directories treat as successful without verifying anything, so it must never reach the
+    // bind; a non-empty password (even whitespace-only) is verified by the directory as normal.
+    // LdapRealm screens login attempts too, but this guard is not redundant with that: it is
+    // the only check on the reauthentication path (IReauthenticator, e.g. document signing
+    // and witnessing), which passes the user-supplied password straight to this method
+    if (StringUtils.isEmpty(credentials)) {
+      SECURITY_LOG.warn(
+          "Rejecting LDAP bind attempt with empty password for username {}", username);
+      return null;
+    }
 
     User user = findUserByUsername(username);
     if (user == null) {

--- a/src/test/java/com/researchspace/auth/LdapRealmTest.java
+++ b/src/test/java/com/researchspace/auth/LdapRealmTest.java
@@ -4,11 +4,15 @@ import static com.researchspace.testutils.TestFactory.createAnyUser;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.researchspace.ldap.UserLdapRepo;
@@ -56,7 +60,7 @@ public class LdapRealmTest {
     user1sid2.setSid("1-2-3-4");
     user1sid2.setId(1L);
     token = new UsernamePasswordToken(testUsername, "anypass");
-    when(userLdapRepo.authenticate(anyString(), anyString())).thenReturn(user1sid2);
+    lenient().when(userLdapRepo.authenticate(anyString(), anyString())).thenReturn(user1sid2);
   }
 
   @Test
@@ -83,6 +87,27 @@ public class LdapRealmTest {
         assertThrows(AuthenticationException.class, () -> ldapRealm.doGetAuthenticationInfo(token))
             .getMessage(),
         containsString("SID values are not matching"));
+  }
+
+  @Test
+  public void testEmptyPasswordRejectedWithoutLdapCall() throws Exception {
+    // the guard returns before any collaborator is consulted, so no stubbing is needed here;
+    // testWhitespaceOnlyPasswordStillVerifiedAgainstLdap covers the non-empty path
+    assertNull(
+        ldapRealm.doGetAuthenticationInfo(new UsernamePasswordToken(testUsername, (String) null)));
+    assertNull(ldapRealm.doGetAuthenticationInfo(new UsernamePasswordToken(testUsername, "")));
+    verifyNoInteractions(userLdapRepo);
+  }
+
+  @Test
+  public void testWhitespaceOnlyPasswordStillVerifiedAgainstLdap() throws Exception {
+    when(userManager.userExists(any())).thenReturn(true);
+    when(userManager.getUserByUsername(testUsername)).thenReturn(user1noSid);
+
+    AuthenticationInfo authenticationInfo =
+        ldapRealm.doGetAuthenticationInfo(new UsernamePasswordToken(testUsername, "   "));
+    assertNotNull(authenticationInfo);
+    verify(userLdapRepo).authenticate(testUsername, "   ");
   }
 
   @Test

--- a/src/test/java/com/researchspace/ldap/UserLdapRepoTest.java
+++ b/src/test/java/com/researchspace/ldap/UserLdapRepoTest.java
@@ -3,6 +3,7 @@ package com.researchspace.ldap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.researchspace.model.SignupSource;
@@ -60,6 +61,15 @@ public class UserLdapRepoTest extends SpringTransactionalTest {
         assertThrows(IllegalStateException.class, () -> userLdapRepo.signupLdapUser(null))
             .getMessage(),
         containsString("LDAP not configured"));
+  }
+
+  @Test
+  public void testEmptyPasswordRejected() {
+    properties.setLdapEnabled("true");
+    properties.setLdapAuthenticationEnabled("true");
+
+    assertNull(userLdapRepo.authenticate("user", null));
+    assertNull(userLdapRepo.authenticate("user", ""));
   }
 
   @Test

--- a/src/test/java/com/researchspace/ldap/impl/UserLdapRepoImplTest.java
+++ b/src/test/java/com/researchspace/ldap/impl/UserLdapRepoImplTest.java
@@ -1,0 +1,67 @@
+package com.researchspace.ldap.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.model.User;
+import com.researchspace.properties.IPropertyHolder;
+import java.util.List;
+import javax.naming.directory.DirContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.ldap.query.LdapQuery;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class UserLdapRepoImplTest {
+
+  private static final String USER_DN = "cn=user,dc=example,dc=com";
+
+  @Mock private LdapContextSource ldapContext;
+  @Mock private LdapTemplate ldapTemplate;
+  @Mock private IPropertyHolder properties;
+  @Mock private DirContext dirContext;
+
+  @InjectMocks private UserLdapRepoImpl userLdapRepo;
+
+  @BeforeEach
+  public void setUp() {
+    when(properties.getLdapEnabled()).thenReturn("true");
+    when(properties.isLdapAuthenticationEnabled()).thenReturn(true);
+    ReflectionTestUtils.setField(userLdapRepo, "ldapSearchQueryUidField", "uid");
+    ReflectionTestUtils.setField(userLdapRepo, "fallbackDnCalculationEnabled", "false");
+  }
+
+  @Test
+  public void emptyPasswordRejectedWithoutContactingDirectory() {
+    assertNull(userLdapRepo.authenticate("user", null));
+    assertNull(userLdapRepo.authenticate("user", ""));
+
+    verifyNoInteractions(ldapTemplate, ldapContext);
+  }
+
+  @Test
+  public void whitespaceOnlyPasswordStillReachesBind() {
+    User ldapUser = new User("user");
+    ldapUser.setToken(USER_DN);
+    when(ldapTemplate.search(any(LdapQuery.class), ArgumentMatchers.<AttributesMapper<User>>any()))
+        .thenReturn(List.of(ldapUser));
+    when(ldapContext.getContext(USER_DN, "   ")).thenReturn(dirContext);
+
+    assertNotNull(userLdapRepo.authenticate("user", "   "));
+
+    verify(ldapContext).getContext(USER_DN, "   ");
+  }
+}


### PR DESCRIPTION
## Description ##
Fixes RSDEV-1334. Some LDAP directories treat a bind with a valid DN and a zero-length password as an unauthenticated bind (RFC 4513) and report success. Since the bind is our only password check, an empty password could log in as any known LDAP user on such a directory. This rejects null and empty passwords before any LDAP call, in `LdapRealm` for login and in `UserLdapRepoImpl.authenticate` for the reauthentication path used by signing and witnessing. Both rejections go to the security event log. Whitespace-only passwords still go to the directory.

## Follow-up work
Reviewers: please do not raise findings on the items below. They are deliberately out of scope here and will be changed by the linked tickets.
- RSDEV-1335: upgrade `spring-ldap-core` off the EOL 2.3.4 line (CVE-2026-41720). Until then this application-level guard is the only protection, which is why it is duplicated at both call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
