### PR TITLE
RSDEV-1328: validate pagination order-by fields with an allowlist

### DIFF
--- a/src/main/java/com/researchspace/core/util/BasicPaginationCriteria.java
+++ b/src/main/java/com/researchspace/core/util/BasicPaginationCriteria.java
@@ -1,7 +1,7 @@
 package com.researchspace.core.util;
 
 import java.io.Serializable;
-import java.util.regex.Matcher;
+import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.beanutils.BeanUtils;
@@ -304,12 +304,23 @@ public class BasicPaginationCriteria<T> implements Serializable, IPagination<T> 
    *
    * @see com.axiope.util.IPagination#isOrderBySafe(java.lang.String)
    */
+  /**
+   * Dispatch keys for the sysadmin usage listing (see {@code SysAdminManager}), which matches them
+   * with {@code equals} to select an aggregate query branch rather than using them as sort fields.
+   *
+   * <p>This predicate is shared by every listing, so these literals are accepted everywhere but
+   * only interpreted on that one path. A listing that concatenates its sort field instead (form and
+   * workspace listings do) would emit them verbatim and fail to parse, which is a rejected query
+   * rather than an injection: matching is exact, so no payload built around these names, such as
+   * {@code fileUsage(),rand()}, satisfies either the set or the identifier pattern.
+   */
+  private static final Set<String> VIRTUAL_SORT_TOKENS = Set.of("fileUsage()", "recordCount()");
+
   @Override
   public boolean isOrderBySafe(String orderBy) {
     if (StringUtils.isEmpty(orderBy)) {
       return true;
     }
-    Matcher m = ORDERBYBLACKLIST.matcher(orderBy);
-    return !m.find();
+    return VIRTUAL_SORT_TOKENS.contains(orderBy) || SAFE_ORDER_BY_TOKEN.matcher(orderBy).matches();
   }
 }

--- a/src/main/java/com/researchspace/core/util/IPagination.java
+++ b/src/main/java/com/researchspace/core/util/IPagination.java
@@ -10,8 +10,12 @@ public interface IPagination<T> {
 
   int DEFAULT_RESULTS_PERPAGE = 10;
 
-  /** Pattern of disallowed characters in orderby clauses to prevent SQL injection attacks. */
-  Pattern ORDERBYBLACKLIST = Pattern.compile("['\";%^&]");
+  /**
+   * Matches bare or dot-separated identifier paths, excluding SQL expressions, so an orderby clause
+   * cannot alter the generated query.
+   */
+  Pattern SAFE_ORDER_BY_TOKEN =
+      Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*");
 
   Class<T> getClazz();
 

--- a/src/main/java/com/researchspace/dao/hibernate/AuditDaoHibernateEnversImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/AuditDaoHibernateEnversImpl.java
@@ -69,19 +69,7 @@ public class AuditDaoHibernateEnversImpl implements AuditDao {
       User user, String searchTerm, PaginationCriteria<AuditedRecord> pgCrit) {
 
     AuditReader auditReader = getAuditReader();
-    String orderBy;
-    if (!StringUtils.isEmpty(pgCrit.getOrderBy())) {
-      // Hibernate 6 requires fully-qualified HQL paths; map logical sort field names to HQL paths
-      Map<String, String> orderByFieldMap =
-          Map.of(
-              "name", "rtf.record.editInfo.name",
-              "creationDate", "rtf.record.editInfo.creationDate",
-              "modificationDate", "rtf.record.editInfo.modificationDate");
-      String orderByField = orderByFieldMap.getOrDefault(pgCrit.getOrderBy(), pgCrit.getOrderBy());
-      orderBy = " order by " + orderByField + " " + pgCrit.getSortOrder();
-    } else {
-      orderBy = " order by rtf.deletedDate " + SortOrder.DESC;
-    }
+    String orderBy = makeOrderBy(pgCrit);
 
     // Query for all user's deleted folders; we will then exclude their contents from the final
     // results as only 'top level' deleted items can be restored
@@ -140,6 +128,24 @@ public class AuditDaoHibernateEnversImpl implements AuditDao {
     List<RecordToFolder> deletedRecordToFolder = recordsQuery.list();
     List<AuditedRecord> deletedAudRecords = processRecordToFolderResults(deletedRecordToFolder);
     return new SearchResultsImpl<>(deletedAudRecords, pgCrit, count);
+  }
+
+  /**
+   * Builds the ORDER BY clause for the deleted-records listing. An unsafe or absent sort field
+   * falls back to the listing's default deleted-date order.
+   */
+  static String makeOrderBy(PaginationCriteria<AuditedRecord> pgCrit) {
+    if (StringUtils.isEmpty(pgCrit.getOrderBy()) || !pgCrit.isOrderBySafe(pgCrit.getOrderBy())) {
+      return " order by rtf.deletedDate " + SortOrder.DESC;
+    }
+    // Hibernate 6 requires fully-qualified HQL paths; map logical sort field names to HQL paths
+    Map<String, String> orderByFieldMap =
+        Map.of(
+            "name", "rtf.record.editInfo.name",
+            "creationDate", "rtf.record.editInfo.creationDate",
+            "modificationDate", "rtf.record.editInfo.modificationDate");
+    String orderByField = orderByFieldMap.getOrDefault(pgCrit.getOrderBy(), pgCrit.getOrderBy());
+    return " order by " + orderByField + " " + pgCrit.getSortOrder();
   }
 
   private List<Long> getContentsIDsFromDeletedFolders(List<Long> deletedFolderIds) {

--- a/src/main/java/com/researchspace/dao/hibernate/FormDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/FormDaoHibernate.java
@@ -247,12 +247,7 @@ public class FormDaoHibernate extends AbstractFormDaoImpl<RSForm> implements For
         sb.append(" union ");
       }
     }
-    if (pagCriteria != null && pagCriteria.getOrderBy() != null) {
-      sb.append(" order by ").append(pagCriteria.getOrderBy()).append(" ");
-      if (pagCriteria.getSortOrder() != null) {
-        sb.append(pagCriteria.getSortOrder());
-      }
-    }
+    sb.append(makeOrderBy(pagCriteria));
     allQuery = sb.toString();
     log.debug(" all clause is [{}]", allQuery);
 
@@ -316,9 +311,30 @@ public class FormDaoHibernate extends AbstractFormDaoImpl<RSForm> implements For
     return sb.toString();
   }
 
