### PR TITLE
RSDEV-1103: build and test on Java 17 and 21

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [21]
     services:
       db:
         image: mariadb:10.11
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v5.3.0
+        uses: actions/setup-java@v5.4.0
         with:
           distribution: ${{ inputs.java_vendor || 'temurin' }}
           java-version: ${{ matrix.java-version }}
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [21]
     services:
       db:
         image: mariadb:10.11
@@ -167,7 +167,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v5.3.0
+        uses: actions/setup-java@v5.4.0
         with:
           distribution: ${{ inputs.java_vendor || 'temurin' }}
           java-version: ${{ matrix.java-version }}
@@ -255,7 +255,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [21]
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -263,7 +263,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v5.3.0
+        uses: actions/setup-java@v5.4.0
         with:
           distribution: ${{ inputs.java_vendor || 'temurin' }}
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [21]
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -68,12 +68,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [17]
+        java-version: [21]
         project: [chromium, firefox, webkit, mobile]
         shard: [1, 2, 3]
         # API specs are a single file; run them once, unsharded.
         include:
-          - java-version: 17
+          - java-version: 21
             project: api
             shard: 1
     services:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -79,7 +79,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [17, 21]
     if: |
       (github.event_name == 'push' && github.ref_name == 'main') ||
       inputs.fast_java_tests ||
@@ -118,6 +118,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2.24.0
         if: |
           always() &&
