### PR TITLE
Make e2e tests more resilient to GitHub failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -274,7 +274,15 @@ jobs:
 
       - name: Install Playwright browser
         if: env.E2E_PW_BROWSER != ''
-        run: pnpm exec playwright install --with-deps ${{ env.E2E_PW_BROWSER }}
+        run: |
+          for attempt in 1 2 3; do
+            pnpm exec playwright install --with-deps ${{ env.E2E_PW_BROWSER }} && exit 0
+            if [ "$attempt" -lt 3 ]; then
+              echo "Playwright download failed (attempt ${attempt}/3); retrying..."
+              sleep $((attempt * 10))
+            fi
+          done
+          exit 1
 
       - name: Wait for RSpace readiness
         run: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -388,7 +388,15 @@ jobs:
       # The Vitest browser provider drives real Playwright browsers, so the
       # browser binaries still need installing (just the one for this leg).
       - name: Install Playwright browser
-        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
+        run: |
+          for attempt in 1 2 3; do
+            pnpm exec playwright install --with-deps ${{ matrix.browser }} && exit 0
+            if [ "$attempt" -lt 3 ]; then
+              echo "Playwright download failed (attempt ${attempt}/3); retrying..."
+              sleep $((attempt * 10))
+            fi
+          done
+          exit 1
 
       - name: Run Vitest browser-mode tests
         env:

--- a/src/main/webapp/ui/playwright-e2e.config.ts
+++ b/src/main/webapp/ui/playwright-e2e.config.ts
@@ -59,7 +59,8 @@ export default defineConfig<E2EOptions>({
 
     trace: PW_LOG === "trace" ? "on" : "on-first-retry",
     screenshot: PW_LOG === "off" ? "only-on-failure" : "on",
-    video: PW_LOG === "trace" ? "on" : "retain-on-failure",
+    // CI does not need video artifacts, so avoid recording them.
+    video: env.ci ? "off" : PW_LOG === "trace" ? "on" : "retain-on-failure",
   },
   projects: [
     {


### PR DESCRIPTION
## Description ##
Adds retry attempts to Playwright binary downloads, and disable Playwright recording (we don't look at those)