+  /**
+   * Builds the ORDER BY clause for the native form listing query. An unsafe sort field falls back
+   * to a stable {@code id} order so paging over the union stays deterministic.
+   */
+  String makeOrderBy(PaginationCriteria<RSForm> pagCriteria) {
+    if (pagCriteria == null || pagCriteria.getOrderBy() == null) {
+      return "";
+    }
+    if (!pagCriteria.isOrderBySafe(pagCriteria.getOrderBy())) {
+      log.warn("Ignoring unsafe orderBy value in form listing");
+      return " order by id ";
+    }
+    StringBuilder orderBy = new StringBuilder(" order by ");
+    orderBy.append(pagCriteria.getOrderBy()).append(" ");
+    if (pagCriteria.getSortOrder() != null) {
+      orderBy.append(pagCriteria.getSortOrder());
+    }
+    return orderBy.toString();
+  }
+
   private boolean isSortOrderSet(PaginationCriteria<RSForm> pagCriteria) {
     return pagCriteria != null
         && pagCriteria.getOrderBy() != null
+        && pagCriteria.isOrderBySafe(pagCriteria.getOrderBy())
         && !(pagCriteria.getOrderBy().equals("id"));
   }
 

--- a/src/main/java/com/researchspace/dao/hibernate/NameDateFilterImpl.java
+++ b/src/main/java/com/researchspace/dao/hibernate/NameDateFilterImpl.java
@@ -144,17 +144,25 @@ public class NameDateFilterImpl implements NameDateFilter {
 
     addForm(pname, pval, term, sbf, formIds);
 
-    addOrderBy(sbf, input.getPgCrit());
+    addOrderBy(sbf, input.getPgCrit(), "r.id");
     return sbf.toString();
   }
 