+          matrix.java-version == 17 &&
           (
             github.event_name != 'pull_request' ||
             github.event.pull_request.head.repo.full_name == github.repository
@@ -762,7 +763,7 @@ jobs:
       needs.changed-files.outputs.java == 'true'
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [17, 21]
     steps:
       - uses: actions/checkout@v7.0.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ bump this project's pinned commit hash.
 
 ## Project shape
 
-RSpace is a Java 17/Spring application with a React/TypeScript frontend and
+RSpace is a Java/Spring application (built for Java 17, runs on 17 or 21) with a React/TypeScript frontend and
 MariaDB:
 
 - Backend: `src/main/java`, tests in `src/test/java`

--- a/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
+++ b/DevDocs/DeveloperNotes/GettingStarted/GettingStarted.md
@@ -14,9 +14,11 @@ https://documentation.researchspace.com/article/q5dl9e6oz6-system-requirements-f
 For development you should be able to run all the code and tests fine with Linux/MacOS.  
 
 ### Install required software
-Our build toolchain requires Java 17. Currently using a different Java version to run Maven is not supported because of [spotless not supporting the Maven toolchains plugin](https://github.com/diffplug/spotless/issues/1857).
+RSpace builds and runs on Java 17 or Java 21. The code is compiled for Java 17 (`release 17`), so a WAR built on either JDK runs on both. The Maven build fails fast if Maven itself is started on any other Java version.
 
--   Install Java JDK17 via [Adoptium](https://adoptium.net/temurin/releases/?version=17)
+The JVM that runs Maven must be one of the supported versions too, not just the toolchain JDK, because [Spotless does not use the Maven toolchains plugin](https://github.com/diffplug/spotless/issues/1857).
+
+-   Install Java JDK 21 (or 17) via [Adoptium](https://adoptium.net/temurin/releases/?version=21)
 -   Optionally, install [jenv](https://github.com/jenv/jenv) to manage multiple versions of Java
 -   Install MariaDB 10.11 (the version supported in production). For local development, newer versions (MariaDB 11.x or 12.x) should also work fine (the dockerized RSpace dev stack uses MariaDB 12.3).
 
@@ -51,10 +53,20 @@ path to your java installation.
        <jdkHome>/usr/lib/jvm/java-17-openjdk-amd64</jdkHome>   <!-- path to your local installation -->
      </configuration>
    </toolchain>
+   <toolchain>
+     <type>jdk</type>
+     <provides>
+       <version>21</version>
+       <vendor>openjdk</vendor>
+     </provides>
+     <configuration>
+       <jdkHome>/usr/lib/jvm/java-21-openjdk-amd64</jdkHome>
+     </configuration>
+   </toolchain>
 </toolchains>
 ```
 
-**NOTE:** to use a specific toolchain with maven specify the java properties -Djava-vendor=<vendor> -Djava-version=<version>
+**NOTE:** to use a specific toolchain with maven specify the java properties -Djava-vendor=<vendor> -Djava-version=<version>. The default is 17. Surefire forks the toolchain JDK, not the Maven JVM, so to run the tests on Java 21 you need the 21 toolchain entry above and `-Djava-version=21`; setting only `JAVA_HOME` runs them on 17.
 
 ### Enable git hooks (recommended)
 

--- a/DevDocs/public/Migrating-RSpace-to-Java-21.md
+++ b/DevDocs/public/Migrating-RSpace-to-Java-21.md
@@ -1,0 +1,32 @@
+RSpace runs on Java 17 or Java 21. Moving to Java 21 is optional today and will become required in a later release; we will announce that in advance. This page covers a self-hosted install on Ubuntu with the distribution `tomcat10` package. If you run RSpace with [rspace-docker](https://github.com/rspace-os/rspace-docker), the image manages the JDK for you and there is nothing to do here.
+
+Before starting, gracefully stop the Tomcat service. RSpace will be unavailable while you perform the steps below.
+
+    sudo systemctl stop tomcat10
+
+**Install the Java 21 package**
+
+    sudo apt install openjdk-21-jre-headless
+
+On Ubuntu 24.04 this is the default Java and may already be installed.
+
+**Point Tomcat at Java 21**
+
+Tomcat reads its JVM settings from `/etc/default/tomcat10`. Take a backup of that file, then open it in a text editor.
+
+1. Replace `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64` with `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64`. If `JAVA_HOME` is not set in that file, add the latter line.
+
+2. None of the flags we recommend in `JAVA_OPTS` or `CATALINA_OPTS` were removed between Java 17 and Java 21, so most installs need no further edits. Flags that other tooling may have added and that Java 21 rejects include the biased-locking family (`-XX:+UseBiasedLocking`, `-XX:BiasedLockingStartupDelay=...`). If Tomcat fails to start, `sudo systemctl status tomcat10` names the unrecognised flag; remove it and try again.
+
+3. Check `/usr/libexec/tomcat10/tomcat-locate-java.sh`. It contains a line like `for java_version in 21 17 11 ...`. If `21` is missing from that list, add it at the front.
+
+**Start Tomcat and verify**
+
+    sudo systemctl start tomcat10
+    sudo systemctl status tomcat10
+
+Once RSpace is up, confirm the Java version Tomcat is using:
+
+    sudo bash /usr/share/tomcat10/bin/version.sh
+
+It should report JVM version 21. If you encounter any issues you can email support@researchspace.com for support.

--- a/DevDocs/public/RSpaceConfiguration.md
+++ b/DevDocs/public/RSpaceConfiguration.md
@@ -93,7 +93,7 @@ So we edit this file and set the following;
      -DRS_FILE_BASE=/PATH/TO/FILESTORAGE -Djava.awt.headless=true\
      -Dliquibase.context=run -Dspring.profiles.active=prod -Djmelody.dir=/media/rspace/jmelody"
     
-    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+    JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 
 (Adjust java_home variable to be that of the installed java jdk)
 PLEASE NOTE: "/PATH/TO/FILESTORAGE" should be the server path to your filestore eg. /data/rspace-filestore

--- a/DevDocs/public/ServerSetupUbuntu22.md
+++ b/DevDocs/public/ServerSetupUbuntu22.md
@@ -30,7 +30,7 @@ file-store which can be a local disk or remote disk array/SAN.
 
 The following services/packages are required by RSpace and are the default packages on Ubuntu22.
 
-* Java JDK 17
+* Java 17 or 21 (JRE is sufficient)
 * Tomcat 9.0.x
 * MariaDB (the default Ubuntu 22 package is 10.6; we recommend switching to 10.11 after installation)
 * Webserver (We recommend Apache 2.4.x)
@@ -78,9 +78,13 @@ Update and install required packages.
 	sudo apt-get update
 	sudo apt-get upgrade
 
-Reboot and repeat if necessary. Now install Java 17 (the default for Ubuntu 22 is Java 11)
+Reboot and repeat if necessary. Now install Java (the default for Ubuntu 22 is Java 11, which RSpace does not support). RSpace runs on Java 17 or 21; pick one and use the matching `JAVA_HOME` below.
 
 	 sudo apt install openjdk-17-jre-headless
+
+or
+
+	 sudo apt install openjdk-21-jre-headless
 
 The following will ask you to set a root password on Ubuntu but not on Debian, so have one ready
 	

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,10 @@ echo 'Building rspace-web'
  In Jenkins, it is called from 'rspace-web' project as a multi branch build
  For feature branches, it runs 'quick' JUnit tests
  For master/dev branches, it runs full Java tests (i.e. with IT tests).
- The script takes several parameters; there are other Jenkins jobs to run nightly test-suites using JDK 11 and also
+ The script takes several parameters; there are other Jenkins jobs to run nightly test-suites on other JDKs and also
  with 'nightly' tests which are more long running tests.
+ Java 17 and 21 are both supported. The defaults below stay on 17 until Temurin 21 is installed on the agents,
+ then flip MAVEN_TOOLCHAIN_JAVA_VERSION to 21 and MAVEN_TOOLCHAIN_JAVA_VENDOR to temurin.
 */
 
 pipeline {
@@ -19,7 +21,7 @@ pipeline {
     options { disableConcurrentBuilds() }
 
     parameters {
-        string(name: 'MAVEN_TOOLCHAIN_JAVA_VERSION', defaultValue: '17', description: 'Java version Maven toolchain')
+        string(name: 'MAVEN_TOOLCHAIN_JAVA_VERSION', defaultValue: '17', description: 'Java version Maven toolchain (17 or 21)')
         string(name: 'MAVEN_TOOLCHAIN_JAVA_VENDOR', defaultValue: 'openjdk', description: 'Java vendor Maven toolchain')
         string(name: 'NIGHTLY_BUILD', defaultValue: '', description: 'optional nightly build configuration')
         booleanParam(name: 'ONLY_BUILD_WAR', defaultValue: false, description: 'It only build the WAR file without deploying in AWS')

--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,24 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- The JVM running Maven, not the toolchain JDK: Spotless and other plugins run in
+                 it, and a wrong version fails late with cryptic errors otherwise. -->
+            <id>enforce-java-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[17,22)</version>
+                  <message>RSpace builds on Java 17 or 21. Run Maven with one of those (JAVA_HOME), and pass -Djava-version to pick the toolchain JDK.</message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description ##

Second of three PRs for RSDEV-1103 phase 1, stacked on #1068. Builds and tests on Java 21 as well as 17. Bytecode stays at `release 17`; nothing shipped to customers changes.

- CI: `build` and `fast-junit-tests` also run on 21 per PR (about 10 extra runner-minutes, no extra wall clock). Nightly coverage and the e2e workflows move to 21, so the full test suites and a real app run happen on 21 at no extra cost. Check names are unchanged.
- Enforcer `requireJavaVersion [17,22)` on the JVM running Maven, so a wrong JDK fails early with a clear message instead of late in Spotless.
- Jenkinsfile: defaults stay 17/openjdk until Temurin 21 is on the agents; comments say what to flip.
- Docs: GettingStarted covers both JDKs and the 21 toolchain entry; new `DevDocs/public/Migrating-RSpace-to-Java-21.md` for self-hosted tomcat10 installs; Ubuntu setup docs say 17 or 21.

## Testing notes

Enforcer checked locally: passes on Temurin 17 and 21, fails with the intended message on JDK 26. CI on this PR is the real test of the 21 legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