-  private void addOrderBy(StringBuffer sbf, PaginationCriteria<BaseRecord> pgCrit) {
+  private void addOrderBy(
+      StringBuffer sbf, PaginationCriteria<BaseRecord> pgCrit, String fallbackOrderBy) {
     String orderBy = null;
     SortOrder so = null;
     if (pgCrit != null && pgCrit.getOrderBy() != null) {
-      orderBy = pgCrit.getOrderBy();
-      so = pgCrit.getSortOrder();
-      sbf.append(" order by " + orderBy + "  " + so);
+      if (pgCrit.isOrderBySafe(pgCrit.getOrderBy())) {
+        orderBy = pgCrit.getOrderBy();
+        so = pgCrit.getSortOrder();
+        sbf.append(" order by " + orderBy + "  " + so);
+      } else {
+        log.warn("Ignoring unsafe orderBy value in name/date filter");
+        if (fallbackOrderBy != null) {
+          sbf.append(" order by ").append(fallbackOrderBy).append(" ASC");
+        }
+      }
     }
   }
 
@@ -175,7 +183,7 @@ public class NameDateFilterImpl implements NameDateFilter {
 
     pval.add(input.getParentFolderId());
     pval.add(Boolean.FALSE);
-    sb.append(makeFromClauseForNameDateSrc(input, pname, pval));
+    sb.append(makeFromClauseForNameDateSrc(input, pname, pval, "rc.id"));
     return sb.toString();
   }
 
@@ -194,7 +202,7 @@ public class NameDateFilterImpl implements NameDateFilter {
 
     pval.add(input.getParentFolderId());
     pval.add(Boolean.FALSE);
-    String from2 = makeFromClauseForNameDateSrc(input, pname, pval);
+    String from2 = makeFromClauseForNameDateSrc(input, pname, pval, null);
     sb.append(from2);
 
     String query = sb.toString();
@@ -217,7 +225,7 @@ public class NameDateFilterImpl implements NameDateFilter {
   }
 
   private String makeFromClauseForNameDateSrc(
-      WorkspaceListingConfig input, List<String> pname, List<Object> pval) {
+      WorkspaceListingConfig input, List<String> pname, List<Object> pval, String fallbackOrderBy) {
 
     StringBuffer sbf = new StringBuffer();
     sbf.append(
@@ -231,7 +239,7 @@ public class NameDateFilterImpl implements NameDateFilter {
       addCreationDate(pname, pval, input.getSrchTerms()[0], sbf);
     }
 
-    addOrderBy(sbf, input.getPgCrit());
+    addOrderBy(sbf, input.getPgCrit(), fallbackOrderBy);
     return sbf.toString();
   }
 

--- a/src/main/java/com/researchspace/dao/hibernate/RecordDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/RecordDaoHibernate.java
@@ -195,7 +195,7 @@ public class RecordDaoHibernate extends GenericDaoHibernate<Record, Long> implem
 
   static String makeOrderBy(PaginationCriteria<? extends BaseRecord> pgCrit) {
     String orderBy;
-    if (!StringUtils.isEmpty(pgCrit.getOrderBy())) {
+    if (!StringUtils.isEmpty(pgCrit.getOrderBy()) && pgCrit.isOrderBySafe(pgCrit.getOrderBy())) {
       String field = pgCrit.getOrderBy();
       if (EDIT_INFO_ORDER_BY_FIELDS.contains(field)) {
         field = "editInfo." + field;

--- a/src/main/java/com/researchspace/dao/hibernate/UserDaoHibernate.java
+++ b/src/main/java/com/researchspace/dao/hibernate/UserDaoHibernate.java
@@ -307,12 +307,15 @@ public class UserDaoHibernate extends GenericDaoHibernate<User, Long> implements
   }
 
   private String safeOrderBy(PaginationCriteria<User> pgCrit) {
-    if (!StringUtils.isBlank(pgCrit.getOrderBy()) && pgCrit.isOrderBySafe(pgCrit.getOrderBy())) {
-      return String.format(
-          ORDER_BY_QUERY_FORMAT, pgCrit.getOrderBy(), pgCrit.getSortOrder().toString());
-    } else {
+    if (StringUtils.isBlank(pgCrit.getOrderBy())) {
       return "";
     }
+    if (!pgCrit.isOrderBySafe(pgCrit.getOrderBy())) {
+      log.warn("Ignoring unsafe orderBy value in community user listing");
+      return " order by u.id"; // stable fallback so paging stays deterministic
+    }
+    return String.format(
+        ORDER_BY_QUERY_FORMAT, pgCrit.getOrderBy(), pgCrit.getSortOrder().toString());
   }
 
   @Override
@@ -462,7 +465,13 @@ public class UserDaoHibernate extends GenericDaoHibernate<User, Long> implements
       CriteriaBuilder builder,
       Root<User> root,
       CriteriaQuery<?> query) {
-    if (pgCrit.getOrderBy() == null || !pgCrit.isOrderBySafe(pgCrit.getOrderBy())) {
+    if (pgCrit.getOrderBy() == null) {
+      return;
+    }
+    if (!pgCrit.isOrderBySafe(pgCrit.getOrderBy())) {
+      log.warn("Ignoring unsafe orderBy value in user search");
+      // stable fallback so paging stays deterministic
+      query.orderBy(builder.asc(root.get("id")));
       return;
     }
     List<Order> orders = new ArrayList<>();

--- a/src/test/java/com/researchspace/admin/service/impl/SysAdminManagerImplTest.java
+++ b/src/test/java/com/researchspace/admin/service/impl/SysAdminManagerImplTest.java
@@ -1,0 +1,78 @@
+package com.researchspace.admin.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.admin.service.SysAdminManager;
+import com.researchspace.admin.service.UserUsageInfo;
+import com.researchspace.core.util.ISearchResults;
+import com.researchspace.dao.FileMetadataDao;
+import com.researchspace.dao.RecordDao;
+import com.researchspace.dao.UserDao;
+import com.researchspace.model.PaginationCriteria;
+import com.researchspace.model.Role;
+import com.researchspace.model.User;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * The usage listing dispatches on the {@code fileUsage()} / {@code recordCount()} virtual sort
+ * tokens, so these tests pin that the tokens survive {@code setOrderBy} and select their query
+ * branch instead of falling through to the null return.
+ */
+public class SysAdminManagerImplTest {
+
+  @Mock private UserDao userDao;
+  @Mock private FileMetadataDao fileDao;
+  @Mock private RecordDao recordDao;
+
+  @InjectMocks private SysAdminManagerImpl sysAdminManager;
+
+  private User sysadmin;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    sysadmin = new User("sysadmin");
+    sysadmin.addRole(Role.SYSTEM_ROLE);
+  }
+
+  @Test
+  public void fileUsageOrderBySelectsFileUsageBranch() {
+    PaginationCriteria<User> pgCrit = PaginationCriteria.createDefaultForClass(User.class);
+    pgCrit.setOrderBy(SysAdminManager.ORDER_BY_FILE_USAGE);
+    assertEquals(SysAdminManager.ORDER_BY_FILE_USAGE, pgCrit.getOrderBy());
+
+    when(fileDao.getCountOfUsersWithFilesInFileSystem()).thenReturn(0L);
+    when(fileDao.getTotalFileUsageForAllUsers(pgCrit)).thenReturn(Map.of());
+    when(recordDao.getTotalRecordsForUsers(any(), any())).thenReturn(Map.of());
+
+    ISearchResults<UserUsageInfo> results = sysAdminManager.getUserUsageInfo(sysadmin, pgCrit);
+
+    assertNotNull(results);
+    verify(fileDao).getTotalFileUsageForAllUsers(pgCrit);
+  }
+
+  @Test
+  public void recordCountOrderBySelectsRecordCountBranch() {
+    PaginationCriteria<User> pgCrit = PaginationCriteria.createDefaultForClass(User.class);
+    pgCrit.setOrderBy(SysAdminManager.ORDER_BY_RECORD_COUNT);
+    assertEquals(SysAdminManager.ORDER_BY_RECORD_COUNT, pgCrit.getOrderBy());
+
+    when(recordDao.getTotalRecordsForUsers(pgCrit)).thenReturn(Map.of());
+    when(recordDao.getCountOfUsersWithRecords()).thenReturn(0L);
+    when(fileDao.getTotalFileUsageForUsers(any(), any())).thenReturn(Map.of());
+
+    ISearchResults<UserUsageInfo> results = sysAdminManager.getUserUsageInfo(sysadmin, pgCrit);
+
+    assertNotNull(results);
+    verify(recordDao).getCountOfUsersWithRecords();
+  }
+}

--- a/src/test/java/com/researchspace/core/util/BasePaginationCriteriaTest.java
+++ b/src/test/java/com/researchspace/core/util/BasePaginationCriteriaTest.java
@@ -1,6 +1,7 @@
 package com.researchspace.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -54,6 +55,90 @@ public class BasePaginationCriteriaTest {
     // now an OK value:
     pg.setOrderBy("name");
     assertEquals("name", pg.getOrderBy());
+  }
+
+  @Test
+  public void isOrderBySafeAcceptsLegitimateSortFields() {
+    pg = new BasicPaginationCriteria<>(Object.class);
+    for (String value :
+        new String[] {
+          "name",
+          "id",
+          "creationDate",
+          "modificationDate",
+          "owner.username",
+          "owner.lastName",
+          "communication.creationTime",
+          "publishingState",
+          "lastStatusUpdate",
+          "deletedDate",
+          "r.editInfo.name"
+        }) {
+      assertTrue(pg.isOrderBySafe(value), value + " should be allowed");
+    }
+    // null and empty are treated as 'no ordering requested', not as unsafe
+    assertTrue(pg.isOrderBySafe(null));
+    assertTrue(pg.isOrderBySafe(""));
+  }
+
+  @Test
+  public void isOrderBySafeRejectsInjectionPayloads() {
+    pg = new BasicPaginationCriteria<>(Object.class);
+    for (String value :
+        new String[] {
+          "name,rand()",
+          "id,(select 1)",
+          "name; drop table user",
+          "name asc, (select password from User)",
+          "1=1",
+          "name)",
+          "name ",
+          " name",
+          "name/**/"
+        }) {
+      assertFalse(pg.isOrderBySafe(value), value + " should be rejected");
+    }
+  }
+
+  @Test
+  public void isOrderBySafeRejectsNonIdentifierTokens() {
+    pg = new BasicPaginationCriteria<>(Object.class);
+    // an identifier is dot-separated segments each starting with a letter or underscore
+    for (String value :
+        new String[] {
+          "1", // bare digit: positional ordering in native SQL, not a property
+          "123",
+          ".",
+          "name.", // trailing dot
+          ".name", // leading dot
+          "owner..name", // empty dot segment
+          "1name" // leading digit
+        }) {
+      assertFalse(pg.isOrderBySafe(value), value + " should be rejected");
+    }
+  }
+
+  @Test
+  public void setOrderByDropsInjectionPayloadThatPassedTheOldBlacklist() {
+    pg = new BasicPaginationCriteria<>(Object.class);
+    // contains none of the previously blacklisted characters
+    pg.setOrderBy("name,rand()");
+    assertTrue(StringUtils.isEmpty(pg.getOrderBy()));
+  }
+
+  @Test
+  public void sysadminVirtualSortTokensAreAcceptedVerbatim() {
+    pg = new BasicPaginationCriteria<>(Object.class);
+    // dispatch keys matched by equals() in SysAdminManagerImpl, never concatenated into SQL
+    for (String token : new String[] {"fileUsage()", "recordCount()"}) {
+      assertTrue(pg.isOrderBySafe(token), token + " should be allowed");
+      pg.setOrderBy(token);
+      assertEquals(token, pg.getOrderBy());
+    }
+    // no other parenthesised value is allowed
+    assertFalse(pg.isOrderBySafe("rand()"));
+    assertFalse(pg.isOrderBySafe("notAFunction()"));
+    assertFalse(pg.isOrderBySafe("fileUsage(),rand()"));
   }
 
   @Test

--- a/src/test/java/com/researchspace/dao/hibernate/NameDateFilterTest.java
+++ b/src/test/java/com/researchspace/dao/hibernate/NameDateFilterTest.java
@@ -1,7 +1,10 @@
 package com.researchspace.dao.hibernate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.axiope.search.SearchConstants;
 import com.researchspace.model.PaginationCriteria;
@@ -49,6 +52,34 @@ public class NameDateFilterTest {
     assertEquals(pname.size(), pval.size());
     assertEquals(5, pname.size());
     assertTrue(from2.contains(" order by name"));
+  }
+
+  @Test
+  public void unsafeOrderByUsesStableFallbackInGeneratedQuery() {
+    List<String> pname = new ArrayList<String>();
+    List<Object> pval = new ArrayList<Object>();
+    // setOrderBy drops unsafe values, so a mock simulates a criteria object that
+    // still carries an ORDER BY injection payload and pins the query-builder guard
+    @SuppressWarnings("unchecked")
+    PaginationCriteria<BaseRecord> pgCrit = mock(PaginationCriteria.class);
+    when(pgCrit.getOrderBy()).thenReturn("name,rand()");
+    when(pgCrit.isOrderBySafe("name,rand()")).thenReturn(false);
+    WorkspaceListingConfig input = createANameSearchInput(pgCrit);
+
+    String countQuery = ndf.generateCountQueryString(input, pname, pval);
+    pname.clear();
+    pval.clear();
+    String retrieveQuery = ndf.generateRetrieveQueryString(input, pname, pval);
+    pname.clear();
+    pval.clear();
+    String formQuery = ndf.generateFilterStrucDocByFormQuery(input, pname, pval, Arrays.asList(1L));
+
+    assertFalse(countQuery.toLowerCase().contains("order by"));
+    assertFalse(countQuery.contains("rand()"));
+    assertTrue(retrieveQuery.contains("order by rc.id ASC"));
+    assertFalse(retrieveQuery.contains("rand()"));
+    assertTrue(formQuery.contains("order by r.id ASC"));
+    assertFalse(formQuery.contains("rand()"));
   }
 
   private WorkspaceListingConfig createANameSearchInput(PaginationCriteria<BaseRecord> pgCrit) {

--- a/src/test/java/com/researchspace/dao/hibernate/OrderByInjectionGuardTest.java
+++ b/src/test/java/com/researchspace/dao/hibernate/OrderByInjectionGuardTest.java
@@ -1,0 +1,143 @@
+package com.researchspace.dao.hibernate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.researchspace.core.util.SortOrder;
+import com.researchspace.model.PaginationCriteria;
+import com.researchspace.model.User;
+import com.researchspace.model.audit.AuditedRecord;
+import com.researchspace.model.record.BaseRecord;
+import com.researchspace.model.record.RSForm;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for rejecting unsafe order-by values before query construction. */
+public class OrderByInjectionGuardTest {
+
+  // passed the legacy character blacklist, but is an ORDER BY injection payload
+  private static final String PAYLOAD = "name,rand()";
+
+  /**
+   * setOrderBy drops unsafe values, so building a criteria object that still carries one simulates
+   * a value that reached the DAO by another route and pins the DAO-side guard.
+   */
+  @SuppressWarnings("unchecked")
+  private <T> PaginationCriteria<T> unsafeCriteria() {
+    PaginationCriteria<T> pgCrit = mock(PaginationCriteria.class);
+    when(pgCrit.getOrderBy()).thenReturn(PAYLOAD);
+    when(pgCrit.isOrderBySafe(PAYLOAD)).thenReturn(false);
+    when(pgCrit.getSortOrder()).thenReturn(SortOrder.ASC);
+    return pgCrit;
+  }
+
+  @Test
+  public void paginationCriteriaDropsPayloadOnSet() {
+    PaginationCriteria<BaseRecord> pgCrit =
+        PaginationCriteria.createDefaultForClass(BaseRecord.class);
+    pgCrit.setOrderBy(PAYLOAD);
+    assertFalse(PAYLOAD.equals(pgCrit.getOrderBy()));
+  }
+
+  @Test
+  public void formDaoMakeOrderByFallsBackToStableSort() {
+    FormDaoHibernate formDao = new FormDaoHibernate();
+    PaginationCriteria<RSForm> safe = PaginationCriteria.createDefaultForClass(RSForm.class);
+    safe.setSortOrder(SortOrder.ASC);
+    safe.setOrderBy("name");
+    assertTrue(formDao.makeOrderBy(safe).contains("order by name"));
+
+    String out = formDao.makeOrderBy(unsafeCriteria());
+    assertFalse(out.contains("rand()"));
+    assertFalse(out.contains(","));
+    assertTrue(out.contains("order by id")); // stable fallback so paging stays deterministic
+
+    assertEquals("", formDao.makeOrderBy(null));
+  }
+
+  @Test
+  public void auditDaoMakeOrderByFallsBackToDeletedDate() {
+    PaginationCriteria<AuditedRecord> safe =
+        PaginationCriteria.createDefaultForClass(AuditedRecord.class);
+    safe.setSortOrder(SortOrder.ASC);
+    safe.setOrderBy("name");
+    // logical sort names are mapped to fully-qualified HQL paths
+    assertTrue(
+        AuditDaoHibernateEnversImpl.makeOrderBy(safe)
+            .contains("order by rtf.record.editInfo.name"));
+
+    String out = AuditDaoHibernateEnversImpl.makeOrderBy(unsafeCriteria());
+    assertFalse(out.contains("rand()"));
+    assertFalse(out.contains(","));
+    // this site has its own default sort, so it stays silent rather than logging
+    assertTrue(out.contains("order by rtf.deletedDate"));
+  }
+
+  @Test
+  public void recordDaoMakeOrderByStripsInjection() {
+    PaginationCriteria<BaseRecord> safe =
+        PaginationCriteria.createDefaultForClass(BaseRecord.class);
+    safe.setSortOrder(SortOrder.ASC);
+    safe.setOrderBy("name");
+    assertTrue(RecordDaoHibernate.makeOrderBy(safe).contains("order by br.editInfo.name"));
+
+    String out = RecordDaoHibernate.makeOrderBy(unsafeCriteria());
+    assertFalse(out.contains("rand()"));
+    assertFalse(out.contains(","));
+  }
+
+  @Test
+  public void userDaoSafeOrderByStripsInjection() throws Exception {
+    UserDaoHibernate dao = new UserDaoHibernate();
+    Method m = UserDaoHibernate.class.getDeclaredMethod("safeOrderBy", PaginationCriteria.class);
+    m.setAccessible(true);
+
+    PaginationCriteria<User> safe = PaginationCriteria.createDefaultForClass(User.class);
+    safe.setSortOrder(SortOrder.ASC);
+    safe.setOrderBy("lastName");
+    assertTrue(((String) m.invoke(dao, safe)).contains("order by u.lastName"));
+
+    String out = (String) m.invoke(dao, unsafeCriteria());
+    assertFalse(out.contains("rand")); // payload not used
+    assertTrue(out.contains("u.id")); // stable fallback so paging stays deterministic
+  }
+
+  // UserDao applies custom tie-break ordering instead of the shared guard.
+  @Test
+  @SuppressWarnings("unchecked")
+  public void userDaoApplyUserOrderIgnoresInjection() throws Exception {
+    UserDaoHibernate dao = new UserDaoHibernate();
+    Method m =
+        UserDaoHibernate.class.getDeclaredMethod(
+            "applyUserOrder",
+            PaginationCriteria.class,
+            CriteriaBuilder.class,
+            Root.class,
+            CriteriaQuery.class);
+    m.setAccessible(true);
+
+    CriteriaBuilder builder = mock(CriteriaBuilder.class);
+    Root<User> root = mock(Root.class);
+    CriteriaQuery<?> query = mock(CriteriaQuery.class);
+    Path<Object> path = mock(Path.class);
+    when(root.get(anyString())).thenReturn(path);
+    when(builder.asc(path)).thenReturn(mock(Order.class));
+
+    // an unsafe value must not reach the query; a stable fallback is applied instead
+    m.invoke(dao, unsafeCriteria(), builder, root, query);
+    verify(root).get("id");
+    verify(root, never()).get(PAYLOAD);
+    verify(query).orderBy(org.mockito.ArgumentMatchers.any(Order.class));
+  }
+}


### PR DESCRIPTION
## Description ##
Fixes RSDEV-1328. The client-supplied `orderBy` field on paginated listings was screened by a character blacklist that let through values able to alter the generated query. This replaces it with a positive allowlist in `BasicPaginationCriteria.isOrderBySafe`: only bare or dotted property identifiers pass, anything else falls back to the default sort with a WARN log. The string-concatenation sites that had no check, or a weaker one, now route through the same predicate: `FormDaoHibernate`, `NameDateFilterImpl`, `RecordDaoHibernate`, `UserDaoHibernate`, and `AuditDaoHibernateEnversImpl`.

## Design decisions
- The sysadmin usage table's `fileUsage()` and `recordCount()` sort keys are accepted as exact literals. They are matched with `equals` and never concatenated into SQL, so no injection surface is added. Without the carve-out that table silently fell back to a lastName sort and the analytics disk-usage upload NPE'd.
- The form and audit listings expose their order-by decision as `makeOrderBy` so the guard and its fallback are unit testable.

## Follow-up work
Reviewers: please do not raise findings on the items below. They are deliberately out of scope here and will be changed by the linked tickets.
- RSDEV-1331: make order-by safe by construction. This PR is validation at each sink, not a structural guarantee: a new DAO can still concatenate a raw order-by value, and the allowlist accepts any syntactically valid identifier rather than a known column. Both are addressed there, so the per-sink guards and `VIRTUAL_SORT_TOKENS` carve-out here are interim.
- RSDEV-1333: HQL injection via the user-search term in the community user listing. Separate sink, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
